### PR TITLE
fix(mcp): four correctness fixes — ESM require, parseFloat, signingMode cast, refund-clamp

### DIFF
--- a/sdks/mcp/src/client.ts
+++ b/sdks/mcp/src/client.ts
@@ -227,7 +227,17 @@ export class GatewayClient {
       // HF5: parse402 throws instead of returning null.
       const paymentInfo = parse402(await resp.text());
 
-      const cost = parseFloat(paymentInfo.cost_breakdown.total);
+      // Defense-in-depth: parse402 also validates this field, but using Number()
+      // (vs parseFloat) here means trailing-garbage like "0.001SOL" is rejected
+      // even if the upstream validator regresses or a third party generates the
+      // body. The check matters because `cost` drives both a budget mutation
+      // and a signed transaction below.
+      const cost = Number(paymentInfo.cost_breakdown.total);
+      if (!Number.isFinite(cost) || cost < 0) {
+        throw new Error(
+          `Gateway returned invalid total cost: ${paymentInfo.cost_breakdown.total}`,
+        );
+      }
 
       // T1-H: Atomic budget reservation — both check and increment must be in the same
       // critical section to prevent two parallel calls from both passing the budget check.
@@ -257,10 +267,12 @@ export class GatewayClient {
         });
       } else {
         // Filter accepts by signing mode before handing off to the SDK signer.
-        const filteredAccepts = filterAccepts(
-          paymentInfo.accepts,
-          this.signingMode as 'auto' | 'escrow' | 'direct',
-        );
+        // Bind to a typed local so TS verifies the narrowing produced by the
+        // `signingMode === 'off'` check — replaces the previous `as` cast that
+        // silently masked the 'off' branch and would have lied if the if-ladder
+        // above were ever refactored.
+        const mode: 'auto' | 'escrow' | 'direct' = this.signingMode;
+        const filteredAccepts = filterAccepts(paymentInfo.accepts, mode);
         const filteredPaymentInfo = { ...paymentInfo, accepts: filteredAccepts };
         const privateKey = process.env['SOLANA_WALLET_KEY'];
 
@@ -271,10 +283,13 @@ export class GatewayClient {
           // HF2: Refund the reserved budget — signer never succeeded.
           await this.budgetMutex.runExclusive(async () => {
             const before = this.sessionSpentMicro;
-            if (before > 0 && before < costMicro) {
-              // Math.max(0, ...) would clamp — indicates a race condition in budget accounting.
+            // Warn whenever Math.max(0, ...) would clamp. Dropping the prior
+            // `before > 0` guard means `before === 0` also surfaces a warning —
+            // that case implies a parallel refund already zeroed the counter
+            // (double-refund / race), which silently no-op'd before.
+            if (before < costMicro) {
               process.stderr.write(
-                `[solvela-mcp] WARN: budget refund clamped to 0 (before=${before}, costMicro=${costMicro}) — possible race condition\n`,
+                `[solvela-mcp] WARN: budget refund clamped (before=${before}, costMicro=${costMicro}). Possible double-refund or race.\n`,
               );
             }
             this.sessionSpentMicro = Math.max(0, this.sessionSpentMicro - costMicro);
@@ -436,10 +451,13 @@ export class GatewayClient {
       // Phase 3-refund: reservation never landed on-chain; roll back.
       await this.budgetMutex.runExclusive(async () => {
         const before = this.escrowDepositsSessionMicro;
-        if (before > 0 && before < amountMicro) {
+        // Warn whenever Math.max(0, ...) would clamp. Dropping the prior
+        // `before > 0` guard means `before === 0` also surfaces a warning —
+        // that case implies a parallel refund already zeroed the counter
+        // (double-refund / race), which silently no-op'd before.
+        if (before < amountMicro) {
           process.stderr.write(
-            `[solvela-mcp] WARN: escrow refund clamped (before=$${(before / 1_000_000).toFixed(6)}, refund=$${amount.toFixed(6)}). ` +
-            `Possible race condition.\n`,
+            `[solvela-mcp] WARN: escrow refund clamped (before=$${(before / 1_000_000).toFixed(6)}, refund=$${amount.toFixed(6)}). Possible double-refund or race.\n`,
           );
         }
         this.escrowDepositsSessionMicro = Math.max(0, this.escrowDepositsSessionMicro - amountMicro);

--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -37,7 +37,7 @@ import { getTools } from './tools.js';
 import { createSessionStore } from './session.js';
 import { createPaymentHeader } from '@solvela/sdk/x402';
 import type { PaymentRequired, PaymentAccept } from '@solvela/sdk/types';
-import { PublicKey } from '@solana/web3.js';
+import { Connection, PublicKey } from '@solana/web3.js';
 
 // ---------------------------------------------------------------------------
 // Bootstrap client from environment
@@ -432,9 +432,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             );
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          const solanaWeb3 = require('@solana/web3.js');
-          const { Connection } = solanaWeb3;
+          // Connection is imported statically at the top of the file; require()
+          // here was a runtime ReferenceError under ESM ("type": "module"). The
+          // existing tests pass through a callback seam (runEscrowDeposit) that
+          // bypasses this branch, which is why CI never caught it.
           const connection = new Connection(rpcUrl, 'confirmed');
 
           // Fetch blockhash BEFORE broadcast so lastValidBlockHeight is available for confirmTransaction.


### PR DESCRIPTION
## Summary

Four independent correctness bugs flagged in code review of `@solvela/mcp-server`. All in `sdks/mcp/src/client.ts` and `sdks/mcp/src/index.ts`. Two MUST-FIX (one would crash a real escrow deposit; one would let a malformed gateway response sign a transaction at the wrong amount); two SHOULD-FIX (unsafe cast hiding a state branch; missing telemetry on a real budget-accounting race).

## Bugs and fixes

### 1. MUST-FIX: `require()` in an ESM module (`src/index.ts:435`)

Package is `"type": "module"`. The `deposit_escrow` handler had:

```ts
// eslint-disable-next-line @typescript-eslint/no-var-requires
const solanaWeb3 = require('@solana/web3.js');
const { Connection } = solanaWeb3;
```

`require` is **not defined** in pure ESM — this throws `ReferenceError: require is not defined` the moment a real escrow deposit is attempted. The eslint-disable hid the warning but didn't solve the problem. Tests use the `runEscrowDeposit` callback seam and never enter this branch, which is why CI never caught it.

**Fix:** Added `Connection` to the existing top-level `import { PublicKey } from '@solana/web3.js';` at line 40; removed the require block. Pure static ESM import — works.

### 2. MUST-FIX: `parseFloat` coerces trailing garbage (`src/client.ts:230`)

```ts
const cost = parseFloat(paymentInfo.cost_breakdown.total);
const costMicro = Math.round(cost * 1_000_000);
```

`parseFloat("0.001SOL")` returns `0.001`, not `NaN`. The MCP server then commits a budget reservation **and signs a payment** against a value the parser was supposed to validate.

**Fix:** Switch to `Number()` with explicit rejection:

```ts
const cost = Number(paymentInfo.cost_breakdown.total);
if (!Number.isFinite(cost) || cost < 0) {
  throw new Error(`Gateway returned invalid total cost: ${paymentInfo.cost_breakdown.total}`);
}
```

Defense-in-depth — `parse402` also validates this field (PR #127), but `Number()` here means trailing garbage is rejected even if the upstream validator regresses or a third party generates the body. The check matters because `cost` drives both a budget mutation and a signed transaction.

### 3. SHOULD-FIX: unsafe cast hides the `'off'` signing-mode branch (`src/client.ts:262`)

```ts
const filteredAccepts = filterAccepts(
  paymentInfo.accepts,
  this.signingMode as 'auto' | 'escrow' | 'direct',
);
```

The cast lies — `signingMode` is genuinely `'auto' | 'escrow' | 'direct' | 'off'`. The code "works" only because the surrounding `if` gates on `signingMode !== 'off'`. That's an invariant the type system should enforce, not a comment.

**Fix:** Replace with a typed local inside the `else` branch so TS verifies the narrowing — protects against a future refactor of the if-ladder silently breaking the assumption.

```ts
} else {
  const mode: 'auto' | 'escrow' | 'direct' = this.signingMode;
  const filteredAccepts = filterAccepts(paymentInfo.accepts, mode);
  ...
}
```

### 4. SHOULD-FIX: refund-clamp telemetry has wrong predicate (`src/client.ts:274` and `:439`)

```ts
if (before > 0 && before < costMicro) {
  process.stderr.write(`...WARN: budget refund clamped...`);
}
this.sessionSpentMicro = Math.max(0, this.sessionSpentMicro - costMicro);
```

The `Math.max(0, ...)` clamp kicks in whenever `before < costMicro`. The warning correctly predicates on `before < costMicro` — but the additional `before > 0` excludes a real race: when a parallel call already refunded everything (`before === 0`) and we silently apply a no-op, we never warn that **two refund paths fired for one reservation**. That's a budget-accounting bug masquerading as a normal flow.

**Fix:** Drop `before > 0`. Warning now fires whenever the clamp would actually trigger, including the silent-no-op case. Same fix at the escrow refund site (`runEscrowDeposit`, line 439). Updated wording to "Possible double-refund or race." for clarity.

## Out of scope

`npm run build` reports 5 pre-existing errors on main, none caused by this PR (verified via `git stash && build && git stash pop`):

- `Cannot find module '@solvela/sdk/x402'` and `'@solvela/sdk/types'` (4 occurrences across `client.ts` and `index.ts`) — workspace dep paths don't resolve because the linked SDK package's `exports` map doesn't surface those subpaths, or the SDK isn't being built before mcp.
- `'err' is of type 'unknown'` at the `instanceof SigningError` branch — strict-TS narrowing isn't kicking in, possibly because `SigningError` is imported as a type-only declaration. Line number shifted from 287 → 302 in this PR (my new validation block adds ~6 lines), but the diagnostic is the same.

These block local `npm test` for the package — tests fail at module-load with `Cannot find module '@solvela/sdk/x402'`. **Worth a separate fix** (build SDK first, or fix the SDK's package exports map). Filing as a follow-up if it doesn't already have one.

## Test plan

- [x] Code review: each fix maps to the user-flagged finding
- [x] Pre-edit vs post-edit `npm run build` diff: same 5 pre-existing errors, no new diagnostics introduced
- [ ] Once workspace dep issue is fixed (separate PR), `npm --prefix sdks/mcp test` should run — the existing `runEscrowDeposit` callback seam tests don't exercise the require-block path so won't catch fix #1; consider adding a test that calls the deposit handler without the seam to cover fix #1 going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)