### PR TITLE
chore(ai-sdk-provider): polish — 5 review findings

### DIFF
--- a/sdks/ai-sdk-provider/src/adapters/local.ts
+++ b/sdks/ai-sdk-provider/src/adapters/local.ts
@@ -115,7 +115,11 @@ function makeAbortError(): Error {
  */
 async function loadSolvelaSdk(): Promise<SolvelaSdkModule> {
   try {
-    const mod = (await import('@solvela/sdk' as string)) as unknown as Record<
+    // @ts-expect-error — optional peer dependency; not resolvable when the
+    // peer isn't installed (the whole point of this dynamic-import branch).
+    // If the peer ever becomes resolvable, this directive will fail and
+    // signal that the suppression can be removed. See PEER_INSTALL_MESSAGE.
+    const mod = (await import('@solvela/sdk')) as unknown as Record<
       string,
       unknown
     >;
@@ -145,7 +149,9 @@ async function loadSolvelaSdk(): Promise<SolvelaSdkModule> {
  */
 async function loadBs58(): Promise<Bs58Module> {
   try {
-    const mod = (await import('bs58' as string)) as unknown as Record<
+    // @ts-expect-error — optional peer dependency; not resolvable when the
+    // peer isn't installed. See PEER_INSTALL_MESSAGE.
+    const mod = (await import('bs58')) as unknown as Record<
       string,
       unknown
     >;
@@ -189,9 +195,14 @@ async function loadBs58(): Promise<Bs58Module> {
  *   constructor already scrubs base58/hex from the cause message.
  *
  * The `Keypair` reference is captured in a closure — the private key never
- * surfaces in adapter-side error surfaces. The `bs58`-encoded secret key is
- * a short-lived string passed directly into `createPaymentHeader` and GC'd
- * after the call returns.
+ * surfaces in adapter-side error surfaces. The `bs58`-encoded secret key
+ * cannot be securely zeroed in JavaScript: it is an immutable string in V8's
+ * heap until the runtime schedules a major GC, which under load may be
+ * many requests later. Heap dumps captured for any other reason will
+ * contain the encoded private key. **This adapter is for development and
+ * testing only — do not run it in any process that handles production
+ * funds.** A future SDK boundary that accepts `Uint8Array` directly would
+ * permit `secretKey.fill(0)` post-call; tracked as a follow-up.
  *
  * @example
  * ```typescript
@@ -233,8 +244,10 @@ export function createLocalWalletAdapter(
       const [sdk, bs58] = await Promise.all([loadSolvelaSdk(), loadBs58()]);
 
       // Encode the 64-byte secret key as base58 for the existing SDK API.
-      // The short-lived string is passed directly into createPaymentHeader
-      // and eligible for GC after the call returns.
+      // NOTE: privateKeyB58 cannot be securely zeroed in JavaScript — strings
+      // are immutable in the V8 heap until GC. This is dev/test-only code
+      // (see module banner); production signers must use a wallet boundary
+      // that does not materialize the secret in JS string memory.
       const privateKeyB58 = bs58.encode(keypair.secretKey);
 
       // Let createPaymentHeader errors propagate unchanged. The fetch-wrapper

--- a/sdks/ai-sdk-provider/src/budget.ts
+++ b/sdks/ai-sdk-provider/src/budget.ts
@@ -29,6 +29,14 @@ export class BudgetState {
   private available: bigint | undefined;
   /** Per-request reservations keyed by the per-invocation requestId. */
   private readonly reserved: Map<string, bigint> = new Map();
+  /**
+   * Running total of all entries in `reserved`, maintained synchronously
+   * by reserve / finalize / release. Reads (the hot path) stay O(1).
+   * Walking the map on every check was O(n) in outstanding reservations
+   * — fine at low concurrency, quadratic on throughput at the high-fan-out
+   * agent workloads this provider targets.
+   */
+  private totalReserved: bigint = 0n;
 
   constructor(total: bigint | undefined) {
     this.available = total;
@@ -47,7 +55,7 @@ export class BudgetState {
    */
   get remaining(): bigint | undefined {
     if (this.available === undefined) return undefined;
-    return this.available - this.sumReserved();
+    return this.available - this.totalReserved;
   }
 
   /**
@@ -69,7 +77,7 @@ export class BudgetState {
         requestBodyValues: undefined,
       });
     }
-    const remaining = this.available - this.sumReserved();
+    const remaining = this.available - this.totalReserved;
     if (remaining < cost) {
       throw new SolvelaBudgetExceededError({
         message:
@@ -80,6 +88,7 @@ export class BudgetState {
       });
     }
     this.reserved.set(requestId, cost);
+    this.totalReserved += cost;
   }
 
   /**
@@ -90,6 +99,7 @@ export class BudgetState {
     const cost = this.reserved.get(requestId);
     if (cost === undefined) return;
     this.reserved.delete(requestId);
+    this.totalReserved -= cost;
     if (this.available !== undefined) {
       this.available -= cost;
     }
@@ -100,14 +110,9 @@ export class BudgetState {
    * absent (idempotent).
    */
   release(requestId: string): void {
+    const cost = this.reserved.get(requestId);
+    if (cost === undefined) return;
     this.reserved.delete(requestId);
-  }
-
-  private sumReserved(): bigint {
-    let sum = 0n;
-    for (const v of this.reserved.values()) {
-      sum += v;
-    }
-    return sum;
+    this.totalReserved -= cost;
   }
 }

--- a/sdks/ai-sdk-provider/src/fetch-wrapper.ts
+++ b/sdks/ai-sdk-provider/src/fetch-wrapper.ts
@@ -311,8 +311,8 @@ export function createSolvelaFetch(
         statusCode: resp.status,
       });
     }
-    const parsed = parseGateway402(parsedBody);
-    const selected = selectAccept(parsed);
+    const parsed = parseGateway402(parsedBody, resolvedUrl);
+    const selected = selectAccept(parsed, resolvedUrl);
 
     // (f) Body type + size check (T2-C). `createOpenAICompatible` always
     // serialises to a JSON string; anything else is out-of-scope in v1.
@@ -415,12 +415,24 @@ export function createSolvelaFetch(
     if (retryResp.status === 402) {
       budget.release(requestId);
       logger?.({ event: 'release', attempt: fetchCount, requestId });
+      // Surface the gateway's reason for the second 402 so callers can
+      // tell apart "expired payment", "wrong amount", "wrong recipient",
+      // etc. without needing to capture network logs. The error
+      // constructor sanitizes responseBody / responseHeaders (redactBase58
+      // + redactHex on strings, stripPaymentSignature on headers) so no
+      // signature material can leak through this path.
+      const retryBody = await safeReadText(retryResp);
+      const retryHeadersRecord = stripPaymentSignature(
+        headersToRecord(retryResp.headers),
+      );
       // Do not loop. Surface a single payment error.
       throw new SolvelaPaymentError({
         message: 'Payment rejected after retry',
         url: resolvedUrl,
         requestBodyValues: undefined,
         statusCode: retryResp.status,
+        responseHeaders: retryHeadersRecord,
+        responseBody: retryBody,
       });
     }
 

--- a/sdks/ai-sdk-provider/src/util/parse-402.ts
+++ b/sdks/ai-sdk-provider/src/util/parse-402.ts
@@ -89,11 +89,15 @@ function isNumberField(obj: Record<string, unknown>, key: string): boolean {
  * Drops every field not in the plan-level allowlist (T2-G).
  * Throws if required fields are missing or mistyped.
  */
-function applyAcceptAllowlist(raw: unknown, index: number): SolvelaPaymentAccept {
+function applyAcceptAllowlist(
+  raw: unknown,
+  index: number,
+  url: string,
+): SolvelaPaymentAccept {
   if (!isObject(raw)) {
     throw new SolvelaPaymentError({
       message: `[solvela] 402 envelope: accepts[${index}] is not an object`,
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -113,7 +117,7 @@ function applyAcceptAllowlist(raw: unknown, index: number): SolvelaPaymentAccept
     if (!present) {
       throw new SolvelaPaymentError({
         message: `[solvela] 402 envelope: accepts[${index}].${key} missing or wrong type`,
-        url: '',
+        url,
         requestBodyValues: undefined,
       });
     }
@@ -135,11 +139,14 @@ function applyAcceptAllowlist(raw: unknown, index: number): SolvelaPaymentAccept
  * Extract an allowlisted `SolvelaPaymentCostBreakdown`.
  * Every field mirrors `wallet-adapter.ts`'s declared shape.
  */
-function applyCostBreakdownAllowlist(raw: unknown): SolvelaPaymentCostBreakdown {
+function applyCostBreakdownAllowlist(
+  raw: unknown,
+  url: string,
+): SolvelaPaymentCostBreakdown {
   if (!isObject(raw)) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: cost_breakdown is not an object',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -149,7 +156,7 @@ function applyCostBreakdownAllowlist(raw: unknown): SolvelaPaymentCostBreakdown 
     if (!isStringField(raw, key)) {
       throw new SolvelaPaymentError({
         message: `[solvela] 402 envelope: cost_breakdown.${key} missing or wrong type`,
-        url: '',
+        url,
         requestBodyValues: undefined,
       });
     }
@@ -157,7 +164,7 @@ function applyCostBreakdownAllowlist(raw: unknown): SolvelaPaymentCostBreakdown 
   if (!isNumberField(raw, 'fee_percent')) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: cost_breakdown.fee_percent missing or wrong type',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -174,18 +181,21 @@ function applyCostBreakdownAllowlist(raw: unknown): SolvelaPaymentCostBreakdown 
 /**
  * Extract an allowlisted `resource` object: `{ url: string, method: string }`.
  */
-function applyResourceAllowlist(raw: unknown): { url: string; method: string } {
+function applyResourceAllowlist(
+  raw: unknown,
+  url: string,
+): { url: string; method: string } {
   if (!isObject(raw)) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: resource is not an object',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
   if (!isStringField(raw, 'url') || !isStringField(raw, 'method')) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: resource.url/method missing or wrong type',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -203,14 +213,21 @@ function applyResourceAllowlist(raw: unknown): { url: string; method: string } {
  *   { error: { type: "invalid_payment", message: "<JSON PaymentRequired>" } }
  *
  * @param body - Raw JSON-parsed body from the 402 response.
+ * @param url  - The request URL, used to populate `SolvelaPaymentError.url`
+ *               on any thrown errors. Defaults to `''` for callers that
+ *               don't have a URL (legacy / tests); the fetch-wrapper passes
+ *               the resolved URL.
  * @returns Allowlisted `ParsedPaymentRequired`.
  * @throws SolvelaPaymentError if the envelope is unrecognized or malformed.
  */
-export function parseGateway402(body: unknown): ParsedPaymentRequired {
+export function parseGateway402(
+  body: unknown,
+  url: string = '',
+): ParsedPaymentRequired {
   if (!isObject(body)) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: body is not a JSON object',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -219,7 +236,7 @@ export function parseGateway402(body: unknown): ParsedPaymentRequired {
   if (!isObject(errorField)) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: missing `error` object',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -229,14 +246,14 @@ export function parseGateway402(body: unknown): ParsedPaymentRequired {
   if (typeof type !== 'string' || typeof messageJson !== 'string') {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: `error.type` or `error.message` missing or wrong type',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
   if (type !== 'invalid_payment') {
     throw new SolvelaPaymentError({
       message: `[solvela] 402 envelope: unsupported error.type "${type}"; expected "invalid_payment"`,
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -248,7 +265,7 @@ export function parseGateway402(body: unknown): ParsedPaymentRequired {
   } catch {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: `error.message` is not valid JSON',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -256,7 +273,7 @@ export function parseGateway402(body: unknown): ParsedPaymentRequired {
   if (!isObject(inner)) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: inner PaymentRequired is not an object',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
@@ -265,30 +282,30 @@ export function parseGateway402(body: unknown): ParsedPaymentRequired {
   if (!isNumberField(inner, 'x402_version')) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: `x402_version` missing or wrong type',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
   if (!Array.isArray(inner['accepts'])) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: `accepts` is not an array',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
   if (!isStringField(inner, 'error')) {
     throw new SolvelaPaymentError({
       message: '[solvela] 402 envelope: inner `error` missing or wrong type',
-      url: '',
+      url,
       requestBodyValues: undefined,
     });
   }
 
   const accepts = (inner['accepts'] as unknown[]).map((entry, i) =>
-    applyAcceptAllowlist(entry, i),
+    applyAcceptAllowlist(entry, i, url),
   );
-  const cost_breakdown = applyCostBreakdownAllowlist(inner['cost_breakdown']);
-  const resource = applyResourceAllowlist(inner['resource']);
+  const cost_breakdown = applyCostBreakdownAllowlist(inner['cost_breakdown'], url);
+  const resource = applyResourceAllowlist(inner['resource'], url);
 
   return {
     x402_version: inner['x402_version'] as number,
@@ -308,10 +325,15 @@ export function parseGateway402(body: unknown): ParsedPaymentRequired {
  *   first `accepts[]` entry with `scheme === 'exact'` AND `asset === USDC`.
  *
  * @param parsed - Result of `parseGateway402`.
+ * @param url    - Request URL for `SolvelaPaymentError.url` on thrown errors.
+ *                 Defaults to `''` for callers without URL context.
  * @returns The matching entry plus its `amount` as a `bigint`.
  * @throws SolvelaPaymentError if no entry matches.
  */
-export function selectAccept(parsed: ParsedPaymentRequired): SelectedAccept {
+export function selectAccept(
+  parsed: ParsedPaymentRequired,
+  url: string = '',
+): SelectedAccept {
   for (const accept of parsed.accepts) {
     if (accept.scheme === REQUIRED_SCHEME && accept.asset === USDC_MINT_MAINNET) {
       // Parse amount → bigint. Amount is USDC atomic units as a decimal string.
@@ -321,14 +343,14 @@ export function selectAccept(parsed: ParsedPaymentRequired): SelectedAccept {
       } catch {
         throw new SolvelaPaymentError({
           message: `[solvela] 402 envelope: selected accept.amount "${accept.amount}" is not a valid integer`,
-          url: '',
+          url,
           requestBodyValues: undefined,
         });
       }
       if (cost < 0n) {
         throw new SolvelaPaymentError({
           message: '[solvela] 402 envelope: selected accept.amount is negative',
-          url: '',
+          url,
           requestBodyValues: undefined,
         });
       }
@@ -339,7 +361,7 @@ export function selectAccept(parsed: ParsedPaymentRequired): SelectedAccept {
   throw new SolvelaPaymentError({
     message:
       'no supported payment scheme in accepts[]: v1 requires scheme=exact + asset=USDC',
-    url: '',
+    url,
     requestBodyValues: undefined,
   });
 }


### PR DESCRIPTION
## Summary

Bundles 5 review findings from the post-#137 / post-#140 audit of `sdks/ai-sdk-provider` into a single PR (path A: extend scope, leave the package fully polished rather than punt to follow-ups).

### Two SHOULD-FIX
| # | File | Fix |
|---|---|---|
| 1 | `src/budget.ts` | Track `totalReserved: bigint` synchronously instead of walking the reserved Map on every `reserve` / `remaining` read. Drops hot path from **O(n) → O(1)** in outstanding reservations. Public `BudgetState` surface unchanged. |
| 2 | `src/adapters/local.ts` | Rewrite the *"GC'd after the call returns"* comment. JS strings are immutable in V8's heap until major GC; private-key residue can persist many requests later. The file already warns "dev/test only" loudly — the comment now says so accurately rather than overpromising. |

### Three NIT
| # | File | Fix |
|---|---|---|
| 3 | `src/adapters/local.ts` | `await import('@solvela/sdk' as string)` → `// @ts-expect-error` + bare specifier. Same effect; the directive declares intent and self-detects when the peer becomes resolvable (signaling the suppression can drop). Two occurrences (`@solvela/sdk` and `bs58`). |
| 4 | `src/util/parse-402.ts` | Take `url: string = ''` parameter on `parseGateway402` and `selectAccept`; thread to the three private allowlist helpers so all **18** `SolvelaPaymentError` sites carry the real URL. Backward compatible — default-valued. Threaded from the fetch-wrapper at the two call sites. |
| 5 | `src/fetch-wrapper.ts` | Surface the gateway's reason on the retry-bomb (second 402) by reading `retryResp` body + headers and passing them to `SolvelaPaymentError`. The constructor sanitizes `responseBody` / `responseHeaders` (`redactBase58` + `redactHex` on strings, `stripPaymentSignature` on headers — see `errors.ts:71-72`), so no signature material can leak. |

## Validation
- [x] `npm run typecheck` — clean
- [x] `npm run build` (tsup) — clean (`dist/index.js` 39.28 KB raw / 22.9 KB gzipped)
- [x] `npm run test:unit` — 257/257
- [x] `npm run test:integration` — 92/92
- [x] `npm run size` — 22.9 kB (cap: 50 kB)
- [ ] CI to confirm

## Net diff

```
sdks/ai-sdk-provider/src/adapters/local.ts | 27 ++++++++---
sdks/ai-sdk-provider/src/budget.ts         | 25 ++++++----
sdks/ai-sdk-provider/src/fetch-wrapper.ts  | 16 ++++++-
sdks/ai-sdk-provider/src/util/parse-402.ts | 76 +++++++++++++++++++-----------
4 files changed, 98 insertions(+), 46 deletions(-)
```

## Out of scope
- Cross-repo SDK boundary that accepts `Uint8Array` directly so `secretKey.fill(0)` is possible. Tracked as a follow-up — would require a change in `@solvela/sdk` (now `@solvela/signer-core`) to add a `Uint8Array` overload for `createPaymentHeader`.
