### PR TITLE
chore: exempt bot authors from DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -40,6 +40,18 @@ jobs:
           while read -r sha; do
             author_email="$(git log -1 --format='%ae' "$sha")"
             author_name="$(git log -1 --format='%an' "$sha")"
+            # Bot authors cannot make a DCO certification — the DCO certifies
+            # a *human's* right to contribute under the project license, and a
+            # bot has no such right to certify. The human contribution on a
+            # bot-authored PR is the maintainer's act of accepting it at merge
+            # time. Add bot authors here as needed; human-authored commits
+            # remain subject to the full check.
+            case "$author_name" in
+              "dependabot[bot]"|"github-actions[bot]")
+                echo "skipping DCO for $sha — bot author $author_name"
+                continue
+                ;;
+            esac
             sob_lines="$(git log -1 --format='%B' "$sha" | grep -E '^Signed-off-by: ' || true)"
             if [ -z "$sob_lines" ]; then
               echo "::error::Commit $sha by $author_name <$author_email> is missing a Signed-off-by trailer."


### PR DESCRIPTION
## Summary

Exempts bot authors (`dependabot[bot]`, `github-actions[bot]`) from the DCO
sign-off check. Without this, every Dependabot PR fails — currently blocking
#125 (openssl `0.10.79`, **HIGH** [`GHSA-xp3w-r5p5-63rr`](https://github.com/advisories/GHSA-xp3w-r5p5-63rr)) and 20+ other routine dependency bumps.

## Why this is correct under DCO

The Developer Certificate of Origin certifies a *human* contributor's right
to submit work under the project license. A bot has no such right to
certify. The human contribution on a bot-authored PR is the maintainer's
act of accepting and merging it — captured at merge time, not at the bot's
commit time.

Standard pattern in OSS projects with strict DCO + Dependabot.

## What changed

`.github/workflows/dco.yml` — one `case` block in the verification loop
that early-exits the per-commit check for `dependabot[bot]` or
`github-actions[bot]` authors. Other bot identities (custom Apps,
Renovate, etc.) are not exempted; add to the case statement if/when
needed. Human-authored commits remain subject to the full DCO check.

## Test plan

- [x] This PR's own commit (human-authored, `sky4`) passes the full DCO
      check — proves human-authored gating is intact
- [x] Workflow YAML parses without error (CI runs on push)
- [ ] After merge, #125's DCO check passes on next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
