### PR TITLE
fix: apply 5% platform fee once at boundary (was double-applying)

### DIFF
--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -323,6 +323,39 @@ mod tests {
     }
 
     #[test]
+    fn test_compute_actual_atomic_cost_applies_single_fee_via_registry() {
+        // Regression: prevents double-application of the 5% platform fee.
+        // Exercises the production wiring TOML → ModelRegistry → compute_actual_atomic_cost.
+        // A hand-crafted ModelInfo cannot catch a registry-side bake-in; this test must.
+        let toml = r#"
+[models.test-model]
+provider = "test"
+model_id = "test-model"
+display_name = "Test"
+input_cost_per_million = 1.00
+output_cost_per_million = 1.00
+context_window = 4096
+supports_streaming = false
+supports_tools = false
+supports_vision = false
+"#;
+        let registry = solvela_router::models::ModelRegistry::from_toml(toml)
+            .expect("valid test registry TOML");
+        let model_info = registry
+            .get("test/test-model")
+            .expect("model registered under canonical id");
+
+        // 1M input tokens @ $1.00/M = $1.00 provider cost = 1_000_000 atomic.
+        // Single 5% fee → 1_050_000. A double-applied fee would yield 1_102_500.
+        let atomic = compute_actual_atomic_cost(1_000_000, 0, model_info);
+        assert_eq!(
+            atomic, 1_050_000,
+            "expected exactly 1.05x provider cost (single 5% fee); got {atomic}. \
+             1_102_500 here means the fee is being applied twice."
+        );
+    }
+
+    #[test]
     fn test_compute_actual_atomic_cost_includes_5_percent_fee() {
         let model_info = ModelInfo {
             id: "test/model".to_string(),

--- a/crates/router/src/models.rs
+++ b/crates/router/src/models.rs
@@ -67,9 +67,8 @@ impl ModelRegistry {
                     provider: entry.provider,
                     model_id: entry.model_id,
                     display_name: entry.display_name,
-                    input_cost_per_million: entry.input_cost_per_million * PLATFORM_FEE_MULTIPLIER,
-                    output_cost_per_million: entry.output_cost_per_million
-                        * PLATFORM_FEE_MULTIPLIER,
+                    input_cost_per_million: entry.input_cost_per_million,
+                    output_cost_per_million: entry.output_cost_per_million,
                     context_window: entry.context_window,
                     supports_streaming: entry.supports_streaming,
                     supports_tools: entry.supports_tools,
@@ -115,8 +114,8 @@ impl ModelRegistry {
 
         let input_cost = (input_tokens as f64 / 1_000_000.0) * model.input_cost_per_million;
         let output_cost = (output_tokens as f64 / 1_000_000.0) * model.output_cost_per_million;
-        let total_with_fee = input_cost + output_cost;
-        let provider_cost = total_with_fee / PLATFORM_FEE_MULTIPLIER;
+        let provider_cost = input_cost + output_cost;
+        let total_with_fee = provider_cost * PLATFORM_FEE_MULTIPLIER;
         let platform_fee = total_with_fee - provider_cost;
 
         Ok(CostBreakdown {
@@ -165,16 +164,47 @@ supports_streaming = true
     }
 
     #[test]
-    fn test_pricing_includes_fee() {
+    fn test_registry_stores_raw_provider_rates() {
+        // ModelRegistry stores raw provider rates as-loaded from TOML.
+        // The 5% platform fee is applied at the boundary by estimate_cost
+        // and compute_actual_atomic_cost — never baked into ModelInfo.
         let registry = ModelRegistry::from_toml(TEST_TOML).unwrap();
         let model = registry.get("openai/gpt-4o").unwrap();
-
-        // Provider charges $2.50/M input — with 5% fee user pays $2.625/M
-        let expected = 2.50 * PLATFORM_FEE_MULTIPLIER;
         assert!(
-            (model.input_cost_per_million - expected).abs() < 0.001,
+            (model.input_cost_per_million - 2.50).abs() < 0.001,
             "got {}",
             model.input_cost_per_million
+        );
+        assert!(
+            (model.output_cost_per_million - 10.00).abs() < 0.001,
+            "got {}",
+            model.output_cost_per_million
+        );
+    }
+
+    #[test]
+    fn test_estimate_cost_applies_exactly_one_5_percent_fee() {
+        // Pin the effective fee at exactly 5% (not 10.25%). This is the
+        // regression test for the double-application bug fixed in Option A.
+        let registry = ModelRegistry::from_toml(TEST_TOML).unwrap();
+        // 1M input tokens @ $2.50/M = $2.50 provider; 0 output tokens.
+        let cost = registry
+            .estimate_cost("openai/gpt-4o", 1_000_000, 0)
+            .unwrap();
+        let provider: f64 = cost.provider_cost.parse().unwrap();
+        let fee: f64 = cost.platform_fee.parse().unwrap();
+        let total: f64 = cost.total.parse().unwrap();
+        assert!(
+            (provider - 2.50).abs() < 1e-6,
+            "provider_cost should be 2.50, got {provider}"
+        );
+        assert!(
+            (fee - 0.125).abs() < 1e-6,
+            "platform_fee should be 0.125 (5% of 2.50), got {fee}"
+        );
+        assert!(
+            (total - 2.625).abs() < 1e-6,
+            "total should be 2.625 (2.50 * 1.05), got {total}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Bug:** `ModelRegistry::from_toml` baked the 5% fee into every `ModelInfo` at load time, then `compute_actual_atomic_cost` (chat/cost.rs) and `/pricing` (routes/pricing.rs) each multiplied by `1.05` again — effective fee in those paths was 1.05 × 1.05 = **10.25%**.
- **Practical impact:** users were *mostly* still charged 5% in production (the 402 cost breakdown uses `estimate_cost` which had its own `/1.05` recovery; escrow over-claims were silently clamped by `cap_claim_amount` back to the 402 deposit). But `GET /pricing` example math and `GET /v1/models` rates were publicly broken.
- **Fix (Option A — single boundary):** registry stores **raw provider rates** as loaded from TOML; the fee is applied exactly once at the consuming sites. `compute_actual_atomic_cost` and `pricing.rs` become correct as already written.

## Why the existing test missed it

`test_compute_actual_atomic_cost_includes_5_percent_fee` hand-constructed a `ModelInfo` and asserted single-fee math, bypassing `ModelRegistry::from_toml` and missing the bake-in.

## What changed

| File | Change |
|---|---|
| `crates/router/src/models.rs` | Drop `* PLATFORM_FEE_MULTIPLIER` in `from_toml`; rewrite `estimate_cost` to compute `provider_cost` first then `total = provider * 1.05` (mathematically identical f64 result, semantically consistent). |
| `crates/router/src/models.rs` | Renamed `test_pricing_includes_fee` → `test_registry_stores_raw_provider_rates`; new `test_estimate_cost_applies_exactly_one_5_percent_fee`. |
| `crates/gateway/src/routes/chat/cost.rs` | New `test_compute_actual_atomic_cost_applies_single_fee_via_registry` — exercises the **production wiring** (TOML → registry → `compute_actual_atomic_cost`). Would have caught the original bug. |

## Behavior change to flag

`GET /v1/models`'s `input_per_million` / `output_per_million` fields now expose the **raw provider rate** instead of the gross (× 1.05) rate. This is more honest — consumers expect `raw + fee_percent = total`. Any client that was displaying the gross rate as "the cost" will see it drop ~5%, but adding `fee_percent` back recovers the same total.

## Test plan

- [x] `cargo test -p solvela-router` — 14/14 pass (incl. 2 new)
- [x] `cargo test -p gateway` — 412 lib + 122 integration pass (incl. 1 new regression test, plus the existing `cost_breakdown.platform_fee == provider_cost * 0.05` integration assertion at `tests/integration.rs:1003`)
- [x] `cargo test --workspace` — all green (750+ tests)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] CI status checks pass on this PR
- [ ] Manual smoke: hit `/pricing` against a built gateway and confirm `example_1k_token_request.total_usdc` reflects 5%, not 10.25%

🤖 Generated with [Claude Code](https://claude.com/claude-code)