### PR TITLE
refactor(signer-core): extract isStubTransaction for direct tx checks

### DIFF
--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -35,7 +35,7 @@ import {
 import { GatewayClient, type ChatMessage } from './client.js';
 import { getTools } from './tools.js';
 import { createSessionStore } from './session.js';
-import { createPaymentHeader, decodePaymentHeader } from '@solvela/signer-core';
+import { createPaymentHeader, decodePaymentHeader, isStubTransaction } from '@solvela/signer-core';
 import type { PaymentRequired, PaymentAccept } from '@solvela/signer-core';
 import { Connection, PublicKey } from '@solana/web3.js';
 
@@ -425,7 +425,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const agentPubkey = decoded?.payload?.agent_pubkey;
           const serviceIdB64 = decoded?.payload?.service_id;
 
-          if (!depositTxB64 || depositTxB64.startsWith('STUB_')) {
+          if (!depositTxB64 || isStubTransaction(depositTxB64)) {
             throw new Error(
               'Escrow deposit tx is a stub — ensure SOLANA_WALLET_KEY is set and valid.',
             );

--- a/sdks/signer-core/src/index.ts
+++ b/sdks/signer-core/src/index.ts
@@ -13,7 +13,8 @@
  *   - SigningError: thrown by createPaymentHeader on signing failure
  *   - parse402: accepts both envelope and direct shapes, throws on malformed
  *   - filterAccepts: scheme-based filtering with mode support
- *   - isStubHeader: detects stub payment headers
+ *   - isStubHeader: detects stub payment headers (envelope-level)
+ *   - isStubTransaction: detects stub markers in an extracted tx string
  *   - sanitizeGatewayError: slices + redacts gateway error bodies
  *   - redactBase58, redactHex: byte-pattern redactors
  */
@@ -22,5 +23,5 @@ export type { PaymentRequired, PaymentAccept, CostBreakdown } from './types.js';
 export { createPaymentHeader, decodePaymentHeader, SigningError } from './sign.js';
 export { parse402 } from './parse-402.js';
 export { filterAccepts } from './scheme-filter.js';
-export { isStubHeader } from './stub-guard.js';
+export { isStubHeader, isStubTransaction } from './stub-guard.js';
 export { sanitizeGatewayError, redactBase58, redactHex } from './redact.js';

--- a/sdks/signer-core/src/stub-guard.ts
+++ b/sdks/signer-core/src/stub-guard.ts
@@ -1,16 +1,37 @@
 /**
- * Stub payment header guard.
+ * Stub payment guards.
  *
- * Detects stub payment headers produced by the SDK when @solana/web3.js
- * is unresolvable at runtime (no real private key signing occurred).
- * Stub headers contain transactions starting with 'STUB_'.
+ * Detects stub payment headers / transactions produced by the SDK when
+ * @solana/web3.js is unresolvable at runtime (no real private key signing
+ * occurred). Stub transactions contain markers starting with 'STUB_'.
+ *
+ * The convention lives here as a single source of truth so callers can
+ * check at either layer — the outer envelope (isStubHeader) or an
+ * already-extracted inner transaction string (isStubTransaction).
  */
+
+/**
+ * Check whether a transaction string is a stub marker.
+ *
+ * Stub markers begin with 'STUB_' (e.g. 'STUB_BASE64_TX',
+ * 'STUB_ESCROW_DEPOSIT_TX'). Real transactions are standard base64 — alphabet
+ * is `A-Z a-z 0-9 + / =`, which excludes `_`, so the prefix check has zero
+ * false positives. (If the wire ever switches to base64url, revisit.)
+ *
+ * @param tx - The transaction string from a decoded payment payload's
+ *             `transaction` or `deposit_tx` field.
+ * @returns true if `tx` is a stub marker, false otherwise.
+ */
+export function isStubTransaction(tx: string): boolean {
+  return tx.startsWith('STUB_');
+}
 
 /**
  * Check whether a base64-encoded payment header is a stub transaction.
  *
  * Decodes the base64 string, parses as JSON, and checks whether
- * payload.transaction or payload.deposit_tx starts with 'STUB_'.
+ * payload.transaction or payload.deposit_tx is a stub marker via
+ * isStubTransaction.
  *
  * Returns false (not a stub) if the header cannot be decoded or parsed —
  * malformed headers are a separate concern handled downstream by the gateway.
@@ -28,8 +49,8 @@ export function isStubHeader(headerBase64: string): boolean {
     const payload = parsed?.payload as Record<string, unknown> | undefined;
     const tx = payload?.transaction;
     const depositTx = payload?.deposit_tx;
-    if (typeof tx === 'string' && tx.startsWith('STUB_')) return true;
-    if (typeof depositTx === 'string' && depositTx.startsWith('STUB_')) return true;
+    if (typeof tx === 'string' && isStubTransaction(tx)) return true;
+    if (typeof depositTx === 'string' && isStubTransaction(depositTx)) return true;
     return false;
   } catch {
     // Decode or parse failure — not a stub

--- a/sdks/signer-core/tests/stub-guard.test.ts
+++ b/sdks/signer-core/tests/stub-guard.test.ts
@@ -1,11 +1,12 @@
 /**
- * Tests for isStubHeader — stub payment header detection.
+ * Tests for isStubHeader / isStubTransaction — stub payment header
+ * and transaction detection.
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isStubHeader } from '../src/stub-guard.ts';
+import { isStubHeader, isStubTransaction } from '../src/stub-guard.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -81,5 +82,37 @@ describe('isStubHeader', () => {
       const header = Buffer.from('null').toString('base64');
       assert.equal(isStubHeader(header), false);
     });
+  });
+});
+
+describe('isStubTransaction', () => {
+  it('returns true for STUB_BASE64_TX', () => {
+    assert.equal(isStubTransaction('STUB_BASE64_TX'), true);
+  });
+
+  it('returns true for STUB_ESCROW_DEPOSIT_TX', () => {
+    assert.equal(isStubTransaction('STUB_ESCROW_DEPOSIT_TX'), true);
+  });
+
+  it('returns true for any STUB_-prefixed string', () => {
+    assert.equal(isStubTransaction('STUB_FUTURE_MARKER'), true);
+  });
+
+  it('returns false for a real-looking base64 transaction', () => {
+    assert.equal(isStubTransaction('AQABAtPVl4cMz9c='), false);
+  });
+
+  it('returns false for empty string', () => {
+    assert.equal(isStubTransaction(''), false);
+  });
+
+  it('returns false for STUB without trailing underscore', () => {
+    // Defensive: only the documented marker convention triggers.
+    assert.equal(isStubTransaction('STUB'), false);
+    assert.equal(isStubTransaction('STUBABC'), false);
+  });
+
+  it('case-sensitive — lowercase stub_ does not match', () => {
+    assert.equal(isStubTransaction('stub_base64_tx'), false);
   });
 });


### PR DESCRIPTION
## Summary

Tiny refactor surfaced during code review of #137 / #140: `sdks/mcp/src/index.ts:428` inlined `.startsWith('STUB_')` on a `deposit_tx` string instead of using the canonical helper. The existing `isStubHeader` helper does the same check but at the *envelope* level — redundant work when the surrounding code has already decoded and extracted the inner field.

## Change

Extract the prefix check into a tiny new helper:

```ts
// sdks/signer-core/src/stub-guard.ts
export function isStubTransaction(tx: string): boolean {
  return tx.startsWith('STUB_');
}
```

- `isStubHeader` (existing, signature unchanged) now delegates to `isStubTransaction` for its inner-field check — single source of truth.
- `mcp/src/index.ts:428` now calls `isStubTransaction(depositTxB64)` directly — no redundant decode-and-parse.

## On false positives

The prefix check has zero false positives under standard base64. The base64 alphabet is `A-Z a-z 0-9 + / =` — `_` is not in it, so a real signed transaction cannot start with `STUB_`. Documented in the new helper's docstring along with a caveat for any future base64url migration.

## Validation

- [x] `cd sdks/signer-core && npm run build` — clean
- [x] `cd sdks/signer-core && npm test` — 65/65 pass (was 58, +7 for `isStubTransaction`)
- [x] `cd sdks/mcp && npm run build` — clean
- [x] `cd sdks/mcp && npm test` — 69/69 pass (unchanged)

## Files

| File | Change |
|---|---|
| `sdks/signer-core/src/stub-guard.ts` | New `isStubTransaction` export; `isStubHeader` delegates to it; doc updated to explain the convention + the base64 alphabet rationale |
| `sdks/signer-core/src/index.ts` | Re-export `isStubTransaction`; doc-comment updated |
| `sdks/mcp/src/index.ts` | Import `isStubTransaction`; line 428 uses it instead of inline `.startsWith('STUB_')` |
| `sdks/signer-core/tests/stub-guard.test.ts` | 7 new unit tests for `isStubTransaction` (markers, real-looking tx, empty, no-underscore, case sensitivity) |
