### PR TITLE
fix(gateway): deny durable-nonce payments when Redis is unavailable (GHSA-fq3f-c8p7-873f)

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -296,9 +296,29 @@ async fn handle_payment_submitted(
             solvela_x402::types::PayloadData::Escrow(p) => &p.deposit_tx,
         };
 
+        let is_durable_nonce = crate::routes::chat::uses_durable_nonce(tx_raw);
+
         let replay_detected = if let Some(cache) = &state.cache {
-            cache.check_and_record_tx(tx_raw, false).await.is_err()
+            cache
+                .check_and_record_tx(tx_raw, is_durable_nonce)
+                .await
+                .is_err()
         } else {
+            // GHSA-fq3f-c8p7-873f: durable-nonce transactions carry a 24-hour replay window.
+            // The in-memory LRU cannot cover that window, so deny rather than accept with
+            // degraded protection.
+            if is_durable_nonce {
+                tracing::warn!(
+                    tx = %tx_raw,
+                    "durable-nonce A2A payment rejected: Redis unavailable (GHSA-fq3f-c8p7-873f)"
+                );
+                return Err(JsonRpcErrorData {
+                    code: ERR_PAYMENT_FAILED,
+                    message: "Payment service is temporarily degraded; please retry shortly."
+                        .to_string(),
+                    data: None,
+                });
+            }
             // In-memory replay check via std::sync::Mutex + LRU
             let mut set = state
                 .replay_set

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -308,8 +308,9 @@ async fn handle_payment_submitted(
             // The in-memory LRU cannot cover that window, so deny rather than accept with
             // degraded protection.
             if is_durable_nonce {
+                // Log only the signature prefix, not the full base64 tx.
                 tracing::warn!(
-                    tx = %tx_raw,
+                    tx_prefix = &tx_raw[..tx_raw.len().min(88)],
                     "durable-nonce A2A payment rejected: Redis unavailable (GHSA-fq3f-c8p7-873f)"
                 );
                 return Err(JsonRpcErrorData {

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -410,7 +410,24 @@ pub async fn chat_completions(
                     .await
                     .is_err()
             } else {
-                // No Redis — fall back to in-memory LRU replay set with TTL
+                // No Redis — fall back to in-memory LRU replay set with TTL.
+                //
+                // GHSA-fq3f-c8p7-873f: durable-nonce transactions carry a 24-hour replay
+                // window. The 10 k-entry LRU cannot reliably cover that window, so we deny
+                // the request rather than accept it with degraded replay protection.
+                // Regular (recent-blockhash) transactions have a ~90s window and are safe
+                // to accept under LRU fallback.
+                if is_durable_nonce {
+                    warn!(
+                        tx = %tx_raw,
+                        "durable-nonce payment rejected: Redis unavailable (GHSA-fq3f-c8p7-873f)"
+                    );
+                    return Err(GatewayError::InvalidPayment(
+                        "Payment service is temporarily degraded; please retry shortly."
+                            .to_string(),
+                    ));
+                }
+
                 // GHSA-wc9q-wc6q-gwmq: recover from poisoned lock instead of panicking,
                 // which would propagate a poisoned state to every subsequent payment request.
                 // Same pattern as crates/x402/src/fee_payer.rs and a2a/handler.rs.

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -418,8 +418,12 @@ pub async fn chat_completions(
                 // Regular (recent-blockhash) transactions have a ~90s window and are safe
                 // to accept under LRU fallback.
                 if is_durable_nonce {
+                    // Log only the signature prefix, not the full base64 tx — the
+                    // full payload is attacker-controlled and would pollute log
+                    // pipelines with arbitrary bytes (Datadog/Loki indexing cost,
+                    // log-injection surface).
                     warn!(
-                        tx = %tx_raw,
+                        tx_prefix = &tx_raw[..tx_raw.len().min(88)],
                         "durable-nonce payment rejected: Redis unavailable (GHSA-fq3f-c8p7-873f)"
                     );
                     return Err(GatewayError::InvalidPayment(

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -710,7 +710,7 @@ mod tests {
 
         let app = axum::Router::new()
             .route(
-                "/v1/services/:service_id/proxy",
+                "/v1/services/{service_id}/proxy",
                 axum::routing::post(proxy_service),
             )
             .with_state(state);

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -254,7 +254,22 @@ pub async fn proxy_service(
             .await
             .is_err()
     } else {
-        let mut replay_set = state.replay_set.lock().expect("replay_set mutex poisoned");
+        // GHSA-fq3f-c8p7-873f: durable-nonce transactions carry a 24-hour replay window.
+        // The in-memory LRU cannot cover that window, so deny rather than accept with
+        // degraded protection.
+        if is_durable_nonce {
+            warn!(
+                tx = %tx_raw,
+                "durable-nonce proxy payment rejected: Redis unavailable (GHSA-fq3f-c8p7-873f)"
+            );
+            return Err(GatewayError::InvalidPayment(
+                "Payment service is temporarily degraded; please retry shortly.".to_string(),
+            ));
+        }
+        let mut replay_set = state
+            .replay_set
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if replay_set.get(tx_raw).is_some() {
             true
         } else {
@@ -562,5 +577,168 @@ mod tests {
         assert_eq!(extract_signer_from_base64_tx("not-base64!!!"), None);
         assert_eq!(extract_signer_from_base64_tx(""), None);
         assert_eq!(extract_signer_from_base64_tx("AAAA"), None);
+    }
+
+    // =========================================================================
+    // GHSA-fq3f-c8p7-873f: durable-nonce replay guard
+    // =========================================================================
+
+    /// Build a minimal base64-encoded Solana transaction whose first instruction
+    /// is AdvanceNonceAccount (discriminator = [4, 0, 0, 0]) so that
+    /// `uses_durable_nonce` returns `true`.
+    fn make_durable_nonce_tx_b64() -> String {
+        use base64::Engine;
+        // Legacy message layout:
+        //   header [req_sigs=1, ro_signed=0, ro_unsigned=1]
+        //   compact-u16 num_accounts = 3
+        //   key[0] = system program ([0;32])
+        //   key[1] = nonce account ([1;32])
+        //   key[2] = system program ([0;32])   ← used as program_id
+        //   recent_blockhash [0;32]
+        //   compact-u16 num_instructions = 1
+        //   ix: program_id_index=2, accounts=[1,0], data=[4,0,0,0]
+        let mut msg: Vec<u8> = vec![1u8, 0u8, 1u8, 3u8];
+        msg.extend_from_slice(&[0u8; 32]); // system program
+        msg.extend_from_slice(&[1u8; 32]); // nonce account
+        msg.extend_from_slice(&[0u8; 32]); // system program again (as program_id)
+        msg.extend_from_slice(&[0u8; 32]); // recent blockhash
+        msg.push(1u8); // 1 instruction
+        msg.push(2u8); // program_id_index = 2
+        msg.push(2u8); // 2 accounts
+        msg.extend_from_slice(&[1u8, 0u8]); // account indices
+        msg.push(4u8); // data len = 4
+        msg.extend_from_slice(&[4u8, 0u8, 0u8, 0u8]); // AdvanceNonceAccount
+
+        let mut tx_data = vec![0x01u8]; // 1 signature
+        tx_data.extend_from_slice(&[0xAAu8; 64]); // placeholder signature
+        tx_data.extend_from_slice(&msg);
+        base64::engine::general_purpose::STANDARD.encode(&tx_data)
+    }
+
+    #[tokio::test]
+    async fn test_durable_nonce_payment_denied_when_redis_down() {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use base64::Engine;
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+        use tower::ServiceExt;
+
+        use crate::config::AppConfig;
+        use crate::providers::health::{CircuitBreakerConfig, ProviderHealthTracker};
+        use crate::providers::ProviderRegistry;
+        use crate::routes::escrow::new_slot_cache;
+        use crate::services::{ServiceEntry, ServiceRegistry};
+        use crate::usage::UsageTracker;
+        use solvela_router::models::ModelRegistry;
+        use solvela_x402::facilitator::Facilitator;
+
+        let durable_nonce_b64 = make_durable_nonce_tx_b64();
+        assert!(
+            crate::routes::chat::uses_durable_nonce(&durable_nonce_b64),
+            "test fixture must be detected as a durable-nonce transaction"
+        );
+
+        // Build a PaymentPayload that passes all pre-replay validation.
+        // price=0.01 USDC → expected_atomic = 10_000 * 105/100 = 10_500
+        let pp = solvela_x402::types::PaymentPayload {
+            x402_version: 2,
+            resource: solvela_x402::types::Resource {
+                url: "/v1/services/test-svc/proxy".to_string(),
+                method: "POST".to_string(),
+            },
+            accepted: solvela_x402::types::PaymentAccept {
+                scheme: "exact".to_string(),
+                network: SOLANA_NETWORK.to_string(),
+                amount: "10500".to_string(),
+                asset: USDC_MINT.to_string(),
+                // AppConfig::default().solana.recipient_wallet is an empty string
+                pay_to: String::new(),
+                max_timeout_seconds: 300,
+                escrow_program_id: None,
+            },
+            payload: solvela_x402::types::PayloadData::Direct(solvela_x402::types::SolanaPayload {
+                transaction: durable_nonce_b64,
+            }),
+        };
+        let header_value = base64::engine::general_purpose::STANDARD
+            .encode(serde_json::to_vec(&pp).expect("serialize")); // safe: known-good struct
+
+        // Register a test service so the registry lookup succeeds.
+        let mut reg = ServiceRegistry::empty();
+        reg.register(ServiceEntry {
+            id: "test-svc".to_string(),
+            name: "Test Service".to_string(),
+            category: "test".to_string(),
+            endpoint: "https://test.example.com/api".to_string(),
+            x402_enabled: true,
+            internal: false,
+            description: None,
+            pricing_label: "per-request".to_string(),
+            chains: vec!["solana".to_string()],
+            source: "api".to_string(),
+            healthy: None,
+            price_per_request_usdc: Some(0.01),
+        })
+        .expect("valid test service entry"); // safe: known-good test data
+
+        let state = Arc::new(crate::AppState {
+            config: AppConfig::default(),
+            model_registry: ModelRegistry::from_toml(
+                "[models.placeholder]\nprovider=\"t\"\nmodel_id=\"t\"\ndisplay_name=\"T\"\ninput_cost_per_million=1.0\noutput_cost_per_million=1.0\ncontext_window=4096\nsupports_streaming=false\nsupports_tools=false\nsupports_vision=false",
+            )
+            .expect("valid placeholder model TOML"), // safe: known-good test data
+            service_registry: RwLock::new(reg),
+            providers: ProviderRegistry::from_env(reqwest::Client::new()),
+            facilitator: Facilitator::new(vec![]),
+            usage: UsageTracker::noop(),
+            cache: None, // no Redis — triggers the LRU fallback path
+            provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+            escrow_claimer: None,
+            fee_payer_pool: None,
+            nonce_pool: None,
+            db_pool: None,
+            session_secret: b"test-secret".to_vec(),
+            http_client: reqwest::Client::new(),
+            replay_set: crate::AppState::new_replay_set(),
+            slot_cache: new_slot_cache(),
+            escrow_metrics: None,
+            admin_token: None,
+            prometheus_handle: None,
+            dev_bypass_payment: false,
+        });
+
+        let app = axum::Router::new()
+            .route(
+                "/v1/services/:service_id/proxy",
+                axum::routing::post(proxy_service),
+            )
+            .with_state(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/services/test-svc/proxy")
+            .header("payment-signature", &header_value)
+            .body(Body::empty())
+            .expect("valid test request"); // safe: known-good test data
+
+        let response = app.oneshot(request).await.expect("handler must not panic");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYMENT_REQUIRED,
+            "durable-nonce payment must be denied (402) when Redis is unavailable"
+        );
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), 65_536)
+            .await
+            .expect("read response body"); // safe: small test response
+        let body: serde_json::Value =
+            serde_json::from_slice(&body_bytes).expect("valid JSON error body"); // safe: gateway always returns JSON
+        let message = body["error"]["message"].as_str().unwrap_or("");
+        assert!(
+            message.contains("temporarily degraded"),
+            "error message must indicate service degradation, got: {message}"
+        );
     }
 }

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -258,8 +258,10 @@ pub async fn proxy_service(
         // The in-memory LRU cannot cover that window, so deny rather than accept with
         // degraded protection.
         if is_durable_nonce {
+            // Log only the signature prefix, not the full base64 tx (attacker-
+            // controlled, would pollute log pipelines).
             warn!(
-                tx = %tx_raw,
+                tx_prefix = &tx_raw[..tx_raw.len().min(88)],
                 "durable-nonce proxy payment rejected: Redis unavailable (GHSA-fq3f-c8p7-873f)"
             );
             return Err(GatewayError::InvalidPayment(


### PR DESCRIPTION
## Security advisory

Fixes [GHSA-fq3f-c8p7-873f](https://github.com/solvela-ai/solvela/security/advisories/GHSA-fq3f-c8p7-873f) — **CRITICAL**: durable-nonce replay possible when Redis is down + LRU saturated.

## Problem

Durable-nonce Solana transactions carry a **24-hour replay window**. When Redis is unavailable the code fell back to a 10 k-entry in-memory LRU. At any meaningful request rate the LRU evicts entries long before the 24 h TTL expires, leaving a window where the same durable-nonce transaction can be replayed without detection.

Affected code paths (all three fell through to the LRU when `state.cache = None`):
- `routes/chat/mod.rs` — main chat completions handler
- `a2a/handler.rs` — A2A payment-submitted path (additionally hardcoded `is_durable_nonce=false` when calling Redis, preventing the correct 24 h TTL from being set even when Redis **was** available)
- `routes/proxy.rs` — service marketplace proxy handler

## Design decision: deny, not raise-LRU-capacity

Two options were considered:

| Option | Pro | Con |
|--------|-----|-----|
| **Raise LRU + add per-entry TTL** | Agents keep working during Redis outage | Never fully safe: at high volume, even a large LRU is evicted within the 24 h window; adds complexity and memory pressure |
| **Deny durable-nonce when Redis is down** ✓ | Guaranteed correctness regardless of volume or outage duration | Durable-nonce payments temporarily unavailable during Redis outage |

Durable nonce is an **optimisation** (it lets agents pre-sign transactions offline), not a correctness requirement. Agents can always fall back to standard recent-blockhash transactions, which have a ~90 s window that the LRU **can** safely cover. The deny path returns a client-readable "Payment service is temporarily degraded; please retry shortly." message, which is the correct response when a safety invariant cannot be upheld.

## Changes

| File | Change |
|------|--------|
| `routes/chat/mod.rs` | Guard the LRU `else`-branch: return `InvalidPayment` if `is_durable_nonce && state.cache.is_none()` |
| `a2a/handler.rs` | Detect durable nonce (was hardcoded `false`); apply same deny guard; pass `is_durable_nonce` to `check_and_record_tx` so Redis gets the correct 24 h TTL |
| `routes/proxy.rs` | Apply same deny guard; fix poisoned-lock recovery (`expect` → `unwrap_or_else`) |

## Tests

`test_durable_nonce_payment_denied_when_redis_down` (in `routes/proxy.rs`):
- Builds a real durable-nonce Solana transaction (AdvanceNonceAccount as first instruction)
- Wraps it in a fully-valid `PaymentPayload` that passes all pre-replay validation
- Calls `proxy_service` via `tower::ServiceExt::oneshot` with `state.cache = None`
- Asserts HTTP 402 with `"temporarily degraded"` in the error body

## Out of scope

The broader LRU infrastructure improvements (capacity review, per-entry TTL, metrics on LRU eviction rate) are tracked separately and can be done without a security window.

---

> **Draft — awaiting human review of the deny-vs-degrade design decision before CI/review.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGgUcTqP1Vury9DZUSt6Ks)_