### PR TITLE
security: fix A2A replay TTL, HSTS emission, nonce-pool warning (#66, #70, #71)

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -320,13 +320,37 @@ async fn handle_payment_submitted(
                     data: None,
                 });
             }
-            // In-memory replay check via std::sync::Mutex + LRU
+            // In-memory replay check via std::sync::Mutex + LRU with TTL.
+            //
+            // GHSA-wc9q-wc6q-gwmq: recover from poisoned lock instead of panicking.
             let mut set = state
                 .replay_set
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            set.put(tx_raw.to_string(), std::time::Instant::now())
-                .is_some()
+            let now = std::time::Instant::now();
+            let found = match set.get(tx_raw) {
+                Some(&inserted_at)
+                    if now.duration_since(inserted_at) < crate::AppState::REPLAY_TTL =>
+                {
+                    true
+                }
+                Some(_) => {
+                    // Entry expired — remove and treat as not found
+                    set.pop(tx_raw);
+                    false
+                }
+                None => false,
+            };
+            if found {
+                true
+            } else {
+                set.put(tx_raw.to_string(), now);
+                warn!(
+                    tx = %tx_raw,
+                    "A2A payment accepted under degraded in-memory replay protection (no Redis)"
+                );
+                false
+            }
         };
 
         if replay_detected {

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -247,20 +247,17 @@ pub fn build_router(state: Arc<AppState>, rate_limiter: RateLimiter) -> Router {
             HeaderValue::from_static("default-src 'none'"),
         ))
         .layer({
-            // Only add HSTS in production to avoid issues with local dev (HTTP).
+            // Only add HSTS in production — omit the layer entirely in non-prod
+            // environments so the header is never emitted (not even as an empty value).
             // SOLVELA_ENV is canonical; RCR_ENV is accepted as a deprecated fallback.
             let env_value = std::env::var("SOLVELA_ENV").or_else(|_| std::env::var("RCR_ENV"));
             let is_prod = matches!(env_value.as_deref(), Ok("production") | Ok("prod"));
-            SetResponseHeaderLayer::if_not_present(
-                HeaderName::from_static("strict-transport-security"),
-                if is_prod {
-                    HeaderValue::from_static("max-age=31536000; includeSubDomains")
-                } else {
-                    // Empty value — Tower's if_not_present still sets the header,
-                    // so we skip via a no-op value that browsers ignore.
-                    HeaderValue::from_static("")
-                },
-            )
+            tower::util::option_layer(is_prod.then(|| {
+                SetResponseHeaderLayer::if_not_present(
+                    HeaderName::from_static("strict-transport-security"),
+                    HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+                )
+            }))
         })
         // Request ID
         .layer(RequestIdLayer)

--- a/crates/x402/src/solana.rs
+++ b/crates/x402/src/solana.rs
@@ -419,7 +419,8 @@ impl PaymentVerifier for SolanaVerifier {
                 "detected durable nonce transaction — skipping blockhash recency check"
             );
 
-            // If a nonce pool is configured, verify the nonce account is registered
+            // If a nonce pool is configured, verify the nonce account is registered.
+            // If not configured, warn operators and accept any client-supplied nonce account.
             if let Some(pool) = &self.nonce_pool {
                 let nonce_account_b58 = nonce_account.to_string();
                 let is_known = pool
@@ -430,6 +431,12 @@ impl PaymentVerifier for SolanaVerifier {
                         "nonce account {nonce_account_b58} is not registered in the gateway nonce pool"
                     )));
                 }
+            } else {
+                tracing::warn!(
+                    nonce_account = %nonce_account,
+                    "nonce_pool not configured — skipping nonce-account validation; \
+                     any client-supplied nonce account is accepted"
+                );
             }
 
             // Simulate WITHOUT replacing the blockhash (nonce tx must keep its nonce value)


### PR DESCRIPTION
## Summary

Three security hardening fixes identified in issues #66, #70, and #71:

- **#66 A2A replay check enforces TTL**: The in-memory LRU path in `a2a/handler.rs` was calling `set.put()` and treating any `Some(old_value)` as a replay without checking whether the entry was still within the 120-second window. A legitimate re-use after TTL expiry was incorrectly rejected. Now mirrors the TTL-gated pattern from `routes/chat/mod.rs` using `AppState::REPLAY_TTL`, with explicit eviction of stale entries.

- **#70 HSTS layer omitted in non-prod**: `SetResponseHeaderLayer::if_not_present` with an empty `HeaderValue` still emits the header (Tower sets it regardless of value). Replaced with `tower::util::option_layer` so the HSTS middleware is simply absent in non-production environments — no header is ever emitted.

- **#71 Nonce pool absence logged**: When `self.nonce_pool` is `None` and a durable-nonce payment is processed, a `tracing::warn!` is now emitted including the nonce account pubkey, so operators know they are running without nonce-account validation.

Fixes #66
Fixes #70
Fixes #71

## Test plan

- [ ] `cargo test -p gateway` — existing replay tests pass; no regressions
- [ ] `cargo test -p x402` — nonce verification tests pass
- [ ] CI build passes (Cargo is not installed locally — CI is the verification gate)
- [ ] In production (`SOLVELA_ENV=production`) the `Strict-Transport-Security` response header is present
- [ ] In development (`SOLVELA_ENV=development` or unset) the `Strict-Transport-Security` header is absent (not present as empty string)
- [ ] When nonce_pool is None and a durable-nonce tx is processed, `WARN nonce_pool not configured` appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)