### PR TITLE
docs: add LICENSE-COMMERCIAL.md template and link from README

### DIFF
--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -1,0 +1,252 @@
+# Solvela Gateway Commercial License Agreement
+
+> **This is a template.** Replace bracketed placeholders, attach a completed Order Form (Schedule A), and have both parties sign. Companion document to the [BUSL-1.1 LICENSE](./LICENSE) and [ADDITIONAL_USE_GRANT.md](./ADDITIONAL_USE_GRANT.md). When this Agreement is in force between the Licensor and a Licensee, it supersedes the Additional Use Grant for that Licensee for the agreed Term and Scope.
+>
+> Plain-English summary of who needs this:
+> - You exceed USD $1,000,000 in annual revenue derived from the Licensed Work, **or**
+> - You want to offer the Licensed Work to third parties as a hosted, managed, or SaaS offering, **or**
+> - You need contractual support, indemnification, or warranty terms beyond what the public license provides.
+>
+> Contact: `kd@sky64.io`
+
+---
+
+**This Solvela Gateway Commercial License Agreement** (this "**Agreement**") is entered into as of `[EFFECTIVE DATE]` (the "**Effective Date**") by and between:
+
+- **Solvela Contributors**, the licensor of the Solvela Gateway (the "**Licensor**"), with notice address `kd@sky64.io`; and
+- `[LICENSEE LEGAL NAME]`, a `[STATE/COUNTRY OF INCORPORATION]` `[ENTITY TYPE]` with principal place of business at `[LICENSEE ADDRESS]` (the "**Licensee**").
+
+Each a "**Party**" and together the "**Parties**".
+
+---
+
+## 1. Definitions
+
+**1.1** "**Licensed Work**" means the Solvela Gateway software, including the `gateway` crate and the `solvela-gateway` binary, and any updates or modifications made available by Licensor under this Agreement.
+
+**1.2** "**Order Form**" means an executed schedule, in substantially the form of **Schedule A**, identifying the specific Scope, Term, Fees, and any Support Plan.
+
+**1.3** "**Scope**" means the permitted use cases set forth in the applicable Order Form, which may include any of: (i) **Internal Production Use** at any revenue level, (ii) **Hosted Service Use** (offering the Licensed Work to third parties as a managed or SaaS offering), and (iii) **Distribution** (embedding the Licensed Work in a product distributed to third parties).
+
+**1.4** "**Term**" means the duration set forth in the Order Form, beginning on the Effective Date.
+
+**1.5** "**Fees**" means the amounts payable by Licensee as set forth in the Order Form.
+
+**1.6** "**Support Plan**" means the optional support, response-time, and update terms set forth in the Order Form, if any.
+
+**1.7** "**Confidential Information**" means non-public information disclosed by one Party to the other and marked or reasonably understood to be confidential, including the commercial terms of this Agreement.
+
+---
+
+## 2. License Grant
+
+**2.1 Grant.** Subject to Licensee's compliance with this Agreement and timely payment of Fees, Licensor grants Licensee a non-exclusive, non-transferable (except as permitted in Section 12.4), worldwide license during the Term to use, copy, modify, and create derivative works of the Licensed Work solely within the Scope set forth in the Order Form.
+
+**2.2 Supersedes Additional Use Grant.** During the Term and within the Scope, the rights granted in this Agreement supersede the Additional Use Grant in `ADDITIONAL_USE_GRANT.md`. Licensee is not subject to the revenue cap or the prohibition on hosted-service offerings while operating within Scope.
+
+**2.3 No Sublicensing of Source.** Licensee may not sublicense or redistribute the source code of the Licensed Work to third parties except as expressly permitted by the Scope. Distribution of binary or compiled forms embedded within Licensee's product is permitted only if "Distribution" is included in the Scope.
+
+**2.4 Reservation.** All rights not expressly granted are reserved by Licensor.
+
+---
+
+## 3. Restrictions
+
+Licensee will not, and will not permit any third party to:
+
+**(a)** remove, alter, or obscure any copyright, trademark, license, or other proprietary notices in the Licensed Work;
+
+**(b)** use the Licensed Work to develop a product or service that is substantially similar to and competitive with the Licensor's own commercial offering of the Licensed Work, except as expressly permitted by the Scope;
+
+**(c)** use Licensor's name, logo, or trademarks except as expressly permitted in writing or as required for attribution by this Agreement;
+
+**(d)** represent that any modifications made by Licensee are endorsed or supported by Licensor; or
+
+**(e)** use the Licensed Work in violation of applicable export control, sanctions, or other laws.
+
+---
+
+## 4. Fees and Payment
+
+**4.1** Licensee will pay the Fees set forth in the Order Form on the schedule specified therein. Unless otherwise stated, Fees are due net thirty (30) days from invoice date and are non-refundable except as expressly stated in this Agreement.
+
+**4.2** Fees are exclusive of taxes other than taxes on Licensor's net income. Licensee is responsible for all applicable sales, use, value-added, and similar taxes.
+
+**4.3** Past-due amounts accrue interest at the lesser of 1.5% per month or the maximum permitted by law.
+
+---
+
+## 5. Support and Updates
+
+**5.1** Licensor will provide the Support Plan, if any, set forth in the Order Form. In the absence of a Support Plan, support is not included and is provided, if at all, on a commercially reasonable best-efforts basis.
+
+**5.2** Licensor will make updates and bug fixes generally available to Licensee at no additional charge during the Term to the extent Licensor makes them available to its other commercial licensees.
+
+---
+
+## 6. Intellectual Property
+
+**6.1 Licensor IP.** As between the Parties, Licensor owns all right, title, and interest in and to the Licensed Work, including all modifications and derivative works made by Licensor, and all related intellectual property rights.
+
+**6.2 Licensee Modifications.** Licensee owns the modifications and derivative works it creates from the Licensed Work, subject to Licensor's underlying rights in the Licensed Work itself. Nothing in this Agreement requires Licensee to disclose or contribute back its modifications.
+
+**6.3 Feedback.** If Licensee provides Licensor with feedback, suggestions, or ideas regarding the Licensed Work, Licensor may use such feedback without restriction or obligation. Licensee retains ownership of its underlying ideas; this Section grants Licensor a perpetual, royalty-free license to use them.
+
+---
+
+## 7. Warranties
+
+**7.1 Mutual.** Each Party represents and warrants that it has the legal authority to enter into and perform this Agreement.
+
+**7.2 Limited Licensor Warranty.** Licensor warrants that, for thirty (30) days following the Effective Date, the Licensed Work as delivered will materially conform to its then-current published documentation. Licensee's exclusive remedy for breach of this warranty is, at Licensor's option, (i) correction of the non-conformity or (ii) refund of the Fees paid for the affected period.
+
+**7.3 Disclaimer.** EXCEPT FOR THE LIMITED WARRANTY IN SECTION 7.2, THE LICENSED WORK IS PROVIDED "AS IS" AND LICENSOR DISCLAIMS ALL OTHER WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND THOSE ARISING FROM COURSE OF DEALING OR USAGE OF TRADE.
+
+---
+
+## 8. Limitation of Liability
+
+**8.1 Cap.** EXCEPT FOR (i) BREACHES OF SECTIONS 3 (RESTRICTIONS) OR 9 (CONFIDENTIALITY), (ii) A PARTY'S INDEMNIFICATION OBLIGATIONS, OR (iii) LICENSEE'S OBLIGATION TO PAY FEES, EACH PARTY'S TOTAL CUMULATIVE LIABILITY UNDER THIS AGREEMENT WILL NOT EXCEED THE FEES PAID OR PAYABLE BY LICENSEE TO LICENSOR IN THE TWELVE (12) MONTHS PRECEDING THE EVENT GIVING RISE TO LIABILITY.
+
+**8.2 Exclusion.** NEITHER PARTY WILL BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR FOR LOST PROFITS, REVENUE, OR DATA, EVEN IF ADVISED OF THE POSSIBILITY.
+
+---
+
+## 9. Confidentiality
+
+**9.1** Each Party will (i) use the other's Confidential Information solely to perform under this Agreement and (ii) protect it with the same degree of care it uses for its own Confidential Information, and in no event less than reasonable care.
+
+**9.2** Confidential Information does not include information that is or becomes public through no fault of the receiving Party, was lawfully known prior to disclosure, is rightfully obtained from a third party without restriction, or is independently developed without reference to the disclosing Party's Confidential Information.
+
+**9.3** A Party may disclose the other's Confidential Information as required by law, provided it gives prompt notice (where lawful) to allow the other Party to seek a protective order.
+
+---
+
+## 10. Indemnification
+
+**10.1 By Licensor (IP).** Licensor will defend Licensee against any third-party claim alleging that the unmodified Licensed Work, as provided by Licensor and used within Scope, infringes a third party's United States copyright or trade secret, and will pay damages and costs finally awarded against Licensee, provided Licensee promptly notifies Licensor of the claim, gives Licensor sole control of the defense, and reasonably cooperates. Licensor has no obligation for claims arising from (i) Licensee's modifications, (ii) combination of the Licensed Work with software not provided by Licensor, or (iii) use outside Scope.
+
+**10.2 By Licensee.** Licensee will defend Licensor against any third-party claim arising from Licensee's use of the Licensed Work in violation of this Agreement or applicable law, and will pay damages and costs finally awarded against Licensor, on the same procedural terms as Section 10.1.
+
+**10.3 Sole Remedy.** This Section 10 sets forth the Parties' sole and exclusive remedies for third-party claims.
+
+---
+
+## 11. Term and Termination
+
+**11.1 Term.** This Agreement begins on the Effective Date and continues for the Term set forth in the Order Form, unless earlier terminated as provided herein.
+
+**11.2 Termination for Breach.** Either Party may terminate this Agreement upon thirty (30) days' written notice if the other Party materially breaches and fails to cure within the notice period. Failure to pay undisputed Fees is a material breach.
+
+**11.3 Effect of Termination.** Upon termination, (i) the license in Section 2 ends, (ii) Licensee will cease use of the Licensed Work within thirty (30) days, except that Licensee may continue to use any version of the Licensed Work that has reached its Change Date under the BUSL-1.1 Change License, and (iii) Sections 3, 6, 7.3, 8, 9, 10, and 12 survive.
+
+**11.4 Refunds.** If Licensor terminates for material breach by Licensor, Licensee is entitled to a pro-rata refund of prepaid Fees for the unused portion of the Term.
+
+---
+
+## 12. General
+
+**12.1 Governing Law.** This Agreement is governed by the laws of the State of `[GOVERNING LAW STATE — typically Delaware]`, excluding its conflict-of-laws rules. The Parties consent to exclusive jurisdiction in the state and federal courts located in `[VENUE COUNTY, STATE]` for any dispute arising under this Agreement.
+
+**12.2 Notices.** Notices must be in writing and sent to the addresses on the signature page (or as updated in writing). Email notice is sufficient if sent to `kd@sky64.io` for Licensor and to the email on the signature page for Licensee, with confirmation of receipt.
+
+**12.3 Entire Agreement.** This Agreement, together with all executed Order Forms, is the entire agreement between the Parties on its subject matter and supersedes all prior or contemporaneous agreements. Any conflicting terms in a Licensee purchase order are rejected.
+
+**12.4 Assignment.** Neither Party may assign this Agreement without the other's written consent, except that either Party may assign without consent to a successor in connection with a merger, acquisition, or sale of substantially all assets, provided the successor agrees in writing to be bound.
+
+**12.5 Severability.** If any provision is held unenforceable, the remainder remains in effect, and the unenforceable provision will be modified to the minimum extent necessary to make it enforceable.
+
+**12.6 No Waiver.** Failure to enforce any provision is not a waiver.
+
+**12.7 Force Majeure.** Neither Party is liable for delays or failures (other than payment obligations) due to causes beyond its reasonable control.
+
+**12.8 Independent Contractors.** The Parties are independent contractors. Nothing creates a partnership, joint venture, or agency.
+
+**12.9 Counterparts and Electronic Signatures.** This Agreement may be executed in counterparts, including by electronic signature, each of which is an original.
+
+---
+
+## Signatures
+
+**LICENSOR — Solvela Contributors**
+
+Signature: ______________________________
+
+Name: `[LICENSOR SIGNATORY NAME]`
+
+Title: `[LICENSOR SIGNATORY TITLE]`
+
+Date: `[DATE]`
+
+Notice email: `kd@sky64.io`
+
+---
+
+**LICENSEE — `[LICENSEE LEGAL NAME]`**
+
+Signature: ______________________________
+
+Name: `[LICENSEE SIGNATORY NAME]`
+
+Title: `[LICENSEE SIGNATORY TITLE]`
+
+Date: `[DATE]`
+
+Notice email: `[LICENSEE NOTICE EMAIL]`
+
+---
+
+# Schedule A — Order Form
+
+This Order Form is incorporated into and governed by the Solvela Gateway Commercial License Agreement dated `[EFFECTIVE DATE]` between the Parties named above.
+
+## A.1 Scope (select all that apply)
+
+- [ ] **Internal Production Use** — Use of the Licensed Work for Licensee's internal business operations and first-party products, with no revenue cap.
+- [ ] **Hosted Service Use** — Offering the Licensed Work, or material derivatives, to third parties as a hosted, managed, or software-as-a-service offering.
+- [ ] **Distribution** — Embedding the Licensed Work, in source or binary form, in a product distributed by Licensee to third parties.
+
+## A.2 Permitted Use Description
+
+`[FREE-TEXT DESCRIPTION OF THE PERMITTED USE — e.g., "Licensee may operate the Licensed Work as the inference-payment routing layer of its hosted product 'Acme AI Studio' available at acme.example, with no per-end-user limit."]`
+
+## A.3 Term
+
+`[INITIAL TERM — e.g., "Twelve (12) months from the Effective Date, automatically renewing for successive 12-month terms unless either Party gives 30 days' notice of non-renewal."]`
+
+## A.4 Fees
+
+| Component | Amount | Schedule |
+|---|---|---|
+| Initial license fee | `[USD AMOUNT]` | `[ANNUAL / ONE-TIME / OTHER]` |
+| Renewal fee | `[USD AMOUNT or "same as initial"]` | `[ANNUAL]` |
+| Per-unit / metered fee (if any) | `[USD AMOUNT per UNIT]` | `[INVOICED MONTHLY/QUARTERLY/ANNUALLY]` |
+
+Total Year 1 commitment: `[USD AMOUNT]`
+
+## A.5 Support Plan (optional)
+
+Select one:
+
+- [ ] **None** — No formal support; updates are made available as released.
+- [ ] **Standard** — Email support during business hours (Pacific Time), best-effort response within two (2) business days.
+- [ ] **Priority** — Email and Slack support, response within one (1) business day for non-critical issues, four (4) hours for production-down issues.
+- [ ] **Custom** — `[DESCRIBE CUSTOM SUPPORT TERMS]`
+
+## A.6 Special Terms (optional)
+
+`[ANY NEGOTIATED DEVIATIONS FROM THE BASE AGREEMENT — e.g., source escrow, security review rights, extended warranty period, audit rights, SLA credits, etc. Special Terms in this Section A.6 control over conflicting terms in the body of the Agreement.]`
+
+## A.7 Order Form Signatures
+
+**LICENSOR**
+
+Signature: ______________________________  Date: `[DATE]`
+
+Name / Title: `[NAME / TITLE]`
+
+**LICENSEE**
+
+Signature: ______________________________  Date: `[DATE]`
+
+Name / Title: `[NAME / TITLE]`

--- a/README.md
+++ b/README.md
@@ -435,7 +435,8 @@ Solvela uses a **per-component license split**. Pick the license of the piece yo
 
 - **You're a developer using Solvela's hosted gateway at `api.solvela.ai`** → no license obligations on you, just use it.
 - **You're self-hosting the gateway internally for your own product** → free under the Additional Use Grant if your gross annual revenue attributable to the gateway is under USD $1M.
-- **You're building a competing managed gateway service from this code** → you need a commercial license. Contact `kd@sky64.io`.
+- **You're building a competing managed gateway service from this code** → you need a commercial license. See [LICENSE-COMMERCIAL.md](./LICENSE-COMMERCIAL.md) for the standard template, then contact `kd@sky64.io`.
+- **Your annual revenue derived from the gateway will exceed USD $1M** → you need a commercial license. See [LICENSE-COMMERCIAL.md](./LICENSE-COMMERCIAL.md) for the standard template, then contact `kd@sky64.io`.
 - **You're embedding the SDK or building on top of the protocol/router crates** → standard MIT obligations apply (preserve the copyright notice, no warranty). No payment to Solvela required.
 
 ### Trademark


### PR DESCRIPTION
## Summary

- Adds `LICENSE-COMMERCIAL.md` — a fillable commercial license template prospects can review before contacting `kd@sky64.io`. Includes a Schedule A Order Form for Scope, Term, Fees, and Support Plan.
- Updates the README LICENSING quick-reference so both trip points in the BUSL Additional Use Grant (hosted-service rehosting, and \$1M+ annual revenue from the Licensed Work) link to the template.

## Why

Right now, a prospect who needs a commercial license has to email cold and wait for a draft. With a template in the repo, they can read the terms first, redline against it, and arrive at the conversation with a concrete starting point. Reduces friction for the exact transaction we want to make easy.

## Template highlights

- Supersedes the Additional Use Grant for the Licensee within the agreed Scope and Term.
- Three Scope flags on the Order Form: Internal Production Use (revenue-cap removed), Hosted Service Use, Distribution.
- 12-months-of-fees liability cap, with the standard carve-outs.
- Limited Licensor IP indemnification (US copyright/trade-secret), Licensee indemnification for misuse.
- Clean Order Form pattern so the base agreement stays reusable across deals.
- Plain-English summary at the top so prospects can self-qualify in 10 seconds.

## Test plan

- [x] `LICENSE-COMMERCIAL.md` renders cleanly on GitHub
- [x] README links resolve to the new file
- [x] No existing license files touched (BUSL `LICENSE`, `LICENSE-MIT`, `ADDITIONAL_USE_GRANT.md` unchanged)