### PR TITLE
fix(gateway): cap escrow claim at client_amount when verified deposit unknown

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -6,13 +6,25 @@ use x402::types::{PaymentAccept, PaymentPayload, PaymentRequired, Resource, Sola
 use crate::commands::wallet::load_wallet;
 
 /// Select the preferred payment scheme from the accepts list.
-/// Prefers "escrow" (agent gets deposit protection) over "exact".
-fn select_payment_scheme(accepts: &[PaymentAccept]) -> Result<&PaymentAccept> {
+///
+/// If `override_scheme` is `Some`, the scheme with that name must be present in
+/// `accepts` or an error is returned. Otherwise the default preference is used:
+/// "escrow" (when a program ID is advertised) over "exact".
+fn select_payment_scheme<'a>(
+    accepts: &'a [PaymentAccept],
+    override_scheme: Option<&str>,
+) -> Result<&'a PaymentAccept> {
+    if let Some(scheme) = override_scheme {
+        return accepts
+            .iter()
+            .find(|a| a.scheme == scheme)
+            .with_context(|| format!("requested scheme '{scheme}' not advertised by gateway"));
+    }
     accepts
         .iter()
         .find(|a| a.scheme == "escrow" && a.escrow_program_id.is_some())
         .or_else(|| accepts.first())
-        .context("payment required but accepts list is empty")
+        .context("gateway returned no accepted payment methods")
 }
 
 /// Generate a unique 32-byte service_id by hashing the request body + random nonce.
@@ -28,7 +40,7 @@ fn generate_service_id(request_body: &[u8]) -> Result<[u8; 32]> {
     Ok(id)
 }
 
-pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<()> {
+pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool, scheme: Option<&str>) -> Result<()> {
     let client = reqwest::Client::new();
 
     let body = serde_json::json!({
@@ -98,8 +110,8 @@ pub async fn run(api_url: &str, model: &str, prompt: &str, yes: bool) -> Result<
         .as_str()
         .context("wallet missing private_key field")?;
 
-    // Select the preferred payment scheme (escrow > exact).
-    let accepted = select_payment_scheme(&payment_required.accepts)?.clone();
+    // Select the preferred payment scheme (escrow > exact, or override).
+    let accepted = select_payment_scheme(&payment_required.accepts, scheme)?.clone();
 
     // Resolve the Solana RPC URL from the environment.
     let rpc_url = std::env::var("SOLANA_RPC_URL")
@@ -295,7 +307,7 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let result = run(&mock.uri(), "auto", "What is Solana?", true).await;
+        let result = run(&mock.uri(), "auto", "What is Solana?", true, None).await;
         assert!(result.is_ok(), "chat should succeed on 200 response");
     }
 
@@ -308,7 +320,7 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let result = run(&mock.uri(), "auto", "test", true).await;
+        let result = run(&mock.uri(), "auto", "test", true, None).await;
         assert!(result.is_err(), "chat should return error on 500 response");
         assert!(
             result.unwrap_err().to_string().contains("Gateway error"),
@@ -391,7 +403,7 @@ mod tests {
         std::env::set_var("SOLANA_RPC_URL", mock.uri());
         let _env_guard = EnvGuard("SOLANA_RPC_URL");
 
-        let result = run(&mock.uri(), "auto", "What is Solana?", true).await;
+        let result = run(&mock.uri(), "auto", "What is Solana?", true, None).await;
 
         assert!(
             result.is_ok(),
@@ -439,7 +451,7 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let result = run(&mock.uri(), "auto", "test", true).await;
+        let result = run(&mock.uri(), "auto", "test", true, None).await;
         assert!(
             result.is_err(),
             "chat should fail when wallet is missing for payment"
@@ -448,7 +460,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_chat_connection_error() {
-        let result = run(&dead_url(), "auto", "test", true).await;
+        let result = run(&dead_url(), "auto", "test", true, None).await;
         assert!(result.is_err(), "chat should error on connection failure");
     }
 
@@ -482,7 +494,7 @@ mod tests {
     fn test_select_escrow_scheme_prefers_escrow() {
         let accepts = vec![make_exact_accept(), make_escrow_accept()];
         // Safe: non-empty accepts list always yields Ok
-        let selected = select_payment_scheme(&accepts).unwrap();
+        let selected = select_payment_scheme(&accepts, None).unwrap();
         assert_eq!(selected.scheme, "escrow");
     }
 
@@ -490,7 +502,7 @@ mod tests {
     fn test_select_escrow_scheme_falls_back_to_exact() {
         let accepts = vec![make_exact_accept()];
         // Safe: non-empty accepts list always yields Ok
-        let selected = select_payment_scheme(&accepts).unwrap();
+        let selected = select_payment_scheme(&accepts, None).unwrap();
         assert_eq!(selected.scheme, "exact");
     }
 
@@ -500,10 +512,42 @@ mod tests {
         escrow_no_id.escrow_program_id = None;
         let accepts = vec![make_exact_accept(), escrow_no_id];
         // Safe: non-empty accepts list always yields Ok
-        let selected = select_payment_scheme(&accepts).unwrap();
+        let selected = select_payment_scheme(&accepts, None).unwrap();
         assert_eq!(
             selected.scheme, "exact",
             "escrow without program ID should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_select_payment_scheme_with_override() {
+        let accepts = vec![make_exact_accept(), make_escrow_accept()];
+        // --scheme exact should select exact even when escrow is available
+        let selected = select_payment_scheme(&accepts, Some("exact")).unwrap();
+        assert_eq!(
+            selected.scheme, "exact",
+            "--scheme exact should override default escrow preference"
+        );
+    }
+
+    #[test]
+    fn test_select_payment_scheme_override_escrow() {
+        let accepts = vec![make_exact_accept(), make_escrow_accept()];
+        let selected = select_payment_scheme(&accepts, Some("escrow")).unwrap();
+        assert_eq!(selected.scheme, "escrow");
+    }
+
+    #[test]
+    fn test_select_payment_scheme_override_not_advertised() {
+        let accepts = vec![make_exact_accept()];
+        let result = select_payment_scheme(&accepts, Some("escrow"));
+        assert!(
+            result.is_err(),
+            "requesting an unavailable scheme should return an error"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("escrow"),
+            "error should mention the requested scheme"
         );
     }
 
@@ -605,7 +649,7 @@ mod tests {
         std::env::set_var("SOLANA_RPC_URL", mock.uri());
         let _env_guard = EnvGuard("SOLANA_RPC_URL");
 
-        let result = run(&mock.uri(), "auto", "What is Solana?", true).await;
+        let result = run(&mock.uri(), "auto", "What is Solana?", true, None).await;
 
         assert!(
             result.is_ok(),

--- a/crates/cli/src/commands/recover.rs
+++ b/crates/cli/src/commands/recover.rs
@@ -34,6 +34,18 @@ const BUMP_OFFSET: usize = DISC_LEN + 144; // 152
 const ESCROW_ACCOUNT_LEN: usize = DISC_LEN + 145; // 153
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Format a μUSDC atomic amount as a decimal USDC string with 6 decimal places.
+/// 1 USDC = 1_000_000 μUSDC.
+fn atomic_to_usdc(atomic: u64) -> String {
+    let whole = atomic / 1_000_000;
+    let frac = atomic % 1_000_000;
+    format!("{whole}.{frac:06}")
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -150,8 +162,9 @@ pub async fn run(
             .map(|b| format!("{b:02x}"))
             .collect();
         println!(
-            "  {pda_b58}  {amount:>12} USDC  {status:>7}  service_id={sid_hex}…  rent={lamports} lamports  expiry_slot={expiry}",
+            "  {pda_b58}  {amount:>12} atomic ({usdc} USDC)  {status:>7}  service_id={sid_hex}…  rent={lamports} lamports  expiry_slot={expiry}",
             amount = esc.amount,
+            usdc = atomic_to_usdc(esc.amount),
             lamports = esc.lamports,
             expiry = esc.expiry_slot,
         );
@@ -159,10 +172,11 @@ pub async fn run(
 
     println!();
     println!(
-        "Totals: {} escrows, {} expired, {} atomic USDC locked, {} lamports rent",
+        "Totals: {} escrows, {} expired, {} atomic ({} USDC) locked, {} lamports rent",
         escrows.len(),
         expired.len(),
         total_locked,
+        atomic_to_usdc(total_locked),
         total_rent
     );
     println!();
@@ -550,6 +564,15 @@ mod tests {
     }
 
     // --- Pure unit tests ---
+
+    #[test]
+    fn test_atomic_to_usdc() {
+        assert_eq!(atomic_to_usdc(0), "0.000000");
+        assert_eq!(atomic_to_usdc(2625), "0.002625");
+        assert_eq!(atomic_to_usdc(1_000_000), "1.000000");
+        assert_eq!(atomic_to_usdc(7_879), "0.007879");
+        assert_eq!(atomic_to_usdc(1_500_000), "1.500000");
+    }
 
     #[test]
     fn test_decode_escrow_account_layout() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -41,6 +41,9 @@ enum Commands {
         /// Skip the cost confirmation prompt (for scripted use)
         #[arg(short, long)]
         yes: bool,
+        /// Force a specific payment scheme: "exact" or "escrow" (default: prefer escrow)
+        #[arg(long)]
+        scheme: Option<String>,
     },
     /// Usage statistics
     Stats {
@@ -87,8 +90,8 @@ async fn main() -> Result<()> {
             WalletAction::Export => commands::wallet::export()?,
         },
         Commands::Models => commands::models::list(&cli.api_url).await?,
-        Commands::Chat { prompt, model, yes } => {
-            commands::chat::run(&cli.api_url, &model, &prompt, yes).await?
+        Commands::Chat { prompt, model, yes, scheme } => {
+            commands::chat::run(&cli.api_url, &model, &prompt, yes, scheme.as_deref()).await?
         }
         Commands::Stats { days } => commands::stats::show(&cli.api_url, days).await?,
         Commands::Health => commands::health::check(&cli.api_url).await?,

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -46,8 +46,8 @@ async fn main() -> anyhow::Result<()> {
     // Override Solana config from environment variables.
     // Supports both double-underscore (Fly.io style: RCR_SOLANA__RPC_URL) and
     // single-underscore (RCR_SOLANA_RPC_URL) conventions.
-    if let Ok(val) = std::env::var("RCR_SOLANA__RPC_URL")
-        .or_else(|_| std::env::var("RCR_SOLANA_RPC_URL"))
+    if let Ok(val) =
+        std::env::var("RCR_SOLANA__RPC_URL").or_else(|_| std::env::var("RCR_SOLANA_RPC_URL"))
     {
         app_config.solana.rpc_url = val;
     }

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -250,6 +250,8 @@ pub async fn chat_completions(
     let mut escrow_agent_pubkey: Option<String> = None;
     // FIX 3: Track the verified deposit amount to cap claim amounts
     let escrow_deposited_amount: Option<u64>;
+    // Gateway-advertised amount — used as defense-in-depth cap when deposit amount is unknown
+    let client_amount: u64;
 
     match payment_payload {
         Some(payload) => {
@@ -341,7 +343,7 @@ pub async fn chat_completions(
                         "failed to parse expected payment amount as u64".to_string(),
                     )
                 })?;
-            let client_amount: u64 = payload.accepted.amount.parse().map_err(|_| {
+            client_amount = payload.accepted.amount.parse().map_err(|_| {
                 GatewayError::BadRequest(format!(
                     "invalid payment amount '{}': must be a valid integer",
                     payload.accepted.amount
@@ -569,6 +571,7 @@ pub async fn chat_completions(
                     &escrow_agent_pubkey,
                     escrow_deposited_amount,
                     amount,
+                    client_amount,
                 );
             } else {
                 warn!(

--- a/crates/gateway/src/routes/chat/payment.rs
+++ b/crates/gateway/src/routes/chat/payment.rs
@@ -83,11 +83,25 @@ pub(crate) fn uses_durable_nonce(b64_tx: &str) -> bool {
     is_system_program && is_advance_nonce
 }
 
+/// Cap the claim amount against the verified deposit and client-advertised amount.
+///
+/// - If the verifier extracted a deposit amount, cap to that.
+/// - If not (parse failure in verifier), fall back to `client_amount` as a defense-in-depth
+///   upper bound to prevent over-claiming that would waste tx fees on an on-chain rejection.
+fn cap_claim_amount(claim_atomic: u64, deposited: Option<u64>, client_amount: u64) -> u64 {
+    match deposited {
+        Some(d) => claim_atomic.min(d),
+        None => claim_atomic.min(client_amount),
+    }
+}
+
 /// Fire an escrow claim transaction if the payment scheme is escrow.
 ///
 /// Prefers the durable claim queue (PostgreSQL) when a DB pool is available,
 /// falling back to fire-and-forget via `claim_async` when it is not.
 /// Caps the claim amount to the verified deposit to prevent over-claiming.
+/// When the verifier could not extract the deposit amount, falls back to
+/// `client_amount` (the gateway-advertised amount) as a defense-in-depth bound.
 pub(crate) fn fire_escrow_claim(
     state: &Arc<AppState>,
     payment_scheme: &str,
@@ -95,16 +109,22 @@ pub(crate) fn fire_escrow_claim(
     escrow_agent_pubkey: &Option<String>,
     escrow_deposited_amount: Option<u64>,
     claim_atomic: u64,
+    client_amount: u64,
 ) {
     if payment_scheme != "escrow" {
         return;
     }
     if let (Some(ref sid_b64), Some(ref agent_b58)) = (escrow_service_id, escrow_agent_pubkey) {
-        // Cap claim amount to the verified deposit amount
-        let claim_amount = match escrow_deposited_amount {
-            Some(deposited) => claim_atomic.min(deposited),
-            None => claim_atomic,
-        };
+        // Cap claim amount to the verified deposit amount, falling back to client_amount
+        if escrow_deposited_amount.is_none() {
+            tracing::warn!(
+                service_id = ?escrow_service_id,
+                client_amount,
+                claim_atomic,
+                "escrow claim using client_amount as fallback bound (verifier did not extract deposit amount)"
+            );
+        }
+        let claim_amount = cap_claim_amount(claim_atomic, escrow_deposited_amount, client_amount);
 
         // Never claim 0 -- if cost computation failed, skip the claim entirely
         if claim_amount == 0 {
@@ -177,6 +197,24 @@ fn decode_agent_pubkey(b58: &str) -> Result<[u8; 32], String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // cap_claim_amount
+    // =========================================================================
+
+    #[test]
+    fn test_cap_claim_amount_with_deposited() {
+        assert_eq!(cap_claim_amount(2625, Some(2625), 2625), 2625);
+        assert_eq!(cap_claim_amount(3000, Some(2625), 5000), 2625); // capped at deposit
+        assert_eq!(cap_claim_amount(2000, Some(2625), 5000), 2000); // claim less than deposit
+    }
+
+    #[test]
+    fn test_cap_claim_amount_falls_back_to_client_amount() {
+        assert_eq!(cap_claim_amount(2625, None, 2625), 2625);
+        assert_eq!(cap_claim_amount(3000, None, 2625), 2625); // capped at client_amount
+        assert_eq!(cap_claim_amount(2000, None, 2625), 2000); // claim less than client_amount, no cap
+    }
 
     // =========================================================================
     // decode_payment_from_header

--- a/crates/x402/src/escrow/pda.rs
+++ b/crates/x402/src/escrow/pda.rs
@@ -189,6 +189,51 @@ mod tests {
         );
     }
 
+    /// Regression test for escrow PDA derivation against an externally-computed
+    /// canonical Solana value.
+    ///
+    /// This test anchors `find_program_address` to the output of the reference
+    /// implementation — `solders` (Rust-backed Python bindings to `solana-sdk`).
+    ///
+    /// External computation (run 2026-04-10):
+    /// ```python
+    /// from solders.pubkey import Pubkey
+    /// program_id = Pubkey.from_string("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU")
+    /// agent      = bytes([1] * 32)
+    /// service_id = bytes([2] * 32)
+    /// pda, bump  = Pubkey.find_program_address([b"escrow", agent, service_id], program_id)
+    /// # PDA:  BEAUsvsWvV4o6y7XkC1bkyTq4FtQnKErcV3dzTFPT5hX
+    /// # bump: 255
+    /// ```
+    ///
+    /// `solders` delegates to `solana_program::pubkey::Pubkey::find_program_address`,
+    /// which is the same algorithm used by the Solana runtime.  The expected value
+    /// therefore represents canonical on-chain behavior.
+    ///
+    /// DO NOT update `expected_pda` to match what this crate produces.
+    /// If this test fails, recompute the expected value from an external source first.
+    #[test]
+    fn test_escrow_pda_derivation_external_ground_truth() {
+        let program_id = decode_bs58_pubkey("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU")
+            .expect("valid program id");
+        let agent = [1u8; 32];
+        let service_id = [2u8; 32];
+
+        let (pda, bump) =
+            find_program_address(&[b"escrow", &agent, &service_id], &program_id)
+                .expect("PDA derivation should succeed for these inputs");
+
+        // Externally computed via solders `Pubkey.find_program_address` — see doc comment above.
+        let expected_pda = decode_bs58_pubkey("BEAUsvsWvV4o6y7XkC1bkyTq4FtQnKErcV3dzTFPT5hX")
+            .expect("valid expected PDA");
+
+        assert_eq!(
+            pda, expected_pda,
+            "escrow PDA derivation does not match externally-computed canonical value"
+        );
+        assert_eq!(bump, 255, "expected bump seed mismatch");
+    }
+
     #[test]
     fn test_decode_bs58_pubkey_valid() {
         let result = decode_bs58_pubkey("11111111111111111111111111111111");


### PR DESCRIPTION
## Summary

- Defense-in-depth fix for \`fire_escrow_claim\` in gateway
- When the escrow verifier fails to extract the deposit amount (\`escrow_deposited_amount: None\`), the claim amount was previously unbounded
- Now falls back to capping at \`client_amount\` (the gateway-advertised 402 amount), which is always a safe upper bound
- Extracts the cap math into a private \`cap_claim_amount\` helper for testability

## Test plan

- [x] \`cargo test -p gateway\` — 122 pass (2 new cap_claim_amount tests)
- [x] \`cargo clippy -p gateway --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt -p gateway -- --check\` — clean