### PR TITLE
chore: add DCO sign-off git hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Enforce DCO sign-off on every commit.
+#
+# This mirrors the GitHub-side "Verify DCO sign-off" check so failures
+# show up at commit time (locally) instead of at PR-merge time. To
+# enable this hook in a fresh clone, run once:
+#
+#   git config core.hooksPath .githooks
+#
+# The companion `.githooks/prepare-commit-msg` hook auto-injects the
+# trailer on every commit, and this hook catches the cases where the
+# trailer is missing or doesn't match the commit author (typo'd email,
+# copy-pasted from another author, etc.).
+#
+# Bypass with `git commit --no-verify` for emergencies (e.g. mechanical
+# reverts where DCO is contested) — the GitHub check will still fire.
+
+msg_file="$1"
+
+# Build the expected trailer from the commit author identity. We use
+# `git var GIT_AUTHOR_IDENT` rather than reading user.name/user.email
+# directly so amends and `--author=...` overrides resolve correctly.
+ident=$(git var GIT_AUTHOR_IDENT)
+author_name=$(printf '%s' "$ident" | sed 's/ <.*//')
+author_email=$(printf '%s' "$ident" | sed 's/^[^<]*<\([^>]*\)>.*/\1/')
+expected="Signed-off-by: ${author_name} <${author_email}>"
+
+# Use `git interpret-trailers --parse` to extract trailers in their
+# normalized form, then check the expected trailer is present. This is
+# more robust than a raw grep against the raw message body.
+if git interpret-trailers --parse "$msg_file" 2>/dev/null | grep -qxF "$expected"; then
+    exit 0
+fi
+
+cat >&2 <<EOF
+ERROR: Commit message is missing or has a mismatched DCO sign-off trailer.
+
+Expected: $expected
+
+Fix any one of:
+  • Re-run with:            git commit -s
+  • Amend the last commit:  git commit --amend -s --no-edit
+  • Bypass once (rare):     git commit --no-verify
+
+The companion .githooks/prepare-commit-msg hook auto-injects this
+trailer on every commit. If you're seeing this error, check that
+\`git config core.hooksPath\` is set to \`.githooks\` — without that,
+prepare-commit-msg never runs.
+
+This project requires the Developer Certificate of Origin (DCO) on every
+commit. See https://developercertificate.org/ for the certificate text.
+EOF
+
+exit 1

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Auto-inject a Signed-off-by trailer matching the commit author.
+#
+# Runs BEFORE commit-msg, so commits drafted via `git commit -m "…"`
+# from a HEREDOC pick up the trailer automatically (the `commit.signoff`
+# / `format.signOff` config flags don't reliably cover all git
+# invocation paths). The companion `.githooks/commit-msg` hook then
+# enforces the result.
+#
+# Idempotent: if a matching trailer is already present, this is a
+# no-op. Runs on every commit source (message, template, merge,
+# squash, amend) so DCO sign-off is uniform across the project.
+
+msg_file="$1"
+
+ident=$(git var GIT_AUTHOR_IDENT)
+author_name=$(printf '%s' "$ident" | sed 's/ <.*//')
+author_email=$(printf '%s' "$ident" | sed 's/^[^<]*<\([^>]*\)>.*/\1/')
+expected="Signed-off-by: ${author_name} <${author_email}>"
+
+# Skip if the trailer is already present (handles `git commit -s`,
+# manual signoff, and re-runs after an amend).
+if git interpret-trailers --parse "$msg_file" 2>/dev/null | grep -qxF "$expected"; then
+    exit 0
+fi
+
+git interpret-trailers --in-place \
+    --trailer "Signed-off-by: ${author_name} <${author_email}>" \
+    "$msg_file"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,30 @@ RUST_LOG=info cargo run -p gateway  # listens on :8402
 
 Migrations in `migrations/` are applied automatically by `docker compose up` and on gateway startup via `run_migrations()` (idempotent).
 
+## Local Setup (one-time per clone)
+
+```bash
+# Activate the tracked git hooks (auto-signoff + DCO enforcement).
+git config core.hooksPath .githooks
+```
+
+Two hooks live in `.githooks/`:
+
+- **`prepare-commit-msg`** auto-injects a `Signed-off-by: <name> <email>`
+  trailer matching the configured `user.name`/`user.email` on every
+  commit (idempotent — skips if already present). Runs before the
+  message reaches commit-msg, so messages drafted via `git commit -m`
+  from a HEREDOC pick up the trailer automatically. The `format.signOff`
+  / `commit.signoff` config flags do not reliably cover all git
+  invocation paths, so this hook is the source of truth.
+- **`commit-msg`** enforces that the trailer is present and matches the
+  author identity, mirroring the GitHub-side DCO check. Catches the
+  rare case where the trailer was stripped or rewritten between
+  prepare-commit-msg and the actual commit.
+
+Bypass once with `git commit --no-verify` for emergencies; the
+GitHub-side DCO check will still fire on push.
+
 ## Architecture
 
 ### Workspace Crates (`crates/`)


### PR DESCRIPTION
## Summary

Adds two tracked git hooks under `.githooks/` so DCO failures surface at commit time locally instead of at PR-merge time. Motivated by PR #113, where missing `Signed-off-by:` trailers on two commits forced a force-push + CI rerun + stack rebase before the merge could fire.

## What's in here

### `.githooks/prepare-commit-msg`
Auto-injects a `Signed-off-by: <name> <email>` trailer matching the configured `user.name`/`user.email` on every commit. Idempotent — skips if a matching trailer is already present. Crucially, this **covers `git commit -m` from a HEREDOC**, which neither `format.signOff = true` nor `commit.signoff = true` reliably reaches in this git version (verified empirically before writing this hook).

### `.githooks/commit-msg`
Enforces that the trailer is present and matches the author identity, mirroring the GitHub-side "Verify DCO sign-off" check. Backstop in case the trailer was stripped or rewritten between prepare-commit-msg and the actual commit.

Both hooks:
- Use `git interpret-trailers --parse` / `--in-place` rather than raw grep, so formatting edge cases (extra whitespace, multi-line bodies, mixed trailer ordering) don't cause false negatives.
- Run on every commit source (regular, amend, merge, squash, template) — DCO sign-off is uniform across the project, no special-case skip logic. (`commit-msg` only receives one argument from git, so source-based skipping wasn't viable as a backstop anyway.)
- Read the expected identity from `git var GIT_AUTHOR_IDENT` so `--author=` overrides and amends resolve correctly.

### CLAUDE.md
New `## Local Setup (one-time per clone)` section documenting the single `git config core.hooksPath .githooks` activation step, with a clear note explaining why `format.signOff` / `commit.signoff` weren't sufficient and that prepare-commit-msg is the source of truth.

## Verification

- `.githooks/commit-msg` directly:
  - No-signoff input → exit 1 with the helpful error
  - Properly signed-off input → exit 0
- This very PR's commit dogfoods both hooks: drafted via `git commit -m` from a HEREDOC, prepare-commit-msg auto-injected the trailer, commit-msg accepted, no `-s` was passed.

## Test plan

- [x] Hook scripts pass shellcheck-style sanity (POSIX sh, no bashisms)
- [x] Hooks fire only when `core.hooksPath = .githooks` is set (so contributors who haven't enabled them aren't blocked, and CI's existing GitHub-side DCO check is the real gate)
- [x] This PR's own commit passes both hooks without explicit `-s`
- [ ] Reviewer enables on their clone (`git config core.hooksPath .githooks`) and confirms next commit picks up the trailer automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
