### PR TITLE
fix(dashboard): chart formatter types after recharts patch-and-minor bump

### DIFF
--- a/dashboard/src/components/charts/model-pie.tsx
+++ b/dashboard/src/components/charts/model-pie.tsx
@@ -61,10 +61,10 @@ export function ModelPie({ data }: ModelPieProps) {
               fontFamily: "JetBrains Mono",
               color: "#DEDCD1",
             }}
-            formatter={(v: number | undefined) => [
-              v != null ? `${v}%` : "—",
-              "Share",
-            ]}
+            formatter={(value) => {
+              const v = typeof value === "number" ? value : undefined;
+              return [v != null ? `${v}%` : "—", "Share"];
+            }}
           />
         </PieChart>
       </ResponsiveContainer>

--- a/dashboard/src/components/charts/requests-bar.tsx
+++ b/dashboard/src/components/charts/requests-bar.tsx
@@ -49,10 +49,10 @@ export function RequestsBar({ data }: RequestsBarProps) {
             fontFamily: "JetBrains Mono",
             color: "#DEDCD1",
           }}
-          formatter={(v: number | undefined) => [
-            v != null ? v.toLocaleString() : "—",
-            "Requests",
-          ]}
+          formatter={(value) => {
+            const v = typeof value === "number" ? value : undefined;
+            return [v != null ? v.toLocaleString() : "—", "Requests"];
+          }}
         />
         <Bar dataKey="requests" fill={BAR_COLOR} radius={[2, 2, 0, 0]} />
       </BarChart>

--- a/dashboard/src/components/charts/spend-chart.tsx
+++ b/dashboard/src/components/charts/spend-chart.tsx
@@ -57,10 +57,10 @@ export function SpendChart({ data }: SpendChartProps) {
             fontFamily: "JetBrains Mono",
             color: "#DEDCD1",
           }}
-          formatter={(v: number | undefined) => [
-            v != null ? `$${v.toFixed(2)} USDC` : "—",
-            "Spend",
-          ]}
+          formatter={(value) => {
+            const v = typeof value === "number" ? value : undefined;
+            return [v != null ? `$${v.toFixed(2)} USDC` : "—", "Spend"];
+          }}
         />
         <Area
           type="monotone"


### PR DESCRIPTION
## Summary
PR #48 (auto-merged dependabot patch-and-minor batch) bumped recharts to a version where the Tooltip `formatter` prop signature changed. The three chart components (`model-pie`, `requests-bar`, `spend-chart`) used the narrow `(v: number | undefined)` annotation that is no longer assignable to the new `Formatter<ValueType, NameType>` type.

Vercel deploys have been failing on type-check since the dependabot merge (~2 hours ago). Production is still serving the last successful build (sha `45c91c7a`), so there's no user-facing impact yet, but every new commit since then has been blocked from deploy.

## Fix
Drop the explicit narrow annotation; let TypeScript infer the parameter type from recharts and narrow inside the formatter:

```tsx
// before
formatter={(v: number | undefined) => [v != null ? `${v}%` : "—", "Share"]}

// after
formatter={(value) => {
  const v = typeof value === "number" ? value : undefined;
  return [v != null ? `${v}%` : "—", "Share"];
}}
```

Functional behavior unchanged — number values format the same way, non-number values render `—`.

## Test plan
- [ ] CI green (Rust checks unaffected, Vercel Preview build now passes type-check)
- [ ] Visit `app.solvela.ai/dashboard/overview` post-merge and confirm tooltips on all 3 charts render correctly