### PR TITLE
fix(gateway): atomic Redis incr+expire and solvela: key prefix rebrand

### DIFF
--- a/crates/gateway/src/cache.rs
+++ b/crates/gateway/src/cache.rs
@@ -14,6 +14,16 @@ use tracing::{info, warn};
 
 use solvela_protocol::{ChatRequest, ChatResponse};
 
+/// Redis key prefix for response cache entries.
+///
+/// Centralised here so a rename never requires hunting down inline literals.
+/// Replacing the legacy `rcr:` prefix completes the Solvela rebrand in the
+/// Redis keyspace; existing `rcr:` keys will expire naturally — no dual-write.
+const CACHE_KEY_PREFIX: &str = "solvela:cache:";
+
+/// Redis key prefix for transaction replay-protection entries.
+const REPLAY_KEY_PREFIX: &str = "solvela:txn:";
+
 /// Cache configuration.
 #[derive(Debug, Clone)]
 pub struct CacheConfig {
@@ -104,7 +114,7 @@ impl ResponseCache {
             hasher.update(temp.to_le_bytes());
         }
         let hash = hasher.finalize();
-        format!("rcr:cache:{}", hex::encode(hash))
+        format!("{}{}", CACHE_KEY_PREFIX, hex::encode(hash))
     }
 
     /// Try to get a cached response.
@@ -212,7 +222,7 @@ impl ResponseCache {
             120
         };
 
-        let key = format!("rcr:txn:{}", tx_signature);
+        let key = format!("{}{}", REPLAY_KEY_PREFIX, tx_signature);
 
         match self.client.get_multiplexed_async_connection().await {
             Ok(mut conn) => {
@@ -404,7 +414,7 @@ mod tests {
         let key1 = ResponseCache::cache_key(&req);
         let key2 = ResponseCache::cache_key(&req);
         assert_eq!(key1, key2);
-        assert!(key1.starts_with("rcr:cache:"));
+        assert!(key1.starts_with("solvela:cache:"));
     }
 
     #[test]

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -488,29 +488,30 @@ impl UsageTracker {
 // Redis + DB helper functions for budget enforcement
 // ---------------------------------------------------------------------------
 
-/// Increment a Redis key by `amount` and set its TTL. Fire-and-forget style
-/// (logs warnings on failure, never panics).
+/// Increment a Redis key by `amount` and set its TTL atomically.
+///
+/// Both commands are sent in a single pipelined round-trip via `MULTI/EXEC`,
+/// so a process crash between the two commands can never leave a spend key
+/// without a TTL (which would otherwise permanently block future requests).
 async fn incr_and_expire(
     conn: &mut redis::aio::MultiplexedConnection,
     key: &str,
     amount: f64,
     ttl_secs: u64,
 ) {
-    if let Err(e) = redis::cmd("INCRBYFLOAT")
+    let result: Result<(), redis::RedisError> = redis::pipe()
+        .atomic()
+        .cmd("INCRBYFLOAT")
         .arg(key)
         .arg(amount)
-        .query_async::<()>(conn)
-        .await
-    {
-        warn!(error = %e, key = %key, "failed to INCRBYFLOAT in Redis");
-    }
-    if let Err(e) = redis::cmd("EXPIRE")
+        .cmd("EXPIRE")
         .arg(key)
         .arg(ttl_secs)
-        .query_async::<()>(conn)
-        .await
-    {
-        warn!(error = %e, key = %key, "failed to set TTL in Redis");
+        .query_async(conn)
+        .await;
+
+    if let Err(e) = result {
+        warn!(error = %e, key = %key, "failed to atomically INCRBYFLOAT+EXPIRE in Redis");
     }
 }
 


### PR DESCRIPTION
## Summary

- **Fixes #67** — `incr_and_expire` in `crates/gateway/src/usage.rs` issued `INCRBYFLOAT` and `EXPIRE` as two separate commands. A process crash between them left spend keys with no TTL, which permanently blocked future budget checks for affected wallets. Fixed by replacing both commands with `redis::pipe().atomic()` (MULTI/EXEC), making the increment+TTL-set an atomic operation in a single round-trip.

- **Fixes #69** — Response-cache and replay-protection Redis keys in `crates/gateway/src/cache.rs` still used the legacy `rcr:` prefix post-rebrand. Added two named constants (`CACHE_KEY_PREFIX = "solvela:cache:"` and `REPLAY_KEY_PREFIX = "solvela:txn:"`) at the top of the file and updated both `format!` callsites. Existing `rcr:` keys will expire naturally — no dual-write needed. Updated the unit test assertion to match the new prefix.

## Files changed

| File | Issue | Change |
|---|---|---|
| `crates/gateway/src/usage.rs` | #67 | `incr_and_expire` now uses `redis::pipe().atomic()` |
| `crates/gateway/src/cache.rs` | #69 | Two constants replace inline `"rcr:"` literals; test updated |

## Test plan

- [ ] `cargo test -p gateway --lib` passes (covers `test_cache_key_deterministic` which asserts the new `solvela:cache:` prefix)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] CI build and test suite green

## Notes

- No dual-write for the key prefix change — this is a one-time cold-start on the Redis keyspace. Old `rcr:` keys expire naturally (10 min TTL for cache, 120 s / 24 h for replay entries).
- The `incr_and_expire` change does NOT alter semantics — it only makes the two-command sequence crash-safe.