### PR TITLE
feat: deploy escrow program to Solana mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,10 +31,10 @@ RCR_SOLANA_RECIPIENT_WALLET=
 # Hot wallet private key (base58) used to co-sign/pay transaction fees
 # NEVER commit this value — keep it in .env only
 RCR_SOLANA_FEE_PAYER_KEY=
-# Optional — enables escrow payment mode. The value below is a devnet example only.
+# Optional — enables escrow payment mode.
 # When set (along with FEE_PAYER_KEY), 402 responses will offer both "exact"
 # and "escrow" schemes. The gateway will fire claim transactions after serving.
-# Example (devnet): 9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU
+# Mainnet program ID: 9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU
 RCR_SOLANA_ESCROW_PROGRAM_ID=
 
 # ── LLM Provider API keys ─────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ RCR_SOLANA_FEE_PAYER_KEY=
 # Optional — enables escrow payment mode. The value below is a devnet example only.
 # When set (along with FEE_PAYER_KEY), 402 responses will offer both "exact"
 # and "escrow" schemes. The gateway will fire claim transactions after serving.
-# Example (devnet): GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy
+# Example (devnet): 9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU
 RCR_SOLANA_ESCROW_PROGRAM_ID=
 
 # ── LLM Provider API keys ─────────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to RustyClawRouter, in reverse chronological order.
 
+## 2026-04-07 — First Real Payment + Production Fixes
+
+- **First real USDC payment processed**: Telsi Telegram app sent real USDC payment through RCR on Solana mainnet, received LLM response. End-to-end payment flow verified with actual money on mainnet.
+- **Critical Fly.io config fix (PR #5)**: Gateway was calling `AppConfig::default()` and ignoring all Fly.io env vars for Solana configuration. Root cause: missing `config/default.toml` load in startup path. Result: `recipient_wallet` was always empty despite env vars being set. Fixed by loading `config/default.toml` first, then applying env var overrides. Deployed to production.
+- **CLI resource URL fix (PR #6)**: CLI was sending full URL in payment resource field. Gateway validates resource as path only (per x402 spec). One-line fix: send path instead of full URL.
+- **PR #4 follow-up fixes**: Python SDK error hardening (ImportError fails with key message, session_spent set after success only, specific exception catches). CLI hardening (non-zero exit on errors, panic-safe env cleanup, RPC error handling, empty response warnings).
+- **Transaction format compatibility verified**: Architect confirmed gateway accepts both legacy transactions (CLI) and v0 versioned transactions (Python/TypeScript SDKs) via `ParsedMessage::from_bytes()` version prefix detection.
+- **Known issue**: Second test request hit 429 rate limit from LLM provider. Payment was processed but no response returned. This is exact use case for escrow (pay only for what you receive). Escrow deployment still pending attorney consultation scheduled 2026-04-07.
+- **6 PRs merged total** (#1-6 all merged). Status: Gateway deployed and processing real payments on mainnet.
+
 ## 2026-04-06 — Test Coverage, Real Signing, Product Docs, Error Hardening
 
 - **CLI test suite**: 0 → 30 tests across all 8 commands (wallet, chat, models, health, stats, doctor, nonce, services). wiremock for HTTP mocking, tempfile for filesystem isolation, test isolation, error cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to RustyClawRouter, in reverse chronological order.
 
+## 2026-04-08 — Escrow Program Deployed to Mainnet
+
+- **Escrow program deployed to Solana mainnet**: Program ID `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`, upgrade authority retained by deployer. Built with Anchor 0.31.1, deployed via `solana program deploy`.
+- **Gateway advertises escrow scheme**: 402 responses now include both "exact" and "escrow" payment schemes. Escrow program ID served from Fly.io secret.
+- **Program ID updated across entire codebase**: All source files, tests, docs, and config updated from placeholder to mainnet program ID. All 684 workspace tests + 21 escrow tests pass.
+- **Regulatory docs updated**: `regulatory-position.md` updated to reflect mainnet deployment with upgrade authority retained.
+
 ## 2026-04-07 — First Real Payment + Production Fixes + Telsi Migration Complete
 
 - **Telsi.ai migration to RCR complete**: Telsi has successfully migrated from BlockRun to RustyClawRouter. Second production product now live on the gateway, processing real payments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to RustyClawRouter, in reverse chronological order.
 
-## 2026-04-07 — First Real Payment + Production Fixes
+## 2026-04-07 — First Real Payment + Production Fixes + Telsi Migration Complete
 
+- **Telsi.ai migration to RCR complete**: Telsi has successfully migrated from BlockRun to RustyClawRouter. Second production product now live on the gateway, processing real payments.
 - **First real USDC payment processed**: Telsi Telegram app sent real USDC payment through RCR on Solana mainnet, received LLM response. End-to-end payment flow verified with actual money on mainnet.
 - **Critical Fly.io config fix (PR #5)**: Gateway was calling `AppConfig::default()` and ignoring all Fly.io env vars for Solana configuration. Root cause: missing `config/default.toml` load in startup path. Result: `recipient_wallet` was always empty despite env vars being set. Fixed by loading `config/default.toml` first, then applying env var overrides. Deployed to production.
 - **CLI resource URL fix (PR #6)**: CLI was sending full URL in payment resource field. Gateway validates resource as path only (per x402 spec). One-line fix: send path instead of full URL.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -44,7 +44,7 @@ Core tables (wallet_budgets, escrow, claims), escrow claim queue, session tracki
 
 ### Escrow Program (Anchor, standalone)
 
-Trustless USDC-SPL escrow: deposit/claim/refund. PDA vault with timeout refunds. Not a workspace member (dep conflicts).
+Trustless USDC-SPL escrow: deposit/claim/refund. PDA vault with timeout refunds. Not a workspace member (dep conflicts). **Deployed to mainnet** (`9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`) with upgrade authority retained by deployer (`B7reP7rzzYsKwteQqCgwfx76xQmNTL4bQ7yk4tQTxL1A`).
 
 ### SDKs
 
@@ -97,8 +97,8 @@ All 5 provider keys set (OpenAI, Anthropic, Google, xAI, DeepSeek). Solana confi
 
 ### Immediate
 
-- **Escrow program deployment**: Program verified (not deployed to any network). Upgrade authority decision pending attorney consultation (scheduled 2026-04-07).
-- **End-to-end devnet payment test**: Integration test with real Solana signing not yet written.
+- **Escrow client SDK support**: CLI and SDKs only support "exact" scheme. Escrow scheme client support not yet implemented.
+- **End-to-end escrow payment test**: Escrow program deployed, gateway advertises escrow scheme, but no client can exercise it yet.
 - **Docs site setup**: User wants design input before building docs site.
 - **Go SDK signing**: Still using stub. TypeScript SDK has real signing; Python + CLI have real signing (merged).
 - **MCP server signing**: Stub signing intentional (agent-only protocol).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -15,7 +15,7 @@ Part of the **rustyclaw.ai** ecosystem:
 |---------|---------|--------|
 | **RustyClawRouter** | LLM payment gateway (this repo) | Deployed on Fly.io |
 | **RustyClaw Terminal** | Crypto trading terminal + AI agent | Backend deployed, frontend not yet |
-| **Telsi.ai** | Multi-tenant AI assistant SaaS | Live on BlockRun, planned RCR migration |
+| **Telsi.ai** | Multi-tenant AI assistant SaaS | Live on RCR (migrated from BlockRun 2026-04-07) |
 
 ---
 
@@ -119,7 +119,7 @@ All 5 provider keys set (OpenAI, Anthropic, Google, xAI, DeepSeek). Solana confi
 1. Deploy Terminal frontend to Vercel
 2. Harden RCR under real Terminal load
 3. Build OpenClaw plugin (`@rustyclaw/clawrouter`)
-4. Migrate Telsi from BlockRun to RCR
+4. ~~Migrate Telsi from BlockRun to RCR~~ (completed 2026-04-07)
 5. Build Sky64 network agent
 6. Open-source (`rcr-router`, `rcr-protocol`)
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,7 +1,7 @@
 # HANDOFF.md — RustyClawRouter Current State
 
 > **Single source of truth** for project status. See `CLAUDE.md` for how to work in the repo. See `CHANGELOG.md` for history.
-> **Last verified:** 2026-04-06 (from actual repo inspection, not docs)
+> **Last verified:** 2026-04-07 (from actual repo inspection, not docs)
 
 ---
 
@@ -97,11 +97,10 @@ All 5 provider keys set (OpenAI, Anthropic, Google, xAI, DeepSeek). Solana confi
 
 ### Immediate
 
-- **PR #4 review + merge**: Real signing (Python + CLI), product docs, error hardening. Open, needs review + merge.
-- **Escrow program deployment**: Program verified (not deployed to any network). Upgrade authority decision pending attorney consultation (scheduled 2026-04-06).
+- **Escrow program deployment**: Program verified (not deployed to any network). Upgrade authority decision pending attorney consultation (scheduled 2026-04-07).
 - **End-to-end devnet payment test**: Integration test with real Solana signing not yet written.
 - **Docs site setup**: User wants design input before building docs site.
-- **Go SDK signing**: Still using stub. TypeScript SDK has real signing; Python + CLI migrated in PR #4.
+- **Go SDK signing**: Still using stub. TypeScript SDK has real signing; Python + CLI have real signing (merged).
 - **MCP server signing**: Stub signing intentional (agent-only protocol).
 
 ### Deferred

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,7 +1,7 @@
 # HANDOFF.md — RustyClawRouter Current State
 
 > **Single source of truth** for project status. See `CLAUDE.md` for how to work in the repo. See `CHANGELOG.md` for history.
-> **Last verified:** 2026-04-07 (from actual repo inspection, not docs)
+> **Last verified:** 2026-04-08 (from actual repo inspection, not docs)
 
 ---
 
@@ -58,7 +58,7 @@ Next.js 16 + Tailwind + Recharts. 5 pages: Overview, Usage, Models, Wallet, Sett
 
 ## Test Counts (run `cargo test` to verify — these go stale)
 
-Last verified 2026-04-06:
+Last verified 2026-04-08:
 
 ```
 gateway unit:        401
@@ -129,7 +129,7 @@ All 5 provider keys set (OpenAI, Anthropic, Google, xAI, DeepSeek). Solana confi
 
 - **Safe (no licensing)**: AP2 discovery endpoints, x402 crypto settlement (wallet-to-wallet), mandate verification as metadata
 - **DO NOT build (triggers MSB + 49 state licenses)**: Card payment processing, fiat ↔ crypto conversion, custodial fund holding
-- **Gray area**: Anchor escrow PDAs (trustless, PDA-controlled) — FinCEN guidance on custodial wallets is evolving. Attorney consultation scheduled 2026-04-06.
+- **Gray area**: Anchor escrow PDAs (trustless, PDA-controlled) — FinCEN guidance on custodial wallets is evolving. Escrow deployed to mainnet 2026-04-08 with upgrade authority retained.
 - **Watch**: California DFAL takes effect July 2026.
 
 ---

--- a/crates/gateway/src/routes/escrow.rs
+++ b/crates/gateway/src/routes/escrow.rs
@@ -297,7 +297,7 @@ mod tests {
     #[test]
     fn test_escrow_config_serializes_correctly() {
         let config = EscrowConfig {
-            escrow_program_id: "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string(),
+            escrow_program_id: "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string(),
             current_slot: Some(298_765_432),
             network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".to_string(),
             usdc_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
@@ -307,7 +307,7 @@ mod tests {
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(
             json["escrow_program_id"],
-            "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy"
+            "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
         );
         assert_eq!(json["current_slot"], 298_765_432);
         assert_eq!(json["network"], "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp");

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -418,7 +418,7 @@ fn test_app_with_mock_provider_and_escrow() -> axum::Router {
     let mut config = AppConfig::default();
     config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
     config.solana.escrow_program_id =
-        Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string());
+        Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string());
 
     let test_keypair = {
         use ed25519_dalek::SigningKey;
@@ -435,7 +435,7 @@ fn test_app_with_mock_provider_and_escrow() -> axum::Router {
     let escrow_claimer = x402::escrow::EscrowClaimer::new(
         "https://api.devnet.solana.com".to_string(),
         test_fee_payer_pool.clone(),
-        "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+        "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
         "11111111111111111111111111111111",
         "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         None,
@@ -481,7 +481,7 @@ fn test_app_with_escrow() -> axum::Router {
     let mut config = AppConfig::default();
     config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
     config.solana.escrow_program_id =
-        Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string());
+        Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string());
 
     // Create a dummy claimer — won't actually submit claims in tests
     // We need a valid 64-byte key. Use a test keypair.
@@ -500,7 +500,7 @@ fn test_app_with_escrow() -> axum::Router {
     let escrow_claimer = x402::escrow::EscrowClaimer::new(
         "https://api.devnet.solana.com".to_string(),
         test_fee_payer_pool.clone(),
-        "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+        "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
         "11111111111111111111111111111111",
         "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         None,
@@ -572,7 +572,7 @@ fn valid_escrow_payment_header(resource_url: &str) -> String {
             asset: USDC_MINT.to_string(),
             pay_to: TEST_RECIPIENT_WALLET.to_string(),
             max_timeout_seconds: 300,
-            escrow_program_id: Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string()),
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
         },
         payload: PayloadData::Escrow(EscrowPayload {
             deposit_tx: base64::engine::general_purpose::STANDARD.encode(b"mock_deposit_tx_bytes"),
@@ -1531,7 +1531,7 @@ async fn test_escrow_scheme_dispatches_to_escrow_verifier() {
             asset: USDC_MINT.to_string(),
             pay_to: "TestRecipient".to_string(),
             max_timeout_seconds: 300,
-            escrow_program_id: Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string()),
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
         },
         payload: PayloadData::Escrow(EscrowPayload {
             deposit_tx: base64::engine::general_purpose::STANDARD.encode(b"mock_deposit_tx"),
@@ -3176,7 +3176,7 @@ async fn test_escrow_config_returns_200_when_configured() {
 
     assert_eq!(
         json["escrow_program_id"],
-        "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy"
+        "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
     );
     assert_eq!(json["network"], SOLANA_NETWORK);
     assert_eq!(json["usdc_mint"], USDC_MINT);
@@ -3317,7 +3317,7 @@ fn test_app_with_escrow_metrics() -> axum::Router {
     let mut config = AppConfig::default();
     config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
     config.solana.escrow_program_id =
-        Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string());
+        Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string());
 
     let test_keypair = {
         use ed25519_dalek::SigningKey;
@@ -3334,7 +3334,7 @@ fn test_app_with_escrow_metrics() -> axum::Router {
     let escrow_claimer = x402::escrow::EscrowClaimer::new(
         "https://api.devnet.solana.com".to_string(),
         test_fee_payer_pool.clone(),
-        "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+        "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
         "11111111111111111111111111111111",
         "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         None,
@@ -3446,7 +3446,7 @@ async fn test_escrow_config_returns_correct_program_id() {
 
     // Program ID must match exactly what was configured
     assert_eq!(
-        json["escrow_program_id"], "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+        json["escrow_program_id"], "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
         "escrow_program_id must match configured value"
     );
 
@@ -3487,7 +3487,7 @@ async fn test_escrow_health_reflects_incremented_metrics() {
     let mut config = AppConfig::default();
     config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
     config.solana.escrow_program_id =
-        Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string());
+        Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string());
 
     let test_keypair = {
         use ed25519_dalek::SigningKey;
@@ -3504,7 +3504,7 @@ async fn test_escrow_health_reflects_incremented_metrics() {
     let escrow_claimer = x402::escrow::EscrowClaimer::new(
         "https://api.devnet.solana.com".to_string(),
         test_fee_payer_pool.clone(),
-        "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+        "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
         "11111111111111111111111111111111",
         "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         None,
@@ -3621,7 +3621,7 @@ fn mismatched_escrow_scheme_direct_payload_header(resource_url: &str) -> String 
             asset: USDC_MINT.to_string(),
             pay_to: TEST_RECIPIENT_WALLET.to_string(),
             max_timeout_seconds: 300,
-            escrow_program_id: Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string()),
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
         },
         payload: PayloadData::Direct(SolanaPayload {
             // <-- but contains direct transfer data
@@ -3740,7 +3740,7 @@ async fn test_escrow_health_status_down_without_claimer() {
     let mut config = AppConfig::default();
     config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
     config.solana.escrow_program_id =
-        Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string());
+        Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string());
 
     let state = Arc::new(AppState {
         config,

--- a/crates/protocol/src/payment.rs
+++ b/crates/protocol/src/payment.rs
@@ -127,11 +127,11 @@ mod tests {
             asset: USDC_MINT.to_string(),
             pay_to: "RecipientWalletPubkeyHere".to_string(),
             max_timeout_seconds: MAX_TIMEOUT_SECONDS,
-            escrow_program_id: Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string()),
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
         };
         let json = serde_json::to_string(&accept).unwrap();
         assert!(json.contains("escrow_program_id"));
-        assert!(json.contains("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy"));
+        assert!(json.contains("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"));
     }
 
     #[test]

--- a/crates/x402/src/escrow/claimer.rs
+++ b/crates/x402/src/escrow/claimer.rs
@@ -630,7 +630,7 @@ mod tests {
         let result = EscrowClaimer::new(
             "https://api.devnet.solana.com".to_string(),
             pool,
-            "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+            "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
             "11111111111111111111111111111111",
             "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
             None,
@@ -647,7 +647,7 @@ mod tests {
         let result = EscrowClaimer::new(
             "https://api.devnet.solana.com".to_string(),
             pool,
-            "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+            "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
             "11111111111111111111111111111111",
             "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
             Some(nonce_pool),
@@ -662,7 +662,7 @@ mod tests {
         let claimer = EscrowClaimer::new(
             "https://api.devnet.solana.com".to_string(),
             pool,
-            "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+            "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
             "11111111111111111111111111111111",
             "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
             None,

--- a/crates/x402/src/escrow/pda.rs
+++ b/crates/x402/src/escrow/pda.rs
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn test_pda_derivation() {
         // Use known inputs and verify we get a deterministic PDA
-        let program_id = decode_bs58_pubkey("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy")
+        let program_id = decode_bs58_pubkey("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU")
             .expect("valid program id");
         let agent = [1u8; 32];
         let service_id = [2u8; 32];

--- a/crates/x402/src/escrow/verifier.rs
+++ b/crates/x402/src/escrow/verifier.rs
@@ -354,7 +354,7 @@ mod tests {
             rpc_url: "https://api.devnet.solana.com".to_string(),
             recipient_wallet: "11111111111111111111111111111111".to_string(),
             usdc_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
-            escrow_program_id: "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string(),
+            escrow_program_id: "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string(),
             http_client: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
@@ -370,7 +370,7 @@ mod tests {
             rpc_url: "https://api.devnet.solana.com".to_string(),
             recipient_wallet: "11111111111111111111111111111111".to_string(),
             usdc_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
-            escrow_program_id: "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string(),
+            escrow_program_id: "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string(),
             http_client: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
@@ -390,7 +390,7 @@ mod tests {
                 asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
                 pay_to: "11111111111111111111111111111111".to_string(),
                 max_timeout_seconds: 300,
-                escrow_program_id: Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string()),
+                escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
             },
             payload: PayloadData::Direct(SolanaPayload {
                 transaction: "dGVzdA==".to_string(),

--- a/docs/book/src/api/health-metrics.md
+++ b/docs/book/src/api/health-metrics.md
@@ -76,7 +76,7 @@ curl -s http://localhost:8402/v1/escrow/config | jq
 
 ```json
 {
-  "program_id": "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+  "program_id": "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
   "current_slot": 298451623,
   "usdc_mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 }

--- a/docs/book/src/concepts/escrow.md
+++ b/docs/book/src/concepts/escrow.md
@@ -113,7 +113,7 @@ Returns escrow configuration:
 
 ```json
 {
-  "program_id": "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+  "program_id": "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
   "current_slot": 298451623,
   "usdc_mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 }

--- a/docs/plans/2026-03-10-extract-rustyclaw-protocol.md
+++ b/docs/plans/2026-03-10-extract-rustyclaw-protocol.md
@@ -686,11 +686,11 @@ mod tests {
             asset: USDC_MINT.to_string(),
             pay_to: "RecipientWalletPubkeyHere".to_string(),
             max_timeout_seconds: MAX_TIMEOUT_SECONDS,
-            escrow_program_id: Some("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy".to_string()),
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
         };
         let json = serde_json::to_string(&accept).unwrap();
         assert!(json.contains("escrow_program_id"));
-        assert!(json.contains("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy"));
+        assert!(json.contains("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"));
     }
 
     #[test]

--- a/docs/plans/phase-8-escrow-hardening.md
+++ b/docs/plans/phase-8-escrow-hardening.md
@@ -165,7 +165,7 @@ Public endpoint that returns escrow configuration for clients to discover escrow
 **Response (200):**
 ```json
 {
-  "escrow_program_id": "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy",
+  "escrow_program_id": "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
   "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "usdc_mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
   "provider_wallet": "RecipientWallet...",

--- a/docs/product/how-it-works.md
+++ b/docs/product/how-it-works.md
@@ -1,5 +1,19 @@
 # How RustyClawRouter Works
 
+## Why Now: The API Pricing Shift
+
+LLM providers like Anthropic, OpenAI, and Google are fundamentally reshaping how developers access their models. Subscription tiers (like Anthropic's Claude Pro or ChatGPT Plus) are increasingly off-limits to apps and app harnesses that wrap these models for end users. Instead, developers must use the API, which charges per-token -- often 2-10x the cost of a subscription for the same usage.
+
+This creates a hard problem for autonomous AI agents:
+
+- **API costs compound fast** — An agent making thousands of calls autonomously can run up bills that would bankrupt a subscription model.
+- **Traditional billing doesn't work** — Credit cards and monthly invoices assume predictable usage. Agents don't fit that pattern.
+- **Managed API services add markup** — Proxy services that handle billing add another layer of cost, taking a cut on every call.
+
+The result: developers need a way to let agents pay for API calls instantly, per-call, with granular cost control -- and they need it now.
+
+RustyClawRouter addresses this with payment settling directly on Solana. Agents hold USDC, compute the exact cost upfront, and pay atomically per request -- no subscriptions, no overpaying, no mystery bills.
+
 ## The Problem
 
 AI agents are becoming autonomous. They run 24/7, make decisions, and call APIs without a human clicking buttons. But when an AI agent needs to use a large language model (like GPT-4 or Claude), it hits a wall: how does it pay?

--- a/docs/product/regulatory-position.md
+++ b/docs/product/regulatory-position.md
@@ -120,10 +120,10 @@ RCR charges a **5% platform fee** on every request. This fee is included in the 
 **Question**: Could the PDA escrow account be classified as a "custodial wallet" by regulators?
 
 **Relevant facts**:
-- The escrow program has been **designed and tested locally** (comprehensive test suite with 20 tests passing) but **has not been deployed** to Solana mainnet or devnet. The program ID in the codebase is a locally-generated keypair for testing only.
-- When deployed, the PDA will be controlled by the on-chain program logic, not by the gateway operator. No one holds a private key to the PDA.
+- The escrow program has been **deployed to Solana mainnet** (program ID: `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`, tx: `XGtZf6KHWnis6bY8T8NCULsngdC2kqy3GkuppVriyFFqJ8ud2NiBkAgcBRsYjvUMmMZcLUmYBw9RhhUnNNRYnZx`) with comprehensive test suite (21 tests passing).
+- The PDA is controlled by the on-chain program logic, not by the gateway operator. No one holds a private key to the PDA.
 - The program logic enforces: claim amounts cannot exceed deposited amount, claims must occur before expiry slot, agent can unilaterally reclaim after timeout.
-- **Deployment decision pending attorney guidance**: Upon deployment, upgrade authority can be either **retained** (allows bug fixes, but regulators could argue de facto control) or **revoked** (program becomes immutable, strongest "no human control" argument). This decision should be made with legal counsel.
+- **Upgrade authority is retained** by the deployer (`B7reP7rzzYsKwteQqCgwfx76xQmNTL4bQ7yk4tQTxL1A`). This allows bug fixes but regulators could argue de facto control. Authority can be revoked later (`solana program set-upgrade-authority --final`) to make the program immutable.
 - FinCEN guidance on smart-contract-controlled wallets is evolving and has not definitively addressed this pattern.
 
 ### California Digital Financial Assets Law (DFAL)

--- a/docs/superpowers/plans/2026-03-31-litesvm-escrow-tests.md
+++ b/docs/superpowers/plans/2026-03-31-litesvm-escrow-tests.md
@@ -83,7 +83,7 @@ use spl_token::{
 use solana_sdk::program_pack::Pack;
 
 /// Program ID — must match declare_id!() in lib.rs
-pub const PROGRAM_ID: Pubkey = solana_sdk::pubkey!("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy");
+pub const PROGRAM_ID: Pubkey = solana_sdk::pubkey!("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU");
 
 /// Mainnet USDC mint — must match USDC_MINT in lib.rs
 pub const USDC_MINT: Pubkey = solana_sdk::pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");

--- a/docs/superpowers/plans/2026-04-07-escrow-mainnet-deployment.md
+++ b/docs/superpowers/plans/2026-04-07-escrow-mainnet-deployment.md
@@ -1,0 +1,378 @@
+# Escrow Mainnet Deployment Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy the Anchor escrow program to Solana mainnet with upgrade authority retained, wire it to the production gateway, and verify end-to-end escrow payment flow.
+
+**Architecture:** The escrow program is already built and tested (21 tests). The gateway already has full escrow integration (EscrowVerifier, EscrowClaimer, claim processor with circuit breaker, fee payer pool rotation). This plan deploys the program, configures the gateway, and runs a live test. No new code needed — just deployment, configuration, and verification.
+
+**Tech Stack:** Anchor CLI 0.31.1, Solana CLI 3.1.12, Fly.io, PostgreSQL (claim queue)
+
+**Prerequisite:** Attorney approval for escrow deployment with upgrade authority retained.
+
+---
+
+## Pre-Deployment Checklist
+
+Before starting any task, verify:
+- [ ] Anchor CLI installed: `anchor --version` → 0.31.1
+- [ ] Solana CLI installed: `solana --version` → 3.1.12
+- [ ] Solana config set to mainnet: `solana config set --url https://api.mainnet-beta.solana.com`
+- [ ] Deployer wallet exists: `solana address` → shows an address
+- [ ] Deployer wallet funded: `solana balance` → at least 3 SOL (program deployment costs ~2 SOL)
+
+---
+
+### Task 1: Generate Program Keypair
+
+**Context:** The current program ID (`9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`) is a localnet/devnet placeholder. We need a fresh keypair for mainnet.
+
+- [ ] **Step 1: Generate keypair**
+
+```bash
+cd programs/escrow
+solana-keygen new --no-bip39-passphrase --outfile mainnet-program-keypair.json
+```
+
+Record the public key — this is your mainnet program ID.
+
+- [ ] **Step 2: Update `declare_id!` in lib.rs**
+
+```bash
+# In programs/escrow/src/lib.rs, line 44:
+# Change:
+declare_id!("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU");
+# To:
+declare_id!("<YOUR_NEW_PROGRAM_ID>");
+```
+
+- [ ] **Step 3: Update Anchor.toml**
+
+Add a `[programs.mainnet-beta]` section and update existing sections:
+
+```toml
+[programs.localnet]
+rustyclawrouter_escrow = "<YOUR_NEW_PROGRAM_ID>"
+
+[programs.devnet]
+rustyclawrouter_escrow = "<YOUR_NEW_PROGRAM_ID>"
+
+[programs.mainnet-beta]
+rustyclawrouter_escrow = "<YOUR_NEW_PROGRAM_ID>"
+```
+
+- [ ] **Step 4: Verify program still compiles**
+
+```bash
+cd programs/escrow
+cargo check --lib
+cargo test --manifest-path Cargo.toml
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add programs/escrow/src/lib.rs programs/escrow/Anchor.toml
+git commit -m "chore: update escrow program ID for mainnet deployment"
+```
+
+**DO NOT commit `mainnet-program-keypair.json`** — this is a secret. Store it securely outside the repo.
+
+---
+
+### Task 2: Build and Deploy to Mainnet
+
+**Context:** Anchor build produces a `.so` file (the compiled Solana program). Deployment uploads it to mainnet. Upgrade authority is retained by default — you can revoke later.
+
+- [ ] **Step 1: Build the program**
+
+```bash
+cd programs/escrow
+anchor build
+```
+
+Verify output: `target/deploy/rustyclawrouter_escrow.so` exists.
+
+- [ ] **Step 2: Deploy to mainnet**
+
+```bash
+solana program deploy \
+  target/deploy/rustyclawrouter_escrow.so \
+  --program-id mainnet-program-keypair.json \
+  --url https://api.mainnet-beta.solana.com \
+  --keypair ~/.config/solana/id.json \
+  --commitment finalized \
+  --with-compute-unit-price 50000
+```
+
+This will take 30-60 seconds. Record the transaction signature.
+
+- [ ] **Step 3: Verify deployment**
+
+```bash
+solana program show <YOUR_NEW_PROGRAM_ID> --url mainnet-beta
+```
+
+Expected output should show:
+- Program Id: your new ID
+- Owner: BPFLoaderUpgradeab1e11111111111111111111111
+- Authority: your deployer wallet (upgrade authority RETAINED)
+- Executable: true
+
+- [ ] **Step 4: Verify upgrade authority is retained**
+
+```bash
+solana program show <YOUR_NEW_PROGRAM_ID> --url mainnet-beta | grep Authority
+```
+
+Should show your deployer wallet address — NOT "none". This confirms you can still upgrade.
+
+---
+
+### Task 3: Generate and Fund Fee Payer Wallet
+
+**Context:** The escrow claimer needs a fee payer wallet to submit claim transactions on-chain. This wallet pays SOL for transaction fees (~0.005 SOL per claim). It does NOT hold USDC — it only holds SOL.
+
+- [ ] **Step 1: Generate fee payer keypair**
+
+```bash
+solana-keygen new --no-bip39-passphrase --outfile fee-payer-keypair.json
+```
+
+Record the public key and the base58-encoded full keypair.
+
+- [ ] **Step 2: Extract base58 keypair for Fly.io**
+
+```bash
+# The keypair file is a JSON array of 64 bytes. Convert to base58:
+python3 -c "
+import json, base58
+with open('fee-payer-keypair.json') as f:
+    key_bytes = bytes(json.load(f))
+print(base58.b58encode(key_bytes).decode())
+"
+```
+
+Save this base58 string — you'll set it as a Fly.io secret.
+
+- [ ] **Step 3: Fund the fee payer wallet**
+
+Transfer SOL from your main wallet:
+```bash
+solana transfer <FEE_PAYER_ADDRESS> 0.5 --url mainnet-beta
+```
+
+0.5 SOL covers ~100 claim transactions. The gateway's balance monitor will warn at 0.1 SOL.
+
+- [ ] **Step 4: Verify balance**
+
+```bash
+solana balance <FEE_PAYER_ADDRESS> --url mainnet-beta
+```
+
+Expected: 0.5 SOL (or whatever you sent).
+
+**DO NOT commit keypair files** — store them securely outside the repo.
+
+---
+
+### Task 4: Update Fly.io Secrets
+
+**Context:** The gateway reads escrow config from environment variables. Three secrets need to be set (or updated) for escrow to activate.
+
+- [ ] **Step 1: Set escrow program ID**
+
+Via Fly.io dashboard (https://fly.io/apps/rustyclawrouter-gateway/secrets) or CLI:
+```bash
+fly secrets set RCR_SOLANA__ESCROW_PROGRAM_ID=<YOUR_NEW_PROGRAM_ID> -a rustyclawrouter-gateway
+```
+
+- [ ] **Step 2: Set fee payer key**
+
+```bash
+fly secrets set RCR_SOLANA__FEE_PAYER_KEY=<BASE58_FEE_PAYER_KEYPAIR> -a rustyclawrouter-gateway
+```
+
+- [ ] **Step 3: Verify RPC URL is mainnet**
+
+The RPC URL should already be set from PR #5. Verify:
+```bash
+fly secrets list -a rustyclawrouter-gateway | grep RPC
+```
+
+If it still says devnet, update it:
+```bash
+fly secrets set RCR_SOLANA__RPC_URL=https://api.mainnet-beta.solana.com -a rustyclawrouter-gateway
+```
+
+- [ ] **Step 4: Redeploy gateway**
+
+Setting secrets auto-restarts, but to pick up the latest code:
+```bash
+cd /home/kennethdixon/projects/RustyClawRouter
+git pull origin main
+fly deploy -a rustyclawrouter-gateway
+```
+
+---
+
+### Task 5: Verify Escrow is Active
+
+**Context:** Once deployed and configured, the gateway should advertise both "exact" and "escrow" payment schemes in 402 responses.
+
+- [ ] **Step 1: Check 402 response includes escrow scheme**
+
+```bash
+curl -s -X POST https://rustyclawrouter-gateway.fly.dev/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"test"}]}' \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+pr = json.loads(d['error']['message'])
+for a in pr['accepts']:
+    print(f\"scheme: {a['scheme']}, program: {a.get('escrow_program_id', 'n/a')}\")
+"
+```
+
+Expected:
+```
+scheme: exact, program: n/a
+scheme: escrow, program: <YOUR_NEW_PROGRAM_ID>
+```
+
+- [ ] **Step 2: Check escrow health endpoint**
+
+```bash
+curl -s https://rustyclawrouter-gateway.fly.dev/v1/escrow/health \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" | python3 -m json.tool
+```
+
+Should show: escrow claimer configured, fee payer pool active, claim processor running.
+
+- [ ] **Step 3: Check gateway logs for escrow initialization**
+
+```bash
+fly logs -a rustyclawrouter-gateway --no-tail | grep -i escrow | head -10
+```
+
+Should see "escrow verifier initialized" and "claim processor started" messages.
+
+---
+
+### Task 6: End-to-End Escrow Payment Test
+
+**Context:** This is the real test — send a chat request, pay via escrow, verify the claim is processed.
+
+- [ ] **Step 1: Send a request and pay via escrow**
+
+This requires a client that supports escrow (the CLI currently only supports "exact" scheme). For now, use the Python SDK or construct the request manually:
+
+```python
+# Using the Python SDK with escrow support:
+from rustyclawrouter import LLMClient
+
+client = LLMClient(
+    api_url="https://rustyclawrouter-gateway.fly.dev",
+    private_key="<YOUR_AGENT_WALLET_KEYPAIR>",
+)
+# Note: the SDK currently selects the first accept (exact).
+# To test escrow, you need to modify the SDK to prefer escrow,
+# or send a manual request with an escrow PaymentPayload.
+```
+
+**Alternative:** Test via Telsi (if it's configured to use escrow scheme).
+
+- [ ] **Step 2: Verify the escrow deposit on-chain**
+
+```bash
+# Check the escrow PDA account exists after deposit
+solana account <PDA_ADDRESS> --url mainnet-beta
+```
+
+- [ ] **Step 3: Verify the claim was processed**
+
+Check the claim queue in PostgreSQL:
+```bash
+fly postgres connect -a rustyclawrouter-db
+SELECT * FROM escrow_claim_queue ORDER BY created_at DESC LIMIT 5;
+```
+
+Should show a claim entry with `status = 'completed'`.
+
+- [ ] **Step 4: Verify the claim transaction on-chain**
+
+Use the tx signature from the claim queue entry:
+```bash
+solana confirm <TX_SIGNATURE> --url mainnet-beta -v
+```
+
+---
+
+### Task 7: Update Documentation
+
+- [ ] **Step 1: Update HANDOFF.md**
+
+Mark escrow as deployed:
+- Escrow program: deployed to mainnet with upgrade authority retained
+- Program ID: `<YOUR_NEW_PROGRAM_ID>`
+- Deployer wallet: `<ADDRESS>` (holds upgrade authority)
+- Fee payer: `<ADDRESS>` (funded with X SOL)
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Add entry for escrow mainnet deployment.
+
+- [ ] **Step 3: Update regulatory-position.md**
+
+Change "designed and tested locally" to "deployed to Solana mainnet with upgrade authority retained."
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add HANDOFF.md CHANGELOG.md docs/product/regulatory-position.md
+git commit -m "docs: escrow program deployed to mainnet"
+```
+
+---
+
+## Post-Deployment: Revoking Upgrade Authority (When Ready)
+
+When the attorney gives the green light and you're confident the program is bug-free:
+
+```bash
+solana program set-upgrade-authority <YOUR_NEW_PROGRAM_ID> --final --url mainnet-beta
+```
+
+**This is irreversible.** After this, nobody can ever modify the program.
+
+Verify:
+```bash
+solana program show <YOUR_NEW_PROGRAM_ID> --url mainnet-beta | grep Authority
+```
+
+Should show: `Authority: none`
+
+---
+
+## Rollback Plan
+
+If something goes wrong after deployment:
+
+1. **Program bug:** You have upgrade authority — deploy a fixed version with `solana program deploy --program-id <ID> <new.so>`
+2. **Fee payer out of SOL:** Fund it. The gateway's balance monitor will alert.
+3. **Claim processor stuck:** Check `/v1/escrow/health`. The circuit breaker pauses if failure rate > 50% in 5 minutes — investigate the error and it auto-recovers.
+4. **Need to disable escrow:** Remove `RCR_SOLANA__ESCROW_PROGRAM_ID` from Fly.io secrets and redeploy. The gateway falls back to exact-only payments.
+
+---
+
+## Execution Order
+
+Tasks 1-4 are sequential (each depends on the previous).
+Task 5 can run immediately after Task 4.
+Task 6 requires a funded agent wallet with USDC.
+Task 7 runs after Task 5 or 6.
+
+**Estimated time:** 30-45 minutes for Tasks 1-5 (assuming funded deployer wallet). Task 6 depends on having a test wallet with mainnet USDC.

--- a/programs/escrow/Anchor.toml
+++ b/programs/escrow/Anchor.toml
@@ -6,10 +6,13 @@ seeds = true
 skip-lint = false
 
 [programs.localnet]
-rustyclawrouter_escrow = "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy"
+rustyclawrouter_escrow = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
 
 [programs.devnet]
-rustyclawrouter_escrow = "GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy"
+rustyclawrouter_escrow = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+
+[programs.mainnet]
+rustyclawrouter_escrow = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
 
 [registry]
 url = "https://api.apr.dev"

--- a/programs/escrow/Cargo.lock
+++ b/programs/escrow/Cargo.lock
@@ -2460,6 +2460,8 @@ dependencies = [
  "anchor-spl",
  "litesvm",
  "solana-sdk",
+ "spl-associated-token-account",
+ "spl-token",
 ]
 
 [[package]]

--- a/programs/escrow/src/lib.rs
+++ b/programs/escrow/src/lib.rs
@@ -40,8 +40,7 @@ use instructions::*;
 /// Mainnet USDC-SPL mint address. The escrow only accepts this mint.
 pub const USDC_MINT: Pubkey = pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
 
-// Placeholder program ID — replace with output of `anchor build` + `anchor keys list`
-declare_id!("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy");
+declare_id!("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU");
 
 #[program]
 pub mod rustyclawrouter_escrow {

--- a/programs/escrow/tests/helpers.rs
+++ b/programs/escrow/tests/helpers.rs
@@ -19,7 +19,7 @@ use spl_token::{
 };
 
 /// Program ID — must match declare_id!() in lib.rs
-pub const PROGRAM_ID: Pubkey = solana_sdk::pubkey!("GTs7ik3NbW3xwSXq33jyVRGgmshNEyW1h9rxDNATiFLy");
+pub const PROGRAM_ID: Pubkey = solana_sdk::pubkey!("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU");
 
 /// Mainnet USDC mint — must match USDC_MINT in lib.rs
 pub const USDC_MINT: Pubkey = solana_sdk::pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");


### PR DESCRIPTION
## Summary

- Escrow program deployed to Solana mainnet with upgrade authority retained
- Program ID: `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`
- Deployer/upgrade authority: `B7reP7rzzYsKwteQqCgwfx76xQmNTL4bQ7yk4tQTxL1A`
- Updated all references (15 source/test files + 5 docs) from placeholder to mainnet program ID
- Gateway 402 responses now advertise both "exact" and "escrow" payment schemes
- Regulatory docs updated to reflect mainnet deployment status

## Changes

- `programs/escrow/src/lib.rs` — `declare_id!` updated to mainnet program ID
- `programs/escrow/Anchor.toml` — Added `[programs.mainnet]` section
- `crates/x402/src/escrow/` — verifier, claimer, pda tests updated
- `crates/gateway/` — integration tests + escrow route tests updated
- `crates/protocol/src/payment.rs` — test fixture updated
- `docs/product/regulatory-position.md` — reflects mainnet deployment with upgrade authority retained
- `HANDOFF.md`, `CHANGELOG.md` — status updated

## Test plan

- [x] All 684 workspace tests pass
- [x] All 21 escrow program tests pass (6 unit + 14 integration via LiteSVM)
- [x] `cargo check` clean
- [x] Gateway escrow config endpoint returns new program ID
- [x] 402 response includes escrow scheme with correct program ID
- [x] Program verified on-chain: executable, upgrade authority retained