### PR TITLE
docs: post-launch update — STATUS, CHANGELOG, CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Solvela (formerly RustyClawRouter), in reverse chronological order.
 
+## 2026-04-29 — Security audit + hardening
+
+End-to-end security audit across the gateway and all four SDK repos (`solvela-python`, `solvela-ts`, `solvela-go`, `solvela-client`). 5 GitHub Security Advisories drafted on `solvela-ai/solvela`, 8 hardening issues filed publicly, and 4 SDK security-fix PRs landed.
+
+### Gateway (PR [#74](https://github.com/solvela-ai/solvela/pull/74) — merged)
+
+- **GHSA-wc9q-wc6q-gwmq (HIGH)** — `replay_set` mutex panic-poison no longer takes down `/v1/chat/completions`. Recovered via `PoisonError::into_inner()`.
+- **GHSA-6ggq-cvwx-4f67 (HIGH)** — Rate-limit key switched from client-supplied `pay_to` to the payer wallet derived from the signed transaction. An attacker can no longer escape into a fresh per-client bucket by varying `pay_to`.
+- **GHSA-cgqx-mg48-949v (HIGH)** — `GatewayError::InvalidPayment` and related variants no longer echo attacker-controlled payment fields or raw verifier errors. The internal Solana RPC URL and the recipient wallet stay server-side.
+
+Two CRITICAL/HIGH advisories deferred to a follow-up PR (durable-nonce replay [GHSA-fq3f-c8p7-873f], f64 budget bypass [GHSA-86cr-h3rx-vj6j]).
+
+### SDK security release — Python v0.1.0, TypeScript v0.2.0, Go v0.1.0, Client (Rust) v0.2.0
+
+Cross-SDK fixes (applied uniformly to all 4):
+
+- **Default `gateway_url` flipped to `https://api.solvela.ai`**. Plaintext `http://` is rejected for non-loopback hosts.
+- **`network` and `asset` validation** added to the 402 handshake. A malicious or MITM'd gateway can no longer redirect payments to a different SPL token or non-mainnet network.
+- **`max_payment_amount` defaults to 10 USDC** (`10_000_000` atomic). Wallet-drain protection is now opt-out.
+
+Per-SDK highlights:
+
+- **Python**: BIP39 mnemonic no longer echoed in `WalletError` (CRITICAL — exfil risk via Sentry/`logging.exception`); `chat_stream` now honors the signer via a non-streaming 402 pre-flight; RPC blockhash error path no longer leaks raw response body; `solders` upper-bound pinned.
+- **TypeScript**: `parseAtomicAmount` rejects `NaN`/`Infinity`/`<=0` before any cap check; `Wallet.signTransaction()` replaces public `getKeypair()`; SSE chunks `try/catch` instead of crashing the generator; gateway error strings sanitized for log injection; `npm audit` added to CI.
+- **Go**: `NewClient` now returns `(*SolvelaClient, error)` so config validation can fail closed; `Wallet.Sign(msg)` replaces public `PrivateKey()`; `ChatStream` runs the 402 handshake; `DeriveSessionIDWithSalt` mixes per-client `crypto/rand` salt; `FetchModels` body capped via `io.LimitReader`.
+- **Client (Rust)**: `Wallet` stores `Zeroizing<[u8; 64]>` for real zero-on-drop (the previous `Drop` impl zeroed a stack copy); `ahash` replaces `DefaultHasher` for cache keys; `BudgetExceeded` error tracks cumulative spend across retries; new CI workflow runs fmt + clippy + test + `cargo audit`.
+
+### Repository hardening
+
+- **Branch protection on `main`** — 1 PR approval, 4 required CI checks (Rust fmt/clippy/test, Smoke test, Security audit, Docker build), branches must be up-to-date, force-push/delete blocked.
+- **Hourly deploy-staleness check** (`.github/workflows/deploy-staleness-check.yml`) — opens a tracking issue if production sha lags `main` by more than 1 hour. Closes the gap that caused a 10-day silent stall.
+- **`www.solvela.ai`** added as a 308 redirect to the apex on Vercel.
+- **GitHub Releases** — first releases tagged on the main repo (`v0.1.1`, `solvela-x402-v0.1.2`) and on all four SDK repos.
+
 ## 2026-04-27 — v0.1.1 Patch Release
 
 - **Fixed `solvela models` showing `?` for every price**: CLI was reading `pricing.input_cost_per_million` / `pricing.output_cost_per_million` but the gateway returns `pricing.input_per_million` / `pricing.output_per_million`. Prices now render correctly (e.g. `$0.42`). Test mock updated to match the real production response shape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Solvela is a Solana-native AI agent payment gateway built in Rust (Axum). AI agents pay for LLM API calls with USDC-SPL on Solana via the x402 protocol. No API keys, no accounts, just wallets.
 
-Read `.claude/plan/solvela.md` for the full implementation plan. See `HANDOFF.md` for current project status and what's been completed. See `CHANGELOG.md` for chronological history.
+Read `.claude/plan/solvela.md` for the full implementation plan. See `STATUS.md` for live shipping status and `CHANGELOG.md` for chronological history. (`HANDOFF.md` was retired pre-launch; the public-facing trio is `STATUS.md` + `CHANGELOG.md` + `SECURITY.md`.)
 
 ## Build & Test Commands
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,20 +2,22 @@
 
 > Live shipping status. See [`CHANGELOG.md`](./CHANGELOG.md) for history, [`SECURITY.md`](./SECURITY.md) for disclosure.
 
+_Last refreshed: 2026-04-29 — security audit + hardening pass._
+
 ## Shipped
 
 - **Gateway** — Axum HTTP server with chat completions, image generation, A2A protocol, model registry, escrow endpoints, enterprise org/team/audit/budget endpoints, Prometheus metrics. 5 LLM providers (OpenAI, Anthropic, Google, xAI, DeepSeek).
 - **Protocol** — `solvela-protocol`, `solvela-x402`, `solvela-router`, `solvela-cli` published to crates.io as v0.1.1 (MIT). `cargo install solvela-cli` works.
 - **Escrow program** — Anchor / USDC-SPL trustless escrow. Deployed to Solana mainnet at `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`.
-- **SDKs** — Python, TypeScript, Go, MCP server (in separate repos: `solvela-python`, `solvela-ts`, `solvela-go`, `solvela-client`).
-- **Dashboard + Docs** — Next.js app serving `solvela.ai`, `app.solvela.ai`, `docs.solvela.ai` via subdomain middleware.
+- **SDKs** — Python, TypeScript, Go, and a wallet-client (Rust) SDK in separate repos: `solvela-python` (v0.1.0), `solvela-ts` (v0.2.0), `solvela-go` (v0.1.0), `solvela-client` (v0.2.0). Tagged + GitHub Released 2026-04-29 as the security-hardening release; Go is live via the module proxy, PyPI/npm/crates.io uploads pending operator credentials.
+- **Dashboard + Docs** — Next.js app serving `solvela.ai`, `app.solvela.ai`, `docs.solvela.ai` via subdomain middleware. `www.solvela.ai` 308-redirects to apex.
 
 ## Deployed
 
 | Service | URL | Region |
 |---|---|---|
 | Gateway | `api.solvela.ai` | Fly.io ord |
-| Dashboard / Docs | `solvela.ai`, `app.solvela.ai`, `docs.solvela.ai` | Vercel |
+| Dashboard / Docs | `solvela.ai`, `app.solvela.ai`, `docs.solvela.ai`, `www.solvela.ai` | Vercel |
 | Escrow program | mainnet `9neDH…HLU` | Solana |
 
 ## Verified
@@ -23,3 +25,16 @@
 - All-provider end-to-end payment tests pass with real USDC.
 - Load tested to ~400 RPS sustained at p99 < 300 ms.
 - `cargo test` suite green at HEAD.
+- 4 required CI checks gate every merge to `main`: Rust (fmt, clippy, test), Smoke test, Security audit (cargo-audit), Docker build.
+
+## Repo hardening
+
+- **Branch protection on `solvela-ai/solvela:main`** — 1 PR approval required, 4 required CI checks, branches must be up-to-date, conversation resolution required, force-push and delete blocked.
+- **Auto-merge enabled** for dependabot patch/minor batches with required-checks gating.
+- **Hourly deploy-staleness check** (`.github/workflows/deploy-staleness-check.yml`) opens an issue if production lags `main` HEAD by more than an hour.
+
+## Known follow-ups
+
+- **2 deferred security advisories** — durable-nonce replay (GHSA-fq3f-c8p7-873f), f64 budget bypass (GHSA-86cr-h3rx-vj6j). A scheduled agent opens draft PRs for both 2026-04-29 14:00 UTC.
+- **Registry uploads for SDKs** (PyPI, npm, crates.io) — pending operator credentials.
+- **Vercel API token rotation** and **GitHub org 2FA enforcement** — operator-side actions still pending.


### PR DESCRIPTION
## Summary

Three small doc updates to reflect post-launch reality:

1. **`CLAUDE.md`** — replace the dead pointer to `HANDOFF.md` (retired in commit `7581deb`) with `STATUS.md`. Notes that the public-facing trio is `STATUS.md` + `CHANGELOG.md` + `SECURITY.md`.
2. **`STATUS.md`** — add today's date stamp; record the four SDK release versions (v0.1.0/v0.2.0); add `www.solvela.ai` to the deployed list; new `Repo hardening` section covering branch protection, the hourly deploy-staleness check, and auto-merge config; new `Known follow-ups` section noting the two deferred security advisories and pending registry uploads.
3. **`CHANGELOG.md`** — new `2026-04-29 — Security audit + hardening` entry summarizing PR #74's three GHSA fixes, the 4 SDK security-release PRs (with their cross-cutting trio of fixes and per-SDK highlights), and the repo hardening landed today.

## Test plan
- [ ] CI green — docs-only change, should pass `cargo fmt`/clippy/tests trivially
- [ ] Branch is up-to-date with main (`docs/post-launch-update` branched from current main HEAD)