### PR TITLE
fix: use path-only resource URL in payment payload

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -109,7 +109,7 @@ pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<
     let payment_payload = PaymentPayload {
         x402_version: x402::types::X402_VERSION,
         resource: Resource {
-            url: endpoint_url.clone(),
+            url: "/v1/chat/completions".to_string(),
             method: "POST".to_string(),
         },
         accepted,


### PR DESCRIPTION
CLI was sending full URL (https://...fly.dev/v1/chat/completions) but gateway validates against path only (/v1/chat/completions). One-line fix.