### PR TITLE
docs(demo): add 90-second demo video production kit

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,0 +1,50 @@
+# Solvela Demo Video — Production Kit
+
+This directory contains everything needed to record the canonical 90-second Solvela demo video.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [`script.md`](./script.md) | The 90-second voiceover script with timestamps, on-screen text, and shot list |
+| [`shot-list.md`](./shot-list.md) | Detailed shot-by-shot breakdown with terminal commands and screen targets |
+| [`pre-record-checklist.md`](./pre-record-checklist.md) | Everything to set up before hitting record (gateway running, wallet funded, terminal styled, etc.) |
+| [`b-roll.md`](./b-roll.md) | Optional supplementary footage to capture (architecture animations, code zoom-ins, Solana Explorer) |
+
+## Recording targets
+
+- **Length:** 90 seconds. Hard cap 105 seconds. Anything longer loses acquihire-evaluator attention.
+- **Aspect ratio:** 16:9 at 1080p minimum (1920×1080). Record at 60fps if your machine handles it; 30fps is acceptable.
+- **Audio:** Voiceover only. No music bed for the v1 cut — music is a polish pass after the cut works.
+- **Format:** MP4 (H.264) for upload. Master in your editor's native format, export MP4 last.
+
+## Recommended tooling
+
+| Need | Tool | Why |
+|---|---|---|
+| Screen capture | **OBS Studio** (free) | Reliable, scriptable scene switching, separate audio tracks |
+| Alternative | **Loom** | One-click record/share if OBS feels heavy |
+| Terminal styling | iTerm2 (mac) / Windows Terminal | Set font to JetBrains Mono 16pt+, dark theme, matching Solvela orange (`#F97316`) accent |
+| Voiceover mic | Anything decent — phone earbuds beat laptop mic | Listeners forgive okay video, never bad audio |
+| Editing | DaVinci Resolve (free) or CapCut Desktop | Both handle cuts + lower-thirds + export |
+| Upload host | YouTube (unlisted) **plus** raw MP4 in a GitHub release | YouTube embed in README; raw file for grant/acquirer offline review |
+
+## Distribution checklist (after recording)
+
+- [ ] Upload to YouTube as **unlisted** (not private — grant officers can't see private videos without a Google login)
+- [ ] Add the embed to `README.md` directly under the project tagline
+- [ ] Add a thumbnail image (`docs/demo/thumbnail.png`) — the YouTube auto-thumbnail is almost always wrong
+- [ ] Attach the raw MP4 to a GitHub release (tag it `demo-v1`) so it survives YouTube link rot
+- [ ] Drop the link into `docs/exit-readiness.md` under the "Demo materials" section
+- [ ] Drop the link into `docs/grants/` application templates
+- [ ] Tweet/post the link with the GitHub link as the second line
+
+## Why 90 seconds
+
+Acquirers, grant evaluators, and prospective enterprise buyers all share one behavior: they decide whether to read the README in the first 60 seconds of contact with a project. A 90-second video gives them:
+
+- **0–15s:** the hook (what problem this solves)
+- **15–60s:** proof it works (live demo of the actual product)
+- **60–90s:** what makes it defensible (the architecture and traction signal)
+
+Anything longer than 105 seconds and they bounce. Anything shorter than 60 and they don't believe the demo is real. 90 is the sweet spot.

--- a/docs/demo/b-roll.md
+++ b/docs/demo/b-roll.md
@@ -1,0 +1,61 @@
+# B-Roll Capture List (Optional)
+
+Supplementary footage you can capture **after** the v1 cut is shipped, in case you decide to do a polish pass. None of this is required for v1. Skip this entire file unless v1 has shipped, the conversion is below expectations, and you want to A/B test a richer cut.
+
+## Why optional
+
+The v1 cut is a single linear demo. It works. Adding B-roll buys you ~10% more polish at ~3x the production cost. The marginal return rarely justifies the time on a v1, but it can matter for a v2 if you're cutting a longer-form pitch (3+ minutes) for a specific acquirer.
+
+## Categories
+
+### 1. Architecture animations [optional, ~2 hours work]
+
+A 4–6 second animated reveal of the architecture mermaid would replace shot 11 (`arch-diagram-zoom` static hold) with motion. Tools:
+
+- **Excalidraw → Lottie** if you want hand-drawn aesthetic.
+- **After Effects** if you have it. Otherwise **Motion Canvas** (open source, code-driven animations, very on-brand for a developer tool).
+- **Manim** if you want a CS-paper aesthetic (we have a `manim-video` skill for this).
+
+What to animate: client request entering the gateway, gateway calling Solana, Solana confirming, gateway calling provider, response returning. ~5 second loop.
+
+### 2. Code zoom-ins [optional, ~30 minutes]
+
+Cut to a static, syntax-highlighted slice of the actual production code for ~3 seconds during the relevant claim. Examples:
+
+- The 15-dimension scorer's match statement (during shot 11) — backs the "fifteen dimensions in microseconds" claim with visible evidence.
+- The escrow program's `claim` instruction (during shot 11) — backs the "escrow live on mainnet" claim.
+
+Use **Carbon** or **ray.so** to render the code into an image with the matching dark + orange theme. Ken-Burns slow zoom in DaVinci.
+
+### 3. Solana Explorer scroll-throughs [optional, ~15 minutes]
+
+Instead of a static hold on the Token Balances Change section in shot 10, do a slow scroll from the top of the txn page down to the balance changes. Conveys "this is a real, full transaction record, not a screenshot" more strongly. Use OBS's scene transition or just a slow trackpad scroll.
+
+### 4. README scroll-through [optional, ~10 minutes]
+
+A 3-second slow-scroll past the README's badge row + LICENSING table during the close shot. Reinforces the "open source, real license, real SDKs" closing message. Cheap and high-signal.
+
+### 5. SDK matrix flash [optional, ~20 minutes]
+
+A 2-second flash card showing the four SDK logos (Python, TypeScript, Go, Rust) plus the MCP logo, animated in. Goes into the close at 1:25–1:27. Tools: Figma → export PNG sequence → import to editor.
+
+## What NOT to capture
+
+These are tempting but they don't pay off:
+
+- **Office or workspace shots** — Nobody cares where you work. They care that the product works.
+- **Stock developer footage** (hands typing on a keyboard, generic code on a screen) — instantly reads as "padding to hit a length target."
+- **Talking-head intro** — Adds 5–10 seconds and shifts attention from the product to the founder. Save the founder for the longer-form acquirer pitch deck, not the cold demo.
+- **Slow zooms over the whole architecture diagram** — Eats 8–10 seconds and conveys less than the static zoomed-in version.
+
+## Capture order
+
+If you do go through with B-roll for a v2, capture in this order so you don't redo work:
+
+1. Architecture animation (longest pole, most reusable across other materials)
+2. Code zoom-ins (cheap, high signal, can be reused in pitch decks)
+3. SDK matrix flash (cheap, reusable)
+4. Solana Explorer scroll (free)
+5. README scroll (free)
+
+Then re-edit the v1 timeline with the new clips slotted into the existing scene markers. Do not re-shoot the live demo footage — your v1 take is already canon.

--- a/docs/demo/pre-record-checklist.md
+++ b/docs/demo/pre-record-checklist.md
@@ -1,0 +1,57 @@
+# Pre-Record Checklist
+
+Run through this list **before** hitting record. Skipping any of these will force a retake or, worse, ship a video with a flaw nobody noticed in editing.
+
+## Environment — 30 minutes before
+
+- [ ] **Gateway is running locally** — `cargo run -p gateway --release` listening on `:8402`. Confirm with `curl -s http://localhost:8402/pricing | jq '.models | length'` returning a number.
+- [ ] **Postgres + Redis are up** — `docker compose ps` shows both healthy.
+- [ ] **At least one provider key is configured** — `.env` has a working `OPENAI_API_KEY` (or whichever provider you'll route to). Test with one real call before recording.
+- [ ] **Wallet has USDC** — at least 5 USDC on Solana mainnet. Demo will use ~0.001 USDC but you don't want a "Insufficient funds" error mid-take.
+- [ ] **Wallet keypair is at the path the SDK expects** — `~/.solvela/wallet.json` (or update the script). Permissions `0600`.
+- [ ] **Solana RPC is responsive** — `solana balance` returns in <2 seconds. If you're using a public RPC, switch to a paid one (Helius / Triton / QuickNode) for the recording session — public RPCs sometimes throttle and the txn confirmation will lag.
+- [ ] **Network is stable** — close anything that might pop a notification mid-take (Slack, Mail, calendar, OS update prompts).
+
+## Visuals — 15 minutes before
+
+- [ ] **Terminal font:** JetBrains Mono or similar, **16pt minimum**, **18pt recommended** at 1080p. Anything smaller and viewers can't read it.
+- [ ] **Terminal theme:** dark background. The Solvela accent color is `#F97316` (orange) — set the prompt color to match if you can. Otherwise stick with a neutral white prompt.
+- [ ] **Terminal window size:** width that fits ~110 columns without wrapping the curl command. Test by pasting the longest command from `shot-list.md`.
+- [ ] **Hide the OS dock/taskbar** — full screen the terminal and browser.
+- [ ] **Disable browser extensions that show overlays** — ad blockers showing counts, password managers showing badges, dev tools panels. You want clean GitHub and Solana Explorer pages.
+- [ ] **Browser tabs:** only the tabs the demo uses. Close everything else. (Acquirers do read tab titles in screenshots, even if they don't admit it.)
+- [ ] **Browser zoom:** 125% on GitHub and Solana Explorer.
+- [ ] **Display resolution:** if recording at 1080p, set the OS display to 1920×1080 or use OBS's downsample. Recording at native 4K and exporting 1080p produces a sharper result if your machine handles it.
+
+## OBS / recording setup — 10 minutes before
+
+- [ ] **Scenes set up:** `intro-terminal`, `demo-terminal`, `readme-arch`, `solana-explorer`, `arch-diagram-zoom`, `github-badges`, `final-card`. Each scene captures the appropriate window or display source.
+- [ ] **Audio levels:** voice peaks at -12 to -6 dB. Test with a 5-second sample. If you're peaking at 0 dB you'll clip and ruin the voiceover.
+- [ ] **Recording format:** MP4, H.264, 30 or 60 fps, CRF 18 (high quality master, you can compress later).
+- [ ] **Disk space:** at least 5 GB free. A 90-second high-quality master is ~500 MB.
+- [ ] **Hotkeys configured:** F1–F7 for scene switches. Practice the sequence once cold before the real take.
+
+## Voice — 5 minutes before
+
+- [ ] **Drink water.** Not coffee, not soda. Cold water relaxes the vocal cords.
+- [ ] **Read the script aloud once.** Find the words that snag your tongue. Mark them and slow down on those.
+- [ ] **Do not whisper-rehearse.** Speak at full volume so your warm-up matches your take volume.
+- [ ] **Phone on Do Not Disturb.** Including watch notifications.
+- [ ] **Close your office door.** A passing siren or a delivery driver's knock will end your take.
+
+## The take
+
+- [ ] Roll camera (start OBS recording) **before** speaking. Add a 3-second silence head and tail — easier to trim than to recover from a clipped first word.
+- [ ] If you flub a line, **don't stop**. Pause for 2 seconds, restart that sentence cleanly. You'll cut to the clean restart in editing. Stopping and restarting the take wastes 5 minutes per attempt.
+- [ ] After the final word, **hold still and silent** for 3 seconds. Then stop recording.
+- [ ] **Watch the take immediately.** If anything is broken (audio noise, terminal cut off, network error visible), retake now while everything is still set up.
+
+## After the take
+
+- [ ] **Save raw recording with a clear name:** `solvela-demo-v1-take<N>-YYYY-MM-DD.mp4`.
+- [ ] **Note the txn signature** from the demo's Solana payment — you'll want it for the description and for verification artifacts.
+- [ ] **Back up the raw recording** to a second location before you start editing. Editors crash. Lost takes can't be reshot if you've already torn down the demo state.
+
+---
+
+If you've checked all of the above and you're sitting in front of a stable, ready, full-screen terminal and your voice feels warmed up — you're ready. Hit record.

--- a/docs/demo/script.md
+++ b/docs/demo/script.md
@@ -1,0 +1,129 @@
+# Demo Video Script — 90 Seconds
+
+> **Tone:** Calm, confident, evidence-first. You are showing, not selling. Read the script once cold, then once recording — do not over-rehearse.
+>
+> **VO style notes:** Drop pitch slightly at the end of declarative sentences. Pause one beat after each numbered demonstration. Do not laugh, do not apologize, do not say "um."
+>
+> **Run time target:** 90 seconds. Each section's target duration is in brackets.
+
+---
+
+## ACT 1 — The Hook [0:00 – 0:15]
+
+**Scene:** Full-screen terminal. Cursor blinking. Solvela logo wordmark fades in top-left.
+
+**Voiceover:**
+
+> AI agents need to pay for the things they use — LLM calls, tools, data, other agents. Today they do that with API keys, monthly invoices, and trust. None of that scales to a world where agents transact every few seconds.
+
+**On-screen text overlay (seconds 8–14):**
+
+```
+API keys → don't compose
+Invoices → don't settle in real time
+Trust → doesn't survive autonomy
+```
+
+---
+
+## ACT 2 — What It Is [0:15 – 0:25]
+
+**Scene:** Cut to README header in browser, scrolled to the architecture mermaid diagram. Hold for 4 seconds, then cut back to terminal.
+
+**Voiceover:**
+
+> Solvela is a Solana-native payment gateway for AI inference. Agents pay for LLM calls in USDC, on-chain, per request. No accounts. No keys. Just wallets.
+
+---
+
+## ACT 3 — The Live Demo [0:25 – 1:10]
+
+This is the meat. Three demonstrations, each ~15 seconds. Type slowly enough that viewers can read, but do not narrate every keystroke.
+
+### Demonstration 1 — The 402 [0:25 – 0:40]
+
+**Scene:** Terminal, command typed live.
+
+```bash
+curl -s http://localhost:8402/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello"}]}' | jq
+```
+
+**Voiceover (over the curl execution):**
+
+> A request without payment returns a 402. The response includes the cost breakdown, the recipient wallet, and the accepted payment schemes — direct transfer, or trustless escrow.
+
+**On-screen text overlay during JSON output:**
+
+> HTTP 402 — the original "Payment Required"
+
+### Demonstration 2 — Pay & Get the Response [0:40 – 0:55]
+
+**Scene:** Switch to the Python SDK or CLI. Run the `pay-and-call` example.
+
+```bash
+python -c "
+from solvela import Client
+c = Client(wallet='~/.solvela/wallet.json')
+print(c.chat('Explain Solana in one sentence.', model='auto').content)
+"
+```
+
+**Voiceover (during execution):**
+
+> The SDK signs a USDC transfer, attaches it to the retry, and the gateway settles on-chain in roughly four hundred milliseconds. The agent never holds a credit card. The provider never sees the agent's identity.
+
+### Demonstration 3 — Proof It Settled [0:55 – 1:10]
+
+**Scene:** Open Solana Explorer (mainnet) in browser. Paste the txn signature returned in the SDK output. Show the USDC transfer to the gateway's recipient ATA.
+
+**Voiceover:**
+
+> Here is the transaction on Solana mainnet. USDC moves from the agent's wallet to the gateway. The platform fee splits to the protocol treasury. Every request is a settled, public, verifiable financial event.
+
+---
+
+## ACT 4 — Why It Matters [1:10 – 1:25]
+
+**Scene:** Cut back to terminal. Pull up the mermaid architecture diagram from `docs/architecture.md`, full screen, zoomed to the smart router box.
+
+**Voiceover:**
+
+> The router classifies every request across fifteen dimensions in microseconds, then picks the best of OpenAI, Anthropic, Google, xAI, or DeepSeek. The escrow program is live on mainnet. The gateway sustains four hundred requests per second at sub-three-hundred millisecond p99.
+
+**On-screen text overlay (lower third):**
+
+```
+Mainnet escrow:  9neD…HLU
+Providers:       5
+p99 @ 400 RPS:   <300ms
+```
+
+---
+
+## ACT 5 — The Close [1:25 – 1:30]
+
+**Scene:** GitHub repo page, scrolled to the badges and license table. Hold 3 seconds. Cut to a final card with the URL.
+
+**Voiceover:**
+
+> Open source. SDKs in Python, TypeScript, Go, and Rust. MCP server for Claude Code, Cursor, and Claude Desktop. Solvela on GitHub.
+
+**Final card (full screen, 2 seconds):**
+
+```
+github.com/solvela-ai/solvela
+```
+
+---
+
+## After the Cut
+
+Once the v1 cut is exported and watchable end to end, do exactly **one** revision pass to fix:
+
+1. Any moment where the terminal is unreadable (font too small, contrast too low, command clipped)
+2. Any voiceover line that lands more than 0.5s off its scene
+3. The first and last 3 seconds — these get the most replay attention and are worth the polish
+
+Do not add music, transitions, or animations on the v1 pass. Ship the cut, then iterate if the v1 fails to convert. Most of the time it doesn't.

--- a/docs/demo/shot-list.md
+++ b/docs/demo/shot-list.md
@@ -1,0 +1,65 @@
+# Demo Video — Shot List
+
+Detailed scene-by-scene breakdown. Use this as your monitor reference while recording. Each shot lists the source (terminal, browser, editor), the exact target, and the cue.
+
+| # | Time | Source | Target | Cue / Action |
+|---|---|---|---|---|
+| 1 | 0:00 – 0:05 | OBS scene `intro-terminal` | Empty terminal, prompt visible | Cursor blinking. No keystrokes yet. Wordmark fades in top-left. |
+| 2 | 0:05 – 0:15 | Same scene | Same | VO over static frame. Text overlay appears at 0:08, fades at 0:14. |
+| 3 | 0:15 – 0:19 | OBS scene `readme-arch` | Browser at `https://github.com/solvela-ai/solvela#architecture` | Scroll-snap to the architecture mermaid. Hold. |
+| 4 | 0:19 – 0:25 | OBS scene `intro-terminal` | Terminal | Cut back. VO continues without pause. |
+| 5 | 0:25 – 0:35 | OBS scene `demo-terminal` | Terminal at the project root, gateway running on `:8402` | Type the curl command from `script.md` Act 3 / Demo 1. Use `pv` or pacing if you can't hand-type at ~60ms per char. |
+| 6 | 0:35 – 0:40 | Same | Terminal | `jq` formatted output visible. Highlight (with cursor or terminal reverse-video) the `accepts` field showing both `exact` and `escrow`. |
+| 7 | 0:40 – 0:48 | Same | Terminal | Type the Python SDK invocation. Tab-complete is fine. |
+| 8 | 0:48 – 0:55 | Same | Terminal | SDK runs. The completion text scrolls in. Last line printed is the txn signature. |
+| 9 | 0:55 – 1:00 | OBS scene `solana-explorer` | Browser at `https://explorer.solana.com/tx/<TXN_SIG>` | Paste the signature from shot 8. Page loads. |
+| 10 | 1:00 – 1:10 | Same | Same | Scroll-snap to the Token Balances Change section. Highlight the USDC mint and the two-account delta. |
+| 11 | 1:10 – 1:18 | OBS scene `arch-diagram-zoom` | Browser at `docs/architecture.md` rendered, zoomed to router box | Hold. VO covers the routing claim. |
+| 12 | 1:18 – 1:25 | Same | Same | Lower-third text overlay appears at 1:18, fades at 1:25. |
+| 13 | 1:25 – 1:28 | OBS scene `github-badges` | Browser at `https://github.com/solvela-ai/solvela` | Top of page. Badges visible. License table just below. |
+| 14 | 1:28 – 1:30 | OBS scene `final-card` | Static slide, dark bg, orange accent | "github.com/solvela-ai/solvela" centered. Wordmark below. |
+
+## Terminal commands — copy/paste ready
+
+Keep these in a scratch buffer. During recording you'll re-type from memory but it's good to have the canonical version handy if a take fails.
+
+### Demonstration 1 — The 402
+
+```bash
+curl -s http://localhost:8402/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello"}]}' | jq
+```
+
+### Demonstration 2 — Pay & call
+
+```python
+python -c "
+from solvela import Client
+c = Client(wallet='~/.solvela/wallet.json')
+r = c.chat('Explain Solana in one sentence.', model='auto')
+print(r.content)
+print('txn:', r.payment_signature)
+"
+```
+
+### Demonstration 3 — Verify on-chain
+
+```bash
+# Open in default browser
+xdg-open "https://explorer.solana.com/tx/$(pbpaste)"   # macOS
+# or
+open "https://explorer.solana.com/tx/$(pbpaste)"        # macOS alt
+# or just paste manually into the browser
+```
+
+## Visual continuity rules
+
+- Use the **same terminal window** for shots 1, 2, 4, 5–8. Switching windows mid-demo signals "this was edited together" and breaks the live-demo feeling.
+- Keep the same **prompt prefix** the entire video. Don't `cd` into different directories between takes.
+- Browser zoom: **125%** for GitHub and Solana Explorer, so text reads at 1080p.
+- Cursor: hide the OS cursor in still shots. Show it only when typing.
+
+## What to do if a take fails
+
+A failed take usually means: a network blip on the curl, a wallet that ran out of USDC, a typo. Don't try to "save" the take in editing. Just retake it. The whole video is 90 seconds — re-recording one demonstration costs you ~20 seconds of fresh take vs. 10 minutes of editing patch work.

--- a/docs/exit-readiness.md
+++ b/docs/exit-readiness.md
@@ -81,6 +81,8 @@ Things we keep current so an inbound deal doesn't take six months to close on ou
 - [ ] Quarterly infra-spend disclosure on `/metrics` (depends on first quarter of sponsorship clearing)
 - [ ] All operator credentials catalogued in a single sealed location for transfer (1Password vault or equivalent)
 - [ ] One-page deal summary (this document, kept current) ready to share
+- [x] Demo video production kit ready (script, shot list, pre-record checklist, b-roll guide) at [`docs/demo/`](./demo/)
+- [ ] 90-second demo video recorded, uploaded to YouTube (unlisted), embedded in `README.md`, and attached to a `demo-v1` GitHub release
 
 ## 6. Realistic acquirer shortlist
 


### PR DESCRIPTION
## Summary

Adds `docs/demo/` with the full production kit for the canonical Solvela 90-second demo video. Maintainer can sit down, run the pre-record checklist, follow the shot list, and ship a v1 cut without further planning.

## What's in the kit

- `script.md` — 90-second voiceover script with timestamps, scene cues, on-screen text overlays
- `shot-list.md` — shot-by-shot breakdown with copy/paste-ready terminal commands and visual continuity rules
- `pre-record-checklist.md` — environment, visuals, OBS, and voice prep gates to run before recording
- `b-roll.md` — optional v2 polish materials (skip unless v1 underperforms)
- `README.md` — kit overview, recording targets, distribution checklist (YouTube unlisted + GitHub release attachment)

## Why 90 seconds

Acquirer / grant evaluator attention is decided in the first 60 seconds of contact. 90s is the empirically-correct length: enough to land the hook + live demo + traction signal; short enough to hold attention.

## Cross-references

- Linked from `docs/exit-readiness.md` Section 5 (operator-side checklist) — kit marked done, recording marked todo.

## Test plan

- [ ] `docs/demo/README.md` renders cleanly on GitHub
- [ ] All four sub-docs render without broken markdown
- [ ] Internal links between files resolve
- [ ] `docs/exit-readiness.md` checklist updates render correctly