### PR TITLE
fix(license): make BUSL-1.1 detectable by GitHub's licensee classifier

### DIFF
--- a/.github/licensee.yml
+++ b/.github/licensee.yml
@@ -1,0 +1,13 @@
+# Hint file for GitHub's licensee gem (https://github.com/licensee/licensee).
+#
+# The Solvela monorepo is governed by Business Source License 1.1 at the root.
+# Per-component licensing is documented in README.md (LICENSING section):
+#   - gateway crate / solvela-gateway binary: BUSL-1.1 (this LICENSE)
+#   - protocol, x402, router, cli crates:     Apache-2.0 (LICENSE-APACHE)
+#   - SDK repos (solvela-python/-ts/-go):     MIT (separate repos)
+#
+# This file exists because our LICENSE includes an expanded Additional Use
+# Grant (SaaS restriction + $1M revenue cap), which can cause licensee's
+# similarity matcher to fall back to "NOASSERTION". The SPDX header at the
+# top of LICENSE plus this hint should make detection deterministic.
+expose: BUSL-1.1

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: BUSL-1.1
+
 Business Source License 1.1
 
 Parameters
@@ -53,7 +55,11 @@ You must conspicuously display this License on each original or modified copy of
 
 Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
 
-This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE. MariaDB hereby grants you permission to use this License’s text to license your works, and to refer to it using the trademark “Business Source License”, as long as you comply with the Covenants of Licensor below.
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license your works, and to refer to it using the trademark “Business Source License”, as long as you comply with the Covenants of Licensor below.
 
 Covenants of Licensor
 In consideration of the right to use this License’s text and the “Business Source License” name and trademark, Licensor covenants to MariaDB, and to all other recipients of the licensed work to be provided by Licensor:


### PR DESCRIPTION
## Summary

After #94 landed the relicense, GitHub's repo sidebar shows **License: Other** (NOASSERTION) instead of **Business Source License 1.1**. Three small, legally-neutral changes restore deterministic detection.

## Diagnosis

GitHub uses the [`licensee`](https://github.com/licensee/licensee) gem, which classifies via:
1. **SPDX identifier match** (a header like `SPDX-License-Identifier: BUSL-1.1`)
2. **Filename + similarity match** against [SPDX templates](https://github.com/spdx/license-list-XML)

Our LICENSE failed both:
- No SPDX header
- Line 56 joined the trademark sentence and the warranty disclaimer into one ~600-char paragraph (`License).TO THE EXTENT PERMITTED BY...`). The SPDX BUSL-1.1 template keeps these as separate paragraphs; `licensee`'s similarity scorer is paragraph-structure sensitive, so the score dropped below the detection threshold.

## Changes

1. **`LICENSE` line 1** — Add `SPDX-License-Identifier: BUSL-1.1` as the first line. Canonical hint, takes priority over similarity matching.

2. **`LICENSE` line ~56** — Restore the paragraph break between the trademark sentence and the `TO THE EXTENT PERMITTED BY APPLICABLE LAW...` disclaimer (and another break before the MariaDB permission sentence). Aligns with the canonical SPDX template fingerprint.

3. **`.github/licensee.yml` (new)** — `expose: BUSL-1.1`. Belt-and-suspenders so even if the similarity scorer still wavers because of our expanded Additional Use Grant (SaaS restriction + USD \$1M cap), GitHub knows which SPDX identifier to display.

## Legal force

**Unchanged.** This is purely a classifier-detection fix. The Licensor, Licensed Work, Additional Use Grant, Change Date, Change License, Terms, Notice, and Covenants of Licensor sections are all bit-identical. Diff is whitespace + one new line at the top + a new YAML hint file.

## Verification plan

- [ ] CI green (fmt, clippy, test, smoke, security audit, docker build, vercel preview)
- [ ] After merge, refresh `https://github.com/solvela-ai/solvela` and confirm sidebar reads **Business Source License 1.1**
- [ ] If still "Other" after ~10 min, GitHub may be cache-stale; otherwise file a follow-up

## Risk

Low. Worst case: classifier still shows "Other" and we ship an additional fix. The legal license remains in full force regardless.