### PR TITLE
fix(signer-core): sanitizeGatewayError now composes redactHex and redactBase58

### DIFF
--- a/sdks/signer-core/src/redact.ts
+++ b/sdks/signer-core/src/redact.ts
@@ -13,6 +13,9 @@ const BASE58_RE = /[1-9A-HJ-NP-Za-km-z]{44,88}/g;
  * Replaces 64+ character hex sequences in `s` with `[REDACTED]`.
  * Must be called BEFORE redactBase58 because the hex alphabet is a subset
  * of the base58 alphabet.
+ *
+ * Used internally by `sanitizeGatewayError`; also exported so downstream
+ * SDKs that build their own error formatters can compose the same primitives.
  */
 export function redactHex(s: string): string {
   return s.replace(HEX_RE, '[REDACTED]');
@@ -21,6 +24,9 @@ export function redactHex(s: string): string {
 /**
  * Replaces 44–88 character base58 sequences in `s` with `[REDACTED]`.
  * Call redactHex first if the input may contain hex-encoded keys.
+ *
+ * Used internally by `sanitizeGatewayError`; also exported so downstream
+ * SDKs that build their own error formatters can compose the same primitives.
  */
 export function redactBase58(s: string): string {
   return s.replace(BASE58_RE, '[REDACTED]');
@@ -29,12 +35,24 @@ export function redactBase58(s: string): string {
 /**
  * Sanitize a gateway error body string for safe inclusion in error messages.
  *
- * Slices to maxLen characters then redacts payment-signature header fragments.
+ * Pipeline:
+ *   1. Slice to `maxLen` (avoids spending regex work on bytes that get discarded).
+ *   2. Replace `payment-signature` header fragments with `[redacted]`.
+ *   3. Apply `redactHex` (catches private keys + hex tx signatures, ≥ 64 chars).
+ *   4. Apply `redactBase58` (catches wallet addresses + base58 tx signatures,
+ *      44–88 chars).
+ *
+ * Hex must run before base58 because the hex alphabet is a strict subset of
+ * the base58 alphabet — a 64-char hex private key would otherwise be matched
+ * (and replaced) by the base58 pass first, losing the more specific signal.
  *
  * @param text - Raw gateway response body text.
  * @param maxLen - Maximum length to slice to before redaction (default: 500).
  * @returns Sanitized string safe for error messages.
  */
 export function sanitizeGatewayError(text: string, maxLen = 500): string {
-  return text.slice(0, maxLen).replace(/payment-signature[^\s,}"]+/gi, '[redacted]');
+  const sliced = text
+    .slice(0, maxLen)
+    .replace(/payment-signature[^\s,}"]+/gi, '[redacted]');
+  return redactBase58(redactHex(sliced));
 }

--- a/sdks/signer-core/tests/redact.test.ts
+++ b/sdks/signer-core/tests/redact.test.ts
@@ -89,13 +89,16 @@ describe('sanitizeGatewayError', () => {
   });
 
   it('slices to maxLen (default 500) before redacting', () => {
-    const long = 'a'.repeat(1000);
+    // Spaces pass through both redactors untouched, so we can assert the
+    // post-slice length directly. (A long run of base58-alphabet chars
+    // would be redacted into shorter `[REDACTED]` markers.)
+    const long = ' '.repeat(1000);
     const result = sanitizeGatewayError(long);
     assert.equal(result.length, 500);
   });
 
   it('respects custom maxLen', () => {
-    const long = 'a'.repeat(1000);
+    const long = ' '.repeat(1000);
     const result = sanitizeGatewayError(long, 100);
     assert.equal(result.length, 100);
   });
@@ -107,5 +110,41 @@ describe('sanitizeGatewayError', () => {
 
   it('handles empty string', () => {
     assert.equal(sanitizeGatewayError(''), '');
+  });
+
+  // ── redactor composition: the file's own redactHex + redactBase58 must
+  //    apply to gateway error bodies, not just payment-signature fragments.
+  //    Regression for the bug where wallet addresses and key-shaped hex
+  //    leaked through error messages despite the helpers existing in the
+  //    same module.
+
+  it('redacts wallet addresses (base58) embedded in error bodies', () => {
+    const text = `upstream rejected tx for wallet ${BASE58_44}: insufficient balance`;
+    const result = sanitizeGatewayError(text);
+    assert.equal(
+      result,
+      'upstream rejected tx for wallet [REDACTED]: insufficient balance',
+    );
+  });
+
+  it('redacts private-key-shaped hex fragments in error bodies', () => {
+    const text = `signing failed: leaked key ${HEX_64} mid-message`;
+    const result = sanitizeGatewayError(text);
+    assert.equal(result, 'signing failed: leaked key [REDACTED] mid-message');
+  });
+
+  it('redacts both base58 and hex in the same error body', () => {
+    const text = `wallet ${BASE58_44} signed tx ${HEX_64} but it was rejected`;
+    const result = sanitizeGatewayError(text);
+    assert.equal(
+      result,
+      'wallet [REDACTED] signed tx [REDACTED] but it was rejected',
+    );
+  });
+
+  it('still strips payment-signature alongside hex/base58 redaction', () => {
+    const text = `error: payment-signatureXYZ123 wallet ${BASE58_44} rejected`;
+    const result = sanitizeGatewayError(text);
+    assert.equal(result, 'error: [redacted] wallet [REDACTED] rejected');
   });
 });


### PR DESCRIPTION
## Summary

Fixes a redaction gap in \`@solvela/signer-core\`. The \`sanitizeGatewayError\` function — used by \`sdks/mcp/src/client.ts\` to clean gateway response bodies before they bubble up as error messages — was only slicing and stripping \`payment-signature\` fragments. The module's own \`redactHex\` and \`redactBase58\` helpers were never being applied, so wallet addresses and hex-shaped key fragments leaked through untouched.

## Concrete leak

A realistic upstream error body before this PR:

\`\`\`
upstream error: rejected tx for wallet 7xKXtg9aPzvYqmA2jUw6QcKSv3bRb1QmS3C5C5kqJxYZ insufficient balance
\`\`\`

was sanitized to **itself** — the wallet pubkey, any private-key-shaped hex, and any base58 tx signature all passed through. The companion \`sdks/ai-sdk-provider/src/util/redact.ts:113-115\` already runs the same hex→base58 chain on \`responseBody\`, so this aligns signer-core with house style.

## Why it slipped past 46 green tests

The existing tests covered \`payment-signature\` redaction, length truncation, case insensitivity, and empty input — none exercised hex or base58 leakage. The four new cases lock down each variant.

## Pipeline

\`\`\`
sanitizeGatewayError(text):
  1. slice to maxLen (still cheaper to slice first than redact-then-slice)
  2. strip \`payment-signature\` fragments → '[redacted]'
  3. redactHex   → '[REDACTED]' for ≥64-char hex runs
  4. redactBase58 → '[REDACTED]' for 44-88-char base58 runs
\`\`\`

Hex must run before base58: the hex alphabet is a strict subset of the base58 alphabet, so a 64-char hex private key would otherwise be greedily matched (and replaced) by the base58 pass first, losing the more specific signal.

## Test changes

- **Updated** two existing length-assertion tests to use \` \`.repeat(1000)\` instead of \`'a'.repeat(1000)\`. Under the new pipeline, a long run of base58-alphabet characters would be redacted into shorter \`[REDACTED]\` markers, breaking the \`result.length === 500\` assertion. Spaces pass through both regexes untouched, preserving the slice-length intent of the test.
- **Added** 4 new regression cases:
  - \`redacts wallet addresses (base58) embedded in error bodies\`
  - \`redacts private-key-shaped hex fragments in error bodies\`
  - \`redacts both base58 and hex in the same error body\`
  - \`still strips payment-signature alongside hex/base58 redaction\` (mixed pipeline)

## Caller impact

\`sanitizeGatewayError\`'s signature is unchanged: \`(text: string, maxLen = 500) => string\`. Callers in \`sdks/mcp/src/client.ts:337,351\` and any external consumer get strictly stronger redaction with no API change.

## Test plan

- [x] \`npm --prefix sdks/signer-core test\` — 50 tests passing (up from 46), 0 failures
- [x] Manual: traced the \`mcp/src/client.ts\` call sites to confirm the wider redacted output is still embedded inline in their thrown errors (the function returns a string; callers don't introspect it)
- [ ] CI \`signer-core\` pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)