### PR TITLE
fix(dashboard): tighten test fixture types so @ts-expect-error stays load-bearing

### DIFF
--- a/dashboard/src/__tests__/api.test.ts
+++ b/dashboard/src/__tests__/api.test.ts
@@ -9,6 +9,7 @@ import {
   fetchEscrowConfig,
   fetchEscrowHealth,
 } from "@/lib/api";
+import type { AdminStatsResponse } from "@/types";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -335,8 +336,9 @@ describe("fetchPublicMetrics", () => {
 
   // Realistic fixture mirroring the AdminStatsResponse shape, including the
   // PII-bearing `top_wallets` field and the per-model `cost_usdc` field that
-  // must be stripped before public exposure.
-  const sensitiveStatsPayload = {
+  // must be stripped before public exposure. Typed against AdminStatsResponse
+  // so that any drift in the upstream contract surfaces here at compile time.
+  const sensitiveStatsPayload: AdminStatsResponse = {
     period_days: 30,
     summary: {
       total_requests: 1247,
@@ -516,7 +518,12 @@ describe("fetchPublicMetrics", () => {
     process.env.GATEWAY_ADMIN_KEY = "test-secret-key";
     // Inject a hypothetical future field upstream — we want to be sure that
     // only the explicitly-allowlisted fields make it to the public response.
-    const withRogueField = {
+    // Annotated against AdminStatsResponse so the literal `internal_revenue_usdc`
+    // property triggers TS's excess-property check (TS2353). The directive below
+    // is what makes the test compile; if AdminStatsResponse ever grows a field
+    // called `internal_revenue_usdc`, this directive turns into a TS2578 (unused)
+    // — a useful canary that the test's premise no longer holds.
+    const withRogueField: AdminStatsResponse = {
       ...sensitiveStatsPayload,
       // @ts-expect-error — intentionally injecting an unknown field
       internal_revenue_usdc: "999.99",


### PR DESCRIPTION
## Summary

Fixes a CI break (\`tsc --noEmit\` → \`error TS2578: Unused '@ts-expect-error' directive\`) at \`dashboard/src/__tests__/api.test.ts:521\`, by tightening the fixture types so the directive becomes genuinely load-bearing again rather than deleting it.

## Root cause

The test \"does not expose any field outside the documented PublicMetricsResponse shape\" deliberately injects a rogue field upstream and asserts that \`fetchPublicMetrics\` strips it before public exposure:

\`\`\`ts
const withRogueField = {
  ...sensitiveStatsPayload,
  // @ts-expect-error — intentionally injecting an unknown field
  internal_revenue_usdc: \"999.99\",
};
\`\`\`

But \`sensitiveStatsPayload\` had no type annotation, so its inferred object-literal type permits arbitrary keys. Spreading it and adding \`internal_revenue_usdc\` produced **no diagnostic** — meaning the \`@ts-expect-error\` directive was a no-op, and TS2578 fired.

Deleting the directive would clear CI but lose the test's premise: \"we strip rogue fields\" should be enforced by the type system, not just by runtime allowlist hope.

## Fix

Annotate both consts against the upstream contract:

\`\`\`ts
import type { AdminStatsResponse } from \"@/types\";

const sensitiveStatsPayload: AdminStatsResponse = { /* … */ };

const withRogueField: AdminStatsResponse = {
  ...sensitiveStatsPayload,
  // @ts-expect-error — intentionally injecting an unknown field
  internal_revenue_usdc: \"999.99\",
};
\`\`\`

- \`sensitiveStatsPayload: AdminStatsResponse\` binds the fixture to the upstream contract — future drift (a renamed field, a removed field, a wrong type) surfaces here at compile time.
- \`withRogueField: AdminStatsResponse\` makes the literal \`internal_revenue_usdc\` property trigger TS's excess-property check (TS2353), which the \`@ts-expect-error\` directive then catches as intended.

If \`AdminStatsResponse\` ever grows a field literally named \`internal_revenue_usdc\`, the directive becomes a TS2578 again — a useful canary that the test's premise no longer holds.

## Test plan

- [x] \`cd dashboard && npx tsc --noEmit\` — exits 0 (was failing with TS2578 before this PR)
- [x] Existing test logic unchanged; assertions still verify the runtime allowlist strips the rogue field
- [ ] CI typecheck step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)