### PR TITLE
docs(gateway): document wallet-agnostic cache key design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Next.js 16 + Tailwind + Recharts. Pages: Overview, Usage, Models, Wallet, Settin
 13. **API key auth uses extractor pattern** — `RequireOrg` and `RequireOrgAdmin` are Axum extractors that populate `OrgContext`; org-scoped routes extract `OrgContext` from request extensions, never from query params or body
 14. **A2A is a protocol adapter, not new payment logic** — translates A2A JSON-RPC to existing x402 + chat pipeline. No fiat, no AP2 mandates, no card processing.
 15. **Migration failure is fatal when a DB is configured** — if `DATABASE_URL` is set and `sqlx::migrate!` fails during startup, `run_migrations()` propagates the error and `main()` exits non-zero. Do not reintroduce a `warn!` + continue pattern: serving traffic against a broken schema produces silent query errors on every org/audit/budget path. Graceful degradation only applies when `DATABASE_URL` is unset entirely.
+16. **Response cache is wallet-agnostic** — cache keys hash `(model, messages, temperature)` only; two wallets with identical prompts share a cached response. Both pay the gateway fee; upstream LLM is charged once. See `crates/gateway/src/cache.rs` module docs. If per-wallet isolation is needed, add payer address to the cache key.
 
 ## Request Flow (POST /v1/chat/completions)
 

--- a/crates/gateway/src/cache.rs
+++ b/crates/gateway/src/cache.rs
@@ -3,6 +3,18 @@
 //! Tier 1: Exact match — SHA256(model + messages + temperature) → Redis
 //! TTL: 10min default, configurable per model.
 //! Expected hit rate: 15–30%.
+//!
+//! # Cache key design
+//! Cache keys are keyed on `SHA-256(model ‖ serialised_messages ‖ temperature)` —
+//! deliberately **wallet-agnostic**. A response cached for wallet A will be returned
+//! to wallet B if the prompt is identical. Both wallets pay the gateway's 402 fee
+//! (payment verification runs before the cache check), but the upstream LLM is only
+//! charged once. This is an intentional design trade-off: prompt deduplication lowers
+//! upstream costs and improves margin. The trade-off is that wallet B receives wallet
+//! A's response without the gateway incurring a new upstream cost.
+//!
+//! If per-wallet response isolation is ever required, the cache key must include the
+//! payer wallet address.
 
 use std::num::NonZeroUsize;
 use std::sync::Mutex;


### PR DESCRIPTION
Closes #73

Adds a module-level doc comment to `cache.rs` explaining the deliberate wallet-agnostic cache key design and its trade-offs. Adds rule 16 to CLAUDE.md Key Architectural Rules for the same.

Docs-only — no source code changes.