### PR TITLE
fix(signer-core): use Number() not parseFloat() to validate cost_breakdown.total

### DIFF
--- a/sdks/signer-core/src/parse-402.ts
+++ b/sdks/signer-core/src/parse-402.ts
@@ -88,11 +88,24 @@ function validatePaymentRequired(inner: unknown, context: string): PaymentRequir
     );
   }
 
-  // Validate cost_breakdown.total is a finite positive number
-  const total = parseFloat(obj.cost_breakdown?.total);
+  // Validate cost_breakdown.total parses to a finite non-negative number.
+  //
+  // We use Number() (not parseFloat) so trailing garbage like "1.5USDC" or
+  // "0.001SOL" is rejected — parseFloat would happily return 1.5 / 0.001 and
+  // silently strip the suffix. The typeof guard is needed because Number()
+  // coerces several non-string values to 0 (Number("") === Number(null) ===
+  // Number([]) === 0, Number(true) === 1), which would otherwise pass the
+  // `total < 0` check. The x402 wire format requires `total` to be a string
+  // (decimal USDC kept as text to avoid float precision drift), so anything
+  // else is malformed by definition.
+  const totalRaw = obj.cost_breakdown?.total;
+  const total =
+    typeof totalRaw === 'string' && totalRaw.length > 0
+      ? Number(totalRaw)
+      : NaN;
   if (!Number.isFinite(total) || total < 0) {
     throw new Error(
-      `Gateway 402 has invalid cost_breakdown.total ${context}: ${obj.cost_breakdown?.total}`,
+      `Gateway 402 has invalid cost_breakdown.total ${context}: ${totalRaw}`,
     );
   }
 

--- a/sdks/signer-core/tests/parse-402.test.ts
+++ b/sdks/signer-core/tests/parse-402.test.ts
@@ -138,6 +138,43 @@ describe('parse402', () => {
       );
     });
 
+    // Number() is stricter than parseFloat for trailing garbage:
+    //   parseFloat("1.5USDC") → 1.5  (silently strips the suffix — bug)
+    //   Number("1.5USDC")    → NaN   (correctly rejects)
+    it('throws on cost_breakdown.total with trailing currency suffix', () => {
+      for (const total of ['1.5USDC', '0.001SOL', '0.5 USDC', '1.5,']) {
+        const body = {
+          ...validDirectBody,
+          cost_breakdown: { ...validDirectBody.cost_breakdown, total },
+        };
+        assert.throws(
+          () => parse402(JSON.stringify(body)),
+          /invalid cost_breakdown\.total/,
+          `expected "${total}" to be rejected`,
+        );
+      }
+    });
+
+    // Number() coerces empty strings, null, booleans, and arrays to 0 / 1
+    // (unlike parseFloat which yields NaN). Without the typeof+length guard
+    // around the Number() call, those would silently pass the `total < 0`
+    // check. Numeric-typed totals are also rejected — the wire format keeps
+    // USDC amounts as strings to avoid float precision drift.
+    it('throws on cost_breakdown.total that is empty or non-string', () => {
+      const malformed: unknown[] = ['', null, true, false, [], 0.001];
+      for (const total of malformed) {
+        const body = {
+          ...validDirectBody,
+          cost_breakdown: { ...validDirectBody.cost_breakdown, total },
+        };
+        assert.throws(
+          () => parse402(JSON.stringify(body)),
+          /invalid cost_breakdown\.total/,
+          `expected ${JSON.stringify(total)} to be rejected`,
+        );
+      }
+    });
+
     it('throws on non-object body (array)', () => {
       assert.throws(
         () => parse402('[]'),


### PR DESCRIPTION
## Summary

Tightens the \`cost_breakdown.total\` validator in \`@solvela/signer-core\`'s \`parse402\`. \`parseFloat(\"1.5USDC\")\` returns 1.5 — it silently strips any trailing non-numeric suffix. So a malformed payload like:

\`\`\`json
{ \"cost_breakdown\": { \"total\": \"0.001SOL\", ... } }
\`\`\`

passed validation with \`0.001\` as the parsed amount, even though the body is obviously wrong. The gateway controls this field today so blast radius is low — but the validator is exactly where that protection is supposed to live, and the bug becomes real the moment a third party generates the body (self-hosted facilitator, SDK consumer relaying through their own proxy, third-party x402 implementation).

## Fix

\`parse-402.ts:92\` switches \`parseFloat\` → \`Number\`. \`Number(\"1.5USDC\") === NaN\` — correctly rejects. But \`Number()\` is also **looser** than parseFloat in the other direction:

| Input    | parseFloat | Number |
|----------|-----------|--------|
| \`\"\"\`     | NaN ✗     | 0  ⚠️ |
| \`null\`   | NaN ✗     | 0  ⚠️ |
| \`true\`   | NaN ✗     | 1  ⚠️ |
| \`false\`  | NaN ✗     | 0  ⚠️ |
| \`[]\`     | NaN ✗     | 0  ⚠️ |
| \`0.001\` (number) | NaN ✗ | 0.001 ⚠️ |

Without a guard, those would all pass the \`total < 0\` check (0 / 1 / 0.001 are all finite and non-negative). Adding \`typeof === 'string' && length > 0\` plugs the gap. The x402 wire format requires \`total\` to be a decimal USDC string anyway (text avoids float-precision drift across language boundaries), so non-string values are malformed by definition.

## What's tested

- **New** \`throws on cost_breakdown.total with trailing currency suffix\` — covers \`'1.5USDC'\`, \`'0.001SOL'\`, \`'0.5 USDC'\`, \`'1.5,'\`. Each one parsed cleanly through parseFloat as \`1.5 / 0.001 / 0.5 / 1.5\`; under \`Number()\` they're all NaN.
- **New** \`throws on cost_breakdown.total that is empty or non-string\` — covers \`''\`, \`null\`, \`true\`, \`false\`, \`[]\`, numeric \`0.001\`. The typeof+length guard catches these before \`Number()\` sees them.
- Existing rejection tests for \`'NaN'\` and \`'-1.0'\` still pass; happy-path test for \`'0.002500'\` still passes.

## Out of scope (deliberate)

- \`Number('0xFF')\` returns 255 (hex prefix recognized) — also \`Number('1e2')\` returns 100. These are technically \"valid numbers\" under JS coercion. They're not the bug class flagged here, and the validator's job is loose-validation, not full schema enforcement. If we want to enforce a strict decimal-string regex for amounts later, that's a separate hardening pass.
- The companion \`sdks/ai-sdk-provider/src/util/parse-402.ts\` does **not** have this bug — it uses an allowlist filter (\`applyCostBreakdownAllowlist\`) rather than numeric coercion, so its path is structurally different.

## Test plan

- [x] \`npm --prefix sdks/signer-core test\` — 48 tests passing (up from 46), 0 failures
- [x] Spot-checked existing happy-path fixture (\`total: '0.002500'\`) still parses to 0.0025 under the new pipeline
- [ ] CI \`signer-core\` pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)