### PR TITLE
fix(gateway): add f64 overflow guards to estimated_atomic_cost (GHSA-86cr-h3rx-vj6j)

### DIFF
--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -39,18 +39,35 @@ pub(crate) fn compute_actual_atomic_cost(
     total_atomic as u64
 }
 
+/// Upper bound for the `total` USDC cost that `estimated_atomic_cost` will accept.
+///
+/// Multiplying by 1_000_000 (to convert USDC → atomic units) must not overflow
+/// u64 (max ~1.84 × 10¹⁹).  We cap at u64::MAX / 1_000_000 ≈ $18.4 trillion,
+/// which is far beyond any realistic LLM request cost.
+///
+/// TODO(GHSA-86cr-h3rx-vj6j): remove this guard once cost.rs and usage.rs are
+/// fully migrated to integer atomic-USDC arithmetic so f64 is never used for
+/// financial values.
+const ESTIMATED_COST_MAX_USDC: f64 = (u64::MAX / 1_000_000) as f64;
+
 /// Estimate cost in atomic USDC units using the model registry's cost breakdown.
 ///
 /// Used as a fallback when actual token usage is unavailable (e.g., streaming).
-/// Returns `None` when the estimate cannot be computed (model not found, parse
-/// failure, etc.) so callers can distinguish "failed to compute" from "genuinely
-/// zero cost".
+///
+/// Returns `Err` (not `Ok(0)`) when the estimate cannot be computed so that
+/// callers fail-closed: treating a failed estimate as zero cost would bypass
+/// budget enforcement and under-claim from escrow.
+///
+/// Range checks applied to the parsed f64 before casting to u64:
+/// - Non-finite (NaN, ±∞): indicates a corrupt model registry entry.
+/// - Negative: cost cannot be negative; a negative cast wraps to a huge u64.
+/// - Overflow (> u64::MAX / 1_000_000): the ×1e6 multiplier would exceed u64.
 pub(crate) fn estimated_atomic_cost(
     registry: &solvela_router::models::ModelRegistry,
     model: &str,
     req: &ChatRequest,
-) -> Option<u64> {
-    match registry
+) -> Result<u64, String> {
+    let f = registry
         .estimate_cost(
             model,
             estimate_input_tokens(req),
@@ -60,13 +77,32 @@ pub(crate) fn estimated_atomic_cost(
             c.total
                 .parse::<f64>()
                 .map_err(|e| solvela_router::models::ModelRegistryError::ParseError(e.to_string()))
-        }) {
-        Ok(f) => Some((f * 1_000_000.0) as u64),
-        Err(e) => {
+        })
+        .map_err(|e| {
             warn!(error = %e, model, "failed to estimate atomic cost for escrow claim");
-            None
-        }
+            e.to_string()
+        })?;
+
+    if !f.is_finite() {
+        return Err(format!(
+            "cost estimate for model '{model}' is non-finite ({f}); \
+             refusing to cast NaN/∞ to u64"
+        ));
     }
+    if f < 0.0 {
+        return Err(format!(
+            "cost estimate for model '{model}' is negative ({f}); \
+             negative USDC amounts are invalid"
+        ));
+    }
+    if f > ESTIMATED_COST_MAX_USDC {
+        return Err(format!(
+            "cost estimate for model '{model}' ({f} USDC) exceeds u64 range \
+             after ×1_000_000 conversion; possible overflow in model pricing config"
+        ));
+    }
+
+    Ok((f * 1_000_000.0) as u64)
 }
 
 /// Convert a USDC decimal string to atomic units (6 decimals).
@@ -354,5 +390,106 @@ mod tests {
     fn test_usdc_atomic_unchecked_defaults_to_zero_on_malformed() {
         assert_eq!(usdc_atomic_amount(""), "0");
         assert_eq!(usdc_atomic_amount("not-a-number"), "0");
+    }
+
+    // =========================================================================
+    // estimated_atomic_cost — GHSA-86cr-h3rx-vj6j input-validation guards
+    // =========================================================================
+
+    /// Build a minimal `ModelRegistry` with a single model whose cost fields
+    /// are set to `cost_per_million` USDC, for use in estimated_atomic_cost tests.
+    fn registry_with_cost(cost_per_million: f64) -> solvela_router::models::ModelRegistry {
+        let toml = format!(
+            r#"
+[models.test-model]
+provider = "test"
+model_id = "test-model"
+display_name = "Test"
+input_cost_per_million = {cost_per_million}
+output_cost_per_million = {cost_per_million}
+context_window = 4096
+supports_streaming = false
+supports_tools = false
+supports_vision = false
+"#
+        );
+        solvela_router::models::ModelRegistry::from_toml(&toml).expect("valid test registry TOML")
+        // safe: known-good template
+    }
+
+    fn simple_req() -> ChatRequest {
+        make_request("test-model", vec![user_msg("hello")])
+    }
+
+    #[test]
+    fn test_estimated_atomic_cost_valid_small_amount() {
+        let reg = registry_with_cost(1.0); // $1 per million tokens
+        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
+        assert!(result.is_ok(), "valid cost should succeed, got: {result:?}");
+        assert!(result.unwrap() > 0, "valid cost should be positive");
+    }
+
+    #[test]
+    fn test_estimated_atomic_cost_rejects_nan() {
+        let reg = registry_with_cost(f64::NAN);
+        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
+        // NaN cost_per_million propagates to a NaN total; estimated_atomic_cost
+        // must reject it rather than silently cast NaN→0.
+        match result {
+            Err(e) => assert!(
+                e.contains("non-finite") || e.contains("NaN") || e.contains("failed"),
+                "error should mention non-finite or NaN, got: {e}"
+            ),
+            Ok(v) => panic!("NaN cost must not produce Ok({v})"),
+        }
+    }
+
+    #[test]
+    fn test_estimated_atomic_cost_rejects_positive_infinity() {
+        let reg = registry_with_cost(f64::INFINITY);
+        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
+        match result {
+            Err(e) => assert!(
+                e.contains("non-finite") || e.contains("inf") || e.contains("failed"),
+                "error should mention non-finite or infinity, got: {e}"
+            ),
+            Ok(v) => panic!("INFINITY cost must not produce Ok({v})"),
+        }
+    }
+
+    #[test]
+    fn test_estimated_atomic_cost_rejects_negative_infinity() {
+        let reg = registry_with_cost(f64::NEG_INFINITY);
+        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
+        match result {
+            Err(_) => {} // expected — non-finite or negative check
+            Ok(v) => panic!("-INFINITY cost must not produce Ok({v})"),
+        }
+    }
+
+    #[test]
+    fn test_estimated_atomic_cost_rejects_overflow() {
+        // u64::MAX / 1_000_000 ≈ 1.844e13; anything larger overflows on ×1e6
+        let huge_cost = (u64::MAX / 1_000_000) as f64 * 2.0;
+        let reg = registry_with_cost(huge_cost);
+        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
+        match result {
+            Err(e) => assert!(
+                e.contains("overflow") || e.contains("range") || e.contains("failed"),
+                "error should mention overflow, got: {e}"
+            ),
+            Ok(v) => panic!("overflowing cost must not produce Ok({v})"),
+        }
+    }
+
+    #[test]
+    fn test_estimated_atomic_cost_unknown_model_returns_err() {
+        let reg = registry_with_cost(1.0);
+        let req = make_request("unknown-model", vec![user_msg("hello")]);
+        let result = estimated_atomic_cost(&reg, "unknown-model", &req);
+        assert!(
+            result.is_err(),
+            "unknown model must return Err, got: {result:?}"
+        );
     }
 }

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -396,17 +396,44 @@ mod tests {
     // estimated_atomic_cost — GHSA-86cr-h3rx-vj6j input-validation guards
     // =========================================================================
 
+    /// Format an `f64` as a TOML float literal.
+    ///
+    /// TOML 1.0 spec accepts only lowercase `nan`, `inf`, `+inf`, `-inf` for
+    /// special floats; Rust's `Display` impl prints `NaN` and `inf`. We map
+    /// non-finite values to their TOML-compatible spellings so the registry
+    /// loader can round-trip `f64::NAN` / `f64::INFINITY` for these tests.
+    fn format_f64_for_toml(v: f64) -> String {
+        if v.is_nan() {
+            "nan".to_string()
+        } else if v.is_infinite() {
+            if v.is_sign_positive() {
+                "inf".to_string()
+            } else {
+                "-inf".to_string()
+            }
+        } else if v.abs() < 1e15 {
+            // Finite values in moderate range: emit with one decimal so TOML
+            // always parses as float (bare `1` would deserialize as integer).
+            format!("{v:.1}")
+        } else {
+            // Scientific notation handles very large/small magnitudes (e.g. 1e18
+            // for the overflow test) without precision loss.
+            format!("{v:e}")
+        }
+    }
+
     /// Build a minimal `ModelRegistry` with a single model whose cost fields
     /// are set to `cost_per_million` USDC, for use in estimated_atomic_cost tests.
     fn registry_with_cost(cost_per_million: f64) -> solvela_router::models::ModelRegistry {
+        let cost_str = format_f64_for_toml(cost_per_million);
         let toml = format!(
             r#"
 [models.test-model]
 provider = "test"
 model_id = "test-model"
 display_name = "Test"
-input_cost_per_million = {cost_per_million}
-output_cost_per_million = {cost_per_million}
+input_cost_per_million = {cost_str}
+output_cost_per_million = {cost_str}
 context_window = 4096
 supports_streaming = false
 supports_tools = false
@@ -469,14 +496,18 @@ supports_vision = false
 
     #[test]
     fn test_estimated_atomic_cost_rejects_overflow() {
-        // u64::MAX / 1_000_000 ≈ 1.844e13; anything larger overflows on ×1e6
-        let huge_cost = (u64::MAX / 1_000_000) as f64 * 2.0;
+        // ESTIMATED_COST_MAX_USDC = u64::MAX / 1e6 ≈ 1.844e13 USDC. The estimate
+        // is (input/1e6 + output/1e6) * cost_per_million * PLATFORM_FEE_MULTIPLIER,
+        // which for simple_req() (~1 input token, 1000 output tokens) reduces to
+        // roughly cost_per_million * 1.05e-3. Use 1e18 so the resulting total
+        // (~1.05e15 USDC) exceeds the cap but stays finite.
+        let huge_cost = 1.0e18_f64;
         let reg = registry_with_cost(huge_cost);
         let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
         match result {
             Err(e) => assert!(
-                e.contains("overflow") || e.contains("range") || e.contains("failed"),
-                "error should mention overflow, got: {e}"
+                e.contains("overflow") || e.contains("range") || e.contains("exceeds"),
+                "error should mention overflow/range, got: {e}"
             ),
             Ok(v) => panic!("overflowing cost must not produce Ok({v})"),
         }

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -540,6 +540,22 @@ pub async fn chat_completions(
         .parse::<f64>()
         .map_err(|_| GatewayError::Internal("failed to parse estimated cost as f64".to_string()))?;
 
+    // GHSA-86cr-h3rx-vj6j: budget-enforcement guard. A corrupted model registry
+    // entry can produce NaN or ±Infinity in the cost total. NaN parses back to
+    // f64::NAN successfully, then every comparison in `check_budget` against
+    // wallet limits is `false` — silently bypassing the budget gate. Reject
+    // non-finite or negative values here, fail-closed, before the gate runs.
+    if !estimated_cost.is_finite() || estimated_cost < 0.0 {
+        warn!(
+            estimated_cost,
+            model = %req.model,
+            "model registry produced a non-finite or negative cost; refusing"
+        );
+        return Err(GatewayError::Internal(
+            "estimated cost is not a valid finite non-negative number".to_string(),
+        ));
+    }
+
     if let Err(e) = state
         .usage
         .check_budget(&wallet_address, estimated_cost)

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -598,8 +598,9 @@ pub async fn chat_completions(
             } else {
                 Some(
                     estimated_atomic_cost(&state.model_registry, &req.model, &req)
-                        .unwrap_or_else(|| {
+                        .unwrap_or_else(|e| {
                             warn!(
+                                error = %e,
                                 model = %req.model,
                                 "cost estimation failed for streaming request — using minimum claim amount (1 atomic unit)"
                             );

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -9,6 +9,12 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 
 /// Default daily limit when no per-wallet budget row exists.
+///
+/// TODO(GHSA-86cr-h3rx-vj6j): migrate budget limits and spend counters from f64
+/// USDC to integer atomic units (u64, 6 decimal places) throughout this module
+/// and the Redis INCRBYFLOAT paths below.  This is the broader refactor deferred
+/// from the GHSA-86cr-h3rx-vj6j advisory; the immediate input-validation fix for
+/// `estimated_atomic_cost` is in `routes/chat/cost.rs`.
 const DEFAULT_DAILY_LIMIT_USDC: f64 = 100.0;
 
 /// TTL for cached wallet budget config in Redis (seconds).


### PR DESCRIPTION
## Security advisory

Partial fix for [GHSA-86cr-h3rx-vj6j](https://github.com/solvela-ai/solvela/security/advisories/GHSA-86cr-h3rx-vj6j) — **HIGH**: f64 USDC cost arithmetic can produce 0, silently under-claiming from escrow.

## Problem

`estimated_atomic_cost` in `routes/chat/cost.rs` parsed the model registry's cost as f64 and cast it to u64 without any range checks:

```rust
Ok(f) => Some((f * 1_000_000.0) as u64)
```

Three silent failure modes exist in Rust's f64→u64 cast:

| Input | `(f * 1e6) as u64` result | Impact |
|-------|--------------------------|--------|
| `NaN` | `0` | Escrow claim amount = 0 → claim silently skipped |
| `+∞` / `−∞` | `0` or `u64::MAX` | Claim = 0 (skipped) or garbage huge value (on-chain rejection) |
| Very large value (> `u64::MAX / 1_000_000`) | wraps / saturates | Claim underflows → gateway under-charges |

The `Option<u64>` return type additionally allowed callers to silently skip the budget check by treating `None` as "no cost estimate available."

## What's changed

**`routes/chat/cost.rs`**:
- Return type `Option<u64>` → `Result<u64, String>` (fail-closed: callers must handle the error)
- Three guards before the cast:
  1. `!f.is_finite()` → `Err(...)` (NaN / ±∞)
  2. `f < 0.0` → `Err(...)` (negative USDC is invalid)
  3. `f > ESTIMATED_COST_MAX_USDC` → `Err(...)` where `ESTIMATED_COST_MAX_USDC = (u64::MAX / 1_000_000) as f64 ≈ $18.4T` (overflow guard)
- Add `ESTIMATED_COST_MAX_USDC` constant with a `TODO(GHSA-86cr-h3rx-vj6j)` comment pointing at the broader refactor

**`routes/chat/mod.rs`**:
- Update the one caller to `unwrap_or_else(|e| { warn!(error = %e, ...); 1 })` — logs the specific error string and falls back to 1 atomic unit minimum claim (same semantic as before, now with error visibility)

**`usage.rs`**:
- Add `TODO(GHSA-86cr-h3rx-vj6j)` comment on `DEFAULT_DAILY_LIMIT_USDC` marking the broader integer-migration work that is **out of scope** for this PR

**`lib.rs`, `rate_limit.rs`, `payment.rs`, `proxy.rs`** (commit 1):
- Fix four post-rename typos `middleware::solvela_x402` → `middleware::x402` that were breaking compilation on `main` (the `refactor(x402): rename crate to solvela-x402` commit incorrectly updated the internal middleware path, not just the external crate reference)

## Tests added

All in `routes/chat/cost.rs`:

| Test | Asserts |
|------|---------|
| `test_estimated_atomic_cost_valid_small_amount` | Valid registry entry returns `Ok(n > 0)` |
| `test_estimated_atomic_cost_rejects_nan` | `NaN` cost returns `Err(...)`, not `Ok(0)` |
| `test_estimated_atomic_cost_rejects_positive_infinity` | `+∞` returns `Err(...)` |
| `test_estimated_atomic_cost_rejects_negative_infinity` | `−∞` returns `Err(...)` |
| `test_estimated_atomic_cost_rejects_overflow` | `> u64::MAX / 1e6` returns `Err(...)` |
| `test_estimated_atomic_cost_unknown_model_returns_err` | Unknown model returns `Err(...)` |

## Scope — what's explicitly deferred

The full migration tracked by GHSA-86cr-h3rx-vj6j involves:
- `BudgetConfig` and `TeamBudgetConfig` fields (`f64`) → integer atomic units
- `check_budget` spend comparison → atomic integer comparison
- Redis `INCRBYFLOAT` counters → `INCRBY` with integer atomic values
- `DEFAULT_DAILY_LIMIT_USDC` → atomic constant

**None of the above are in this PR.** The `TODO(GHSA-86cr-h3rx-vj6j)` markers in the code track exactly where changes are needed.

---

> **Draft — awaiting human review of the fail-closed design and scope boundary before CI/review.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGgUcTqP1Vury9DZUSt6Ks)_