### PR TITLE
chore(deps): bump sha2 0.11, hmac 0.13, prometheus 0.18, rand 0.10, getrandom 0.4, secrecy 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio",
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 metrics = "0.24"
-metrics-exporter-prometheus = "0.16"
+metrics-exporter-prometheus = "0.18"
 
 # Utilities
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
-sha2 = "0.10"
-hmac = "0.12"
+sha2 = "0.11"
+hmac = "0.13"
 futures = "0.3"
 
 # CLI

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,9 +34,9 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tempfile = "3"
 url = { workspace = true }
-getrandom = { version = "0.2", features = ["std"] }
+getrandom = { version = "0.4", features = ["std"] }
 hdrhistogram = "7"
-secrecy = "0.8"
+secrecy = "0.10"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -34,7 +34,7 @@ fn generate_service_id(request_body: &[u8]) -> Result<[u8; 32]> {
     let mut hasher = Sha256::new();
     hasher.update(request_body);
     let mut nonce = [0u8; 8];
-    getrandom::getrandom(&mut nonce).context("getrandom failed to generate nonce")?;
+    getrandom::fill(&mut nonce).context("getrandom failed to generate nonce")?;
     hasher.update(nonce);
     let hash = hasher.finalize();
     let mut id = [0u8; 32];

--- a/crates/cli/src/commands/loadtest/dispatcher.rs
+++ b/crates/cli/src/commands/loadtest/dispatcher.rs
@@ -35,7 +35,7 @@ fn select_tier(weights: &TierWeights) -> &'static str {
 /// Generate a single random byte via `getrandom`.
 fn rand_u8() -> u8 {
     let mut buf = [0u8; 1];
-    getrandom::getrandom(&mut buf).unwrap_or_default();
+    getrandom::fill(&mut buf).unwrap_or_default();
     buf[0]
 }
 

--- a/crates/cli/src/commands/loadtest/mod.rs
+++ b/crates/cli/src/commands/loadtest/mod.rs
@@ -185,7 +185,7 @@ pub async fn run(api_url: &str, args: LoadTestArgs) -> Result<()> {
                 .timeout(Duration::from_secs(10))
                 .build()?;
             Arc::new(ExactPaymentStrategy::new(
-                SecretString::new(keypair_b58),
+                SecretString::new(keypair_b58.into_boxed_str()),
                 rpc_client,
             ))
         }
@@ -200,7 +200,7 @@ pub async fn run(api_url: &str, args: LoadTestArgs) -> Result<()> {
                 .timeout(Duration::from_secs(10))
                 .build()?;
             Arc::new(EscrowPaymentStrategy::new(
-                SecretString::new(keypair_b58),
+                SecretString::new(keypair_b58.into_boxed_str()),
                 rpc_client,
                 rpc_url.clone(),
             ))

--- a/crates/cli/src/commands/loadtest/payment.rs
+++ b/crates/cli/src/commands/loadtest/payment.rs
@@ -154,7 +154,7 @@ fn generate_service_id(request_body: &[u8]) -> Result<[u8; 32]> {
     let mut hasher = Sha256::new();
     hasher.update(request_body);
     let mut nonce = [0u8; 8];
-    getrandom::getrandom(&mut nonce).context("getrandom failed to generate nonce")?;
+    getrandom::fill(&mut nonce).context("getrandom failed to generate nonce")?;
     hasher.update(nonce);
     let hash = hasher.finalize();
     let mut id = [0u8; 32];
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn test_exact_payment_debug_redacts_keypair() {
         let strategy = ExactPaymentStrategy::new(
-            SecretString::new("super-secret-keypair".to_string()),
+            SecretString::from("super-secret-keypair"),
             reqwest::Client::new(),
         );
         let debug_output = format!("{:?}", strategy);
@@ -341,15 +341,13 @@ mod tests {
 
     #[test]
     fn test_exact_payment_name() {
-        let strategy =
-            ExactPaymentStrategy::new(SecretString::new("key".to_string()), reqwest::Client::new());
+        let strategy = ExactPaymentStrategy::new(SecretString::from("key"), reqwest::Client::new());
         assert_eq!(strategy.name(), "exact");
     }
 
     #[tokio::test]
     async fn test_exact_payment_no_exact_scheme_returns_error() {
-        let strategy =
-            ExactPaymentStrategy::new(SecretString::new("key".to_string()), reqwest::Client::new());
+        let strategy = ExactPaymentStrategy::new(SecretString::from("key"), reqwest::Client::new());
         // Provide only an escrow accept — no exact scheme available.
         let accepts = vec![PaymentAccept {
             scheme: "escrow".to_string(),
@@ -403,8 +401,10 @@ mod tests {
         full_key[32..].copy_from_slice(verifying_key.as_bytes());
         let keypair_b58 = bs58::encode(&full_key).into_string();
 
-        let strategy =
-            ExactPaymentStrategy::new(SecretString::new(keypair_b58), reqwest::Client::new());
+        let strategy = ExactPaymentStrategy::new(
+            SecretString::new(keypair_b58.into_boxed_str()),
+            reqwest::Client::new(),
+        );
 
         let accepts = vec![PaymentAccept {
             scheme: "exact".to_string(),
@@ -467,7 +467,7 @@ mod tests {
     #[test]
     fn test_escrow_payment_name() {
         let strategy = EscrowPaymentStrategy::new(
-            SecretString::new("key".to_string()),
+            SecretString::from("key"),
             reqwest::Client::new(),
             "http://localhost:8899".to_string(),
         );
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn test_escrow_payment_debug_redacts_keypair() {
         let strategy = EscrowPaymentStrategy::new(
-            SecretString::new("super-secret-escrow-key".to_string()),
+            SecretString::from("super-secret-escrow-key"),
             reqwest::Client::new(),
             "http://localhost:8899".to_string(),
         );
@@ -499,7 +499,7 @@ mod tests {
     #[tokio::test]
     async fn test_escrow_payment_no_escrow_scheme_returns_error() {
         let strategy = EscrowPaymentStrategy::new(
-            SecretString::new("key".to_string()),
+            SecretString::from("key"),
             reqwest::Client::new(),
             "http://localhost:8899".to_string(),
         );
@@ -528,7 +528,7 @@ mod tests {
     #[tokio::test]
     async fn test_escrow_payment_missing_program_id_returns_error() {
         let strategy = EscrowPaymentStrategy::new(
-            SecretString::new("key".to_string()),
+            SecretString::from("key"),
             reqwest::Client::new(),
             "http://localhost:8899".to_string(),
         );
@@ -629,7 +629,7 @@ mod tests {
         let keypair_b58 = make_test_keypair_b58();
 
         let strategy = EscrowPaymentStrategy::new(
-            SecretString::new(keypair_b58.clone()),
+            SecretString::new(keypair_b58.clone().into_boxed_str()),
             reqwest::Client::new(),
             mock_rpc.uri(),
         );

--- a/crates/cli/src/commands/wallet.rs
+++ b/crates/cli/src/commands/wallet.rs
@@ -31,7 +31,7 @@ pub async fn init() -> Result<()> {
     // for signature verification. The 32-byte secret scalar is the private key;
     // the corresponding 32-byte verifying key is the Solana public key.
     let mut seed = [0u8; 32];
-    getrandom::getrandom(&mut seed).context("failed to generate random seed")?;
+    getrandom::fill(&mut seed).context("failed to generate random seed")?;
 
     let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
     let verifying_key = signing_key.verifying_key();

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -43,7 +43,7 @@ sha2 = { workspace = true }
 hmac = { workspace = true }
 lru = { workspace = true }
 hex = "0.4"
-rand = "0.9"
+rand = "0.10"
 
 # Utilities
 uuid = { workspace = true }

--- a/crates/gateway/src/cache.rs
+++ b/crates/gateway/src/cache.rs
@@ -104,7 +104,7 @@ impl ResponseCache {
             hasher.update(temp.to_le_bytes());
         }
         let hash = hasher.finalize();
-        format!("rcr:cache:{:x}", hash)
+        format!("rcr:cache:{}", hex::encode(hash))
     }
 
     /// Try to get a cached response.

--- a/crates/gateway/src/orgs/queries.rs
+++ b/crates/gateway/src/orgs/queries.rs
@@ -1,5 +1,4 @@
 use chrono::Utc;
-use rand::Rng;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -14,8 +13,7 @@ const KEY_PREFIX_LEN: usize = 14;
 
 /// Generate a new API key: "solvela_k_" + 32 random hex chars.
 pub fn generate_api_key() -> String {
-    let mut rng = rand::rng();
-    let bytes: [u8; 16] = rng.random();
+    let bytes: [u8; 16] = rand::random();
     format!("solvela_k_{}", hex::encode(bytes))
 }
 

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -6,7 +6,7 @@
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::time::{SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
## Summary

- Bumps `sha2` 0.10 → 0.11, `hmac` 0.12 → 0.13 (workspace)
- Bumps `metrics-exporter-prometheus` 0.16 → 0.18 (workspace)
- Bumps `rand` 0.9 → 0.10 (gateway)
- Bumps `getrandom` 0.2 → 0.4 (cli)
- Bumps `secrecy` 0.8 → 0.10 (cli)

Replaces PR #83, which could not be merged due to conflicts with 9 dependabot PRs that landed on `main` after the original branch was created. This branch is a clean rebase from current `main` with only the version bumps and the minimal source API fixes they require — no test refactoring included.

**Source API fixes required by new versions:**
- `hmac 0.13`: add `KeyInit` to import in `session.rs`
- `sha2 0.11`: `Array<u8,N>` no longer implements `LowerHex` — replaced `format!("{:x}", hash)` with `hex::encode(hash)` in `cache.rs`
- `getrandom 0.4`: `getrandom::getrandom()` renamed to `getrandom::fill()` — updated in `chat.rs`, `wallet.rs`, `loadtest/dispatcher.rs`, `loadtest/payment.rs`
- `secrecy 0.10`: `SecretString::new` now takes `Box<str>` — updated call sites to use `.into_boxed_str()` or `SecretString::from()` for string literals

## Test plan

- [ ] CI Rust build passes (`cargo build` and `cargo test` across workspace)
- [ ] No regressions in gateway, cli, x402, router, protocol crates
- [ ] Session token create/verify tests pass (hmac change)
- [ ] Cache key generation tests pass (sha2 change)
- [ ] getrandom usage in wallet init, chat, and loadtest compiles and passes tests
- [ ] SecretString construction in loadtest payment strategies works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)