### PR TITLE
fix(license): slim Additional Use Grant to enable BUSL-1.1 detection

### DIFF
--- a/ADDITIONAL_USE_GRANT.md
+++ b/ADDITIONAL_USE_GRANT.md
@@ -1,0 +1,21 @@
+# Additional Use Grant
+
+This document provides the full text of the Additional Use Grant referenced in the [LICENSE](./LICENSE) file (Business Source License 1.1) for the Solvela Gateway.
+
+The legal force of these terms is identical to terms included inline in the LICENSE file. They are split out here for clarity and readability.
+
+## Terms
+
+You may use the Licensed Work in production free of charge, provided that all of the following conditions are met:
+
+**(a)** You do not offer the Licensed Work, or any derivative of it, as a hosted, managed, or software-as-a-service offering to third parties. Operating the Licensed Work for your own internal or first-party use is not an offering to third parties.
+
+**(b)** Your gross annual revenue, in the aggregate across all entities under common control, attributable to or derived from the Licensed Work does not exceed one million United States dollars (USD $1,000,000).
+
+**(c)** You do not remove or obscure any licensing, copyright, or attribution notices contained in the Licensed Work.
+
+If your use does not satisfy all of (a), (b), and (c), you must obtain a commercial license from the Licensor.
+
+## Commercial License
+
+For commercial licensing inquiries (use cases that exceed the Additional Use Grant above), see the LICENSING section in [README.md](./README.md) or contact the Licensor.

--- a/LICENSE
+++ b/LICENSE
@@ -11,29 +11,8 @@ Parameters
                         (the `gateway` crate and the `solvela-gateway` binary).
                         Other components of the Solvela project are licensed
                         separately; see the LICENSING section in README.md.
-  Additional Use Grant: You may use the Licensed Work in production free of
-                        charge, provided that all of the following conditions
-                        are met:
-
-                          (a) You do not offer the Licensed Work, or any
-                              derivative of it, as a hosted, managed, or
-                              software-as-a-service offering to third parties.
-                              Operating the Licensed Work for your own internal
-                              or first-party use is not an offering to third
-                              parties.
-
-                          (b) Your gross annual revenue, in the aggregate
-                              across all entities under common control,
-                              attributable to or derived from the Licensed
-                              Work does not exceed one million United States
-                              dollars (USD $1,000,000).
-
-                          (c) You do not remove or obscure any licensing,
-                              copyright, or attribution notices contained in
-                              the Licensed Work.
-
-                        If your use does not satisfy all of (a), (b), and (c),
-                        you must obtain a commercial license from the Licensor.
+  Additional Use Grant: See ADDITIONAL_USE_GRANT.md in this repository for
+                        the full terms governing limited production use.
 
   Change Date:          2030-05-02
 


### PR DESCRIPTION
## Summary

- Move (a)/(b)/(c) Additional Use Grant terms into `ADDITIONAL_USE_GRANT.md`
- LICENSE Additional Use Grant slot now references the external file (standard "see Exhibit A" pattern)
- Legal force is identical; this is purely a layout change

## Why

PR #95 added SPDX header, paragraph break, and a (non-functional) `licensee.yml` hint. GitHub still shows "Other" because the ~25-line inline Additional Use Grant pushes the similarity score against the canonical SPDX BUSL-1.1 template below the detection threshold.

This PR matches the pattern used by mature BUSL projects — CockroachDB, Sentry, Materialize, MariaDB MaxScale — all of which keep the inline Additional Use Grant short and reference external files when terms are substantial.

## Test plan

- [ ] CI passes
- [ ] Admin-merge to main
- [ ] Verify GitHub repo sidebar flips from "Other" to "Business Source License 1.1" within ~5 minutes
- [ ] Verify ADDITIONAL_USE_GRANT.md renders cleanly on GitHub