### PR TITLE
fix(x402): escrow settle_payment submits tx + polls for confirmation

### DIFF
--- a/crates/x402/src/escrow/verifier.rs
+++ b/crates/x402/src/escrow/verifier.rs
@@ -1,5 +1,7 @@
 //! EscrowVerifier — verifies on-chain escrow deposits and settles payments.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use tracing::info;
 
@@ -366,169 +368,68 @@ impl PaymentVerifier for EscrowVerifier {
 
         // Submit the signed deposit tx to Solana RPC.
         // The tx is already signed by the agent; we're just broadcasting it.
-        // If the tx is already on-chain (double-submission), sendTransaction returns
-        // the same signature — idempotent.
-        let polling_sig = match self.send_transaction(&escrow_payload.deposit_tx).await {
-            Ok(sig) => {
-                info!(signature = %sig, "escrow deposit submitted to Solana RPC");
-                sig
+        // If the tx is already on-chain (double-submission), we treat the
+        // known "already processed" error variants as idempotent success.
+        match crate::solana_rpc::send_transaction(
+            &self.http_client,
+            &self.rpc_url,
+            &escrow_payload.deposit_tx,
+        )
+        .await
+        {
+            Ok(rpc_sig) => {
+                if rpc_sig != sig_b58 {
+                    tracing::warn!(
+                        local = %sig_b58,
+                        rpc = %rpc_sig,
+                        "RPC returned non-matching signature"
+                    );
+                }
+                info!(signature = %sig_b58, "escrow deposit submitted");
+            }
+            Err(e) if crate::solana_rpc::is_already_processed_error(&e) => {
+                info!(
+                    signature = %sig_b58,
+                    "escrow deposit already on-chain, proceeding to confirmation"
+                );
             }
             Err(e) => {
-                // Check if the error is "already processed" (tx already on-chain) — that's OK
-                let err_str = e.to_string();
-                if err_str.contains("already been processed") || err_str.contains("already processed") {
-                    info!("escrow deposit already on-chain, proceeding to confirmation check");
-                    sig_b58.clone()
-                } else {
-                    tracing::warn!(error = %err_str, "escrow deposit submission failed");
-                    return Ok(SettlementResult {
-                        success: false,
-                        tx_signature: Some(sig_b58),
-                        network: SOLANA_NETWORK.to_string(),
-                        error: Some(format!("submission failed: {err_str}")),
-                        verified_amount,
-                    });
-                }
-            }
-        };
-
-        // Poll for confirmation (up to ~10 seconds, 20 attempts at 500ms intervals)
-        for attempt in 0..20u32 {
-            if attempt > 0 {
-                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-            }
-
-            let body = serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "getSignatureStatuses",
-                "params": [[polling_sig]],
-            });
-
-            let response = self
-                .http_client
-                .post(&self.rpc_url)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| Error::Rpc(e.to_string()))?;
-
-            let result: serde_json::Value = response
-                .json()
-                .await
-                .map_err(|e| Error::Rpc(e.to_string()))?;
-
-            if let Some(error) = result.get("error") {
-                return Err(Error::Rpc(error.to_string()));
-            }
-
-            if let Some(value) = result.get("result").and_then(|r| r.get("value")) {
-                if let Some(status) = value.as_array().and_then(|arr| arr.first()) {
-                    if !status.is_null() {
-                        if let Some(err) = status.get("err") {
-                            if !err.is_null() {
-                                return Err(Error::EscrowNotConfirmed(format!(
-                                    "deposit transaction failed on-chain: {err}"
-                                )));
-                            }
-                        }
-                        if let Some(confirmation) =
-                            status.get("confirmationStatus").and_then(|s| s.as_str())
-                        {
-                            match confirmation {
-                                "confirmed" | "finalized" => {
-                                    info!(
-                                        signature = %polling_sig,
-                                        status = confirmation,
-                                        attempt,
-                                        "escrow deposit confirmed"
-                                    );
-                                    return Ok(SettlementResult {
-                                        success: true,
-                                        tx_signature: Some(polling_sig),
-                                        network: SOLANA_NETWORK.to_string(),
-                                        error: None,
-                                        verified_amount,
-                                    });
-                                }
-                                "processed" => {
-                                    info!(
-                                        signature = %polling_sig,
-                                        status = confirmation,
-                                        attempt,
-                                        "escrow deposit processed (optimistic settle)"
-                                    );
-                                    return Ok(SettlementResult {
-                                        success: true,
-                                        tx_signature: Some(polling_sig),
-                                        network: SOLANA_NETWORK.to_string(),
-                                        error: None,
-                                        verified_amount,
-                                    });
-                                }
-                                _ => {
-                                    // Unknown confirmation status — continue polling
-                                }
-                            }
-                        }
-                    }
-                }
+                tracing::warn!(error = %e, "escrow deposit submission failed");
+                return Ok(SettlementResult {
+                    success: false,
+                    tx_signature: Some(sig_b58),
+                    network: SOLANA_NETWORK.to_string(),
+                    error: Some(format!("submission failed: {e}")),
+                    verified_amount,
+                });
             }
         }
 
-        // Exceeded poll budget — deposit not confirmed within ~10 seconds
-        Ok(SettlementResult {
-            success: false,
-            tx_signature: Some(sig_b58),
-            network: SOLANA_NETWORK.to_string(),
-            error: Some("escrow deposit not confirmed within 10 seconds".to_string()),
-            verified_amount,
-        })
-    }
-}
-
-impl EscrowVerifier {
-    /// Broadcast a signed transaction to the Solana cluster.
-    async fn send_transaction(&self, base64_tx: &str) -> Result<String, Error> {
-        let body = serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "sendTransaction",
-            "params": [
-                base64_tx,
-                {
-                    "encoding": "base64",
-                    "skipPreflight": false,
-                    "preflightCommitment": "confirmed",
-                    "maxRetries": 3,
-                }
-            ],
-        });
-
-        let response = self
-            .http_client
-            .post(&self.rpc_url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| Error::Rpc(e.to_string()))?;
-
-        let result: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| Error::Rpc(e.to_string()))?;
-
-        if let Some(error) = result.get("error") {
-            return Err(Error::Rpc(error.to_string()));
+        // Poll for confirmation using shared helper (30s budget, resilient to
+        // transient RPC errors, handles processed/confirmed/finalized uniformly).
+        match crate::solana_rpc::poll_for_confirmation(
+            &self.http_client,
+            &self.rpc_url,
+            &sig_b58,
+            Duration::from_secs(30),
+        )
+        .await
+        {
+            Ok(()) => Ok(SettlementResult {
+                success: true,
+                tx_signature: Some(sig_b58),
+                network: SOLANA_NETWORK.to_string(),
+                error: None,
+                verified_amount,
+            }),
+            Err(e) => Ok(SettlementResult {
+                success: false,
+                tx_signature: Some(sig_b58),
+                network: SOLANA_NETWORK.to_string(),
+                error: Some(e.to_string()),
+                verified_amount,
+            }),
         }
-
-        result
-            .get("result")
-            .and_then(|r| r.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                Error::Rpc("sendTransaction did not return a signature".to_string())
-            })
     }
 }
 

--- a/crates/x402/src/escrow/verifier.rs
+++ b/crates/x402/src/escrow/verifier.rs
@@ -322,7 +322,7 @@ impl PaymentVerifier for EscrowVerifier {
             network = SOLANA_NETWORK,
             scheme = "escrow",
             resource = %payload.resource.url,
-            "settling escrow payment (checking deposit confirmation)"
+            "settling escrow payment (submitting and confirming deposit)"
         );
 
         // Extract escrow payload
@@ -364,12 +364,145 @@ impl PaymentVerifier for EscrowVerifier {
         // Base58-encode the first signature as the tx identifier
         let sig_b58 = bs58::encode(&tx.signatures[0].0).into_string();
 
-        // Check signature status via RPC (using shared client — FIX 7)
+        // Submit the signed deposit tx to Solana RPC.
+        // The tx is already signed by the agent; we're just broadcasting it.
+        // If the tx is already on-chain (double-submission), sendTransaction returns
+        // the same signature — idempotent.
+        let polling_sig = match self.send_transaction(&escrow_payload.deposit_tx).await {
+            Ok(sig) => {
+                info!(signature = %sig, "escrow deposit submitted to Solana RPC");
+                sig
+            }
+            Err(e) => {
+                // Check if the error is "already processed" (tx already on-chain) — that's OK
+                let err_str = e.to_string();
+                if err_str.contains("already been processed") || err_str.contains("already processed") {
+                    info!("escrow deposit already on-chain, proceeding to confirmation check");
+                    sig_b58.clone()
+                } else {
+                    tracing::warn!(error = %err_str, "escrow deposit submission failed");
+                    return Ok(SettlementResult {
+                        success: false,
+                        tx_signature: Some(sig_b58),
+                        network: SOLANA_NETWORK.to_string(),
+                        error: Some(format!("submission failed: {err_str}")),
+                        verified_amount,
+                    });
+                }
+            }
+        };
+
+        // Poll for confirmation (up to ~10 seconds, 20 attempts at 500ms intervals)
+        for attempt in 0..20u32 {
+            if attempt > 0 {
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            }
+
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getSignatureStatuses",
+                "params": [[polling_sig]],
+            });
+
+            let response = self
+                .http_client
+                .post(&self.rpc_url)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| Error::Rpc(e.to_string()))?;
+
+            let result: serde_json::Value = response
+                .json()
+                .await
+                .map_err(|e| Error::Rpc(e.to_string()))?;
+
+            if let Some(error) = result.get("error") {
+                return Err(Error::Rpc(error.to_string()));
+            }
+
+            if let Some(value) = result.get("result").and_then(|r| r.get("value")) {
+                if let Some(status) = value.as_array().and_then(|arr| arr.first()) {
+                    if !status.is_null() {
+                        if let Some(err) = status.get("err") {
+                            if !err.is_null() {
+                                return Err(Error::EscrowNotConfirmed(format!(
+                                    "deposit transaction failed on-chain: {err}"
+                                )));
+                            }
+                        }
+                        if let Some(confirmation) =
+                            status.get("confirmationStatus").and_then(|s| s.as_str())
+                        {
+                            match confirmation {
+                                "confirmed" | "finalized" => {
+                                    info!(
+                                        signature = %polling_sig,
+                                        status = confirmation,
+                                        attempt,
+                                        "escrow deposit confirmed"
+                                    );
+                                    return Ok(SettlementResult {
+                                        success: true,
+                                        tx_signature: Some(polling_sig),
+                                        network: SOLANA_NETWORK.to_string(),
+                                        error: None,
+                                        verified_amount,
+                                    });
+                                }
+                                "processed" => {
+                                    info!(
+                                        signature = %polling_sig,
+                                        status = confirmation,
+                                        attempt,
+                                        "escrow deposit processed (optimistic settle)"
+                                    );
+                                    return Ok(SettlementResult {
+                                        success: true,
+                                        tx_signature: Some(polling_sig),
+                                        network: SOLANA_NETWORK.to_string(),
+                                        error: None,
+                                        verified_amount,
+                                    });
+                                }
+                                _ => {
+                                    // Unknown confirmation status — continue polling
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Exceeded poll budget — deposit not confirmed within ~10 seconds
+        Ok(SettlementResult {
+            success: false,
+            tx_signature: Some(sig_b58),
+            network: SOLANA_NETWORK.to_string(),
+            error: Some("escrow deposit not confirmed within 10 seconds".to_string()),
+            verified_amount,
+        })
+    }
+}
+
+impl EscrowVerifier {
+    /// Broadcast a signed transaction to the Solana cluster.
+    async fn send_transaction(&self, base64_tx: &str) -> Result<String, Error> {
         let body = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "getSignatureStatuses",
-            "params": [[sig_b58]],
+            "method": "sendTransaction",
+            "params": [
+                base64_tx,
+                {
+                    "encoding": "base64",
+                    "skipPreflight": false,
+                    "preflightCommitment": "confirmed",
+                    "maxRetries": 3,
+                }
+            ],
         });
 
         let response = self
@@ -389,70 +522,13 @@ impl PaymentVerifier for EscrowVerifier {
             return Err(Error::Rpc(error.to_string()));
         }
 
-        // Check confirmation status
-        if let Some(value) = result.get("result").and_then(|r| r.get("value")) {
-            if let Some(status) = value.as_array().and_then(|arr| arr.first()) {
-                if !status.is_null() {
-                    if let Some(err) = status.get("err") {
-                        if !err.is_null() {
-                            return Err(Error::EscrowNotConfirmed(format!(
-                                "deposit transaction failed: {err}"
-                            )));
-                        }
-                    }
-                    if let Some(confirmation) =
-                        status.get("confirmationStatus").and_then(|s| s.as_str())
-                    {
-                        match confirmation {
-                            "confirmed" | "finalized" => {
-                                info!(
-                                    signature = %sig_b58,
-                                    status = confirmation,
-                                    "escrow deposit confirmed"
-                                );
-                                return Ok(SettlementResult {
-                                    success: true,
-                                    tx_signature: Some(sig_b58),
-                                    network: SOLANA_NETWORK.to_string(),
-                                    error: None,
-                                    verified_amount,
-                                });
-                            }
-                            "processed" => {
-                                info!(
-                                    signature = %sig_b58,
-                                    status = confirmation,
-                                    "escrow deposit processed (optimistic settle)"
-                                );
-                                return Ok(SettlementResult {
-                                    success: true,
-                                    tx_signature: Some(sig_b58),
-                                    network: SOLANA_NETWORK.to_string(),
-                                    error: None,
-                                    verified_amount,
-                                });
-                            }
-                            _ => {
-                                // Unknown confirmation status — reject
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Not yet confirmed — reject to prevent servicing unconfirmed deposits
-        Ok(SettlementResult {
-            success: false,
-            tx_signature: Some(sig_b58),
-            network: SOLANA_NETWORK.to_string(),
-            error: Some(
-                "escrow deposit not yet confirmed on-chain; \
-                 transaction must reach at least \"processed\" status"
-                    .to_string(),
-            ),
-            verified_amount,
-        })
+        result
+            .get("result")
+            .and_then(|r| r.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                Error::Rpc("sendTransaction did not return a signature".to_string())
+            })
     }
 }
 

--- a/crates/x402/src/lib.rs
+++ b/crates/x402/src/lib.rs
@@ -3,6 +3,7 @@ pub mod facilitator;
 pub mod fee_payer;
 pub mod nonce_pool;
 pub mod solana;
+pub mod solana_rpc;
 pub mod solana_types;
 pub(crate) mod spl_transfer;
 pub mod traits;

--- a/crates/x402/src/solana_rpc.rs
+++ b/crates/x402/src/solana_rpc.rs
@@ -1,0 +1,224 @@
+//! Shared Solana JSON-RPC helpers used by payment verifiers.
+//!
+//! This module centralizes `sendTransaction`, `getSignatureStatuses`, and
+//! confirmation polling so both `SolanaVerifier` (direct) and `EscrowVerifier`
+//! use the exact same behavior.
+
+use std::time::Duration;
+
+use reqwest::Client;
+use tracing::{debug, info, warn};
+
+use crate::traits::Error;
+
+/// Submit a base64-encoded signed transaction to Solana RPC.
+///
+/// Returns the base58 signature string from the RPC response. Retries on the
+/// RPC side (maxRetries: 3). Callers should handle the "already processed"
+/// idempotency case via `is_already_processed_error`.
+pub async fn send_transaction(
+    client: &Client,
+    rpc_url: &str,
+    base64_tx: &str,
+) -> Result<String, Error> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "sendTransaction",
+        "params": [
+            base64_tx,
+            {
+                "encoding": "base64",
+                "skipPreflight": false,
+                "preflightCommitment": "confirmed",
+                "maxRetries": 3,
+            }
+        ],
+    });
+
+    let response = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| Error::Rpc(e.to_string()))?;
+
+    let result: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| Error::Rpc(e.to_string()))?;
+
+    if let Some(error) = result.get("error") {
+        return Err(Error::Rpc(error.to_string()));
+    }
+
+    result
+        .get("result")
+        .and_then(|r| r.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| Error::Rpc("sendTransaction did not return a signature".to_string()))
+}
+
+/// Check if an error from `send_transaction` indicates the transaction is
+/// already on-chain (idempotency — a successful resubmission).
+///
+/// Covers known variants: "already processed" (lowercase/titlecase/spaced),
+/// `AlreadyProcessed` enum form, JSON-RPC code -32002.
+pub fn is_already_processed_error(err: &Error) -> bool {
+    let s = err.to_string();
+    let lower = s.to_lowercase();
+    lower.contains("already processed")
+        || lower.contains("already been processed")
+        || lower.contains("alreadyprocessed")
+        || s.contains("-32002")
+}
+
+/// Poll `getSignatureStatuses` until the transaction reaches `processed`,
+/// `confirmed`, or `finalized` status, or until the budget expires.
+///
+/// Uses exponential backoff (500ms → 4s cap) matching `SolanaVerifier`'s
+/// existing pattern. Treats transient RPC errors as retryable (does NOT abort
+/// the polling loop on network blips).
+///
+/// Returns:
+/// - `Ok(())` if confirmed/processed/finalized
+/// - `Err(Error::SettlementFailed)` if the tx landed with an error
+/// - `Err(Error::SettlementFailed("timeout"))` if not confirmed within budget
+pub async fn poll_for_confirmation(
+    client: &Client,
+    rpc_url: &str,
+    signature_b58: &str,
+    budget: Duration,
+) -> Result<(), Error> {
+    let start = tokio::time::Instant::now();
+    let mut interval = Duration::from_millis(500);
+    let max_interval = Duration::from_secs(4);
+    let mut attempt: u32 = 0;
+
+    loop {
+        if start.elapsed() > budget {
+            return Err(Error::SettlementFailed(format!(
+                "transaction not confirmed within {budget:?}"
+            )));
+        }
+
+        if attempt > 0 {
+            tokio::time::sleep(interval).await;
+            interval = (interval * 2).min(max_interval);
+        }
+        attempt += 1;
+
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getSignatureStatuses",
+            "params": [[signature_b58]],
+        });
+
+        // Treat RPC/network errors as transient — keep polling
+        let response = match client.post(rpc_url).json(&body).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                debug!(error = %e, attempt, "getSignatureStatuses RPC error, retrying");
+                continue;
+            }
+        };
+
+        let result: serde_json::Value = match response.json().await {
+            Ok(j) => j,
+            Err(e) => {
+                debug!(error = %e, attempt, "getSignatureStatuses JSON parse error, retrying");
+                continue;
+            }
+        };
+
+        if result.get("error").is_some() {
+            debug!(error = ?result.get("error"), attempt, "RPC-level error, retrying");
+            continue;
+        }
+
+        let Some(status_arr) = result
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_array())
+        else {
+            continue;
+        };
+
+        let Some(status) = status_arr.first() else {
+            continue;
+        };
+
+        if status.is_null() {
+            // Not yet found — keep polling
+            continue;
+        }
+
+        if let Some(err_val) = status.get("err") {
+            if !err_val.is_null() {
+                return Err(Error::SettlementFailed(format!(
+                    "transaction failed on-chain: {err_val}"
+                )));
+            }
+        }
+
+        if let Some(confirmation) = status.get("confirmationStatus").and_then(|s| s.as_str()) {
+            match confirmation {
+                "processed" | "confirmed" | "finalized" => {
+                    info!(
+                        signature = signature_b58,
+                        status = confirmation,
+                        attempt,
+                        "transaction confirmed"
+                    );
+                    return Ok(());
+                }
+                other => {
+                    warn!(
+                        status = other,
+                        signature = signature_b58,
+                        "unknown confirmationStatus from RPC"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::Error;
+
+    #[test]
+    fn test_is_already_processed_error_lowercase() {
+        let e = Error::Rpc("transaction has already processed".to_string());
+        assert!(is_already_processed_error(&e));
+    }
+
+    #[test]
+    fn test_is_already_processed_error_titlecase() {
+        let e = Error::Rpc("Transaction has already been processed".to_string());
+        assert!(is_already_processed_error(&e));
+    }
+
+    #[test]
+    fn test_is_already_processed_error_enum_variant() {
+        let e = Error::Rpc("AlreadyProcessed".to_string());
+        assert!(is_already_processed_error(&e));
+    }
+
+    #[test]
+    fn test_is_already_processed_error_jsonrpc_code() {
+        let e = Error::Rpc(
+            r#"{"code":-32002,"message":"Transaction simulation failed"}"#.to_string(),
+        );
+        assert!(is_already_processed_error(&e));
+    }
+
+    #[test]
+    fn test_is_already_processed_error_unrelated() {
+        let e = Error::Rpc("blockhash not found".to_string());
+        assert!(!is_already_processed_error(&e));
+    }
+}


### PR DESCRIPTION
## Summary

Second bug discovered during end-to-end escrow testing after merging #10:

- The escrow verifier's \`settle_payment\` was only calling \`getSignatureStatuses\` to check if the deposit tx was already on-chain — it was never actually submitting the tx.
- The direct verifier (\`crates/x402/src/solana.rs\`) correctly submits via \`sendTransaction\` RPC, but the escrow path was missing this step.
- Result: valid deposit txs from the CLI would be accepted by \`verify_payment\` then immediately rejected by \`settle_payment\` with "deposit not yet confirmed on-chain".

## Fix

- Add \`send_transaction\` helper on \`EscrowVerifier\` (mirrors the one in \`SolanaVerifier\`)
- \`settle_payment\` now:
  1. Submits the signed deposit tx via \`sendTransaction\` (treats "already processed" as idempotent)
  2. Polls \`getSignatureStatuses\` up to 20 times × 500ms (~10s) waiting for "processed" or "confirmed" status
  3. Returns failure if not confirmed within the window

## Test plan

- [x] \`cargo test -p x402\` — 88 pass
- [x] \`cargo clippy -p x402 --all-targets -- -D warnings\` — clean
- [x] \`cargo build --release -p rustyclawrouter-cli\` — builds
- [ ] After merge + gateway redeploy: end-to-end escrow payment via CLI against production gateway