### PR TITLE
fix(signer-core): validate accepts[] elements at parse time

### DIFF
--- a/sdks/signer-core/src/parse-402.ts
+++ b/sdks/signer-core/src/parse-402.ts
@@ -88,6 +88,26 @@ function validatePaymentRequired(inner: unknown, context: string): PaymentRequir
     );
   }
 
+  // Validate each accepts[] element has the minimum shape downstream code
+  // assumes (an object with a string `scheme`). Without this, accepts: [null]
+  // or accepts: [{}] would parse cleanly here and then crash in
+  // `scheme-filter.ts` when `a.scheme === 'escrow'` derefs the bad element.
+  // A real schema (zod/valibot) would do this and more — tracked as a
+  // follow-up; this surgical loop closes the immediate bug class.
+  for (let i = 0; i < obj.accepts.length; i++) {
+    const a = obj.accepts[i];
+    if (a === null || typeof a !== 'object' || Array.isArray(a)) {
+      throw new Error(
+        `Gateway 402 accepts[${i}] is not a JSON object ${context}: ${JSON.stringify(a)}`,
+      );
+    }
+    if (typeof (a as { scheme?: unknown }).scheme !== 'string') {
+      throw new Error(
+        `Gateway 402 accepts[${i}] missing or invalid 'scheme' field ${context} (expected string)`,
+      );
+    }
+  }
+
   // Validate cost_breakdown.total parses to a finite non-negative number.
   //
   // We use Number() (not parseFloat) so trailing garbage like "1.5USDC" or

--- a/sdks/signer-core/tests/parse-402.test.ts
+++ b/sdks/signer-core/tests/parse-402.test.ts
@@ -116,6 +116,42 @@ describe('parse402', () => {
       );
     });
 
+    // Per-element validation: without this, accepts: [null] / [{}] would
+    // parse cleanly and then crash downstream in scheme-filter.ts when
+    // a.scheme is dereferenced on a non-object.
+    it('throws on accepts element that is not a JSON object', () => {
+      for (const bad of [null, 'exact', 42, true, []]) {
+        const body = { ...validDirectBody, accepts: [bad] };
+        assert.throws(
+          () => parse402(JSON.stringify(body)),
+          /accepts\[0\] is not a JSON object/,
+          `expected ${JSON.stringify(bad)} to be rejected`,
+        );
+      }
+    });
+
+    it('throws on accepts element missing or non-string scheme field', () => {
+      for (const bad of [{}, { scheme: 42 }, { scheme: null }, { network: 'solana' }]) {
+        const body = { ...validDirectBody, accepts: [bad] };
+        assert.throws(
+          () => parse402(JSON.stringify(body)),
+          /accepts\[0\] missing or invalid 'scheme' field/,
+          `expected ${JSON.stringify(bad)} to be rejected`,
+        );
+      }
+    });
+
+    it('reports the index of the first invalid accepts element', () => {
+      const body = {
+        ...validDirectBody,
+        accepts: [validDirectBody.accepts[0], null, validDirectBody.accepts[0]],
+      };
+      assert.throws(
+        () => parse402(JSON.stringify(body)),
+        /accepts\[1\] is not a JSON object/,
+      );
+    });
+
     it('throws on non-finite cost_breakdown.total', () => {
       const body = {
         ...validDirectBody,


### PR DESCRIPTION
## Summary

Closes a validation gap in `@solvela/signer-core`'s `parse402`. The function checked that `accepts` is a non-empty array but never validated per-element shape, so a payload like `{ accepts: [null] }` or `{ accepts: [{}] }` parsed cleanly. Downstream code in `scheme-filter.ts:29` then dereferenced `a.scheme === 'escrow'` on the bad element, throwing a runtime `TypeError` far from the actual bad-input site.

## Fix

Per-element loop after the existing `Array.isArray` check, with two distinct error messages:

- `accepts[i] is not a JSON object` — for null, array, or primitive elements (caught before any field deref)
- `accepts[i] missing or invalid 'scheme' field` — for objects whose `scheme` isn't a string (or is absent)

The minimum required field is `scheme` because that's what `scheme-filter.ts` reads. Other fields (`network`, `pay_to`, `amount`, etc.) aren't validated here — they're checked later in the signing path where their absence is more directly actionable.

## What's tested

- **New** `throws on accepts element that is not a JSON object` — covers `null`, `'exact'`, `42`, `true`, `[]`.
- **New** `throws on accepts element missing or non-string scheme field` — covers `{}`, `{ scheme: 42 }`, `{ scheme: null }`, `{ network: 'solana' }`.
- **New** `reports the index of the first invalid accepts element` — `[good, null, good]` reports `accepts[1]`, not `accepts[0]`.
- All existing parse-402 tests still pass.

## Why not a schema

Zod/valibot would catch this and more across the full envelope, and is the right long-term answer for a parser-of-record shared across 3+ SDKs. But that work involves a dep choice (zod ~14kb vs valibot ~1kb tree-shaken — signer-core has zero runtime deps today), a cross-SDK consistency pass with `sdks/ai-sdk-provider/src/util/parse-402.ts`, and error-message-shape decisions. Filed as a separate issue so the design pass can happen in isolation. This PR is the surgical fix for the immediate bug class.

## Test plan

- [x] `npm --prefix sdks/signer-core test` — 49 tests passing (up from 46), 0 failures
- [x] Manually traced `scheme-filter.ts` to confirm `accepts: [null]` no longer reaches `a.scheme` deref
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)