### PR TITLE
feat: escrow payment scheme support for CLI and all SDKs

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ base64 = { workspace = true }
 bs58 = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }
+sha2 = { workspace = true }
 getrandom = { version = "0.2", features = ["std"] }
 
 [dev-dependencies]

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -1,8 +1,32 @@
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use x402::types::{PaymentPayload, PaymentRequired, Resource, SolanaPayload};
+use sha2::{Digest, Sha256};
+use x402::types::{PaymentAccept, PaymentPayload, PaymentRequired, Resource, SolanaPayload};
 
 use crate::commands::wallet::load_wallet;
+
+/// Select the preferred payment scheme from the accepts list.
+/// Prefers "escrow" (agent gets deposit protection) over "exact".
+fn select_payment_scheme(accepts: &[PaymentAccept]) -> &PaymentAccept {
+    accepts
+        .iter()
+        .find(|a| a.scheme == "escrow" && a.escrow_program_id.is_some())
+        .or_else(|| accepts.first())
+        .expect("at least one accept required")
+}
+
+/// Generate a unique 32-byte service_id by hashing the request body + random nonce.
+fn generate_service_id(request_body: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(request_body);
+    let mut nonce = [0u8; 8];
+    getrandom::getrandom(&mut nonce).expect("getrandom failed");
+    hasher.update(nonce);
+    let hash = hasher.finalize();
+    let mut id = [0u8; 32];
+    id.copy_from_slice(&hash);
+    id
+}
 
 pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<()> {
     let client = reqwest::Client::new();
@@ -74,12 +98,8 @@ pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<
         .as_str()
         .context("wallet missing private_key field")?;
 
-    // Take the first accepted payment method.
-    let accepted = payment_required
-        .accepts
-        .into_iter()
-        .next()
-        .context("gateway returned no accepted payment methods")?;
+    // Select the preferred payment scheme (escrow > exact).
+    let accepted = select_payment_scheme(&payment_required.accepts).clone();
 
     // Resolve the Solana RPC URL from the environment.
     let rpc_url = std::env::var("SOLANA_RPC_URL")
@@ -91,31 +111,88 @@ pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<
             )
         })?;
 
-    // Build and sign a real USDC-SPL TransferChecked transaction.
-    let signed_tx = crate::commands::solana_tx::build_usdc_transfer(
-        private_key_b58,
-        &accepted.pay_to,
-        accepted
-            .amount
-            .parse::<u64>()
-            .context("invalid payment amount from gateway")?,
-        &rpc_url,
-        &client,
-    )
-    .await
-    .context("failed to build Solana payment transaction")?;
+    let body_bytes = serde_json::to_vec(&body).context("failed to serialize request body")?;
 
-    // Build the PaymentPayload.
-    let payment_payload = PaymentPayload {
-        x402_version: x402::types::X402_VERSION,
-        resource: Resource {
-            url: "/v1/chat/completions".to_string(),
-            method: "POST".to_string(),
-        },
-        accepted,
-        payload: x402::types::PayloadData::Direct(SolanaPayload {
-            transaction: signed_tx,
-        }),
+    // Build the PaymentPayload based on scheme.
+    let payment_payload = match accepted.scheme.as_str() {
+        "escrow" => {
+            let escrow_program_id = accepted
+                .escrow_program_id
+                .as_deref()
+                .context("escrow scheme missing program ID")?;
+            let service_id = generate_service_id(&body_bytes);
+            let current_slot = crate::commands::solana_tx::fetch_current_slot(&rpc_url, &client)
+                .await
+                .context("failed to fetch current slot for escrow expiry")?;
+            let timeout_slots = (accepted.max_timeout_seconds * 1000) / 400;
+            let expiry_slot = current_slot + timeout_slots;
+            let deposit_tx = crate::commands::solana_tx::build_escrow_deposit(
+                private_key_b58,
+                &accepted.pay_to,
+                escrow_program_id,
+                accepted
+                    .amount
+                    .parse::<u64>()
+                    .context("invalid payment amount from gateway")?,
+                service_id,
+                expiry_slot,
+                &rpc_url,
+                &client,
+            )
+            .await
+            .context("failed to build escrow deposit transaction")?;
+
+            // Derive agent pubkey from keypair.
+            let key_bytes = bs58::decode(private_key_b58)
+                .into_vec()
+                .context("keypair decode")?;
+            let seed: [u8; 32] = key_bytes[..32]
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("bad seed"))?;
+            let agent_pubkey = ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key();
+            let agent_pubkey_b58 = bs58::encode(agent_pubkey.as_bytes()).into_string();
+
+            PaymentPayload {
+                x402_version: x402::types::X402_VERSION,
+                resource: Resource {
+                    url: "/v1/chat/completions".to_string(),
+                    method: "POST".to_string(),
+                },
+                accepted: accepted.clone(),
+                payload: x402::types::PayloadData::Escrow(x402::types::EscrowPayload {
+                    deposit_tx,
+                    service_id: BASE64.encode(service_id),
+                    agent_pubkey: agent_pubkey_b58,
+                }),
+            }
+        }
+        _ => {
+            // Exact / direct payment scheme.
+            let signed_tx = crate::commands::solana_tx::build_usdc_transfer(
+                private_key_b58,
+                &accepted.pay_to,
+                accepted
+                    .amount
+                    .parse::<u64>()
+                    .context("invalid payment amount from gateway")?,
+                &rpc_url,
+                &client,
+            )
+            .await
+            .context("failed to build Solana payment transaction")?;
+
+            PaymentPayload {
+                x402_version: x402::types::X402_VERSION,
+                resource: Resource {
+                    url: "/v1/chat/completions".to_string(),
+                    method: "POST".to_string(),
+                },
+                accepted,
+                payload: x402::types::PayloadData::Direct(SolanaPayload {
+                    transaction: signed_tx,
+                }),
+            }
+        }
     };
 
     // Encode as base64(JSON(payload)).
@@ -158,7 +235,7 @@ pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::matchers::{body_string_contains, header_exists, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     /// RAII guard that removes an env var on drop (panic-safe cleanup).
@@ -311,7 +388,7 @@ mod tests {
             .await;
 
         // Point SOLANA_RPC_URL at the mock server root (same server, path "/").
-        std::env::set_var("SOLANA_RPC_URL", &mock.uri());
+        std::env::set_var("SOLANA_RPC_URL", mock.uri());
         let _env_guard = EnvGuard("SOLANA_RPC_URL");
 
         let result = run(&mock.uri(), "auto", "What is Solana?", true).await;
@@ -373,5 +450,162 @@ mod tests {
     async fn test_chat_connection_error() {
         let result = run(&dead_url(), "auto", "test", true).await;
         assert!(result.is_err(), "chat should error on connection failure");
+    }
+
+    // --- select_payment_scheme tests ---
+
+    fn make_exact_accept() -> PaymentAccept {
+        PaymentAccept {
+            scheme: "exact".to_string(),
+            network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".to_string(),
+            amount: "1000".to_string(),
+            asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            pay_to: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string(),
+            max_timeout_seconds: 300,
+            escrow_program_id: None,
+        }
+    }
+
+    fn make_escrow_accept() -> PaymentAccept {
+        PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".to_string(),
+            amount: "1000".to_string(),
+            asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            pay_to: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string(),
+            max_timeout_seconds: 300,
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_select_escrow_scheme_prefers_escrow() {
+        let accepts = vec![make_exact_accept(), make_escrow_accept()];
+        let selected = select_payment_scheme(&accepts);
+        assert_eq!(selected.scheme, "escrow");
+    }
+
+    #[test]
+    fn test_select_escrow_scheme_falls_back_to_exact() {
+        let accepts = vec![make_exact_accept()];
+        let selected = select_payment_scheme(&accepts);
+        assert_eq!(selected.scheme, "exact");
+    }
+
+    #[test]
+    fn test_select_escrow_scheme_skips_escrow_without_program_id() {
+        let mut escrow_no_id = make_escrow_accept();
+        escrow_no_id.escrow_program_id = None;
+        let accepts = vec![make_exact_accept(), escrow_no_id];
+        let selected = select_payment_scheme(&accepts);
+        assert_eq!(
+            selected.scheme, "exact",
+            "escrow without program ID should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_generate_service_id_length() {
+        let id = generate_service_id(b"test request body");
+        assert_eq!(id.len(), 32);
+    }
+
+    #[test]
+    fn test_generate_service_id_unique_with_nonce() {
+        let id1 = generate_service_id(b"same body");
+        let id2 = generate_service_id(b"same body");
+        assert_ne!(id1, id2, "service IDs should differ due to random nonce");
+    }
+
+    #[tokio::test]
+    async fn test_chat_402_escrow_payment_flow() {
+        let _lock = crate::ENV_MUTEX.lock().await;
+        let _wallet = setup_wallet();
+
+        let mock = MockServer::start().await;
+
+        // Mock getSlot RPC call.
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getSlot"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": 12345
+            })))
+            .mount(&mock)
+            .await;
+
+        // Mock getLatestBlockhash RPC call.
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getLatestBlockhash"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "value": {
+                        "blockhash": "11111111111111111111111111111111",
+                        "lastValidBlockHeight": 9999
+                    }
+                }
+            })))
+            .mount(&mock)
+            .await;
+
+        let payment_required = serde_json::json!({
+            "x402_version": 2,
+            "resource": {"url": "/v1/chat/completions", "method": "POST"},
+            "accepts": [{
+                "scheme": "escrow",
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "amount": "1000",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "pay_to": "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                "max_timeout_seconds": 300,
+                "escrow_program_id": "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+            }],
+            "cost_breakdown": {
+                "provider_cost": "0.001000",
+                "platform_fee": "0.000050",
+                "fee_percent": 5,
+                "total": "0.001050",
+                "currency": "USDC"
+            },
+            "error": "Payment required"
+        });
+
+        // Mount 402 first (lower priority).
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(402).set_body_json(serde_json::json!({
+                "error": {
+                    "message": serde_json::to_string(&payment_required).expect("serialize PR")
+                }
+            })))
+            .up_to_n_times(1)
+            .mount(&mock)
+            .await;
+
+        // Mount paid response last (higher priority).
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(header_exists("PAYMENT-SIGNATURE"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "Escrow paid response!"}}]
+            })))
+            .mount(&mock)
+            .await;
+
+        std::env::set_var("SOLANA_RPC_URL", mock.uri());
+        let _env_guard = EnvGuard("SOLANA_RPC_URL");
+
+        let result = run(&mock.uri(), "auto", "What is Solana?", true).await;
+
+        assert!(
+            result.is_ok(),
+            "escrow payment flow should succeed: {:?}",
+            result.err()
+        );
     }
 }

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -7,25 +7,25 @@ use crate::commands::wallet::load_wallet;
 
 /// Select the preferred payment scheme from the accepts list.
 /// Prefers "escrow" (agent gets deposit protection) over "exact".
-fn select_payment_scheme(accepts: &[PaymentAccept]) -> &PaymentAccept {
+fn select_payment_scheme(accepts: &[PaymentAccept]) -> Result<&PaymentAccept> {
     accepts
         .iter()
         .find(|a| a.scheme == "escrow" && a.escrow_program_id.is_some())
         .or_else(|| accepts.first())
-        .expect("at least one accept required")
+        .context("payment required but accepts list is empty")
 }
 
 /// Generate a unique 32-byte service_id by hashing the request body + random nonce.
-fn generate_service_id(request_body: &[u8]) -> [u8; 32] {
+fn generate_service_id(request_body: &[u8]) -> Result<[u8; 32]> {
     let mut hasher = Sha256::new();
     hasher.update(request_body);
     let mut nonce = [0u8; 8];
-    getrandom::getrandom(&mut nonce).expect("getrandom failed");
+    getrandom::getrandom(&mut nonce).context("getrandom failed to generate nonce")?;
     hasher.update(nonce);
     let hash = hasher.finalize();
     let mut id = [0u8; 32];
     id.copy_from_slice(&hash);
-    id
+    Ok(id)
 }
 
 pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<()> {
@@ -99,7 +99,7 @@ pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<
         .context("wallet missing private_key field")?;
 
     // Select the preferred payment scheme (escrow > exact).
-    let accepted = select_payment_scheme(&payment_required.accepts).clone();
+    let accepted = select_payment_scheme(&payment_required.accepts)?.clone();
 
     // Resolve the Solana RPC URL from the environment.
     let rpc_url = std::env::var("SOLANA_RPC_URL")
@@ -120,7 +120,7 @@ pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<
                 .escrow_program_id
                 .as_deref()
                 .context("escrow scheme missing program ID")?;
-            let service_id = generate_service_id(&body_bytes);
+            let service_id = generate_service_id(&body_bytes)?;
             let current_slot = crate::commands::solana_tx::fetch_current_slot(&rpc_url, &client)
                 .await
                 .context("failed to fetch current slot for escrow expiry")?;
@@ -481,14 +481,16 @@ mod tests {
     #[test]
     fn test_select_escrow_scheme_prefers_escrow() {
         let accepts = vec![make_exact_accept(), make_escrow_accept()];
-        let selected = select_payment_scheme(&accepts);
+        // Safe: non-empty accepts list always yields Ok
+        let selected = select_payment_scheme(&accepts).unwrap();
         assert_eq!(selected.scheme, "escrow");
     }
 
     #[test]
     fn test_select_escrow_scheme_falls_back_to_exact() {
         let accepts = vec![make_exact_accept()];
-        let selected = select_payment_scheme(&accepts);
+        // Safe: non-empty accepts list always yields Ok
+        let selected = select_payment_scheme(&accepts).unwrap();
         assert_eq!(selected.scheme, "exact");
     }
 
@@ -497,7 +499,8 @@ mod tests {
         let mut escrow_no_id = make_escrow_accept();
         escrow_no_id.escrow_program_id = None;
         let accepts = vec![make_exact_accept(), escrow_no_id];
-        let selected = select_payment_scheme(&accepts);
+        // Safe: non-empty accepts list always yields Ok
+        let selected = select_payment_scheme(&accepts).unwrap();
         assert_eq!(
             selected.scheme, "exact",
             "escrow without program ID should be skipped"
@@ -506,14 +509,16 @@ mod tests {
 
     #[test]
     fn test_generate_service_id_length() {
-        let id = generate_service_id(b"test request body");
+        // Safe: getrandom is available in the test environment
+        let id = generate_service_id(b"test request body").unwrap();
         assert_eq!(id.len(), 32);
     }
 
     #[test]
     fn test_generate_service_id_unique_with_nonce() {
-        let id1 = generate_service_id(b"same body");
-        let id2 = generate_service_id(b"same body");
+        // Safe: getrandom is available in the test environment
+        let id1 = generate_service_id(b"same body").unwrap();
+        let id2 = generate_service_id(b"same body").unwrap();
         assert_ne!(id1, id2, "service IDs should differ due to random nonce");
     }
 

--- a/crates/cli/src/commands/solana_tx.rs
+++ b/crates/cli/src/commands/solana_tx.rs
@@ -397,4 +397,19 @@ mod tests {
         assert_eq!(&data[1..9], &1_000_000u64.to_le_bytes());
         assert_eq!(data[9], 6); // decimals
     }
+
+    #[test]
+    fn test_x402_escrow_pda_exports_accessible() {
+        // Verify that x402 escrow PDA helpers are publicly accessible
+        let program_id = x402::escrow::pda::decode_bs58_pubkey(
+            "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+        ).unwrap();
+        let agent = [1u8; 32];
+        let service_id = [2u8; 32];
+        let result = x402::escrow::pda::find_program_address(
+            &[b"escrow", &agent, &service_id],
+            &program_id,
+        );
+        assert!(result.is_some());
+    }
 }

--- a/crates/cli/src/commands/solana_tx.rs
+++ b/crates/cli/src/commands/solana_tx.rs
@@ -34,7 +34,7 @@ const USDC_DECIMALS: u8 = 6;
 /// Fetch the latest blockhash from a Solana JSON-RPC endpoint.
 ///
 /// Returns the blockhash as 32 raw bytes.
-async fn fetch_blockhash(rpc_url: &str, client: &reqwest::Client) -> Result<[u8; 32]> {
+pub async fn fetch_blockhash(rpc_url: &str, client: &reqwest::Client) -> Result<[u8; 32]> {
     let body = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -269,6 +269,57 @@ pub async fn build_usdc_transfer(
     Ok(BASE64.encode(&tx_bytes))
 }
 
+/// Fetch the current slot from a Solana JSON-RPC endpoint.
+pub async fn fetch_current_slot(rpc_url: &str, client: &reqwest::Client) -> Result<u64> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getSlot",
+        "params": [{"commitment": "confirmed"}]
+    });
+    let resp = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .context("failed to connect to Solana RPC for getSlot")?;
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .context("failed to parse getSlot response")?;
+    json["result"]
+        .as_u64()
+        .ok_or_else(|| anyhow!("getSlot response missing result field"))
+}
+
+/// Build and sign an escrow deposit transaction.
+///
+/// Wraps `x402::escrow::deposit::build_deposit_tx` with blockhash fetching.
+#[allow(clippy::too_many_arguments)]
+pub async fn build_escrow_deposit(
+    payer_keypair_b58: &str,
+    provider_wallet: &str,
+    escrow_program_id: &str,
+    amount: u64,
+    service_id: [u8; 32],
+    expiry_slot: u64,
+    rpc_url: &str,
+    client: &reqwest::Client,
+) -> Result<String> {
+    let recent_blockhash = fetch_blockhash(rpc_url, client).await?;
+    x402::escrow::deposit::build_deposit_tx(&x402::escrow::deposit::DepositParams {
+        agent_keypair_b58: payer_keypair_b58.to_string(),
+        provider_wallet_b58: provider_wallet.to_string(),
+        usdc_mint_b58: USDC_MINT.to_string(),
+        escrow_program_id_b58: escrow_program_id.to_string(),
+        amount,
+        service_id,
+        expiry_slot,
+        recent_blockhash,
+    })
+    .map_err(|e| anyhow!("escrow deposit tx build failed: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -401,15 +452,32 @@ mod tests {
     #[test]
     fn test_x402_escrow_pda_exports_accessible() {
         // Verify that x402 escrow PDA helpers are publicly accessible
-        let program_id = x402::escrow::pda::decode_bs58_pubkey(
-            "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
-        ).unwrap();
+        let program_id =
+            x402::escrow::pda::decode_bs58_pubkey("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU")
+                .unwrap();
         let agent = [1u8; 32];
         let service_id = [2u8; 32];
-        let result = x402::escrow::pda::find_program_address(
-            &[b"escrow", &agent, &service_id],
-            &program_id,
-        );
+        let result =
+            x402::escrow::pda::find_program_address(&[b"escrow", &agent, &service_id], &program_id);
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_fetch_current_slot_bad_rpc() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let client = reqwest::Client::new();
+        let err = rt
+            .block_on(fetch_current_slot(
+                &format!("http://127.0.0.1:{port}"),
+                &client,
+            ))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("connect") || err.to_string().contains("RPC"),
+            "expected connection error, got: {err}"
+        );
     }
 }

--- a/crates/x402/src/escrow/deposit.rs
+++ b/crates/x402/src/escrow/deposit.rs
@@ -1,0 +1,332 @@
+//! Escrow deposit transaction builder for client SDKs.
+//!
+//! Builds a signed Solana legacy transaction that calls the escrow program's
+//! `deposit` instruction. The transaction is returned as a base64-encoded string
+//! suitable for submission to any Solana RPC endpoint.
+
+use super::pda::{
+    anchor_discriminator, decode_bs58_pubkey, derive_ata_address, find_program_address,
+    ATA_PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID,
+};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Parameters required to build an escrow deposit transaction.
+pub struct DepositParams {
+    /// Base58-encoded 64-byte ed25519 keypair (32-byte secret || 32-byte pubkey).
+    pub agent_keypair_b58: String,
+    /// Base58-encoded provider wallet pubkey.
+    pub provider_wallet_b58: String,
+    /// Base58-encoded USDC mint pubkey.
+    pub usdc_mint_b58: String,
+    /// Base58-encoded escrow program ID.
+    pub escrow_program_id_b58: String,
+    /// Amount to deposit in atomic USDC units (must be > 0).
+    pub amount: u64,
+    /// 32-byte service identifier that seeds the escrow PDA.
+    pub service_id: [u8; 32],
+    /// Slot at which the escrow deposit expires (passed to the on-chain instruction).
+    pub expiry_slot: u64,
+    /// Recent blockhash (32 bytes) from `getLatestBlockhash`.
+    pub recent_blockhash: [u8; 32],
+}
+
+// ---------------------------------------------------------------------------
+// Transaction builder
+// ---------------------------------------------------------------------------
+
+/// Build a signed escrow deposit transaction.
+///
+/// Returns a base64-encoded wire-format Solana transaction ready for
+/// submission via `sendTransaction`.
+///
+/// # Errors
+///
+/// Returns `Err(String)` if:
+/// - `amount` is zero
+/// - Any address fails to decode from base58
+/// - The keypair is invalid or the derived pubkey does not match the stored one
+/// - PDA or ATA derivation fails
+pub fn build_deposit_tx(params: &DepositParams) -> Result<String, String> {
+    use base64::Engine;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    // Step 1: Validate amount
+    if params.amount == 0 {
+        return Err("deposit amount must be non-zero".to_string());
+    }
+
+    // Step 2: Decode the 64-byte keypair and validate derived pubkey
+    let keypair_bytes = bs58::decode(&params.agent_keypair_b58)
+        .into_vec()
+        .map_err(|e| format!("invalid base58 keypair: {e}"))?;
+    if keypair_bytes.len() != 64 {
+        return Err(format!(
+            "keypair must be 64 bytes, got {}",
+            keypair_bytes.len()
+        ));
+    }
+    let mut keypair_arr = [0u8; 64];
+    keypair_arr.copy_from_slice(&keypair_bytes);
+
+    let signing_key = SigningKey::from_keypair_bytes(&keypair_arr)
+        .map_err(|e| format!("invalid keypair: {e}"))?;
+    let agent_pubkey = signing_key.verifying_key().to_bytes();
+
+    // Validate that the stored pubkey in bytes 32..64 matches the derived one
+    let stored_pubkey = &keypair_bytes[32..64];
+    if stored_pubkey != agent_pubkey {
+        return Err("keypair pubkey mismatch: derived pubkey does not match stored pubkey".to_string());
+    }
+
+    // Step 3: Parse all addresses
+    let provider_pubkey = decode_bs58_pubkey(&params.provider_wallet_b58)
+        .map_err(|e| format!("provider_wallet: {e}"))?;
+    let usdc_mint = decode_bs58_pubkey(&params.usdc_mint_b58)
+        .map_err(|e| format!("usdc_mint: {e}"))?;
+    let escrow_program_id = decode_bs58_pubkey(&params.escrow_program_id_b58)
+        .map_err(|e| format!("escrow_program_id: {e}"))?;
+    let token_program = decode_bs58_pubkey(TOKEN_PROGRAM_ID)
+        .map_err(|e| format!("token_program: {e}"))?;
+    let ata_program = decode_bs58_pubkey(ATA_PROGRAM_ID)
+        .map_err(|e| format!("ata_program: {e}"))?;
+    let system_program = decode_bs58_pubkey(SYSTEM_PROGRAM_ID)
+        .map_err(|e| format!("system_program: {e}"))?;
+
+    // Step 4: Derive escrow PDA
+    let (escrow_pda, _bump) = find_program_address(
+        &[b"escrow", &agent_pubkey, &params.service_id],
+        &escrow_program_id,
+    )
+    .ok_or_else(|| "failed to derive escrow PDA".to_string())?;
+
+    // Step 5: Derive agent ATA and vault ATA
+    let agent_ata = derive_ata_address(&agent_pubkey, &usdc_mint)
+        .ok_or_else(|| "failed to derive agent ATA".to_string())?;
+    let vault_ata = derive_ata_address(&escrow_pda, &usdc_mint)
+        .ok_or_else(|| "failed to derive vault ATA".to_string())?;
+
+    // Step 6: Build account keys in the exact order matching the on-chain Deposit accounts struct
+    // 0: agent_pubkey        (signer, writable)
+    // 1: provider            (readonly)
+    // 2: usdc_mint           (readonly)
+    // 3: escrow_pda          (writable)
+    // 4: agent_ata           (writable)
+    // 5: vault_ata           (writable)
+    // 6: token_program       (readonly)
+    // 7: ata_program         (readonly)
+    // 8: system_program      (readonly)
+    // 9: escrow_program_id   (program invoked — appended last)
+    let accounts: Vec<[u8; 32]> = vec![
+        agent_pubkey,     // 0: signer, writable
+        provider_pubkey,  // 1: readonly
+        usdc_mint,        // 2: readonly
+        escrow_pda,       // 3: writable
+        agent_ata,        // 4: writable
+        vault_ata,        // 5: writable
+        token_program,    // 6: readonly
+        ata_program,      // 7: readonly
+        system_program,   // 8: readonly
+        // escrow_program_id appended separately as index 9
+    ];
+
+    // Step 7: Build instruction data
+    // anchor_discriminator("deposit") + amount(u64 LE) + service_id([u8;32]) + expiry_slot(u64 LE)
+    // = 8 + 8 + 32 + 8 = 56 bytes
+    let discriminator = anchor_discriminator("deposit");
+    let mut ix_data = Vec::with_capacity(56);
+    ix_data.extend_from_slice(&discriminator);
+    ix_data.extend_from_slice(&params.amount.to_le_bytes());
+    ix_data.extend_from_slice(&params.service_id);
+    ix_data.extend_from_slice(&params.expiry_slot.to_le_bytes());
+    debug_assert_eq!(ix_data.len(), 56, "deposit ix_data must be 56 bytes");
+
+    // Instruction account indices: all 9 data accounts + program at index 9
+    let ix_account_indices: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
+
+    // Step 8: Build the legacy message
+    // Header: [1, 0, 6] — 1 signer, 0 readonly signed, 6 readonly unsigned
+    // Readonly unsigned: provider(1), mint(2), token_program(6), ata_program(7),
+    //                    system_program(8), escrow_program(9) = 6
+    let msg = build_legacy_message(
+        [1, 0, 6],
+        &accounts,
+        &escrow_program_id,
+        &params.recent_blockhash,
+        9u8, // program_id_index = 9 (last account)
+        &ix_account_indices,
+        &ix_data,
+    );
+
+    // Step 9: Sign the message with the agent keypair
+    let signature = signing_key.sign(&msg);
+
+    // Step 10: Assemble wire-format transaction
+    // compact-u16(1) || signature(64) || message
+    let mut tx_bytes = Vec::with_capacity(1 + 64 + msg.len());
+    tx_bytes.push(0x01); // compact-u16: 1 signature
+    tx_bytes.extend_from_slice(&signature.to_bytes());
+    tx_bytes.extend_from_slice(&msg);
+
+    // Step 11: Base64-encode and return
+    Ok(base64::engine::general_purpose::STANDARD.encode(&tx_bytes))
+}
+
+// ---------------------------------------------------------------------------
+// Helper: serialize Solana legacy message format
+// ---------------------------------------------------------------------------
+
+/// Serialize a Solana legacy transaction message.
+///
+/// Layout:
+/// - header (3 bytes)
+/// - compact-u16 account count + N×32 byte keys (data accounts + program key)
+/// - 32-byte recent blockhash
+/// - compact-u16 instruction count (always 1)
+/// - instruction: program_id_index || compact-u16 accts || accts || compact-u16 data_len || data
+fn build_legacy_message(
+    header: [u8; 3],
+    accounts: &[[u8; 32]],
+    program_id: &[u8; 32],
+    recent_blockhash: &[u8; 32],
+    program_id_index: u8,
+    ix_account_indices: &[u8],
+    ix_data: &[u8],
+) -> Vec<u8> {
+    let total_accounts = accounts.len() + 1; // +1 for the program key
+    debug_assert!(
+        total_accounts <= 127,
+        "compact-u16 single-byte encoding assumes <= 127 accounts; got {total_accounts}"
+    );
+
+    let mut msg = Vec::new();
+
+    // Header
+    msg.extend_from_slice(&header);
+
+    // Account keys (compact-u16 count + keys)
+    msg.push(total_accounts as u8);
+    for acc in accounts {
+        msg.extend_from_slice(acc);
+    }
+    msg.extend_from_slice(program_id); // program key is the last account
+
+    // Recent blockhash
+    msg.extend_from_slice(recent_blockhash);
+
+    // Instruction count (compact-u16): always 1
+    msg.push(1u8);
+
+    // Instruction
+    msg.push(program_id_index); // program_id_index
+    msg.push(ix_account_indices.len() as u8); // compact-u16: account count
+    msg.extend_from_slice(ix_account_indices); // account indices
+    msg.push(ix_data.len() as u8); // compact-u16: data length
+    msg.extend_from_slice(ix_data); // instruction data
+
+    msg
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+    use ed25519_dalek::SigningKey;
+
+    const PROVIDER: &str = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const ESCROW_PROGRAM: &str = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+
+    /// Build a deterministic 64-byte keypair from seed `[42u8; 32]`.
+    fn test_agent_keypair_b58() -> String {
+        let seed = [42u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let mut keypair_bytes = [0u8; 64];
+        keypair_bytes[..32].copy_from_slice(&signing_key.to_bytes());
+        keypair_bytes[32..].copy_from_slice(signing_key.verifying_key().as_bytes());
+        bs58::encode(&keypair_bytes).into_string()
+    }
+
+    fn base_params() -> DepositParams {
+        DepositParams {
+            agent_keypair_b58: test_agent_keypair_b58(),
+            provider_wallet_b58: PROVIDER.to_string(),
+            usdc_mint_b58: USDC_MINT.to_string(),
+            escrow_program_id_b58: ESCROW_PROGRAM.to_string(),
+            amount: 1_000_000,
+            service_id: [1u8; 32],
+            expiry_slot: 99_999_999,
+            recent_blockhash: [0xABu8; 32],
+        }
+    }
+
+    #[test]
+    fn test_build_deposit_tx_produces_valid_base64() {
+        let result = build_deposit_tx(&base_params());
+        assert!(result.is_ok(), "build_deposit_tx failed: {:?}", result.err());
+        let b64 = result.unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .expect("output must be valid base64");
+        assert!(
+            decoded.len() > 100,
+            "transaction too short: {} bytes",
+            decoded.len()
+        );
+    }
+
+    #[test]
+    fn test_build_deposit_tx_contains_correct_discriminator() {
+        let b64 = build_deposit_tx(&base_params()).expect("build should succeed");
+        let tx_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .unwrap();
+        let disc = anchor_discriminator("deposit");
+        let found = tx_bytes
+            .windows(8)
+            .any(|w| w == disc);
+        assert!(found, "transaction bytes must contain the deposit discriminator");
+    }
+
+    #[test]
+    fn test_build_deposit_tx_contains_agent_pubkey() {
+        let keypair_b58 = test_agent_keypair_b58();
+        let keypair_bytes = bs58::decode(&keypair_b58).into_vec().unwrap();
+        let agent_pubkey = &keypair_bytes[32..64]; // stored pubkey portion
+
+        let b64 = build_deposit_tx(&base_params()).expect("build should succeed");
+        let tx_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .unwrap();
+
+        let found = tx_bytes.windows(32).any(|w| w == agent_pubkey);
+        assert!(found, "transaction bytes must contain the agent pubkey");
+    }
+
+    #[test]
+    fn test_build_deposit_tx_zero_amount_rejected() {
+        let mut params = base_params();
+        params.amount = 0;
+        let result = build_deposit_tx(&params);
+        assert!(result.is_err(), "zero amount should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_lowercase().contains("zero") || err.contains("non-zero"),
+            "error message should mention zero: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_deposit_tx_invalid_keypair_rejected() {
+        let mut params = base_params();
+        params.agent_keypair_b58 = "notavalidkeypair!!!".to_string();
+        let result = build_deposit_tx(&params);
+        assert!(result.is_err(), "invalid keypair should be rejected");
+    }
+}

--- a/crates/x402/src/escrow/deposit.rs
+++ b/crates/x402/src/escrow/deposit.rs
@@ -10,6 +10,30 @@ use super::pda::{
 };
 
 // ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur while building an escrow deposit transaction.
+#[derive(Debug, thiserror::Error)]
+pub enum DepositError {
+    /// The deposit amount was zero.
+    #[error("deposit amount must not be zero")]
+    ZeroAmount,
+    /// The agent keypair was invalid (bad base58, wrong length, or pubkey mismatch).
+    #[error("invalid agent keypair: {0}")]
+    InvalidKeypair(String),
+    /// An address field failed to decode from base58.
+    #[error("invalid address for {field}: {reason}")]
+    InvalidAddress {
+        field: &'static str,
+        reason: String,
+    },
+    /// A PDA or ATA derivation failed.
+    #[error("failed to derive {0}")]
+    DerivationFailed(&'static str),
+}
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
@@ -57,71 +81,90 @@ impl std::fmt::Debug for DepositParams {
 ///
 /// # Errors
 ///
-/// Returns `Err(String)` if:
+/// Returns [`DepositError`] if:
 /// - `amount` is zero
 /// - Any address fails to decode from base58
 /// - The keypair is invalid or the derived pubkey does not match the stored one
 /// - PDA or ATA derivation fails
-pub fn build_deposit_tx(params: &DepositParams) -> Result<String, String> {
+pub fn build_deposit_tx(params: &DepositParams) -> Result<String, DepositError> {
     use base64::Engine;
     use ed25519_dalek::{Signer, SigningKey};
 
     // Step 1: Validate amount
     if params.amount == 0 {
-        return Err("deposit amount must be non-zero".to_string());
+        return Err(DepositError::ZeroAmount);
     }
 
     // Step 2: Decode the 64-byte keypair and validate derived pubkey
     let keypair_bytes = bs58::decode(&params.agent_keypair_b58)
         .into_vec()
-        .map_err(|e| format!("invalid base58 keypair: {e}"))?;
+        .map_err(|e| DepositError::InvalidKeypair(format!("invalid base58: {e}")))?;
     if keypair_bytes.len() != 64 {
-        return Err(format!(
-            "keypair must be 64 bytes, got {}",
+        return Err(DepositError::InvalidKeypair(format!(
+            "must be 64 bytes, got {}",
             keypair_bytes.len()
-        ));
+        )));
     }
     let mut keypair_arr = [0u8; 64];
     keypair_arr.copy_from_slice(&keypair_bytes);
 
     let signing_key = SigningKey::from_keypair_bytes(&keypair_arr)
-        .map_err(|e| format!("invalid keypair: {e}"))?;
+        .map_err(|e| DepositError::InvalidKeypair(format!("ed25519 error: {e}")))?;
     let agent_pubkey = signing_key.verifying_key().to_bytes();
 
     // Validate that the stored pubkey in bytes 32..64 matches the derived one
     let stored_pubkey = &keypair_bytes[32..64];
     if stored_pubkey != agent_pubkey {
-        return Err(
-            "keypair pubkey mismatch: derived pubkey does not match stored pubkey".to_string(),
-        );
+        return Err(DepositError::InvalidKeypair(
+            "derived pubkey does not match stored pubkey".to_string(),
+        ));
     }
 
     // Step 3: Parse all addresses
-    let provider_pubkey = decode_bs58_pubkey(&params.provider_wallet_b58)
-        .map_err(|e| format!("provider_wallet: {e}"))?;
+    let provider_pubkey =
+        decode_bs58_pubkey(&params.provider_wallet_b58).map_err(|e| DepositError::InvalidAddress {
+            field: "provider_wallet",
+            reason: e.to_string(),
+        })?;
     let usdc_mint =
-        decode_bs58_pubkey(&params.usdc_mint_b58).map_err(|e| format!("usdc_mint: {e}"))?;
-    let escrow_program_id = decode_bs58_pubkey(&params.escrow_program_id_b58)
-        .map_err(|e| format!("escrow_program_id: {e}"))?;
+        decode_bs58_pubkey(&params.usdc_mint_b58).map_err(|e| DepositError::InvalidAddress {
+            field: "usdc_mint",
+            reason: e.to_string(),
+        })?;
+    let escrow_program_id = decode_bs58_pubkey(&params.escrow_program_id_b58).map_err(|e| {
+        DepositError::InvalidAddress {
+            field: "escrow_program_id",
+            reason: e.to_string(),
+        }
+    })?;
     let token_program =
-        decode_bs58_pubkey(TOKEN_PROGRAM_ID).map_err(|e| format!("token_program: {e}"))?;
+        decode_bs58_pubkey(TOKEN_PROGRAM_ID).map_err(|e| DepositError::InvalidAddress {
+            field: "token_program",
+            reason: e.to_string(),
+        })?;
     let ata_program =
-        decode_bs58_pubkey(ATA_PROGRAM_ID).map_err(|e| format!("ata_program: {e}"))?;
+        decode_bs58_pubkey(ATA_PROGRAM_ID).map_err(|e| DepositError::InvalidAddress {
+            field: "ata_program",
+            reason: e.to_string(),
+        })?;
     let system_program =
-        decode_bs58_pubkey(SYSTEM_PROGRAM_ID).map_err(|e| format!("system_program: {e}"))?;
+        decode_bs58_pubkey(SYSTEM_PROGRAM_ID).map_err(|e| DepositError::InvalidAddress {
+            field: "system_program",
+            reason: e.to_string(),
+        })?;
 
     // Step 4: Derive escrow PDA
     let (escrow_pda, _bump) = find_program_address(
         &[b"escrow", &agent_pubkey, &params.service_id],
         &escrow_program_id,
     )
-    .ok_or_else(|| "failed to derive escrow PDA".to_string())?;
+    .ok_or(DepositError::DerivationFailed("escrow PDA"))?;
 
     // Step 5: Derive agent ATA and vault ATA
     let agent_ata = derive_ata_address(&agent_pubkey, &usdc_mint)
-        .ok_or_else(|| "failed to derive agent ATA".to_string())?;
+        .ok_or(DepositError::DerivationFailed("agent ATA"))?;
     let vault_ata = derive_ata_address(&escrow_pda, &usdc_mint)
-        .ok_or_else(|| "failed to derive vault ATA".to_string())?;
+        .ok_or(DepositError::DerivationFailed("vault ATA"))?;
 
     // Step 6: Build account keys sorted by writability (Solana legacy message requirement):
     //   writable signers first, then writable non-signers, then readonly non-signers.
@@ -340,7 +383,11 @@ mod tests {
         assert!(result.is_err(), "zero amount should be rejected");
         let err = result.unwrap_err();
         assert!(
-            err.to_lowercase().contains("zero") || err.contains("non-zero"),
+            matches!(err, DepositError::ZeroAmount),
+            "expected ZeroAmount variant, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("zero"),
             "error message should mention zero: {err}"
         );
     }

--- a/crates/x402/src/escrow/deposit.rs
+++ b/crates/x402/src/escrow/deposit.rs
@@ -33,6 +33,19 @@ pub struct DepositParams {
     pub recent_blockhash: [u8; 32],
 }
 
+impl std::fmt::Debug for DepositParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DepositParams")
+            .field("agent_keypair_b58", &"[REDACTED]")
+            .field("provider_wallet_b58", &self.provider_wallet_b58)
+            .field("usdc_mint_b58", &self.usdc_mint_b58)
+            .field("escrow_program_id_b58", &self.escrow_program_id_b58)
+            .field("amount", &self.amount)
+            .field("expiry_slot", &self.expiry_slot)
+            .finish()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Transaction builder
 // ---------------------------------------------------------------------------
@@ -78,22 +91,24 @@ pub fn build_deposit_tx(params: &DepositParams) -> Result<String, String> {
     // Validate that the stored pubkey in bytes 32..64 matches the derived one
     let stored_pubkey = &keypair_bytes[32..64];
     if stored_pubkey != agent_pubkey {
-        return Err("keypair pubkey mismatch: derived pubkey does not match stored pubkey".to_string());
+        return Err(
+            "keypair pubkey mismatch: derived pubkey does not match stored pubkey".to_string(),
+        );
     }
 
     // Step 3: Parse all addresses
     let provider_pubkey = decode_bs58_pubkey(&params.provider_wallet_b58)
         .map_err(|e| format!("provider_wallet: {e}"))?;
-    let usdc_mint = decode_bs58_pubkey(&params.usdc_mint_b58)
-        .map_err(|e| format!("usdc_mint: {e}"))?;
+    let usdc_mint =
+        decode_bs58_pubkey(&params.usdc_mint_b58).map_err(|e| format!("usdc_mint: {e}"))?;
     let escrow_program_id = decode_bs58_pubkey(&params.escrow_program_id_b58)
         .map_err(|e| format!("escrow_program_id: {e}"))?;
-    let token_program = decode_bs58_pubkey(TOKEN_PROGRAM_ID)
-        .map_err(|e| format!("token_program: {e}"))?;
-    let ata_program = decode_bs58_pubkey(ATA_PROGRAM_ID)
-        .map_err(|e| format!("ata_program: {e}"))?;
-    let system_program = decode_bs58_pubkey(SYSTEM_PROGRAM_ID)
-        .map_err(|e| format!("system_program: {e}"))?;
+    let token_program =
+        decode_bs58_pubkey(TOKEN_PROGRAM_ID).map_err(|e| format!("token_program: {e}"))?;
+    let ata_program =
+        decode_bs58_pubkey(ATA_PROGRAM_ID).map_err(|e| format!("ata_program: {e}"))?;
+    let system_program =
+        decode_bs58_pubkey(SYSTEM_PROGRAM_ID).map_err(|e| format!("system_program: {e}"))?;
 
     // Step 4: Derive escrow PDA
     let (escrow_pda, _bump) = find_program_address(
@@ -108,28 +123,29 @@ pub fn build_deposit_tx(params: &DepositParams) -> Result<String, String> {
     let vault_ata = derive_ata_address(&escrow_pda, &usdc_mint)
         .ok_or_else(|| "failed to derive vault ATA".to_string())?;
 
-    // Step 6: Build account keys in the exact order matching the on-chain Deposit accounts struct
+    // Step 6: Build account keys sorted by writability (Solana legacy message requirement):
+    //   writable signers first, then writable non-signers, then readonly non-signers.
     // 0: agent_pubkey        (signer, writable)
-    // 1: provider            (readonly)
-    // 2: usdc_mint           (readonly)
-    // 3: escrow_pda          (writable)
-    // 4: agent_ata           (writable)
-    // 5: vault_ata           (writable)
-    // 6: token_program       (readonly)
-    // 7: ata_program         (readonly)
-    // 8: system_program      (readonly)
+    // 1: escrow_pda          (writable, non-signer)
+    // 2: agent_ata           (writable, non-signer)
+    // 3: vault_ata           (writable, non-signer)
+    // 4: provider            (readonly, non-signer)
+    // 5: usdc_mint           (readonly, non-signer)
+    // 6: token_program       (readonly, non-signer)
+    // 7: ata_program         (readonly, non-signer)
+    // 8: system_program      (readonly, non-signer)
     // 9: escrow_program_id   (program invoked — appended last)
     let accounts: Vec<[u8; 32]> = vec![
-        agent_pubkey,     // 0: signer, writable
-        provider_pubkey,  // 1: readonly
-        usdc_mint,        // 2: readonly
-        escrow_pda,       // 3: writable
-        agent_ata,        // 4: writable
-        vault_ata,        // 5: writable
-        token_program,    // 6: readonly
-        ata_program,      // 7: readonly
-        system_program,   // 8: readonly
-        // escrow_program_id appended separately as index 9
+        agent_pubkey,    // 0: signer, writable
+        escrow_pda,      // 1: writable, non-signer
+        agent_ata,       // 2: writable, non-signer
+        vault_ata,       // 3: writable, non-signer
+        provider_pubkey, // 4: readonly
+        usdc_mint,       // 5: readonly
+        token_program,   // 6: readonly
+        ata_program,     // 7: readonly
+        system_program,  // 8: readonly
+                         // escrow_program_id appended separately as index 9
     ];
 
     // Step 7: Build instruction data
@@ -143,12 +159,14 @@ pub fn build_deposit_tx(params: &DepositParams) -> Result<String, String> {
     ix_data.extend_from_slice(&params.expiry_slot.to_le_bytes());
     debug_assert_eq!(ix_data.len(), 56, "deposit ix_data must be 56 bytes");
 
-    // Instruction account indices: all 9 data accounts + program at index 9
-    let ix_account_indices: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
+    // Instruction account indices remapped to the new sorted order.
+    // Anchor program expects: agent, provider, mint, escrow, agent_ata, vault, token, ata, system
+    // New positions:          0,     4,        5,    1,      2,         3,     6,     7,   8
+    let ix_account_indices: Vec<u8> = vec![0, 4, 5, 1, 2, 3, 6, 7, 8];
 
     // Step 8: Build the legacy message
     // Header: [1, 0, 6] — 1 signer, 0 readonly signed, 6 readonly unsigned
-    // Readonly unsigned: provider(1), mint(2), token_program(6), ata_program(7),
+    // Readonly unsigned: provider(4), mint(5), token_program(6), ata_program(7),
     //                    system_program(8), escrow_program(9) = 6
     let msg = build_legacy_message(
         [1, 0, 6],
@@ -269,7 +287,11 @@ mod tests {
     #[test]
     fn test_build_deposit_tx_produces_valid_base64() {
         let result = build_deposit_tx(&base_params());
-        assert!(result.is_ok(), "build_deposit_tx failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "build_deposit_tx failed: {:?}",
+            result.err()
+        );
         let b64 = result.unwrap();
         let decoded = base64::engine::general_purpose::STANDARD
             .decode(&b64)
@@ -288,10 +310,11 @@ mod tests {
             .decode(&b64)
             .unwrap();
         let disc = anchor_discriminator("deposit");
-        let found = tx_bytes
-            .windows(8)
-            .any(|w| w == disc);
-        assert!(found, "transaction bytes must contain the deposit discriminator");
+        let found = tx_bytes.windows(8).any(|w| w == disc);
+        assert!(
+            found,
+            "transaction bytes must contain the deposit discriminator"
+        );
     }
 
     #[test]

--- a/crates/x402/src/escrow/mod.rs
+++ b/crates/x402/src/escrow/mod.rs
@@ -11,7 +11,7 @@ pub mod claim_processor;
 pub mod claim_queue;
 
 mod claimer;
-mod pda;
+pub mod pda;
 mod verifier;
 
 #[cfg(feature = "postgres")]

--- a/crates/x402/src/escrow/mod.rs
+++ b/crates/x402/src/escrow/mod.rs
@@ -11,6 +11,7 @@ pub mod claim_processor;
 pub mod claim_queue;
 
 mod claimer;
+pub mod deposit;
 pub mod pda;
 mod verifier;
 

--- a/crates/x402/src/escrow/pda.rs
+++ b/crates/x402/src/escrow/pda.rs
@@ -4,10 +4,10 @@
 // Constants
 // ---------------------------------------------------------------------------
 
-pub(crate) const ATA_PROGRAM_ID: &str = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJe1bxs";
-pub(crate) const TOKEN_PROGRAM_ID: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
-pub(crate) const SYSTEM_PROGRAM_ID: &str = "11111111111111111111111111111111";
-pub(crate) const SYSVAR_RENT_ID: &str = "SysvarRent111111111111111111111111111111111";
+pub const ATA_PROGRAM_ID: &str = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJe1bxs";
+pub const TOKEN_PROGRAM_ID: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+pub const SYSTEM_PROGRAM_ID: &str = "11111111111111111111111111111111";
+pub const SYSVAR_RENT_ID: &str = "SysvarRent111111111111111111111111111111111";
 
 // ---------------------------------------------------------------------------
 // PDA derivation helpers
@@ -16,7 +16,7 @@ pub(crate) const SYSVAR_RENT_ID: &str = "SysvarRent11111111111111111111111111111
 /// Derive a Program Derived Address using SHA-256 (same as Solana runtime).
 ///
 /// Returns `(pubkey_bytes, bump)` or `None` if no valid off-curve point is found.
-pub(crate) fn find_program_address(
+pub fn find_program_address(
     seeds: &[&[u8]],
     program_id: &[u8; 32],
 ) -> Option<([u8; 32], u8)> {
@@ -44,13 +44,13 @@ pub(crate) fn find_program_address(
 }
 
 /// Check if 32 bytes represent a valid compressed point on the ed25519 curve.
-pub(crate) fn is_on_ed25519_curve(bytes: &[u8; 32]) -> bool {
+pub fn is_on_ed25519_curve(bytes: &[u8; 32]) -> bool {
     use curve25519_dalek::edwards::CompressedEdwardsY;
     CompressedEdwardsY(*bytes).decompress().is_some()
 }
 
 /// Derive the Associated Token Account address for a given wallet and mint.
-pub(crate) fn derive_ata_address(wallet: &[u8; 32], mint: &[u8; 32]) -> Option<[u8; 32]> {
+pub fn derive_ata_address(wallet: &[u8; 32], mint: &[u8; 32]) -> Option<[u8; 32]> {
     let token_program = decode_bs58_pubkey(TOKEN_PROGRAM_ID).ok()?;
     let ata_program = decode_bs58_pubkey(ATA_PROGRAM_ID).ok()?;
 
@@ -59,7 +59,7 @@ pub(crate) fn derive_ata_address(wallet: &[u8; 32], mint: &[u8; 32]) -> Option<[
 }
 
 /// Decode a base58-encoded pubkey into 32 bytes.
-pub(crate) fn decode_bs58_pubkey(s: &str) -> Result<[u8; 32], String> {
+pub fn decode_bs58_pubkey(s: &str) -> Result<[u8; 32], String> {
     let bytes = bs58::decode(s)
         .into_vec()
         .map_err(|e| format!("invalid base58: {e}"))?;
@@ -72,7 +72,7 @@ pub(crate) fn decode_bs58_pubkey(s: &str) -> Result<[u8; 32], String> {
 }
 
 /// Compute the Anchor instruction discriminator: sha256("global:<name>")[..8].
-pub(crate) fn anchor_discriminator(name: &str) -> [u8; 8] {
+pub fn anchor_discriminator(name: &str) -> [u8; 8] {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(format!("global:{name}"));

--- a/integrations/openclaw/dist/index.js
+++ b/integrations/openclaw/dist/index.js
@@ -237,6 +237,16 @@ async function routeStreamingRequest(request, config) {
 }
 
 // src/index.ts
+function normalizeMessages(messages) {
+  return messages.map((msg) => {
+    const m = msg;
+    if (Array.isArray(m.content)) {
+      const textParts = m.content.filter((part) => part.type === "text").map((part) => part.text ?? "");
+      return { ...m, content: textParts.join("\n") };
+    }
+    return msg;
+  });
+}
 function createPlugin(overrides = {}) {
   const config = loadConfig(overrides);
   return {
@@ -244,10 +254,12 @@ function createPlugin(overrides = {}) {
     version: "0.1.0",
     description: "RustyClawRouter \u2014 Solana-native LLM routing with x402 USDC payments",
     async intercept(request) {
-      return routeRequest(request, config);
+      const normalized = { ...request, messages: normalizeMessages(request.messages) };
+      return routeRequest(normalized, config);
     },
     async interceptStream(request) {
-      return routeStreamingRequest(request, config);
+      const normalized = { ...request, messages: normalizeMessages(request.messages) };
+      return routeStreamingRequest(normalized, config);
     }
   };
 }

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -37,6 +37,31 @@ export { ConfigError } from './config.js';
 export type { ChatMessage, ChatRequest, ChatResponse } from './router.js';
 export { PaymentError, RouterError } from './router.js';
 
+// ── Message normalization ─────────────────────────────────────────────────────
+
+/**
+ * Normalize OpenAI-style content arrays to plain strings.
+ *
+ * OpenClaw (and some OpenAI-compatible clients) may send messages where
+ * `content` is an array of content parts rather than a plain string:
+ *   { role: "user", content: [{ type: "text", text: "Hello" }] }
+ *
+ * RustyClawRouter expects `content` to be a string. This function extracts
+ * all text parts and joins them, discarding non-text parts (e.g. image_url).
+ */
+function normalizeMessages(messages: unknown[]): unknown[] {
+  return messages.map((msg) => {
+    const m = msg as Record<string, unknown>;
+    if (Array.isArray(m.content)) {
+      const textParts = (m.content as Array<{ type: string; text?: string }>)
+        .filter((part) => part.type === 'text')
+        .map((part) => part.text ?? '');
+      return { ...m, content: textParts.join('\n') };
+    }
+    return msg;
+  });
+}
+
 // ── OpenClaw plugin interface ─────────────────────────────────────────────────
 
 /**
@@ -78,11 +103,13 @@ export function createPlugin(overrides: Partial<RcrConfig> = {}): OpenClawPlugin
     description: 'RustyClawRouter — Solana-native LLM routing with x402 USDC payments',
 
     async intercept(request: ChatRequest): Promise<ChatResponse | null> {
-      return routeRequest(request, config);
+      const normalized = { ...request, messages: normalizeMessages(request.messages) as ChatMessage[] };
+      return routeRequest(normalized, config);
     },
 
     async interceptStream(request: ChatRequest): Promise<Response | null> {
-      return routeStreamingRequest(request, config);
+      const normalized = { ...request, messages: normalizeMessages(request.messages) as ChatMessage[] };
+      return routeStreamingRequest(normalized, config);
     },
   };
 }

--- a/integrations/openclaw/tests/plugin.test.ts
+++ b/integrations/openclaw/tests/plugin.test.ts
@@ -214,6 +214,64 @@ describe('RcrClient — non-streaming', () => {
   });
 });
 
+describe('normalizeMessages — content array → string', () => {
+  it('normalizes content array to joined string via intercept', async () => {
+    mock.setMode('ok');
+    const plugin = createPlugin({
+      gatewayUrl: mock.url,
+      walletKey: 'stub-key',
+    });
+
+    // Simulate OpenClaw sending content as an array of text parts
+    const resp = await plugin.intercept({
+      messages: [
+        {
+          role: 'user',
+          // Cast to satisfy TypeScript — content arrays are the runtime shape we must handle
+          content: [{ type: 'text', text: 'Hello' }, { type: 'text', text: 'World' }] as unknown as string,
+        },
+      ],
+    });
+    assert.ok(resp !== null);
+    assert.ok(resp!.choices.length > 0);
+  });
+
+  it('normalizes content array to joined string via interceptStream', async () => {
+    mock.setMode('ok');
+    const plugin = createPlugin({
+      gatewayUrl: mock.url,
+      walletKey: 'stub-key',
+    });
+
+    const streamResp = await plugin.interceptStream({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Stream hello' }] as unknown as string,
+        },
+      ],
+      stream: true,
+    });
+
+    assert.ok(streamResp instanceof Response);
+    assert.ok(streamResp.ok);
+  });
+
+  it('leaves plain string content unchanged', async () => {
+    mock.setMode('ok');
+    const plugin = createPlugin({
+      gatewayUrl: mock.url,
+      walletKey: 'stub-key',
+    });
+
+    const resp = await plugin.intercept({
+      messages: [{ role: 'user', content: 'Already a string' }],
+    });
+    assert.ok(resp !== null);
+    assert.ok(resp!.choices.length > 0);
+  });
+});
+
 describe('OpenClaw plugin interface', () => {
   it('intercept returns a ChatResponse', async () => {
     mock.setMode('ok');

--- a/sdks/go/config.go
+++ b/sdks/go/config.go
@@ -8,4 +8,9 @@ const (
 	USDCMint      = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 	SolanaNetwork = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
 	X402Version   = 2
+
+	// Stub values for testing escrow payloads
+	StubEscrowDepositTx = "STUB_ESCROW_DEPOSIT_TX"
+	StubServiceID       = "STUB_SERVICE_ID"
+	StubAgentPubkey     = "STUB_AGENT_PUBKEY"
 )

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -68,6 +68,7 @@ type PaymentAccept struct {
 	Asset             string `json:"asset"`
 	PayTo             string `json:"pay_to"`
 	MaxTimeoutSeconds int    `json:"max_timeout_seconds"`
+	EscrowProgramID   string `json:"escrow_program_id,omitempty"`
 }
 
 // PaymentRequired is the parsed body of an HTTP 402 response.

--- a/sdks/go/x402.go
+++ b/sdks/go/x402.go
@@ -59,23 +59,13 @@ func createPaymentHeader(info *PaymentRequired, resourceURL string) (string, err
 		selectedAccept = &info.Accepts[0]
 	}
 
-	// Build appropriate payload based on scheme
+	// Escrow signing is not implemented in the Go SDK — return a clear error
+	// rather than silently producing a stub payload that will be rejected.
 	if selectedAccept.Scheme == "escrow" && selectedAccept.EscrowProgramID != "" {
-		payload := escrowPaymentPayload{
-			X402Version: X402Version,
-			Resource:    paymentResource{URL: resourceURL, Method: "POST"},
-			Accepted:    *selectedAccept,
-			Payload: escrowPayload{
-				DepositTx:   StubEscrowDepositTx,
-				ServiceID:   StubServiceID,
-				AgentPubkey: StubAgentPubkey,
-			},
+		return "", &PaymentError{
+			Message: "escrow deposit signing is not yet implemented in the Go SDK; " +
+				"use the Python, TypeScript, or Rust CLI for escrow payments",
 		}
-		jsonBytes, err := json.Marshal(payload)
-		if err != nil {
-			return "", err
-		}
-		return base64.StdEncoding.EncodeToString(jsonBytes), nil
 	}
 
 	// Exact scheme (default)

--- a/sdks/go/x402.go
+++ b/sdks/go/x402.go
@@ -5,12 +5,20 @@ import (
 	"encoding/json"
 )
 
-// paymentPayload is the structure encoded into the PAYMENT-SIGNATURE header.
+// paymentPayload is the structure encoded into the PAYMENT-SIGNATURE header for exact scheme.
 type paymentPayload struct {
 	X402Version int             `json:"x402_version"`
 	Resource    paymentResource `json:"resource"`
 	Accepted    PaymentAccept   `json:"accepted"`
 	Payload     solanaPayload   `json:"payload"`
+}
+
+// escrowPaymentPayload is the structure encoded into the PAYMENT-SIGNATURE header for escrow scheme.
+type escrowPaymentPayload struct {
+	X402Version int             `json:"x402_version"`
+	Resource    paymentResource `json:"resource"`
+	Accepted    PaymentAccept   `json:"accepted"`
+	Payload     escrowPayload   `json:"payload"`
 }
 
 type paymentResource struct {
@@ -22,18 +30,59 @@ type solanaPayload struct {
 	Transaction string `json:"transaction"`
 }
 
+type escrowPayload struct {
+	DepositTx   string `json:"deposit_tx"`
+	ServiceID   string `json:"service_id"`
+	AgentPubkey string `json:"agent_pubkey"`
+}
+
 // createPaymentHeader builds the base64-encoded payment header from a 402 response.
 // In production this would sign a real Solana transaction; the stub puts a
 // placeholder transaction so the rest of the flow can be exercised.
+// Prefers escrow scheme if available with non-empty EscrowProgramID.
 func createPaymentHeader(info *PaymentRequired, resourceURL string) (string, error) {
 	if len(info.Accepts) == 0 {
 		return "", &PaymentError{Message: "no payment accepts in 402 response"}
 	}
 
+	// Find escrow scheme with non-empty EscrowProgramID
+	var selectedAccept *PaymentAccept
+	for i := range info.Accepts {
+		if info.Accepts[i].Scheme == "escrow" && info.Accepts[i].EscrowProgramID != "" {
+			selectedAccept = &info.Accepts[i]
+			break
+		}
+	}
+
+	// Fall back to first accept if no escrow found
+	if selectedAccept == nil {
+		selectedAccept = &info.Accepts[0]
+	}
+
+	// Build appropriate payload based on scheme
+	if selectedAccept.Scheme == "escrow" && selectedAccept.EscrowProgramID != "" {
+		payload := escrowPaymentPayload{
+			X402Version: X402Version,
+			Resource:    paymentResource{URL: resourceURL, Method: "POST"},
+			Accepted:    *selectedAccept,
+			Payload: escrowPayload{
+				DepositTx:   StubEscrowDepositTx,
+				ServiceID:   StubServiceID,
+				AgentPubkey: StubAgentPubkey,
+			},
+		}
+		jsonBytes, err := json.Marshal(payload)
+		if err != nil {
+			return "", err
+		}
+		return base64.StdEncoding.EncodeToString(jsonBytes), nil
+	}
+
+	// Exact scheme (default)
 	payload := paymentPayload{
 		X402Version: X402Version,
 		Resource:    paymentResource{URL: resourceURL, Method: "POST"},
-		Accepted:    info.Accepts[0],
+		Accepted:    *selectedAccept,
 		Payload:     solanaPayload{Transaction: "STUB_BASE64_TX"},
 	}
 

--- a/sdks/go/x402_test.go
+++ b/sdks/go/x402_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCreatePaymentHeaderEscrowScheme(t *testing.T) {
+	// Escrow signing is not implemented in the Go SDK — expect an error.
 	info := &PaymentRequired{
 		X402Version: 2,
 		Accepts: []PaymentAccept{{
@@ -21,52 +22,36 @@ func TestCreatePaymentHeaderEscrowScheme(t *testing.T) {
 		CostBreakdown: CostBreakdown{Total: "0.001"},
 	}
 
-	header, err := createPaymentHeader(info, "/v1/chat/completions")
-	if err != nil {
-		t.Fatalf("createPaymentHeader: %v", err)
+	_, err := createPaymentHeader(info, "/v1/chat/completions")
+	if err == nil {
+		t.Fatal("createPaymentHeader: expected error for escrow scheme, got nil")
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(header)
-	if err != nil {
-		t.Fatalf("base64 decode: %v", err)
+	payErr, ok := err.(*PaymentError)
+	if !ok {
+		t.Fatalf("expected *PaymentError, got %T: %v", err, err)
 	}
 
-	var payload escrowPaymentPayload
-	if err := json.Unmarshal(decoded, &payload); err != nil {
-		t.Fatalf("json unmarshal: %v", err)
+	const wantSubstr = "escrow deposit signing is not yet implemented in the Go SDK"
+	if payErr.Message == "" || len(payErr.Message) < len(wantSubstr) {
+		t.Errorf("error message too short: %q", payErr.Message)
 	}
+	if !containsSubstr(payErr.Message, wantSubstr) {
+		t.Errorf("error message = %q, want it to contain %q", payErr.Message, wantSubstr)
+	}
+}
 
-	// Verify x402_version
-	if payload.X402Version != 2 {
-		t.Errorf("x402_version = %d, want 2", payload.X402Version)
-	}
-
-	// Verify resource
-	if payload.Resource.URL != "/v1/chat/completions" {
-		t.Errorf("resource URL = %q, want /v1/chat/completions", payload.Resource.URL)
-	}
-	if payload.Resource.Method != "POST" {
-		t.Errorf("resource method = %q, want POST", payload.Resource.Method)
-	}
-
-	// Verify accepted
-	if payload.Accepted.Scheme != "escrow" {
-		t.Errorf("accepted scheme = %q, want escrow", payload.Accepted.Scheme)
-	}
-	if payload.Accepted.EscrowProgramID != "EscProgram123" {
-		t.Errorf("accepted escrow_program_id = %q, want EscProgram123", payload.Accepted.EscrowProgramID)
-	}
-
-	// Verify payload (escrow stub values)
-	if payload.Payload.DepositTx != StubEscrowDepositTx {
-		t.Errorf("deposit_tx = %q, want %q", payload.Payload.DepositTx, StubEscrowDepositTx)
-	}
-	if payload.Payload.ServiceID != StubServiceID {
-		t.Errorf("service_id = %q, want %q", payload.Payload.ServiceID, StubServiceID)
-	}
-	if payload.Payload.AgentPubkey != StubAgentPubkey {
-		t.Errorf("agent_pubkey = %q, want %q", payload.Payload.AgentPubkey, StubAgentPubkey)
-	}
+// containsSubstr is a simple substring check to avoid importing strings in test.
+func containsSubstr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
 }
 
 func TestPaymentAcceptEscrowProgramID(t *testing.T) {
@@ -98,7 +83,8 @@ func TestPaymentAcceptEscrowProgramID(t *testing.T) {
 }
 
 func TestCreatePaymentHeaderPrefersEscrow(t *testing.T) {
-	// Test that escrow scheme is preferred when available
+	// Escrow is preferred when available, but the Go SDK returns an error for
+	// escrow scheme since deposit signing is not implemented.
 	info := &PaymentRequired{
 		X402Version: 2,
 		Accepts: []PaymentAccept{
@@ -123,27 +109,17 @@ func TestCreatePaymentHeaderPrefersEscrow(t *testing.T) {
 		CostBreakdown: CostBreakdown{Total: "0.001"},
 	}
 
-	header, err := createPaymentHeader(info, "/v1/chat/completions")
-	if err != nil {
-		t.Fatalf("createPaymentHeader: %v", err)
+	_, err := createPaymentHeader(info, "/v1/chat/completions")
+	if err == nil {
+		t.Fatal("createPaymentHeader: expected error when escrow scheme selected, got nil")
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(header)
-	if err != nil {
-		t.Fatalf("base64 decode: %v", err)
+	payErr, ok := err.(*PaymentError)
+	if !ok {
+		t.Fatalf("expected *PaymentError, got %T: %v", err, err)
 	}
-
-	// Should be escrow payload, not exact
-	var payload escrowPaymentPayload
-	if err := json.Unmarshal(decoded, &payload); err != nil {
-		t.Fatalf("json unmarshal as escrow: %v", err)
-	}
-
-	if payload.Accepted.Scheme != "escrow" {
-		t.Errorf("selected scheme = %q, want escrow (should prefer escrow)", payload.Accepted.Scheme)
-	}
-	if payload.Accepted.EscrowProgramID != "EscProgram456" {
-		t.Errorf("selected escrow_program_id = %q, want EscProgram456", payload.Accepted.EscrowProgramID)
+	if !containsSubstr(payErr.Message, "escrow deposit signing is not yet implemented") {
+		t.Errorf("unexpected error message: %q", payErr.Message)
 	}
 }
 

--- a/sdks/go/x402_test.go
+++ b/sdks/go/x402_test.go
@@ -1,0 +1,231 @@
+package rcr
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func TestCreatePaymentHeaderEscrowScheme(t *testing.T) {
+	info := &PaymentRequired{
+		X402Version: 2,
+		Accepts: []PaymentAccept{{
+			Scheme:            "escrow",
+			Network:           SolanaNetwork,
+			Amount:            "1000",
+			Asset:             USDCMint,
+			PayTo:             "recipient",
+			MaxTimeoutSeconds: 300,
+			EscrowProgramID:   "EscProgram123",
+		}},
+		CostBreakdown: CostBreakdown{Total: "0.001"},
+	}
+
+	header, err := createPaymentHeader(info, "/v1/chat/completions")
+	if err != nil {
+		t.Fatalf("createPaymentHeader: %v", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+
+	var payload escrowPaymentPayload
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+
+	// Verify x402_version
+	if payload.X402Version != 2 {
+		t.Errorf("x402_version = %d, want 2", payload.X402Version)
+	}
+
+	// Verify resource
+	if payload.Resource.URL != "/v1/chat/completions" {
+		t.Errorf("resource URL = %q, want /v1/chat/completions", payload.Resource.URL)
+	}
+	if payload.Resource.Method != "POST" {
+		t.Errorf("resource method = %q, want POST", payload.Resource.Method)
+	}
+
+	// Verify accepted
+	if payload.Accepted.Scheme != "escrow" {
+		t.Errorf("accepted scheme = %q, want escrow", payload.Accepted.Scheme)
+	}
+	if payload.Accepted.EscrowProgramID != "EscProgram123" {
+		t.Errorf("accepted escrow_program_id = %q, want EscProgram123", payload.Accepted.EscrowProgramID)
+	}
+
+	// Verify payload (escrow stub values)
+	if payload.Payload.DepositTx != StubEscrowDepositTx {
+		t.Errorf("deposit_tx = %q, want %q", payload.Payload.DepositTx, StubEscrowDepositTx)
+	}
+	if payload.Payload.ServiceID != StubServiceID {
+		t.Errorf("service_id = %q, want %q", payload.Payload.ServiceID, StubServiceID)
+	}
+	if payload.Payload.AgentPubkey != StubAgentPubkey {
+		t.Errorf("agent_pubkey = %q, want %q", payload.Payload.AgentPubkey, StubAgentPubkey)
+	}
+}
+
+func TestPaymentAcceptEscrowProgramID(t *testing.T) {
+	// Test JSON unmarshaling of escrow_program_id field
+	jsonStr := `{
+		"scheme": "escrow",
+		"network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+		"amount": "5000",
+		"asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+		"pay_to": "recipient",
+		"max_timeout_seconds": 300,
+		"escrow_program_id": "TestEscrowProgram"
+	}`
+
+	var accept PaymentAccept
+	if err := json.Unmarshal([]byte(jsonStr), &accept); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+
+	if accept.Scheme != "escrow" {
+		t.Errorf("scheme = %q, want escrow", accept.Scheme)
+	}
+	if accept.EscrowProgramID != "TestEscrowProgram" {
+		t.Errorf("escrow_program_id = %q, want TestEscrowProgram", accept.EscrowProgramID)
+	}
+	if accept.Amount != "5000" {
+		t.Errorf("amount = %q, want 5000", accept.Amount)
+	}
+}
+
+func TestCreatePaymentHeaderPrefersEscrow(t *testing.T) {
+	// Test that escrow scheme is preferred when available
+	info := &PaymentRequired{
+		X402Version: 2,
+		Accepts: []PaymentAccept{
+			{
+				Scheme:            "exact",
+				Network:           SolanaNetwork,
+				Amount:            "1000",
+				Asset:             USDCMint,
+				PayTo:             "recipient1",
+				MaxTimeoutSeconds: 300,
+			},
+			{
+				Scheme:            "escrow",
+				Network:           SolanaNetwork,
+				Amount:            "1000",
+				Asset:             USDCMint,
+				PayTo:             "recipient2",
+				MaxTimeoutSeconds: 300,
+				EscrowProgramID:   "EscProgram456",
+			},
+		},
+		CostBreakdown: CostBreakdown{Total: "0.001"},
+	}
+
+	header, err := createPaymentHeader(info, "/v1/chat/completions")
+	if err != nil {
+		t.Fatalf("createPaymentHeader: %v", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+
+	// Should be escrow payload, not exact
+	var payload escrowPaymentPayload
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		t.Fatalf("json unmarshal as escrow: %v", err)
+	}
+
+	if payload.Accepted.Scheme != "escrow" {
+		t.Errorf("selected scheme = %q, want escrow (should prefer escrow)", payload.Accepted.Scheme)
+	}
+	if payload.Accepted.EscrowProgramID != "EscProgram456" {
+		t.Errorf("selected escrow_program_id = %q, want EscProgram456", payload.Accepted.EscrowProgramID)
+	}
+}
+
+func TestCreatePaymentHeaderExactFallback(t *testing.T) {
+	// Test that exact scheme is used when escrow not available
+	info := &PaymentRequired{
+		X402Version: 2,
+		Accepts: []PaymentAccept{
+			{
+				Scheme:            "exact",
+				Network:           SolanaNetwork,
+				Amount:            "1000",
+				Asset:             USDCMint,
+				PayTo:             "recipient",
+				MaxTimeoutSeconds: 300,
+			},
+		},
+		CostBreakdown: CostBreakdown{Total: "0.001"},
+	}
+
+	header, err := createPaymentHeader(info, "/v1/chat/completions")
+	if err != nil {
+		t.Fatalf("createPaymentHeader: %v", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+
+	var payload paymentPayload
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		t.Fatalf("json unmarshal as exact: %v", err)
+	}
+
+	if payload.Accepted.Scheme != "exact" {
+		t.Errorf("selected scheme = %q, want exact", payload.Accepted.Scheme)
+	}
+	if payload.Payload.Transaction != "STUB_BASE64_TX" {
+		t.Errorf("transaction = %q, want STUB_BASE64_TX", payload.Payload.Transaction)
+	}
+}
+
+func TestEscrowPayloadMarshal(t *testing.T) {
+	// Test that escrowPaymentPayload marshals correctly
+	payload := escrowPaymentPayload{
+		X402Version: 2,
+		Resource: paymentResource{
+			URL:    "/v1/chat/completions",
+			Method: "POST",
+		},
+		Accepted: PaymentAccept{
+			Scheme:            "escrow",
+			Network:           SolanaNetwork,
+			Amount:            "1000",
+			Asset:             USDCMint,
+			PayTo:             "recipient",
+			MaxTimeoutSeconds: 300,
+			EscrowProgramID:   "EscProgram789",
+		},
+		Payload: escrowPayload{
+			DepositTx:   StubEscrowDepositTx,
+			ServiceID:   StubServiceID,
+			AgentPubkey: StubAgentPubkey,
+		},
+	}
+
+	jsonBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	// Verify round-trip
+	var decoded escrowPaymentPayload
+	if err := json.Unmarshal(jsonBytes, &decoded); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+
+	if decoded.Accepted.EscrowProgramID != "EscProgram789" {
+		t.Errorf("round-trip escrow_program_id = %q, want EscProgram789", decoded.Accepted.EscrowProgramID)
+	}
+	if decoded.Payload.DepositTx != StubEscrowDepositTx {
+		t.Errorf("round-trip deposit_tx = %q, want %q", decoded.Payload.DepositTx, StubEscrowDepositTx)
+	}
+}

--- a/sdks/python/rustyclawrouter/client.py
+++ b/sdks/python/rustyclawrouter/client.py
@@ -109,7 +109,10 @@ class LLMClient:
                     f"this request: ${cost:.4f})"
                 )
 
-            payment_header = self._create_payment_header(payment_info, url)
+            request_bytes = json.dumps(request_body).encode()
+            payment_header = self._create_payment_header(
+                payment_info, url, request_body=request_bytes
+            )
 
             # Retry with payment
             resp = self._client.post(
@@ -193,18 +196,25 @@ class LLMClient:
             return None
 
     def _create_payment_header(
-        self, payment_info: PaymentRequired, resource_url: str
+        self,
+        payment_info: PaymentRequired,
+        resource_url: str,
+        request_body: Optional[bytes] = None,
     ) -> str:
         """Create a PAYMENT-SIGNATURE header value.
 
-        Uses real Solana signing when a private key and deps are available.
+        Prefers the escrow scheme when available. Uses real Solana signing
+        when a private key and deps are available.
         """
         if not payment_info.accepts:
             raise PaymentError("Gateway returned no accepted payment methods")
-        accept = payment_info.accepts[0]
+        accept = next(
+            (a for a in payment_info.accepts if a.scheme == "escrow" and a.escrow_program_id),
+            payment_info.accepts[0],
+        )
         private_key = self.wallet.private_key if self.wallet.has_key else None
         return encode_payment_header(
-            accept, resource_url, private_key=private_key
+            accept, resource_url, private_key=private_key, request_body=request_body
         )
 
 
@@ -285,7 +295,10 @@ class AsyncLLMClient:
                     f"this request: ${cost:.4f})"
                 )
 
-            payment_header = self._create_payment_header(payment_info, url)
+            request_bytes = json.dumps(request_body).encode()
+            payment_header = self._create_payment_header(
+                payment_info, url, request_body=request_bytes
+            )
             resp = await self._client.post(
                 url,
                 json=request_body,
@@ -342,16 +355,23 @@ class AsyncLLMClient:
             return None
 
     def _create_payment_header(
-        self, payment_info: PaymentRequired, resource_url: str
+        self,
+        payment_info: PaymentRequired,
+        resource_url: str,
+        request_body: Optional[bytes] = None,
     ) -> str:
         """Create a PAYMENT-SIGNATURE header value.
 
-        Uses real Solana signing when a private key and deps are available.
+        Prefers the escrow scheme when available. Uses real Solana signing
+        when a private key and deps are available.
         """
         if not payment_info.accepts:
             raise PaymentError("Gateway returned no accepted payment methods")
-        accept = payment_info.accepts[0]
+        accept = next(
+            (a for a in payment_info.accepts if a.scheme == "escrow" and a.escrow_program_id),
+            payment_info.accepts[0],
+        )
         private_key = self.wallet.private_key if self.wallet.has_key else None
         return encode_payment_header(
-            accept, resource_url, private_key=private_key
+            accept, resource_url, private_key=private_key, request_body=request_body
         )

--- a/sdks/python/rustyclawrouter/types.py
+++ b/sdks/python/rustyclawrouter/types.py
@@ -64,6 +64,7 @@ class PaymentAccept(BaseModel):
     asset: str
     pay_to: str
     max_timeout_seconds: int
+    escrow_program_id: Optional[str] = None
 
 
 class PaymentRequired(BaseModel):

--- a/sdks/python/rustyclawrouter/x402.py
+++ b/sdks/python/rustyclawrouter/x402.py
@@ -252,7 +252,7 @@ def build_escrow_deposit(
 
     except SigningError:
         raise
-    except Exception as e:
+    except (ValueError, TypeError, AttributeError) as e:
         raise SigningError(f"Failed to build escrow deposit transaction: {e}") from e
 
 

--- a/sdks/python/rustyclawrouter/x402.py
+++ b/sdks/python/rustyclawrouter/x402.py
@@ -134,6 +134,7 @@ def build_escrow_deposit(
     amount: int,
     service_id: bytes,
     private_key: str,
+    max_timeout_seconds: int = 120,
 ) -> str:
     """Build and sign an Anchor escrow deposit transaction.
 
@@ -162,6 +163,7 @@ def build_escrow_deposit(
         from solders.keypair import Keypair
         from solders.message import MessageV0
         from solders.pubkey import Pubkey
+        from solders.system_program import ID as SYSTEM_PROGRAM_ID
         from solders.transaction import VersionedTransaction
         from spl.token.constants import (
             ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -209,7 +211,8 @@ def build_escrow_deposit(
         blockhash = blockhash_resp.value.blockhash
         slot_resp = client.get_slot()
         current_slot = slot_resp.value
-        expiry_slot = current_slot + 300  # ~2 min at 400ms/slot
+        timeout_slots = max((max_timeout_seconds * 1000) // 400, 10)
+        expiry_slot = current_slot + timeout_slots
 
         # Build Anchor deposit discriminator: sha256("global:deposit")[:8]
         discriminator = hashlib.sha256(b"global:deposit").digest()[:8]
@@ -226,13 +229,15 @@ def build_escrow_deposit(
             program_id=program_id,
             data=bytes(ix_data),
             accounts=[
-                AccountMeta(pubkey=kp.pubkey(), is_signer=True, is_writable=True),
-                AccountMeta(pubkey=recipient, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=escrow_pda, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=agent_ata, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=escrow_ata, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=usdc_mint, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=kp.pubkey(), is_signer=True, is_writable=True),   # 0: agent
+                AccountMeta(pubkey=recipient, is_signer=False, is_writable=False),    # 1: provider
+                AccountMeta(pubkey=usdc_mint, is_signer=False, is_writable=False),    # 2: mint
+                AccountMeta(pubkey=escrow_pda, is_signer=False, is_writable=True),    # 3: escrow PDA
+                AccountMeta(pubkey=agent_ata, is_signer=False, is_writable=True),     # 4: agent ATA
+                AccountMeta(pubkey=escrow_ata, is_signer=False, is_writable=True),    # 5: vault ATA
+                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),          # 6
+                AccountMeta(pubkey=ASSOCIATED_TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),  # 7
+                AccountMeta(pubkey=SYSTEM_PROGRAM_ID, is_signer=False, is_writable=False),            # 8
             ],
         )
 
@@ -268,7 +273,7 @@ def build_escrow_payment_payload(
     """
     return {
         "deposit_tx": deposit_tx,
-        "service_id": service_id.hex(),
+        "service_id": base64.b64encode(service_id).decode(),
         "agent_pubkey": agent_pubkey,
     }
 
@@ -350,6 +355,7 @@ def encode_payment_header(
                     amount=amount,
                     service_id=service_id,
                     private_key=private_key,
+                    max_timeout_seconds=accept.max_timeout_seconds,
                 )
             except ImportError:
                 raise ImportError(

--- a/sdks/python/rustyclawrouter/x402.py
+++ b/sdks/python/rustyclawrouter/x402.py
@@ -1,6 +1,7 @@
 """x402 protocol helpers — payment signing and Solana transaction creation."""
 
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -127,6 +128,151 @@ def build_solana_transfer_checked(
         raise SigningError(f"Failed to build Solana payment transaction: {e}") from e
 
 
+def build_escrow_deposit(
+    escrow_program_id: str,
+    pay_to: str,
+    amount: int,
+    service_id: bytes,
+    private_key: str,
+) -> str:
+    """Build and sign an Anchor escrow deposit transaction.
+
+    Requires: ``pip install rustyclawrouter[solana]``
+
+    Environment Variables:
+        SOLANA_RPC_URL: Solana RPC endpoint URL (required).
+
+    Args:
+        escrow_program_id: The Anchor escrow program public key (base58).
+        pay_to: Gateway recipient wallet address (base58) — used as the service authority.
+        amount: Amount in atomic USDC (6 decimals).
+        service_id: 32-byte service identifier for PDA derivation.
+        private_key: Base58-encoded Solana keypair.
+
+    Returns:
+        Base64-encoded serialized VersionedTransaction.
+
+    Raises:
+        ImportError: If solders/solana packages not installed.
+        SigningError: If SOLANA_RPC_URL not set, amount invalid, or signing fails.
+    """
+    try:
+        from solana.rpc.api import Client as SolanaClient
+        from solders.instruction import AccountMeta, Instruction
+        from solders.keypair import Keypair
+        from solders.message import MessageV0
+        from solders.pubkey import Pubkey
+        from solders.transaction import VersionedTransaction
+        from spl.token.constants import (
+            ASSOCIATED_TOKEN_PROGRAM_ID,
+            TOKEN_PROGRAM_ID,
+        )
+    except ImportError:
+        raise ImportError(
+            "Solana signing requires: pip install rustyclawrouter[solana]"
+        )
+
+    rpc_url = os.environ.get("SOLANA_RPC_URL")
+    if not rpc_url:
+        raise SigningError(
+            "SOLANA_RPC_URL environment variable required for on-chain signing."
+        )
+
+    if amount <= 0:
+        raise SigningError(f"Payment amount must be positive, got: {amount}")
+
+    try:
+        kp = Keypair.from_base58_string(private_key)
+        program_id = Pubkey.from_string(escrow_program_id)
+        usdc_mint = Pubkey.from_string(USDC_MINT)
+        recipient = Pubkey.from_string(pay_to)
+
+        # Derive escrow PDA: ["escrow", agent_pubkey, service_id]
+        escrow_pda, _ = Pubkey.find_program_address(
+            [b"escrow", bytes(kp.pubkey()), service_id],
+            program_id,
+        )
+
+        # Derive ATAs
+        agent_ata, _ = Pubkey.find_program_address(
+            [bytes(kp.pubkey()), bytes(TOKEN_PROGRAM_ID), bytes(usdc_mint)],
+            ASSOCIATED_TOKEN_PROGRAM_ID,
+        )
+        escrow_ata, _ = Pubkey.find_program_address(
+            [bytes(escrow_pda), bytes(TOKEN_PROGRAM_ID), bytes(usdc_mint)],
+            ASSOCIATED_TOKEN_PROGRAM_ID,
+        )
+
+        # Fetch slot for expiry and recent blockhash
+        client = SolanaClient(rpc_url)
+        blockhash_resp = client.get_latest_blockhash()
+        blockhash = blockhash_resp.value.blockhash
+        slot_resp = client.get_slot()
+        current_slot = slot_resp.value
+        expiry_slot = current_slot + 300  # ~2 min at 400ms/slot
+
+        # Build Anchor deposit discriminator: sha256("global:deposit")[:8]
+        discriminator = hashlib.sha256(b"global:deposit").digest()[:8]
+
+        # Encode instruction data: discriminator + amount (u64 le) + service_id (32 bytes) + expiry_slot (u64 le)
+        ix_data = (
+            discriminator
+            + amount.to_bytes(8, "little")
+            + service_id[:32].ljust(32, b"\x00")[:32]
+            + expiry_slot.to_bytes(8, "little")
+        )
+
+        ix = Instruction(
+            program_id=program_id,
+            data=bytes(ix_data),
+            accounts=[
+                AccountMeta(pubkey=kp.pubkey(), is_signer=True, is_writable=True),
+                AccountMeta(pubkey=recipient, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=escrow_pda, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=agent_ata, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=escrow_ata, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=usdc_mint, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+            ],
+        )
+
+        msg = MessageV0.try_compile(
+            payer=kp.pubkey(),
+            instructions=[ix],
+            address_lookup_table_accounts=[],
+            recent_blockhash=blockhash,
+        )
+        tx = VersionedTransaction(msg, [kp])
+        return base64.b64encode(bytes(tx)).decode()
+
+    except SigningError:
+        raise
+    except Exception as e:
+        raise SigningError(f"Failed to build escrow deposit transaction: {e}") from e
+
+
+def build_escrow_payment_payload(
+    deposit_tx: str,
+    service_id: bytes,
+    agent_pubkey: str,
+) -> Dict[str, Any]:
+    """Build the escrow payment payload dict.
+
+    Args:
+        deposit_tx: Base64-encoded signed escrow deposit transaction.
+        service_id: 32-byte service identifier (will be hex-encoded).
+        agent_pubkey: Agent's Solana public key (base58).
+
+    Returns:
+        A dict with deposit_tx, service_id, and agent_pubkey.
+    """
+    return {
+        "deposit_tx": deposit_tx,
+        "service_id": service_id.hex(),
+        "agent_pubkey": agent_pubkey,
+    }
+
+
 def build_payment_payload(
     accept: PaymentAccept,
     resource_url: str,
@@ -158,18 +304,23 @@ def encode_payment_header(
     resource_url: str,
     resource_method: str = "POST",
     private_key: Optional[str] = None,
+    request_body: Optional[bytes] = None,
 ) -> str:
     """Create the base64-encoded ``PAYMENT-SIGNATURE`` header value.
 
     When a ``private_key`` is provided and Solana dependencies are installed,
-    builds and signs a real USDC-SPL TransferChecked transaction. Otherwise
-    falls back to a stub transaction for development/testing.
+    builds and signs a real transaction. For the ``escrow`` scheme, builds an
+    Anchor escrow deposit transaction. For the ``exact`` scheme, builds a
+    USDC-SPL TransferChecked transaction. Falls back to stub values when no
+    private key is provided (development/testing mode).
 
     Args:
         accept: The accepted payment terms from the 402 response.
         resource_url: The URL of the resource being purchased.
         resource_method: The HTTP method (default ``POST``).
         private_key: Base58-encoded Solana private key. If None, uses stub tx.
+        request_body: Raw request body bytes used for service_id generation
+            in the escrow scheme. If None, a zero-length body is used.
 
     Returns:
         Base64-encoded JSON string suitable for the PAYMENT-SIGNATURE header.
@@ -177,6 +328,57 @@ def encode_payment_header(
     Raises:
         SigningError: If private key is provided but signing fails.
     """
+    if accept.scheme == "escrow" and accept.escrow_program_id:
+        body = request_body or b""
+        service_id = hashlib.sha256(body + os.urandom(8)).digest()
+
+        if private_key:
+            try:
+                amount = int(accept.amount)
+            except (ValueError, TypeError) as e:
+                raise SigningError(
+                    f"Payment amount '{accept.amount}' must be an integer (atomic USDC units): {e}"
+                ) from e
+            try:
+                from solders.keypair import Keypair
+
+                kp = Keypair.from_base58_string(private_key)
+                agent_pubkey = str(kp.pubkey())
+                deposit_tx = build_escrow_deposit(
+                    escrow_program_id=accept.escrow_program_id,
+                    pay_to=accept.pay_to,
+                    amount=amount,
+                    service_id=service_id,
+                    private_key=private_key,
+                )
+            except ImportError:
+                raise ImportError(
+                    "Private key was provided but Solana signing packages are not installed. "
+                    "Install with: pip install rustyclawrouter[solana]"
+                )
+            # SigningError propagates — caller must handle
+        else:
+            logger.warning(
+                "No private key provided — using stub escrow payload. "
+                "Payments will be rejected by the gateway."
+            )
+            deposit_tx = "STUB_ESCROW_DEPOSIT_TX"
+            agent_pubkey = "STUB_AGENT_PUBKEY"
+
+        escrow_payload = build_escrow_payment_payload(
+            deposit_tx=deposit_tx,
+            service_id=service_id,
+            agent_pubkey=agent_pubkey,
+        )
+        outer = {
+            "x402_version": X402_VERSION,
+            "resource": {"url": resource_url, "method": resource_method},
+            "accepted": accept.model_dump(),
+            "payload": escrow_payload,
+        }
+        return base64.b64encode(json.dumps(outer).encode()).decode()
+
+    # --- exact scheme (default) ---
     transaction_b64 = "STUB_BASE64_TX"
 
     if private_key:

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -426,3 +426,82 @@ class TestAsyncPaymentFlow:
                 await client.chat("gpt-4o", "Hello")
 
         await client.close()
+
+
+# ---------------------------------------------------------------------------
+# Escrow scheme selection (Fix 10)
+# ---------------------------------------------------------------------------
+
+
+class TestEscrowSchemeSelection:
+    """Verify encode_payment_header selects escrow vs exact based on accepts."""
+
+    def _make_accept(self, scheme: str, escrow_program_id: str = "") -> PaymentAccept:
+        return PaymentAccept(
+            scheme=scheme,
+            network="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            amount="2625",
+            asset="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            pay_to="RecipientPubkey",
+            max_timeout_seconds=300,
+            escrow_program_id=escrow_program_id or None,
+        )
+
+    def test_create_payment_header_prefers_escrow(self):
+        """encode_payment_header selects escrow when escrow_program_id is present."""
+        accept = self._make_accept("escrow", escrow_program_id="EscrowProg123")
+        # No private_key → stub mode, no Solana deps needed
+        encoded = encode_payment_header(accept, "http://test/v1/chat/completions")
+        decoded = decode_payment_header(encoded)
+
+        assert decoded["accepted"]["scheme"] == "escrow"
+        # Escrow payload must contain the three escrow-specific fields
+        payload = decoded["payload"]
+        assert "deposit_tx" in payload, "escrow payload missing deposit_tx"
+        assert "service_id" in payload, "escrow payload missing service_id"
+        assert "agent_pubkey" in payload, "escrow payload missing agent_pubkey"
+        # Stub values used since no private key was provided
+        assert payload["deposit_tx"] == "STUB_ESCROW_DEPOSIT_TX"
+        assert payload["agent_pubkey"] == "STUB_AGENT_PUBKEY"
+
+    def test_create_payment_header_falls_back_to_exact(self):
+        """encode_payment_header uses exact when only exact accept is present."""
+        accept = self._make_accept("exact")
+        encoded = encode_payment_header(accept, "http://test/v1/chat/completions")
+        decoded = decode_payment_header(encoded)
+
+        assert decoded["accepted"]["scheme"] == "exact"
+        payload = decoded["payload"]
+        # Exact scheme payload has a 'transaction' field, not escrow fields
+        assert "transaction" in payload, "exact payload missing transaction"
+        assert "deposit_tx" not in payload, "exact payload should not contain deposit_tx"
+        assert payload["transaction"] == "STUB_BASE64_TX"
+
+    def test_create_payment_header_passes_request_body(self):
+        """Different request bodies produce different service_ids in escrow scheme."""
+        accept = self._make_accept("escrow", escrow_program_id="EscrowProg456")
+
+        encoded_a = encode_payment_header(
+            accept,
+            "http://test/v1/chat/completions",
+            request_body=b'{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}',
+        )
+        encoded_b = encode_payment_header(
+            accept,
+            "http://test/v1/chat/completions",
+            request_body=b'{"model":"claude-3","messages":[{"role":"user","content":"world"}]}',
+        )
+
+        decoded_a = decode_payment_header(encoded_a)
+        decoded_b = decode_payment_header(encoded_b)
+
+        # service_id is derived from body + os.urandom(8), so they are almost
+        # certainly different; at minimum both must be non-empty base64 strings.
+        sid_a = decoded_a["payload"]["service_id"]
+        sid_b = decoded_b["payload"]["service_id"]
+        assert sid_a, "service_id must be non-empty"
+        assert sid_b, "service_id must be non-empty"
+        # Verify both are valid base64
+        import base64 as _b64
+        _b64.b64decode(sid_a)  # raises if invalid
+        _b64.b64decode(sid_b)  # raises if invalid

--- a/sdks/python/tests/test_x402.py
+++ b/sdks/python/tests/test_x402.py
@@ -140,7 +140,7 @@ class TestEncodePaymentHeaderEscrowScheme:
         assert payload["deposit_tx"] == "STUB_ESCROW_DEPOSIT_TX"
         assert payload["agent_pubkey"] == "STUB_AGENT_PUBKEY"
 
-    def test_escrow_service_id_is_hex_string(self):
+    def test_escrow_service_id_is_base64_string(self):
         accept = self._make_escrow_accept()
         header = encode_payment_header(
             accept,
@@ -149,11 +149,11 @@ class TestEncodePaymentHeaderEscrowScheme:
             request_body=b"test body",
         )
         decoded = json.loads(base64.b64decode(header))
-        service_id_hex = decoded["payload"]["service_id"]
-        # Must be a valid hex string of 64 chars (32 bytes)
-        assert isinstance(service_id_hex, str)
-        assert len(service_id_hex) == 64
-        int(service_id_hex, 16)  # raises ValueError if not hex
+        service_id_b64 = decoded["payload"]["service_id"]
+        # Must be a valid base64 string decoding to 32 bytes
+        assert isinstance(service_id_b64, str)
+        decoded_bytes = base64.b64decode(service_id_b64)
+        assert len(decoded_bytes) == 32
 
     def test_escrow_service_id_is_random_per_call(self):
         accept = self._make_escrow_accept()
@@ -247,13 +247,13 @@ class TestBuildEscrowPaymentPayload:
         )
         assert payload["deposit_tx"] == "STUB_TX"
         assert payload["agent_pubkey"] == "AgentPubkeyBase58"
-        assert payload["service_id"] == service_id.hex()
+        assert payload["service_id"] == base64.b64encode(service_id).decode()
 
-    def test_service_id_hex_length(self):
+    def test_service_id_base64_decodes_to_32_bytes(self):
         service_id = b"\xde\xad\xbe\xef" * 8
         payload = build_escrow_payment_payload(
             deposit_tx="TX",
             service_id=service_id,
             agent_pubkey="PK",
         )
-        assert len(payload["service_id"]) == 64
+        assert len(base64.b64decode(payload["service_id"])) == 32

--- a/sdks/python/tests/test_x402.py
+++ b/sdks/python/tests/test_x402.py
@@ -1,0 +1,259 @@
+"""Tests for x402 protocol helpers including escrow scheme support."""
+
+import base64
+import json
+
+import pytest
+
+from rustyclawrouter.types import CostBreakdown, PaymentAccept, PaymentRequired
+from rustyclawrouter.x402 import (
+    build_escrow_payment_payload,
+    decode_payment_header,
+    encode_payment_header,
+)
+
+ESCROW_PROGRAM_ID = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+
+class TestPaymentAcceptWithEscrowProgramId:
+    def test_escrow_program_id_field_present(self):
+        accept = PaymentAccept(
+            scheme="escrow",
+            network="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            amount="2625",
+            asset="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            pay_to="RecipientWalletPubkey",
+            max_timeout_seconds=300,
+            escrow_program_id=ESCROW_PROGRAM_ID,
+        )
+        assert accept.escrow_program_id == ESCROW_PROGRAM_ID
+
+    def test_escrow_program_id_defaults_to_none(self):
+        accept = PaymentAccept(
+            scheme="exact",
+            network="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            amount="2625",
+            asset="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            pay_to="RecipientWalletPubkey",
+            max_timeout_seconds=300,
+        )
+        assert accept.escrow_program_id is None
+
+    def test_escrow_accept_roundtrip(self):
+        data = {
+            "scheme": "escrow",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "amount": "2625",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "pay_to": "RecipientWalletPubkey",
+            "max_timeout_seconds": 300,
+            "escrow_program_id": ESCROW_PROGRAM_ID,
+        }
+        accept = PaymentAccept.model_validate(data)
+        assert accept.escrow_program_id == ESCROW_PROGRAM_ID
+        dumped = accept.model_dump()
+        assert dumped["escrow_program_id"] == ESCROW_PROGRAM_ID
+
+    def test_payment_required_with_escrow_accept(self):
+        pr = PaymentRequired(
+            x402_version=2,
+            accepts=[
+                PaymentAccept(
+                    scheme="escrow",
+                    network="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                    amount="2625",
+                    asset="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    pay_to="RecipientWalletPubkey",
+                    max_timeout_seconds=300,
+                    escrow_program_id=ESCROW_PROGRAM_ID,
+                )
+            ],
+            cost_breakdown=CostBreakdown(
+                provider_cost="0.002500",
+                platform_fee="0.000125",
+                total="0.002625",
+                currency="USDC",
+                fee_percent=5,
+            ),
+            error="Payment required",
+        )
+        assert pr.accepts[0].escrow_program_id == ESCROW_PROGRAM_ID
+
+
+class TestEncodePaymentHeaderEscrowScheme:
+    def _make_escrow_accept(self) -> PaymentAccept:
+        return PaymentAccept(
+            scheme="escrow",
+            network="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            amount="2625",
+            asset="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            pay_to="RecipientWalletPubkey",
+            max_timeout_seconds=300,
+            escrow_program_id=ESCROW_PROGRAM_ID,
+        )
+
+    def test_escrow_scheme_produces_valid_header(self):
+        accept = self._make_escrow_accept()
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+            private_key=None,
+        )
+        assert isinstance(header, str)
+        assert len(header) > 0
+
+    def test_escrow_scheme_header_is_base64(self):
+        accept = self._make_escrow_accept()
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+            private_key=None,
+        )
+        # Should decode without error
+        decoded = base64.b64decode(header)
+        data = json.loads(decoded)
+        assert isinstance(data, dict)
+
+    def test_escrow_payload_contains_required_fields(self):
+        accept = self._make_escrow_accept()
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+            private_key=None,
+            request_body=b'{"model":"gpt-4o","messages":[]}',
+        )
+        decoded = json.loads(base64.b64decode(header))
+        payload = decoded["payload"]
+        assert "deposit_tx" in payload
+        assert "service_id" in payload
+        assert "agent_pubkey" in payload
+
+    def test_escrow_stub_values_no_private_key(self):
+        accept = self._make_escrow_accept()
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+            private_key=None,
+        )
+        decoded = json.loads(base64.b64decode(header))
+        payload = decoded["payload"]
+        assert payload["deposit_tx"] == "STUB_ESCROW_DEPOSIT_TX"
+        assert payload["agent_pubkey"] == "STUB_AGENT_PUBKEY"
+
+    def test_escrow_service_id_is_hex_string(self):
+        accept = self._make_escrow_accept()
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+            private_key=None,
+            request_body=b"test body",
+        )
+        decoded = json.loads(base64.b64decode(header))
+        service_id_hex = decoded["payload"]["service_id"]
+        # Must be a valid hex string of 64 chars (32 bytes)
+        assert isinstance(service_id_hex, str)
+        assert len(service_id_hex) == 64
+        int(service_id_hex, 16)  # raises ValueError if not hex
+
+    def test_escrow_service_id_is_random_per_call(self):
+        accept = self._make_escrow_accept()
+        body = b'{"model":"gpt-4o"}'
+        header1 = encode_payment_header(
+            accept, "http://localhost:8402/v1/chat/completions",
+            private_key=None, request_body=body,
+        )
+        header2 = encode_payment_header(
+            accept, "http://localhost:8402/v1/chat/completions",
+            private_key=None, request_body=body,
+        )
+        sid1 = json.loads(base64.b64decode(header1))["payload"]["service_id"]
+        sid2 = json.loads(base64.b64decode(header2))["payload"]["service_id"]
+        assert sid1 != sid2  # os.urandom(8) ensures uniqueness
+
+    def test_escrow_header_contains_x402_version(self):
+        accept = self._make_escrow_accept()
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+            private_key=None,
+        )
+        decoded = json.loads(base64.b64decode(header))
+        assert "x402_version" in decoded
+        assert isinstance(decoded["x402_version"], int)
+
+    def test_escrow_header_contains_resource(self):
+        accept = self._make_escrow_accept()
+        url = "http://localhost:8402/v1/chat/completions"
+        header = encode_payment_header(accept, url, private_key=None)
+        decoded = json.loads(base64.b64decode(header))
+        assert decoded["resource"]["url"] == url
+        assert decoded["resource"]["method"] == "POST"
+
+    def test_escrow_header_contains_accepted(self):
+        accept = self._make_escrow_accept()
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+            private_key=None,
+        )
+        decoded = json.loads(base64.b64decode(header))
+        assert decoded["accepted"]["scheme"] == "escrow"
+        assert decoded["accepted"]["escrow_program_id"] == ESCROW_PROGRAM_ID
+
+    def test_exact_scheme_unchanged_with_request_body_param(self):
+        """Existing exact scheme must still work when request_body is passed."""
+        accept = PaymentAccept(
+            scheme="exact",
+            network="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            amount="2625",
+            asset="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            pay_to="RecipientWalletPubkey",
+            max_timeout_seconds=300,
+        )
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+            private_key=None,
+            request_body=b'{"model":"gpt-4o"}',
+        )
+        decoded = json.loads(base64.b64decode(header))
+        assert decoded["payload"]["transaction"] == "STUB_BASE64_TX"
+
+    def test_exact_scheme_backwards_compatible_no_request_body(self):
+        """encode_payment_header with no request_body still works (exact scheme)."""
+        accept = PaymentAccept(
+            scheme="exact",
+            network="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            amount="2625",
+            asset="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            pay_to="RecipientWalletPubkey",
+            max_timeout_seconds=300,
+        )
+        header = encode_payment_header(
+            accept,
+            "http://localhost:8402/v1/chat/completions",
+        )
+        decoded = json.loads(base64.b64decode(header))
+        assert decoded["payload"]["transaction"] == "STUB_BASE64_TX"
+
+
+class TestBuildEscrowPaymentPayload:
+    def test_basic_payload(self):
+        service_id = bytes(range(32))
+        payload = build_escrow_payment_payload(
+            deposit_tx="STUB_TX",
+            service_id=service_id,
+            agent_pubkey="AgentPubkeyBase58",
+        )
+        assert payload["deposit_tx"] == "STUB_TX"
+        assert payload["agent_pubkey"] == "AgentPubkeyBase58"
+        assert payload["service_id"] == service_id.hex()
+
+    def test_service_id_hex_length(self):
+        service_id = b"\xde\xad\xbe\xef" * 8
+        payload = build_escrow_payment_payload(
+            deposit_tx="TX",
+            service_id=service_id,
+            agent_pubkey="PK",
+        )
+        assert len(payload["service_id"]) == 64

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -82,7 +82,8 @@ export class LLMClient {
         );
       }
 
-      const paymentHeader = await createPaymentHeader(paymentInfo, url);
+      const requestBodyStr = JSON.stringify(body);
+      const paymentHeader = await createPaymentHeader(paymentInfo, url, undefined, requestBodyStr);
       resp = await this.fetchWithTimeout(url, {
         method: 'POST',
         headers: {

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -51,6 +51,7 @@ export interface PaymentAccept {
   asset: string;
   pay_to: string;
   max_timeout_seconds: number;
+  escrow_program_id?: string;
 }
 
 export interface PaymentRequired {

--- a/sdks/typescript/src/x402.ts
+++ b/sdks/typescript/src/x402.ts
@@ -1,4 +1,5 @@
-import { PaymentRequired } from './types';
+import * as crypto from 'crypto';
+import { PaymentAccept, PaymentRequired } from './types';
 
 const X402_VERSION = 2;
 
@@ -34,31 +35,52 @@ export async function createPaymentHeader(
   paymentInfo: PaymentRequired,
   resourceUrl: string,
   privateKey?: string,
+  requestBody?: string,
 ): Promise<string> {
   if (!paymentInfo.accepts || paymentInfo.accepts.length === 0) {
     throw new Error('No payment accept options in 402 response');
   }
 
-  const accept = paymentInfo.accepts[0];
+  // Prefer escrow scheme if available, fall back to first accept
+  const escrowAccept = paymentInfo.accepts.find(
+    (a) => a.scheme === 'escrow' && a.escrow_program_id,
+  );
+  const accept = escrowAccept ?? paymentInfo.accepts[0];
 
-  let transaction = 'STUB_BASE64_TX';
-  if (privateKey) {
-    // Attempt real signing; if @solana/web3.js is missing, degrade to stub.
-    // If the package IS available but signing fails, propagate as SigningError.
-    const solanaAvailable = isSolanaAvailable();
-    if (solanaAvailable) {
-      // Throws SigningError on failure — do not catch here.
-      transaction = await buildSolanaTransferChecked(accept.pay_to, accept.amount, privateKey);
+  let payload: Record<string, unknown>;
+
+  if (accept.scheme === 'escrow' && accept.escrow_program_id) {
+    const escrowPayload = await buildEscrowPaymentHeader(
+      accept,
+      privateKey,
+      requestBody,
+    );
+    payload = {
+      x402_version: X402_VERSION,
+      resource: { url: resourceUrl, method: 'POST' },
+      accepted: accept,
+      payload: escrowPayload,
+    };
+  } else {
+    let transaction = 'STUB_BASE64_TX';
+    if (privateKey) {
+      // Attempt real signing; if @solana/web3.js is missing, degrade to stub.
+      // If the package IS available but signing fails, propagate as SigningError.
+      const solanaAvailable = isSolanaAvailable();
+      if (solanaAvailable) {
+        // Throws SigningError on failure — do not catch here.
+        transaction = await buildSolanaTransferChecked(accept.pay_to, accept.amount, privateKey);
+      }
+      // else: package not installed → stub is acceptable (development / CI mode)
     }
-    // else: package not installed → stub is acceptable (development / CI mode)
-  }
 
-  const payload = {
-    x402_version: X402_VERSION,
-    resource: { url: resourceUrl, method: 'POST' },
-    accepted: accept,
-    payload: { transaction },
-  };
+    payload = {
+      x402_version: X402_VERSION,
+      resource: { url: resourceUrl, method: 'POST' },
+      accepted: accept,
+      payload: { transaction },
+    };
+  }
 
   const json = JSON.stringify(payload);
 
@@ -66,6 +88,187 @@ export async function createPaymentHeader(
     return btoa(json);
   }
   return Buffer.from(json, 'utf-8').toString('base64');
+}
+
+/**
+ * Build the escrow payment payload (stub or real).
+ *
+ * Generates a unique service_id from the request body and random bytes,
+ * then either builds a real escrow deposit transaction (if @solana/web3.js
+ * is available and a private key is supplied) or returns stubs.
+ */
+async function buildEscrowPaymentHeader(
+  accept: PaymentAccept,
+  privateKey?: string,
+  requestBody?: string,
+): Promise<{ deposit_tx: string; service_id: string; agent_pubkey: string }> {
+  // Generate service_id: sha256(bodyBytes + randomBytes(8))
+  const bodyBytes = Buffer.from(requestBody ?? '', 'utf-8');
+  const randomBytes = crypto.randomBytes(8);
+  const serviceId = crypto
+    .createHash('sha256')
+    .update(bodyBytes)
+    .update(randomBytes)
+    .digest();
+
+  const serviceIdB64 = serviceId.toString('base64');
+
+  if (privateKey && isSolanaAvailable()) {
+    // Real escrow deposit — throws SigningError on failure
+    const { depositTx, agentPubkey } = await buildEscrowDeposit(
+      accept.pay_to,
+      accept.amount,
+      accept.escrow_program_id!,
+      privateKey,
+      serviceId,
+    );
+    return { deposit_tx: depositTx, service_id: serviceIdB64, agent_pubkey: agentPubkey };
+  }
+
+  // Stub mode (no key or no @solana/web3.js)
+  return {
+    deposit_tx: 'STUB_ESCROW_DEPOSIT_TX',
+    service_id: serviceIdB64,
+    agent_pubkey: 'STUB_AGENT_PUBKEY',
+  };
+}
+
+/**
+ * Build and sign a real escrow deposit VersionedTransaction.
+ *
+ * Derives the escrow PDA and ATAs, constructs the Anchor deposit instruction,
+ * signs with the agent keypair, and returns the base64-encoded transaction
+ * plus the agent's base58 public key.
+ *
+ * @param providerWallet   - Gateway/provider wallet (base58)
+ * @param amountStr        - Amount in USDC micro-units (6 decimals)
+ * @param programIdStr     - Escrow program ID (base58)
+ * @param privateKey       - Agent's base58-encoded 64-byte Solana keypair secret key
+ * @param serviceId        - 32-byte service ID buffer
+ * @throws SigningError on any signing or RPC failure
+ */
+async function buildEscrowDeposit(
+  providerWallet: string,
+  amountStr: string,
+  programIdStr: string,
+  privateKey: string,
+  serviceId: Buffer,
+): Promise<{ depositTx: string; agentPubkey: string }> {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const solanaWeb3 = require('@solana/web3.js');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const splToken = require('@solana/spl-token');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const bs58 = require('bs58');
+
+  const {
+    Connection,
+    Keypair,
+    PublicKey,
+    SystemProgram,
+    TransactionMessage,
+    VersionedTransaction,
+  } = solanaWeb3;
+  const { getAssociatedTokenAddress, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } = splToken;
+
+  // USDC mainnet mint (6 decimals)
+  const USDC_MINT = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+
+  // Validate amount before touching the key
+  const amount = BigInt(amountStr);
+  if (amount <= 0n) {
+    throw new SigningError(`Escrow deposit amount must be positive, got: ${amountStr}`);
+  }
+
+  let secretKey: Uint8Array | null = null;
+  try {
+    secretKey = bs58.decode(privateKey) as Uint8Array;
+    const payer = Keypair.fromSecretKey(secretKey);
+    const agentPubkey = payer.publicKey.toBase58() as string;
+
+    const providerPubkey = new PublicKey(providerWallet);
+    const programId = new PublicKey(programIdStr);
+
+    // Derive escrow PDA: ["escrow", agent, serviceId]
+    const [escrowPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from('escrow'), payer.publicKey.toBuffer(), serviceId],
+      programId,
+    );
+
+    // Derive ATAs
+    const agentAta = await getAssociatedTokenAddress(USDC_MINT, payer.publicKey);
+    const vaultAta = await getAssociatedTokenAddress(USDC_MINT, escrowPda, true);
+
+    // Fetch recent blockhash
+    const rpcUrl = process.env.SOLANA_RPC_URL;
+    if (!rpcUrl) {
+      throw new SigningError(
+        'SOLANA_RPC_URL environment variable is required for on-chain signing. ' +
+        'Set it to your RPC endpoint (e.g. https://api.mainnet-beta.solana.com).',
+      );
+    }
+    const connection = new Connection(rpcUrl, 'confirmed');
+    const { blockhash } = await connection.getLatestBlockhash('finalized');
+
+    // Build instruction data: sha256("global:deposit")[0:8] + amount(u64 LE) + serviceId + expirySlot(u64 LE)
+    const discriminator = crypto
+      .createHash('sha256')
+      .update(Buffer.from('global:deposit', 'utf-8'))
+      .digest()
+      .subarray(0, 8);
+
+    const amountBuf = Buffer.allocUnsafe(8);
+    // Write u64 LE as two 32-bit halves to avoid BigInt64Array on older Node
+    const amountLow = Number(amount & 0xffffffffn);
+    const amountHigh = Number((amount >> 32n) & 0xffffffffn);
+    amountBuf.writeUInt32LE(amountLow, 0);
+    amountBuf.writeUInt32LE(amountHigh, 4);
+
+    // expirySlot: 0 (no expiry)
+    const expiryBuf = Buffer.alloc(8, 0);
+
+    const data = Buffer.concat([discriminator, amountBuf, serviceId, expiryBuf]);
+
+    // 9 account keys in order
+    const keys = [
+      { pubkey: payer.publicKey, isSigner: true, isWritable: true },   // agent
+      { pubkey: providerPubkey, isSigner: false, isWritable: false },   // provider
+      { pubkey: USDC_MINT, isSigner: false, isWritable: false },        // mint
+      { pubkey: escrowPda, isSigner: false, isWritable: true },         // escrowPda
+      { pubkey: agentAta, isSigner: false, isWritable: true },          // agentAta
+      { pubkey: vaultAta, isSigner: false, isWritable: true },          // vaultAta
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false }, // token program
+      { pubkey: ASSOCIATED_TOKEN_PROGRAM_ID, isSigner: false, isWritable: false }, // ATA program
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },     // system program
+    ];
+
+    const ix = { programId, keys, data };
+
+    const message = new TransactionMessage({
+      payerKey: payer.publicKey,
+      recentBlockhash: blockhash,
+      instructions: [ix],
+    }).compileToV0Message();
+
+    const tx = new VersionedTransaction(message);
+    tx.sign([payer]);
+
+    const serialized = tx.serialize();
+    const depositTx = typeof btoa === 'function'
+      ? btoa(String.fromCharCode(...serialized))
+      : Buffer.from(serialized).toString('base64');
+
+    return { depositTx, agentPubkey };
+  } catch (err) {
+    if (err instanceof SigningError) throw err;
+    throw new SigningError(
+      `Failed to build escrow deposit transaction: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
+  } finally {
+    // Zero the secret key bytes to minimise in-memory exposure window
+    if (secretKey) secretKey.fill(0);
+  }
 }
 
 /** Returns true if @solana/web3.js can be required (optional peer dep). */

--- a/sdks/typescript/src/x402.ts
+++ b/sdks/typescript/src/x402.ts
@@ -113,6 +113,13 @@ async function buildEscrowPaymentHeader(
 
   const serviceIdB64 = serviceId.toString('base64');
 
+  if (privateKey && !isSolanaAvailable()) {
+    throw new Error(
+      'Private key provided but @solana/web3.js is not installed. ' +
+      'Install with: npm install @solana/web3.js @solana/spl-token bs58',
+    );
+  }
+
   if (privateKey && isSolanaAvailable()) {
     // Real escrow deposit — throws SigningError on failure
     const { depositTx, agentPubkey } = await buildEscrowDeposit(
@@ -121,6 +128,7 @@ async function buildEscrowPaymentHeader(
       accept.escrow_program_id!,
       privateKey,
       serviceId,
+      accept.max_timeout_seconds,
     );
     return { deposit_tx: depositTx, service_id: serviceIdB64, agent_pubkey: agentPubkey };
   }
@@ -144,7 +152,8 @@ async function buildEscrowPaymentHeader(
  * @param amountStr        - Amount in USDC micro-units (6 decimals)
  * @param programIdStr     - Escrow program ID (base58)
  * @param privateKey       - Agent's base58-encoded 64-byte Solana keypair secret key
- * @param serviceId        - 32-byte service ID buffer
+ * @param serviceId          - 32-byte service ID buffer
+ * @param maxTimeoutSeconds  - Maximum timeout in seconds; converted to slots (~400ms/slot, min 10 slots)
  * @throws SigningError on any signing or RPC failure
  */
 async function buildEscrowDeposit(
@@ -153,6 +162,7 @@ async function buildEscrowDeposit(
   programIdStr: string,
   privateKey: string,
   serviceId: Buffer,
+  maxTimeoutSeconds: number,
 ): Promise<{ depositTx: string; agentPubkey: string }> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const solanaWeb3 = require('@solana/web3.js');
@@ -199,7 +209,7 @@ async function buildEscrowDeposit(
     const agentAta = await getAssociatedTokenAddress(USDC_MINT, payer.publicKey);
     const vaultAta = await getAssociatedTokenAddress(USDC_MINT, escrowPda, true);
 
-    // Fetch recent blockhash
+    // Fetch recent blockhash and current slot
     const rpcUrl = process.env.SOLANA_RPC_URL;
     if (!rpcUrl) {
       throw new SigningError(
@@ -208,7 +218,14 @@ async function buildEscrowDeposit(
       );
     }
     const connection = new Connection(rpcUrl, 'confirmed');
-    const { blockhash } = await connection.getLatestBlockhash('finalized');
+    const [{ blockhash }, currentSlot] = await Promise.all([
+      connection.getLatestBlockhash('finalized'),
+      connection.getSlot('confirmed'),
+    ]);
+
+    // Compute expiry slot from timeout (Solana ~400ms/slot)
+    const timeoutSlots = Math.max(Math.floor((maxTimeoutSeconds * 1000) / 400), 10);
+    const expirySlot = BigInt(currentSlot + timeoutSlots);
 
     // Build instruction data: sha256("global:deposit")[0:8] + amount(u64 LE) + serviceId + expirySlot(u64 LE)
     const discriminator = crypto
@@ -224,8 +241,12 @@ async function buildEscrowDeposit(
     amountBuf.writeUInt32LE(amountLow, 0);
     amountBuf.writeUInt32LE(amountHigh, 4);
 
-    // expirySlot: 0 (no expiry)
-    const expiryBuf = Buffer.alloc(8, 0);
+    // expirySlot as u64 LE
+    const expiryBuf = Buffer.allocUnsafe(8);
+    const expiryLow = Number(expirySlot & 0xffffffffn);
+    const expiryHigh = Number((expirySlot >> 32n) & 0xffffffffn);
+    expiryBuf.writeUInt32LE(expiryLow, 0);
+    expiryBuf.writeUInt32LE(expiryHigh, 4);
 
     const data = Buffer.concat([discriminator, amountBuf, serviceId, expiryBuf]);
 

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -128,6 +128,99 @@ describe('createPaymentHeader', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Escrow payment header
+// ---------------------------------------------------------------------------
+
+describe('createPaymentHeader (escrow scheme)', () => {
+  const mockEscrowPayment: PaymentRequired = {
+    x402_version: 2,
+    accepts: [
+      {
+        scheme: 'escrow',
+        network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        amount: '2625',
+        asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        pay_to: 'RCRgateway111111111111111111111111111111111',
+        max_timeout_seconds: 300,
+        escrow_program_id: 'RCRescrow1111111111111111111111111111111111',
+      },
+    ],
+    cost_breakdown: {
+      provider_cost: '0.002500',
+      platform_fee: '0.000125',
+      total: '0.002625',
+      currency: 'USDC',
+      fee_percent: 5,
+    },
+    error: 'Payment required',
+  };
+
+  it('stub mode: escrow header contains deposit_tx, service_id, agent_pubkey', async () => {
+    const url = 'http://localhost:8402/v1/chat/completions';
+    const header = await createPaymentHeader(mockEscrowPayment, url, undefined, '{"model":"gpt-4o"}');
+    const decoded = decodePaymentHeader(header) as Record<string, unknown>;
+
+    assert.strictEqual(decoded.x402_version, 2);
+    assert.deepStrictEqual(decoded.resource, { url, method: 'POST' });
+
+    const accepted = decoded.accepted as Record<string, unknown>;
+    assert.strictEqual(accepted.scheme, 'escrow');
+    assert.strictEqual(accepted.escrow_program_id, 'RCRescrow1111111111111111111111111111111111');
+
+    const payload = decoded.payload as Record<string, unknown>;
+    assert.strictEqual(payload.deposit_tx, 'STUB_ESCROW_DEPOSIT_TX');
+    assert.strictEqual(payload.agent_pubkey, 'STUB_AGENT_PUBKEY');
+    // service_id is a base64-encoded sha256 hash — verify it's a non-empty string
+    assert.strictEqual(typeof payload.service_id, 'string');
+    assert.ok((payload.service_id as string).length > 0);
+  });
+
+  it('stub mode: service_id differs across calls (random component)', async () => {
+    const url = 'http://localhost:8402/v1/chat/completions';
+    const body = '{"model":"gpt-4o"}';
+    const h1 = await createPaymentHeader(mockEscrowPayment, url, undefined, body);
+    const h2 = await createPaymentHeader(mockEscrowPayment, url, undefined, body);
+    const d1 = decodePaymentHeader(h1) as Record<string, unknown>;
+    const d2 = decodePaymentHeader(h2) as Record<string, unknown>;
+    const p1 = d1.payload as Record<string, unknown>;
+    const p2 = d2.payload as Record<string, unknown>;
+    // service_id must be unique per call due to random bytes
+    assert.notStrictEqual(p1.service_id, p2.service_id);
+  });
+
+  it('falls back to exact scheme when no escrow_program_id present', async () => {
+    const mixedPayment: PaymentRequired = {
+      ...mockEscrowPayment,
+      accepts: [
+        {
+          scheme: 'escrow',
+          network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          amount: '2625',
+          asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          pay_to: 'RCRgateway111111111111111111111111111111111',
+          max_timeout_seconds: 300,
+          // no escrow_program_id
+        },
+        {
+          scheme: 'exact',
+          network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          amount: '2625',
+          asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          pay_to: 'RCRgateway111111111111111111111111111111111',
+          max_timeout_seconds: 300,
+        },
+      ],
+    };
+    const url = 'http://localhost:8402/v1/chat/completions';
+    const header = await createPaymentHeader(mixedPayment, url);
+    const decoded = decodePaymentHeader(header) as Record<string, unknown>;
+    // Should use first accept (escrow without program_id) → falls back to exact path
+    const payload = decoded.payload as Record<string, unknown>;
+    assert.strictEqual(payload.transaction, 'STUB_BASE64_TX');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // OpenAI compatibility wrapper
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Export x402 escrow PDA helpers (find_program_address, derive_ata, anchor_discriminator) as public API
- Add escrow deposit transaction builder to x402 crate with proper Solana legacy message format (accounts sorted by writability)
- CLI: scheme selection (prefer escrow), service_id generation with nonce, slot-based expiry, deposit tx building
- Python SDK: escrow types, deposit builder with solders, scheme selection, base64 service_id encoding
- TypeScript SDK: escrow types, deposit builder with VersionedTransaction + bs58, computed expiry from timeout
- Go SDK: escrow types with explicit error when escrow signing attempted (stub-only SDK)

All review findings addressed: thiserror enum for DepositError, custom Debug redaction for keypair, Result returns instead of expect(), narrowed Python exception handling, client integration tests.

## Test plan

- [ ] `cargo test` — 697 workspace tests pass (including 5 new deposit builder tests, 8 new CLI tests)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `cd sdks/python && python -m pytest tests/ -v` — 75 pass (23 new x402 + 3 new client escrow tests)
- [ ] `cd sdks/typescript && npm test` — 22 pass (3 new escrow tests)
- [ ] `cd sdks/go && go test -v` — 23 pass (5 new escrow tests)
- [ ] Verify escrow deposit tx account ordering matches on-chain Deposit struct
- [ ] Verify service_id encoding is base64 across all SDKs