### PR TITLE
feat(cli): add recover subcommand to refund expired escrow PDAs

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod chat;
 pub mod doctor;
 pub mod health;
 pub mod models;
+pub mod recover;
 pub(crate) mod solana_tx;
 pub mod stats;
 pub mod wallet;

--- a/crates/cli/src/commands/recover.rs
+++ b/crates/cli/src/commands/recover.rs
@@ -1,0 +1,857 @@
+//! `rcr recover` — discover and refund stranded escrow PDAs.
+//!
+//! Walks the escrow program, filters by the local wallet's pubkey, decodes each
+//! on-chain account, and (optionally) submits refund transactions for any
+//! escrow whose `expiry_slot` has passed.
+//!
+//! Dry-run mode (default) lists what would happen without sending anything.
+//! `--execute` actually submits refund transactions for expired PDAs.
+
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+use crate::commands::wallet::load_wallet;
+
+/// Default mainnet escrow program ID.
+const ESCROW_PROGRAM_ID: &str = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+
+/// USDC mint on Solana mainnet-beta.
+const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+/// Length of Anchor account discriminator.
+const DISC_LEN: usize = 8;
+
+// Escrow account layout (anchor-serialized):
+//   [8 disc][32 agent][32 provider][32 mint][8 amount]
+//   [32 service_id][8 expiry_slot][1 bump]  = 153 bytes total
+const AGENT_OFFSET: usize = DISC_LEN; // 8
+const PROVIDER_OFFSET: usize = DISC_LEN + 32; // 40
+const MINT_OFFSET: usize = DISC_LEN + 64; // 72
+const AMOUNT_OFFSET: usize = DISC_LEN + 96; // 104
+const SERVICE_ID_OFFSET: usize = DISC_LEN + 104; // 112
+const EXPIRY_OFFSET: usize = DISC_LEN + 136; // 144
+const BUMP_OFFSET: usize = DISC_LEN + 144; // 152
+const ESCROW_ACCOUNT_LEN: usize = DISC_LEN + 145; // 153
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Decoded on-chain escrow account with its PDA and rent balance.
+#[derive(Debug, Clone)]
+struct FoundEscrow {
+    pda: [u8; 32],
+    #[allow(dead_code)]
+    agent: [u8; 32],
+    #[allow(dead_code)]
+    provider: [u8; 32],
+    #[allow(dead_code)]
+    mint: [u8; 32],
+    amount: u64,
+    service_id: [u8; 32],
+    expiry_slot: u64,
+    #[allow(dead_code)]
+    bump: u8,
+    lamports: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub async fn run(
+    api_url: &str,
+    execute: bool,
+    yes: bool,
+    program_id_override: Option<String>,
+) -> Result<()> {
+    let _ = api_url; // api_url is unused here — kept for signature symmetry with other commands
+
+    // --- Load wallet ---
+    let wallet = load_wallet()?;
+    let private_key_b58 = wallet["private_key"]
+        .as_str()
+        .context("wallet missing private_key field")?;
+
+    let key_bytes = bs58::decode(private_key_b58)
+        .into_vec()
+        .context("failed to decode private key from base58")?;
+    if key_bytes.len() != 64 {
+        return Err(anyhow!(
+            "private key must be 64 bytes (seed || pubkey), got {}",
+            key_bytes.len()
+        ));
+    }
+    let seed: [u8; 32] = key_bytes[..32]
+        .try_into()
+        .map_err(|_| anyhow!("failed to slice seed from keypair bytes"))?;
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let agent_pubkey: [u8; 32] = signing_key.verifying_key().to_bytes();
+    let agent_pubkey_b58 = bs58::encode(agent_pubkey).into_string();
+
+    // --- Resolve RPC URL ---
+    let rpc_url = std::env::var("SOLANA_RPC_URL")
+        .or_else(|_| std::env::var("RCR_SOLANA_RPC_URL"))
+        .map_err(|_| {
+            anyhow!(
+                "SOLANA_RPC_URL required for recover. \
+                 Set it to your Solana RPC endpoint (e.g. https://api.mainnet-beta.solana.com)."
+            )
+        })?;
+
+    // --- Resolve program ID ---
+    let program_id_str = program_id_override
+        .as_deref()
+        .unwrap_or(ESCROW_PROGRAM_ID)
+        .to_string();
+
+    let client = reqwest::Client::new();
+
+    // --- Discover escrows owned by the local wallet ---
+    let escrows = discover_escrows(&rpc_url, &program_id_str, &agent_pubkey, &client)
+        .await
+        .context("failed to discover escrow PDAs")?;
+
+    let current_slot = crate::commands::solana_tx::fetch_current_slot(&rpc_url, &client)
+        .await
+        .context("failed to fetch current slot")?;
+
+    // --- Summary header ---
+    println!("Escrow recovery");
+    println!("  Agent        : {agent_pubkey_b58}");
+    println!("  Program      : {program_id_str}");
+    println!("  Current slot : {current_slot}");
+    println!("  PDAs found   : {}", escrows.len());
+    println!();
+
+    if escrows.is_empty() {
+        println!("No escrow PDAs owned by this wallet.");
+        return Ok(());
+    }
+
+    // --- Per-escrow table ---
+    let mut expired: Vec<&FoundEscrow> = Vec::new();
+    let mut total_locked: u64 = 0;
+    let mut total_rent: u64 = 0;
+
+    for esc in &escrows {
+        let status = if current_slot >= esc.expiry_slot {
+            expired.push(esc);
+            "expired"
+        } else {
+            "pending"
+        };
+        total_locked = total_locked.saturating_add(esc.amount);
+        total_rent = total_rent.saturating_add(esc.lamports);
+
+        let pda_b58 = bs58::encode(esc.pda).into_string();
+        let sid_hex: String = esc.service_id[..4]
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        println!(
+            "  {pda_b58}  {amount:>12} USDC  {status:>7}  service_id={sid_hex}…  rent={lamports} lamports  expiry_slot={expiry}",
+            amount = esc.amount,
+            lamports = esc.lamports,
+            expiry = esc.expiry_slot,
+        );
+    }
+
+    println!();
+    println!(
+        "Totals: {} escrows, {} expired, {} atomic USDC locked, {} lamports rent",
+        escrows.len(),
+        expired.len(),
+        total_locked,
+        total_rent
+    );
+    println!();
+
+    // --- Dry-run: stop here ---
+    if !execute {
+        println!("Dry run — re-run with --execute to submit refunds.");
+        return Ok(());
+    }
+
+    // --- Execute path ---
+    if expired.is_empty() {
+        println!("Nothing to refund: no expired PDAs.");
+        return Ok(());
+    }
+
+    // Pre-balance
+    let pre_balance = fetch_sol_balance(&rpc_url, &agent_pubkey_b58, &client)
+        .await
+        .unwrap_or(0);
+    println!("Pre-refund SOL balance : {pre_balance} lamports");
+
+    // Confirmation prompt
+    if !yes {
+        print!("Submit {} refund transaction(s)? [y/N] ", expired.len());
+        use std::io::Write;
+        std::io::stdout().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Fetch blockhash once up-front (blockhashes live ~150 slots, plenty for a few txs).
+    let recent_blockhash = crate::commands::solana_tx::fetch_blockhash(&rpc_url, &client)
+        .await
+        .context("failed to fetch recent blockhash")?;
+
+    let mut success = 0usize;
+    let mut failure = 0usize;
+
+    for esc in expired {
+        let pda_b58 = bs58::encode(esc.pda).into_string();
+        print!("  refund {pda_b58} … ");
+        use std::io::Write;
+        std::io::stdout().flush().ok();
+
+        let refund_tx =
+            match x402::escrow::refund::build_refund_tx(&x402::escrow::refund::RefundParams {
+                agent_keypair_b58: private_key_b58.to_string(),
+                escrow_pda_b58: pda_b58.clone(),
+                usdc_mint_b58: USDC_MINT.to_string(),
+                escrow_program_id_b58: program_id_str.clone(),
+                service_id: esc.service_id,
+                recent_blockhash,
+            }) {
+                Ok(tx) => tx,
+                Err(e) => {
+                    println!("build failed: {e}");
+                    failure += 1;
+                    continue;
+                }
+            };
+
+        match submit_refund_tx(&rpc_url, &refund_tx, &client).await {
+            Ok(sig) => {
+                println!("ok ({sig})");
+                success += 1;
+            }
+            Err(e) => {
+                println!("failed: {e}");
+                failure += 1;
+            }
+        }
+    }
+
+    // Post-balance
+    let post_balance = fetch_sol_balance(&rpc_url, &agent_pubkey_b58, &client)
+        .await
+        .unwrap_or(0);
+    println!();
+    println!("Post-refund SOL balance: {post_balance} lamports");
+    println!("Recovery complete: {success} succeeded, {failure} failed");
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+/// Discover all escrow PDAs owned by the given agent pubkey using the
+/// program's `getProgramAccounts` endpoint with a dataSize + memcmp filter.
+async fn discover_escrows(
+    rpc_url: &str,
+    program_id: &str,
+    agent_pubkey: &[u8; 32],
+    client: &reqwest::Client,
+) -> Result<Vec<FoundEscrow>> {
+    let agent_b58 = bs58::encode(agent_pubkey).into_string();
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getProgramAccounts",
+        "params": [
+            program_id,
+            {
+                "encoding": "base64",
+                "commitment": "confirmed",
+                "filters": [
+                    { "dataSize": ESCROW_ACCOUNT_LEN },
+                    { "memcmp": { "offset": AGENT_OFFSET, "bytes": agent_b58 } }
+                ]
+            }
+        ]
+    });
+
+    let resp = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .context("failed to connect to Solana RPC for getProgramAccounts")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(anyhow!("Solana RPC returned HTTP {}: {}", status, text));
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .context("failed to parse getProgramAccounts response")?;
+
+    if let Some(err) = json.get("error") {
+        return Err(anyhow!(
+            "Solana RPC error: {}",
+            serde_json::to_string(err).unwrap_or_default()
+        ));
+    }
+
+    let entries = json["result"]
+        .as_array()
+        .ok_or_else(|| anyhow!("getProgramAccounts response missing result array"))?;
+
+    let mut found = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let pubkey_b58 = entry["pubkey"]
+            .as_str()
+            .ok_or_else(|| anyhow!("entry missing pubkey field"))?;
+        let pda = x402::escrow::pda::decode_bs58_pubkey(pubkey_b58)
+            .map_err(|e| anyhow!("invalid pubkey {pubkey_b58}: {e}"))?;
+
+        let data_array = entry["account"]["data"]
+            .as_array()
+            .ok_or_else(|| anyhow!("entry account.data is not an array"))?;
+        let data_b64 = data_array
+            .first()
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("entry account.data[0] missing"))?;
+        let data_bytes = BASE64
+            .decode(data_b64)
+            .with_context(|| format!("failed to base64-decode account data for {pubkey_b58}"))?;
+
+        let lamports = entry["account"]["lamports"].as_u64().unwrap_or(0);
+
+        if let Some(decoded) = decode_escrow_account(pda, lamports, &data_bytes) {
+            found.push(decoded);
+        }
+    }
+
+    Ok(found)
+}
+
+/// Decode an escrow account's 153-byte data blob into a `FoundEscrow`.
+///
+/// Returns `None` if the data length does not match the expected layout.
+/// The dataSize RPC filter already ensures this, but we double-check defensively.
+fn decode_escrow_account(pda: [u8; 32], lamports: u64, data: &[u8]) -> Option<FoundEscrow> {
+    if data.len() != ESCROW_ACCOUNT_LEN {
+        return None;
+    }
+
+    let mut agent = [0u8; 32];
+    agent.copy_from_slice(&data[AGENT_OFFSET..AGENT_OFFSET + 32]);
+
+    let mut provider = [0u8; 32];
+    provider.copy_from_slice(&data[PROVIDER_OFFSET..PROVIDER_OFFSET + 32]);
+
+    let mut mint = [0u8; 32];
+    mint.copy_from_slice(&data[MINT_OFFSET..MINT_OFFSET + 32]);
+
+    let mut amount_bytes = [0u8; 8];
+    amount_bytes.copy_from_slice(&data[AMOUNT_OFFSET..AMOUNT_OFFSET + 8]);
+    let amount = u64::from_le_bytes(amount_bytes);
+
+    let mut service_id = [0u8; 32];
+    service_id.copy_from_slice(&data[SERVICE_ID_OFFSET..SERVICE_ID_OFFSET + 32]);
+
+    let mut expiry_bytes = [0u8; 8];
+    expiry_bytes.copy_from_slice(&data[EXPIRY_OFFSET..EXPIRY_OFFSET + 8]);
+    let expiry_slot = u64::from_le_bytes(expiry_bytes);
+
+    let bump = data[BUMP_OFFSET];
+
+    Some(FoundEscrow {
+        pda,
+        agent,
+        provider,
+        mint,
+        amount,
+        service_id,
+        expiry_slot,
+        bump,
+        lamports,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Refund submission
+// ---------------------------------------------------------------------------
+
+/// Submit a base64-encoded signed transaction via `sendTransaction`.
+///
+/// Returns the transaction signature on success.
+async fn submit_refund_tx(
+    rpc_url: &str,
+    base64_tx: &str,
+    client: &reqwest::Client,
+) -> Result<String> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "sendTransaction",
+        "params": [
+            base64_tx,
+            {
+                "encoding": "base64",
+                "skipPreflight": false,
+                "preflightCommitment": "confirmed"
+            }
+        ]
+    });
+
+    let resp = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .context("failed to connect to Solana RPC for sendTransaction")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(anyhow!("Solana RPC returned HTTP {}: {}", status, text));
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .context("failed to parse sendTransaction response")?;
+
+    if let Some(err) = json.get("error") {
+        return Err(anyhow!(
+            "Solana RPC error: {}",
+            serde_json::to_string(err).unwrap_or_default()
+        ));
+    }
+
+    json["result"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("sendTransaction response missing result signature"))
+}
+
+/// Fetch a wallet's SOL balance (lamports) via `getBalance`.
+async fn fetch_sol_balance(
+    rpc_url: &str,
+    wallet_b58: &str,
+    client: &reqwest::Client,
+) -> Result<u64> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getBalance",
+        "params": [wallet_b58, {"commitment": "confirmed"}]
+    });
+    let resp = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .context("failed to connect to Solana RPC for getBalance")?;
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .context("failed to parse getBalance response")?;
+    json["result"]["value"]
+        .as_u64()
+        .ok_or_else(|| anyhow!("getBalance response missing result.value"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// RAII guard that removes an env var on drop (panic-safe cleanup).
+    struct EnvGuard(&'static str);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(self.0);
+        }
+    }
+
+    /// Create a temp home with a valid wallet.
+    fn setup_wallet() -> (tempfile::TempDir, [u8; 32], String) {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        std::env::set_var("HOME", tmp.path());
+        let dir = tmp.path().join(".rustyclawrouter");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+
+        let mut seed = [0u8; 32];
+        seed[0] = 42;
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let verifying_key = signing_key.verifying_key();
+        let agent_pubkey = verifying_key.to_bytes();
+        let mut full_key = [0u8; 64];
+        full_key[..32].copy_from_slice(&seed);
+        full_key[32..].copy_from_slice(&agent_pubkey);
+
+        let wallet = serde_json::json!({
+            "private_key": bs58::encode(&full_key).into_string(),
+            "address": bs58::encode(&agent_pubkey).into_string(),
+            "created_at": "2026-01-01T00:00:00Z"
+        });
+        std::fs::write(
+            dir.join("wallet.json"),
+            serde_json::to_string_pretty(&wallet).expect("json"),
+        )
+        .expect("write wallet");
+
+        let agent_b58 = bs58::encode(&agent_pubkey).into_string();
+        (tmp, agent_pubkey, agent_b58)
+    }
+
+    /// Construct a synthetic 153-byte escrow account data blob.
+    fn make_escrow_data(
+        agent: &[u8; 32],
+        amount: u64,
+        service_id: &[u8; 32],
+        expiry_slot: u64,
+    ) -> Vec<u8> {
+        let mut data = vec![0u8; ESCROW_ACCOUNT_LEN];
+        // Discriminator (doesn't matter, we don't validate it)
+        data[..DISC_LEN].copy_from_slice(&[7u8; 8]);
+        data[AGENT_OFFSET..AGENT_OFFSET + 32].copy_from_slice(agent);
+        data[PROVIDER_OFFSET..PROVIDER_OFFSET + 32].copy_from_slice(&[2u8; 32]);
+        let mint = x402::escrow::pda::decode_bs58_pubkey(USDC_MINT).expect("valid mint");
+        data[MINT_OFFSET..MINT_OFFSET + 32].copy_from_slice(&mint);
+        data[AMOUNT_OFFSET..AMOUNT_OFFSET + 8].copy_from_slice(&amount.to_le_bytes());
+        data[SERVICE_ID_OFFSET..SERVICE_ID_OFFSET + 32].copy_from_slice(service_id);
+        data[EXPIRY_OFFSET..EXPIRY_OFFSET + 8].copy_from_slice(&expiry_slot.to_le_bytes());
+        data[BUMP_OFFSET] = 255;
+        data
+    }
+
+    /// Build the PDA b58 string for an agent + service_id combination.
+    fn derived_pda_b58(agent: &[u8; 32], service_id: &[u8; 32]) -> String {
+        let program_id =
+            x402::escrow::pda::decode_bs58_pubkey(ESCROW_PROGRAM_ID).expect("valid program id");
+        let (pda, _bump) =
+            x402::escrow::pda::find_program_address(&[b"escrow", agent, service_id], &program_id)
+                .expect("valid PDA");
+        bs58::encode(pda).into_string()
+    }
+
+    // --- Pure unit tests ---
+
+    #[test]
+    fn test_decode_escrow_account_layout() {
+        let agent = [0xAAu8; 32];
+        let service_id = [0xBBu8; 32];
+        let data = make_escrow_data(&agent, 1_234_567, &service_id, 555);
+        let pda = [0xCCu8; 32];
+        let decoded = decode_escrow_account(pda, 9999, &data).expect("decode should succeed");
+
+        assert_eq!(decoded.pda, pda);
+        assert_eq!(decoded.agent, agent);
+        assert_eq!(decoded.amount, 1_234_567);
+        assert_eq!(decoded.service_id, service_id);
+        assert_eq!(decoded.expiry_slot, 555);
+        assert_eq!(decoded.bump, 255);
+        assert_eq!(decoded.lamports, 9999);
+        // Mint should match USDC
+        let usdc = x402::escrow::pda::decode_bs58_pubkey(USDC_MINT).unwrap();
+        assert_eq!(decoded.mint, usdc);
+    }
+
+    #[test]
+    fn test_decode_escrow_account_wrong_size() {
+        let data = vec![0u8; 100];
+        let result = decode_escrow_account([0u8; 32], 0, &data);
+        assert!(result.is_none(), "wrong-size data should return None");
+    }
+
+    // --- Mocked async tests ---
+
+    #[tokio::test]
+    async fn test_recover_no_pdas_found() {
+        let _lock = crate::ENV_MUTEX.lock().await;
+        let (_wallet_dir, _agent_pubkey, _agent_b58) = setup_wallet();
+
+        let mock = MockServer::start().await;
+
+        // getProgramAccounts → empty
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getProgramAccounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": []
+            })))
+            .mount(&mock)
+            .await;
+
+        // getSlot
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getSlot"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": 100
+            })))
+            .mount(&mock)
+            .await;
+
+        std::env::set_var("SOLANA_RPC_URL", mock.uri());
+        let _env_guard = EnvGuard("SOLANA_RPC_URL");
+
+        let result = run("http://ignored", false, false, None).await;
+        assert!(
+            result.is_ok(),
+            "recover should succeed with empty result: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_list_mode_no_send() {
+        let _lock = crate::ENV_MUTEX.lock().await;
+        let (_wallet_dir, agent_pubkey, _agent_b58) = setup_wallet();
+
+        let mock = MockServer::start().await;
+
+        // Synthetic expired escrow
+        let service_id = [0x11u8; 32];
+        let data = make_escrow_data(&agent_pubkey, 1_000_000, &service_id, 50);
+        let pda_b58 = derived_pda_b58(&agent_pubkey, &service_id);
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getProgramAccounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": [{
+                    "pubkey": pda_b58,
+                    "account": {
+                        "lamports": 2039280,
+                        "owner": ESCROW_PROGRAM_ID,
+                        "data": [BASE64.encode(&data), "base64"],
+                        "executable": false,
+                        "rentEpoch": 0,
+                    }
+                }]
+            })))
+            .mount(&mock)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getSlot"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": 10_000
+            })))
+            .mount(&mock)
+            .await;
+
+        // Fail if sendTransaction is called
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("sendTransaction"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock)
+            .await;
+
+        std::env::set_var("SOLANA_RPC_URL", mock.uri());
+        let _env_guard = EnvGuard("SOLANA_RPC_URL");
+
+        // execute = false
+        let result = run("http://ignored", false, false, None).await;
+        assert!(
+            result.is_ok(),
+            "list mode should succeed: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_skips_pending() {
+        let _lock = crate::ENV_MUTEX.lock().await;
+        let (_wallet_dir, agent_pubkey, _agent_b58) = setup_wallet();
+
+        let mock = MockServer::start().await;
+
+        // Pending escrow: expiry_slot > current slot
+        let service_id = [0x22u8; 32];
+        let data = make_escrow_data(&agent_pubkey, 500_000, &service_id, 20_000);
+        let pda_b58 = derived_pda_b58(&agent_pubkey, &service_id);
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getProgramAccounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": [{
+                    "pubkey": pda_b58,
+                    "account": {
+                        "lamports": 2039280,
+                        "owner": ESCROW_PROGRAM_ID,
+                        "data": [BASE64.encode(&data), "base64"],
+                        "executable": false,
+                        "rentEpoch": 0,
+                    }
+                }]
+            })))
+            .mount(&mock)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getSlot"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": 10_000
+            })))
+            .mount(&mock)
+            .await;
+
+        // getBalance (used in execute path)
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getBalance"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"value": 1_000_000}
+            })))
+            .mount(&mock)
+            .await;
+
+        // Must not be called
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("sendTransaction"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock)
+            .await;
+
+        std::env::set_var("SOLANA_RPC_URL", mock.uri());
+        let _env_guard = EnvGuard("SOLANA_RPC_URL");
+
+        // execute=true, yes=true — but no PDAs are expired, so no sendTransaction
+        let result = run("http://ignored", true, true, None).await;
+        assert!(
+            result.is_ok(),
+            "execute mode with no expired PDAs should succeed: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_executes_expired() {
+        let _lock = crate::ENV_MUTEX.lock().await;
+        let (_wallet_dir, agent_pubkey, _agent_b58) = setup_wallet();
+
+        let mock = MockServer::start().await;
+
+        let service_id = [0x33u8; 32];
+        let data = make_escrow_data(&agent_pubkey, 2_500_000, &service_id, 50);
+        let pda_b58 = derived_pda_b58(&agent_pubkey, &service_id);
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getProgramAccounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": [{
+                    "pubkey": pda_b58,
+                    "account": {
+                        "lamports": 2039280,
+                        "owner": ESCROW_PROGRAM_ID,
+                        "data": [BASE64.encode(&data), "base64"],
+                        "executable": false,
+                        "rentEpoch": 0,
+                    }
+                }]
+            })))
+            .mount(&mock)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getSlot"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": 100_000
+            })))
+            .mount(&mock)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getBalance"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"value": 5_000_000}
+            })))
+            .mount(&mock)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("getLatestBlockhash"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "value": {
+                        "blockhash": "11111111111111111111111111111111",
+                        "lastValidBlockHeight": 9999
+                    }
+                }
+            })))
+            .mount(&mock)
+            .await;
+
+        // Must be called at least once
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("sendTransaction"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": "5Kn9LvXy3T8Z2pQc4rVnYbWxJhGfM6s1uAeTdBjK7CxNhWzQmRpA"
+            })))
+            .expect(1..)
+            .mount(&mock)
+            .await;
+
+        std::env::set_var("SOLANA_RPC_URL", mock.uri());
+        let _env_guard = EnvGuard("SOLANA_RPC_URL");
+
+        let result = run("http://ignored", true, true, None).await;
+        assert!(
+            result.is_ok(),
+            "execute mode with expired PDA should succeed: {:?}",
+            result.err()
+        );
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -52,6 +52,18 @@ enum Commands {
     Health,
     /// AI-powered diagnostics
     Doctor,
+    /// Recover stranded escrow deposits (refund expired PDAs)
+    Recover {
+        /// Submit refund transactions (default is dry-run list)
+        #[arg(long)]
+        execute: bool,
+        /// Skip the confirmation prompt (requires --execute)
+        #[arg(short, long)]
+        yes: bool,
+        /// Override escrow program ID (defaults to mainnet)
+        #[arg(long)]
+        program_id: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -81,6 +93,11 @@ async fn main() -> Result<()> {
         Commands::Stats { days } => commands::stats::show(&cli.api_url, days).await?,
         Commands::Health => commands::health::check(&cli.api_url).await?,
         Commands::Doctor => commands::doctor::run(&cli.api_url).await?,
+        Commands::Recover {
+            execute,
+            yes,
+            program_id,
+        } => commands::recover::run(&cli.api_url, execute, yes, program_id).await?,
     }
 
     Ok(())

--- a/crates/x402/src/escrow/deposit.rs
+++ b/crates/x402/src/escrow/deposit.rs
@@ -247,7 +247,7 @@ pub fn build_deposit_tx(params: &DepositParams) -> Result<String, DepositError> 
 /// - 32-byte recent blockhash
 /// - compact-u16 instruction count (always 1)
 /// - instruction: program_id_index || compact-u16 accts || accts || compact-u16 data_len || data
-fn build_legacy_message(
+pub(super) fn build_legacy_message(
     header: [u8; 3],
     accounts: &[[u8; 32]],
     program_id: &[u8; 32],

--- a/crates/x402/src/escrow/mod.rs
+++ b/crates/x402/src/escrow/mod.rs
@@ -13,6 +13,7 @@ pub mod claim_queue;
 mod claimer;
 pub mod deposit;
 pub mod pda;
+pub mod refund;
 mod verifier;
 
 #[cfg(feature = "postgres")]

--- a/crates/x402/src/escrow/refund.rs
+++ b/crates/x402/src/escrow/refund.rs
@@ -1,0 +1,368 @@
+//! Escrow refund transaction builder for client SDKs.
+//!
+//! Builds a signed Solana legacy transaction that calls the escrow program's
+//! `refund` instruction. The transaction is returned as a base64-encoded string
+//! suitable for submission to any Solana RPC endpoint.
+//!
+//! The `refund` instruction closes the escrow PDA and returns all deposited
+//! tokens (plus rent) to the agent's wallet. It is only callable after the
+//! escrow's `expiry_slot` has passed.
+
+use super::pda::{
+    anchor_discriminator, decode_bs58_pubkey, derive_ata_address, find_program_address,
+    ATA_PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID,
+};
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur while building an escrow refund transaction.
+#[derive(Debug, thiserror::Error)]
+pub enum RefundError {
+    /// The agent keypair was invalid (bad base58, wrong length, or pubkey mismatch).
+    #[error("invalid agent keypair: {0}")]
+    InvalidKeypair(String),
+    /// An address field failed to decode from base58.
+    #[error("invalid address for {field}: {reason}")]
+    InvalidAddress { field: &'static str, reason: String },
+    /// A PDA or ATA derivation failed.
+    #[error("failed to derive {0}")]
+    DerivationFailed(&'static str),
+    /// The caller-provided PDA does not match the one derived from the
+    /// agent pubkey, service_id, and program id.
+    #[error("derived PDA {derived} does not match expected {expected}")]
+    PdaMismatch { derived: String, expected: String },
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Parameters required to build an escrow refund transaction.
+pub struct RefundParams {
+    /// Base58-encoded 64-byte ed25519 keypair (32-byte secret || 32-byte pubkey).
+    pub agent_keypair_b58: String,
+    /// Base58-encoded escrow PDA pubkey. Re-derived from the agent + service_id
+    /// for safety; the caller-provided value must match.
+    pub escrow_pda_b58: String,
+    /// Base58-encoded USDC mint pubkey.
+    pub usdc_mint_b58: String,
+    /// Base58-encoded escrow program ID.
+    pub escrow_program_id_b58: String,
+    /// 32-byte service identifier that seeded the escrow PDA.
+    pub service_id: [u8; 32],
+    /// Recent blockhash (32 bytes) from `getLatestBlockhash`.
+    pub recent_blockhash: [u8; 32],
+}
+
+impl std::fmt::Debug for RefundParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefundParams")
+            .field("agent_keypair_b58", &"[REDACTED]")
+            .field("escrow_pda_b58", &self.escrow_pda_b58)
+            .field("usdc_mint_b58", &self.usdc_mint_b58)
+            .field("escrow_program_id_b58", &self.escrow_program_id_b58)
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transaction builder
+// ---------------------------------------------------------------------------
+
+/// Build a signed escrow refund transaction.
+///
+/// Returns a base64-encoded wire-format Solana transaction ready for
+/// submission via `sendTransaction`.
+///
+/// # Errors
+///
+/// Returns [`RefundError`] if:
+/// - The keypair is invalid or the derived pubkey does not match the stored one
+/// - Any address fails to decode from base58
+/// - PDA or ATA derivation fails
+/// - The caller-provided `escrow_pda_b58` does not match the PDA derived from
+///   the agent pubkey, service_id, and program id
+pub fn build_refund_tx(params: &RefundParams) -> Result<String, RefundError> {
+    use base64::Engine;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    // Step 1: Decode the 64-byte keypair and validate derived pubkey
+    let keypair_bytes = bs58::decode(&params.agent_keypair_b58)
+        .into_vec()
+        .map_err(|e| RefundError::InvalidKeypair(format!("invalid base58: {e}")))?;
+    if keypair_bytes.len() != 64 {
+        return Err(RefundError::InvalidKeypair(format!(
+            "must be 64 bytes, got {}",
+            keypair_bytes.len()
+        )));
+    }
+    let mut keypair_arr = [0u8; 64];
+    keypair_arr.copy_from_slice(&keypair_bytes);
+
+    let signing_key = SigningKey::from_keypair_bytes(&keypair_arr)
+        .map_err(|e| RefundError::InvalidKeypair(format!("ed25519 error: {e}")))?;
+    let agent_pubkey = signing_key.verifying_key().to_bytes();
+
+    // Validate that the stored pubkey in bytes 32..64 matches the derived one.
+    let stored_pubkey = &keypair_bytes[32..64];
+    if stored_pubkey != agent_pubkey {
+        return Err(RefundError::InvalidKeypair(
+            "derived pubkey does not match stored pubkey".to_string(),
+        ));
+    }
+
+    // Step 2: Parse all addresses
+    let expected_escrow_pda =
+        decode_bs58_pubkey(&params.escrow_pda_b58).map_err(|e| RefundError::InvalidAddress {
+            field: "escrow_pda",
+            reason: e.to_string(),
+        })?;
+    let usdc_mint =
+        decode_bs58_pubkey(&params.usdc_mint_b58).map_err(|e| RefundError::InvalidAddress {
+            field: "usdc_mint",
+            reason: e.to_string(),
+        })?;
+    let escrow_program_id = decode_bs58_pubkey(&params.escrow_program_id_b58).map_err(|e| {
+        RefundError::InvalidAddress {
+            field: "escrow_program_id",
+            reason: e.to_string(),
+        }
+    })?;
+    let token_program =
+        decode_bs58_pubkey(TOKEN_PROGRAM_ID).map_err(|e| RefundError::InvalidAddress {
+            field: "token_program",
+            reason: e.to_string(),
+        })?;
+    let ata_program =
+        decode_bs58_pubkey(ATA_PROGRAM_ID).map_err(|e| RefundError::InvalidAddress {
+            field: "ata_program",
+            reason: e.to_string(),
+        })?;
+    let system_program =
+        decode_bs58_pubkey(SYSTEM_PROGRAM_ID).map_err(|e| RefundError::InvalidAddress {
+            field: "system_program",
+            reason: e.to_string(),
+        })?;
+
+    // Step 3: Re-derive the escrow PDA and compare to the caller-provided PDA.
+    // This catches caller bugs (e.g. wrong service_id or wrong program id).
+    let (derived_escrow_pda, _bump) = find_program_address(
+        &[b"escrow", &agent_pubkey, &params.service_id],
+        &escrow_program_id,
+    )
+    .ok_or(RefundError::DerivationFailed("escrow PDA"))?;
+
+    if derived_escrow_pda != expected_escrow_pda {
+        return Err(RefundError::PdaMismatch {
+            derived: bs58::encode(derived_escrow_pda).into_string(),
+            expected: params.escrow_pda_b58.clone(),
+        });
+    }
+
+    // Step 4: Derive agent ATA and vault ATA
+    let agent_token_account = derive_ata_address(&agent_pubkey, &usdc_mint)
+        .ok_or(RefundError::DerivationFailed("agent ATA"))?;
+    let vault_ata = derive_ata_address(&derived_escrow_pda, &usdc_mint)
+        .ok_or(RefundError::DerivationFailed("vault ATA"))?;
+
+    // Step 5: Build account keys sorted by writability (Solana legacy message requirement):
+    //   writable signers first, then writable non-signers, then readonly non-signers.
+    // 0: agent_pubkey         (signer, writable)
+    // 1: escrow_pda           (writable, non-signer — closed to agent)
+    // 2: vault_ata            (writable, non-signer — closed by CPI)
+    // 3: agent_token_account  (writable, non-signer — receives refund)
+    // 4: usdc_mint            (readonly, non-signer)
+    // 5: token_program        (readonly, non-signer)
+    // 6: ata_program          (readonly, non-signer)
+    // 7: system_program       (readonly, non-signer)
+    // 8: escrow_program_id    (program invoked — appended last)
+    let accounts: Vec<[u8; 32]> = vec![
+        agent_pubkey,        // 0: signer, writable
+        derived_escrow_pda,  // 1: writable, non-signer
+        vault_ata,           // 2: writable, non-signer
+        agent_token_account, // 3: writable, non-signer
+        usdc_mint,           // 4: readonly
+        token_program,       // 5: readonly
+        ata_program,         // 6: readonly
+        system_program,      // 7: readonly
+                             // escrow_program_id appended separately as index 8
+    ];
+
+    // Step 6: Build instruction data
+    // refund takes no arguments — just the discriminator.
+    let discriminator = anchor_discriminator("refund");
+    let ix_data = discriminator.to_vec();
+    debug_assert_eq!(ix_data.len(), 8, "refund ix_data must be 8 bytes");
+
+    // Instruction account indices remapped to the sorted wire order.
+    // Anchor program expects (Refund<'info> struct field order):
+    //   [escrow, agent, mint, vault, agent_token_account,
+    //    token_program, associated_token_program, system_program]
+    // Wire positions:
+    //   [1,      0,     4,    2,     3,
+    //    5,             6,                        7]
+    let ix_account_indices: Vec<u8> = vec![1, 0, 4, 2, 3, 5, 6, 7];
+
+    // Step 7: Build the legacy message
+    // Header: [1, 0, 5] — 1 signer, 0 readonly signed, 5 readonly unsigned
+    // Readonly unsigned: mint(4), token_program(5), ata_program(6),
+    //                    system_program(7), escrow_program(8) = 5
+    let msg = super::deposit::build_legacy_message(
+        [1, 0, 5],
+        &accounts,
+        &escrow_program_id,
+        &params.recent_blockhash,
+        8u8, // program_id_index = 8 (last account)
+        &ix_account_indices,
+        &ix_data,
+    );
+
+    // Step 8: Sign the message with the agent keypair
+    let signature = signing_key.sign(&msg);
+
+    // Step 9: Assemble wire-format transaction
+    // compact-u16(1) || signature(64) || message
+    let mut tx_bytes = Vec::with_capacity(1 + 64 + msg.len());
+    tx_bytes.push(0x01); // compact-u16: 1 signature
+    tx_bytes.extend_from_slice(&signature.to_bytes());
+    tx_bytes.extend_from_slice(&msg);
+
+    // Step 10: Base64-encode and return
+    Ok(base64::engine::general_purpose::STANDARD.encode(&tx_bytes))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+    use ed25519_dalek::SigningKey;
+
+    const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const ESCROW_PROGRAM: &str = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+
+    /// Build a deterministic 64-byte keypair from seed `[42u8; 32]`.
+    fn test_agent_keypair_b58() -> String {
+        let seed = [42u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let mut keypair_bytes = [0u8; 64];
+        keypair_bytes[..32].copy_from_slice(&signing_key.to_bytes());
+        keypair_bytes[32..].copy_from_slice(signing_key.verifying_key().as_bytes());
+        bs58::encode(&keypair_bytes).into_string()
+    }
+
+    /// Compute the expected escrow PDA for the test keypair + service_id.
+    fn expected_escrow_pda_b58(service_id: &[u8; 32]) -> String {
+        let seed = [42u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let agent_pubkey = signing_key.verifying_key().to_bytes();
+        let program_id = decode_bs58_pubkey(ESCROW_PROGRAM).expect("valid program id");
+        let (pda, _bump) =
+            find_program_address(&[b"escrow", &agent_pubkey, service_id], &program_id)
+                .expect("valid PDA");
+        bs58::encode(pda).into_string()
+    }
+
+    fn base_params() -> RefundParams {
+        let service_id = [1u8; 32];
+        RefundParams {
+            agent_keypair_b58: test_agent_keypair_b58(),
+            escrow_pda_b58: expected_escrow_pda_b58(&service_id),
+            usdc_mint_b58: USDC_MINT.to_string(),
+            escrow_program_id_b58: ESCROW_PROGRAM.to_string(),
+            service_id,
+            recent_blockhash: [0xABu8; 32],
+        }
+    }
+
+    #[test]
+    fn test_build_refund_tx_produces_valid_base64() {
+        let result = build_refund_tx(&base_params());
+        assert!(result.is_ok(), "build_refund_tx failed: {:?}", result.err());
+        let b64 = result.unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .expect("output must be valid base64");
+        assert!(
+            decoded.len() > 100,
+            "transaction too short: {} bytes",
+            decoded.len()
+        );
+    }
+
+    #[test]
+    fn test_build_refund_tx_contains_correct_discriminator() {
+        let b64 = build_refund_tx(&base_params()).expect("build should succeed");
+        let tx_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .unwrap();
+        let disc = anchor_discriminator("refund");
+        let found = tx_bytes.windows(8).any(|w| w == disc);
+        assert!(
+            found,
+            "transaction bytes must contain the refund discriminator"
+        );
+    }
+
+    #[test]
+    fn test_build_refund_tx_contains_agent_pubkey() {
+        let keypair_b58 = test_agent_keypair_b58();
+        let keypair_bytes = bs58::decode(&keypair_b58).into_vec().unwrap();
+        let agent_pubkey = &keypair_bytes[32..64]; // stored pubkey portion
+
+        let b64 = build_refund_tx(&base_params()).expect("build should succeed");
+        let tx_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .unwrap();
+
+        let found = tx_bytes.windows(32).any(|w| w == agent_pubkey);
+        assert!(found, "transaction bytes must contain the agent pubkey");
+    }
+
+    #[test]
+    fn test_build_refund_tx_pda_mismatch_rejected() {
+        let mut params = base_params();
+        // Replace with a valid base58 pubkey that is definitely not the
+        // derived PDA (system program).
+        params.escrow_pda_b58 = "11111111111111111111111111111111".to_string();
+        let result = build_refund_tx(&params);
+        assert!(result.is_err(), "wrong PDA should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, RefundError::PdaMismatch { .. }),
+            "expected PdaMismatch variant, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_refund_tx_invalid_keypair_rejected() {
+        let mut params = base_params();
+        params.agent_keypair_b58 = "notavalidkeypair!!!".to_string();
+        let result = build_refund_tx(&params);
+        assert!(result.is_err(), "invalid keypair should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, RefundError::InvalidKeypair(_)),
+            "expected InvalidKeypair variant, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_refund_params_debug_redacts_keypair() {
+        let params = base_params();
+        let debug_str = format!("{params:?}");
+        assert!(
+            debug_str.contains("[REDACTED]"),
+            "Debug output must redact the keypair: {debug_str}"
+        );
+        assert!(
+            !debug_str.contains(&params.agent_keypair_b58),
+            "Debug output must not contain the raw keypair: {debug_str}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds \`rcr recover [--execute] [--yes]\` CLI subcommand that discovers and refunds stranded escrow deposits
- New \`x402::escrow::refund::build_refund_tx\` mirrors the deposit builder pattern for cross-SDK reuse
- Default mode: dry-run list of all escrow PDAs owned by the wallet with status (expired/pending), amounts, and recoverable totals
- \`--execute\` mode: prompts for confirmation, then submits refund txs for each expired PDA
- Discovers PDAs via Solana \`getProgramAccounts\` with \`dataSize=153\` + memcmp(offset=8, agent_pubkey)
- Use case: recover ~5252 μUSDC + 0.004 SOL stranded across 2 PDAs from earlier escrow test failures

## Test plan

- [x] \`cargo test -p x402\` — 101 pass (6 new refund tests)
- [x] \`cargo test -p rustyclawrouter-cli\` — 45 pass (6 new recover tests, including layout decode + wiremock execute path)
- [x] \`cargo clippy -p x402 -p rustyclawrouter-cli --all-targets -- -D warnings\` — clean
- [x] \`cargo build --release -p rustyclawrouter-cli\` — builds
- [ ] After merge: dry-run \`rcr recover\` against mainnet — verify it finds the 2 known stranded PDAs
- [ ] After verification: \`rcr recover --execute\` to actually refund them