### PR TITLE
fix(x402): correct Solana PDA hash order and ATA program ID typo

### DIFF
--- a/crates/x402/src/escrow/pda.rs
+++ b/crates/x402/src/escrow/pda.rs
@@ -4,7 +4,7 @@
 // Constants
 // ---------------------------------------------------------------------------
 
-pub const ATA_PROGRAM_ID: &str = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJe1bxs";
+pub const ATA_PROGRAM_ID: &str = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
 pub const TOKEN_PROGRAM_ID: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 pub const SYSTEM_PROGRAM_ID: &str = "11111111111111111111111111111111";
 pub const SYSVAR_RENT_ID: &str = "SysvarRent111111111111111111111111111111111";
@@ -16,6 +16,10 @@ pub const SYSVAR_RENT_ID: &str = "SysvarRent111111111111111111111111111111111";
 /// Derive a Program Derived Address using SHA-256 (same as Solana runtime).
 ///
 /// Returns `(pubkey_bytes, bump)` or `None` if no valid off-curve point is found.
+///
+/// Hash input order matches `solana_program::pubkey::Pubkey::create_program_address`:
+/// `seeds || bump || program_id || "ProgramDerivedAddress"`.
+/// Note: the program id comes BEFORE the PDA marker, not after.
 pub fn find_program_address(
     seeds: &[&[u8]],
     program_id: &[u8; 32],
@@ -28,8 +32,8 @@ pub fn find_program_address(
             hasher.update(seed);
         }
         hasher.update([nonce]);
-        hasher.update(b"ProgramDerivedAddress");
         hasher.update(program_id);
+        hasher.update(b"ProgramDerivedAddress");
         let hash = hasher.finalize();
 
         let mut bytes = [0u8; 32];
@@ -138,6 +142,51 @@ mod tests {
         // Deterministic
         let ata2 = derive_ata_address(&wallet, &mint);
         assert_eq!(ata, ata2);
+    }
+
+    /// Regression test for ATA derivation. This caught a typo in the
+    /// `ATA_PROGRAM_ID` constant that produced addresses that did not match
+    /// the on-chain ATA, causing escrow deposits to fail with
+    /// `AccountNotInitialized` (Anchor error 3012).
+    ///
+    /// Verified on mainnet via Helius getTokenAccounts:
+    ///   wallet = 4P8mSmvv3nfzUtoqhNKG1mfGrHMVbXvKBXR7fDivv6qp
+    ///   mint   = EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v (USDC)
+    ///   ata    = CYHVCkLwiEjMBdRiz5MsrrCbVL2YTZuv57TjV3ggxoSN
+    #[test]
+    fn test_derive_ata_for_known_wallet() {
+        let wallet = decode_bs58_pubkey("4P8mSmvv3nfzUtoqhNKG1mfGrHMVbXvKBXR7fDivv6qp")
+            .expect("valid wallet");
+        let mint = decode_bs58_pubkey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")
+            .expect("valid mint");
+        let ata = derive_ata_address(&wallet, &mint).expect("derivation succeeds");
+        let expected = decode_bs58_pubkey("CYHVCkLwiEjMBdRiz5MsrrCbVL2YTZuv57TjV3ggxoSN")
+            .expect("valid expected ATA");
+        assert_eq!(
+            ata, expected,
+            "derived ATA does not match expected on-chain ATA"
+        );
+    }
+
+    /// Cross-check: the stand-alone `solana_types::derive_ata` should now also
+    /// produce the canonical ATA after the hash-order fix.
+    #[test]
+    fn test_solana_types_derive_ata_matches() {
+        use crate::solana_types::{derive_ata as sol_derive_ata, Pubkey};
+
+        let wallet = Pubkey(
+            decode_bs58_pubkey("4P8mSmvv3nfzUtoqhNKG1mfGrHMVbXvKBXR7fDivv6qp")
+                .expect("valid wallet"),
+        );
+        let mint = Pubkey(
+            decode_bs58_pubkey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")
+                .expect("valid mint"),
+        );
+        let ata = sol_derive_ata(&wallet, &mint, &Pubkey::TOKEN_PROGRAM_ID).expect("derivation");
+        assert_eq!(
+            ata.to_string(),
+            "CYHVCkLwiEjMBdRiz5MsrrCbVL2YTZuv57TjV3ggxoSN"
+        );
     }
 
     #[test]

--- a/crates/x402/src/solana_types.rs
+++ b/crates/x402/src/solana_types.rs
@@ -118,14 +118,16 @@ pub fn derive_ata(wallet: &Pubkey, mint: &Pubkey, token_program: &Pubkey) -> Opt
 
     // find_program_address: iterate nonce 255 down to 0, return first off-curve hash
     for nonce in (0u8..=255).rev() {
-        // Hash: SHA256(seed0 || seed1 || seed2 || nonce || "ProgramDerivedAddress" || program_id)
+        // Hash: SHA256(seed0 || seed1 || seed2 || nonce || program_id || "ProgramDerivedAddress")
+        // Matches `solana_program::pubkey::Pubkey::create_program_address` exactly —
+        // the program id comes BEFORE the PDA marker.
         let mut hasher = Sha256::new();
         for seed in seeds {
             hasher.update(seed);
         }
         hasher.update([nonce]);
-        hasher.update(b"ProgramDerivedAddress");
         hasher.update(program_id.0);
+        hasher.update(b"ProgramDerivedAddress");
         let hash = hasher.finalize();
 
         let mut bytes = [0u8; 32];


### PR DESCRIPTION
## Summary

Two compounding bugs in Solana PDA/ATA derivation that prevented any real escrow deposit from being verified on-chain. Discovered via end-to-end mainnet test failing with `AccountNotInitialized` error 3012 on \`agent_token_account\`.

### Bug 1: PDA hash order

\`find_program_address\` in \`crates/x402/src/escrow/pda.rs\` AND \`derive_ata\` in \`crates/x402/src/solana_types.rs\` hashed in the wrong order:

\`\`\`
seeds || bump || "ProgramDerivedAddress" || program_id   // WRONG
\`\`\`

Solana's canonical \`Pubkey::create_program_address\` uses:

\`\`\`
seeds || bump || program_id || "ProgramDerivedAddress"   // CORRECT
\`\`\`

This affected ALL escrow PDAs (deposit, claim, refund, verifier) AND all ATA derivations. Every escrow account ever derived by this code pointed at the wrong on-chain address.

### Bug 2: ATA program ID typo

\`ATA_PROGRAM_ID\` constant in \`pda.rs\` was \`ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJe1bxs\` (decodes to a non-existent program). The canonical Solana Associated Token Program is \`ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL\`. Verified via Helius \`getAccountInfo\` — the typo'd address has no on-chain account, the canonical one is owned by BPFLoader2111.

### Why wasn't this caught earlier?

All existing tests (including the regression test added in PR #10) validated builder/verifier **consistency** — both sides were consistently wrong, so round-tripping worked. The bug only surfaced when a real mainnet deposit was attempted and the derived ATA didn't match the actual on-chain ATA (verified via Helius \`getTokenAccounts\`).

## Test plan

- [x] \`cargo test -p x402\` — 95 pass (includes new \`test_derive_ata_for_known_wallet\` with external ground truth: wallet \`4P8mSmvv3nfzUtoqhNKG1mfGrHMVbXvKBXR7fDivv6qp\` + USDC mint → expected ATA \`CYHVCkLwiEjMBdRiz5MsrrCbVL2YTZuv57TjV3ggxoSN\` confirmed via Helius)
- [x] \`cargo test --workspace\` — 708 pass
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [ ] After merge + gateway redeploy: end-to-end escrow payment via CLI against production gateway succeeds