### PR TITLE
chore(harness): align CLAUDE.md skills table with ECC plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,11 +38,6 @@
 *~
 .DS_Store
 .claude/
-.claude/skills/memory-safety-patterns
-.claude/skills/rust-async-patterns
-.claude/skills/rust-pro
-.claude/skills/rust-router
-.claude/skills/systems-programming-rust-project
 .env*
 .env*.local
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,19 +239,22 @@ use crate::config::AppConfig;               // 4. Crate-internal modules
 
 These skills contain patterns, checklists, and constraints specific to this project's domains. Invoke them via the `Skill` tool BEFORE writing or modifying code in the matching areas.
 
+> Skills below resolve to plugins installed at user scope — the `everything-claude-code` (ECC) plugin and the `helius` plugin. `security-review` is intentionally unprefixed because it resolves as a top-level Claude Code skill, not from a plugin. Project-local skill overrides were removed (2026-05-06) to stop shadowing the maintained plugin versions. Two domains (Solvela's x402/escrow specifics and 5%-fee fintech math) have no upstream equivalent and are marked TODO; author project skills at `.claude/skills/<name>/SKILL.md` when the plugin coverage isn't enough.
+
 | Skill | Invoke when touching | Key files |
 |---|---|---|
-| `solana-dev` | Solana, Anchor, SPL token, x402 protocol, escrow, fee payer, nonce, PDA, on-chain verification | `crates/x402/`, `programs/escrow/`, `solana.rs`, `fee_payer.rs`, `nonce_pool.rs`, `facilitator.rs` |
+| `helius:build` + `helius:svm` | Solana, SPL token, on-chain verification, fee payer, nonce, PDA basics | `crates/x402/`, `solana.rs`, `fee_payer.rs`, `nonce_pool.rs`, `facilitator.rs` |
+| _(no upstream skill — TODO: author `solvela-x402`)_ | Anchor program work, escrow PDAs, LiteSVM testing, x402-specific protocol details | `programs/escrow/`, `crates/x402/` |
 | `security-review` | Payment verification, crypto, API key handling, CORS, rate limiting, header decoding, secret redaction | `middleware/x402.rs`, `middleware/rate_limit.rs`, `config.rs` (redaction), `solana.rs` |
-| `domain-fintech` | USDC calculations, atomic amounts, cost breakdowns, pricing, 5% fee logic, budget checks | `routes/chat/cost.rs`, `models.rs` (pricing), `usage.rs` (budgets) |
-| `database-migrations` | Schema changes, new columns, indexes, PostgreSQL queries | `migrations/`, `usage.rs`, `wallet_budgets` |
-| `postgres-patterns` | Query optimization, sqlx usage, connection pooling | `usage.rs`, `main.rs` (pool setup) |
-| `domain-web` | Axum routes, middleware, Tower layers, SSE streaming, CORS, request/response handling | `routes/`, `middleware/`, `providers/`, `lib.rs` (`build_router`) |
-| `m07-concurrency` | Async patterns, tokio::spawn, fire-and-forget, background tasks, Arc sharing | `usage.rs`, `cache.rs`, `balance_monitor.rs`, `escrow/claimer.rs`, `main.rs` |
-| `api-design` | Adding/changing HTTP endpoints, 402 response shape, OpenAI compatibility, query params | `routes/chat.rs`, `routes/services.rs`, `routes/models.rs`, x402 types |
-| `tdd-workflow` | Any new feature or bugfix — write tests first | All crates |
-| `docker-patterns` | Container config, compose services, multi-stage builds | `Dockerfile`, `docker-compose.yml` |
-| `deployment-patterns` | Deploy config, CI/CD, infrastructure | `Dockerfile`, `fly.toml` |
+| _(no upstream skill — TODO: author `solvela-fintech`)_ | USDC atomic-amount math, cost breakdowns, 5% fee logic, budget checks — see "Key Architectural Rules" #5 | `routes/chat/cost.rs`, `models.rs` (pricing), `usage.rs` (budgets) |
+| `everything-claude-code:database-migrations` | Schema changes, new columns, indexes, PostgreSQL queries | `migrations/`, `usage.rs`, `wallet_budgets` |
+| `everything-claude-code:postgres-patterns` | Query optimization, sqlx usage, connection pooling | `usage.rs`, `main.rs` (pool setup) |
+| `everything-claude-code:backend-patterns` | Axum routes, middleware, Tower layers, SSE streaming, CORS, request/response handling | `routes/`, `middleware/`, `providers/`, `lib.rs` (`build_router`) |
+| `everything-claude-code:rust-patterns` | Async patterns, tokio::spawn, fire-and-forget, background tasks, Arc sharing | `usage.rs`, `cache.rs`, `balance_monitor.rs`, `escrow/claimer.rs`, `main.rs` |
+| `everything-claude-code:api-design` | Adding/changing HTTP endpoints, 402 response shape, OpenAI compatibility, query params | `routes/chat.rs`, `routes/services.rs`, `routes/models.rs`, x402 types |
+| `everything-claude-code:tdd-workflow` + `everything-claude-code:rust-test` | Any new feature or bugfix — write tests first | All crates |
+| `everything-claude-code:docker-patterns` | Container config, compose services, multi-stage builds | `Dockerfile`, `docker-compose.yml` |
+| `everything-claude-code:deployment-patterns` | Deploy config, CI/CD, infrastructure | `Dockerfile`, `fly.toml` |
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- Replace bare skill names in CLAUDE.md's "Skills — Invoke Before Making Changes" table with their resolvable forms (`everything-claude-code:*`, `helius:*`). The bare names had been resolving only to project-local copies under `.claude/skills/`, which were stale vendored snapshots shadowing the maintained plugin versions.
- Mark two rows as TODO where no upstream skill exists: `solvela-x402` (Anchor / escrow / x402-protocol specifics) and `solvela-fintech` (USDC atomic-amount math + 5% platform-fee logic). These are genuine gaps and warrant project-specific skills later.
- Add a one-line note above the table explaining how skills resolve and where to author project-specific overrides.
- Drop 5 dead `.gitignore` lines that pointed at deleted skill symlinks; the blanket `.claude/` rule already covers them.

No code or behavior change — docs + gitignore hygiene only.

## Test plan
- [x] `git diff --stat` shows only `CLAUDE.md` and `.gitignore`
- [x] `.gitignore` still ignores `.claude/` (`git check-ignore .claude/settings.local.json` returns the rule)
- [ ] Reviewer opens a fresh Claude Code session in the repo and confirms the namespaced skills (e.g. `everything-claude-code:postgres-patterns`, `helius:build`) resolve in the catalogue
- [ ] Reviewer confirms the two TODO rows are accurate (`solvela-x402`, `solvela-fintech` — no upstream equivalent in current ECC marketplace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)