### PR TITLE
fix(signer-core): sanitizeGatewayError now redacts hex + base58 PII

### DIFF
--- a/sdks/signer-core/src/redact.ts
+++ b/sdks/signer-core/src/redact.ts
@@ -29,12 +29,24 @@ export function redactBase58(s: string): string {
 /**
  * Sanitize a gateway error body string for safe inclusion in error messages.
  *
- * Slices to maxLen characters then redacts payment-signature header fragments.
+ * Pipeline (in order):
+ *   1. Slice to `maxLen` characters.
+ *   2. Redact `payment-signature[…]` header fragments.
+ *   3. Redact 64+ hex sequences (e.g. hex-encoded keys / tx signatures).
+ *   4. Redact 44–88 base58 sequences (Solana wallet addresses, base58 tx
+ *      signatures). MUST run after the hex pass — the hex alphabet is a
+ *      subset of base58, so running base58 first would mask hex keys with
+ *      the same `[REDACTED]` token before the hex check sees them.
+ *
+ * Without steps 3 + 4 the function still leaked wallet addresses, full
+ * tx signatures, and hex private-key fragments into downstream error
+ * surfaces (mcp client.ts, openclaw-provider index.ts).
  *
  * @param text - Raw gateway response body text.
  * @param maxLen - Maximum length to slice to before redaction (default: 500).
  * @returns Sanitized string safe for error messages.
  */
 export function sanitizeGatewayError(text: string, maxLen = 500): string {
-  return text.slice(0, maxLen).replace(/payment-signature[^\s,}"]+/gi, '[redacted]');
+  const sliced = text.slice(0, maxLen).replace(/payment-signature[^\s,}"]+/gi, '[redacted]');
+  return redactBase58(redactHex(sliced));
 }

--- a/sdks/signer-core/tests/redact.test.ts
+++ b/sdks/signer-core/tests/redact.test.ts
@@ -89,13 +89,15 @@ describe('sanitizeGatewayError', () => {
   });
 
   it('slices to maxLen (default 500) before redacting', () => {
-    const long = 'a'.repeat(1000);
+    // Use spaces so neither the hex nor base58 redactor matches —
+    // we're asserting the slice happens at maxLen, not the redaction.
+    const long = ' '.repeat(1000);
     const result = sanitizeGatewayError(long);
     assert.equal(result.length, 500);
   });
 
   it('respects custom maxLen', () => {
-    const long = 'a'.repeat(1000);
+    const long = ' '.repeat(1000);
     const result = sanitizeGatewayError(long, 100);
     assert.equal(result.length, 100);
   });
@@ -107,5 +109,39 @@ describe('sanitizeGatewayError', () => {
 
   it('handles empty string', () => {
     assert.equal(sanitizeGatewayError(''), '');
+  });
+
+  it('redacts long hex sequences (e.g. hex-encoded keys / tx signatures)', () => {
+    // 64 hex chars — minimum match for redactHex.
+    const hex = 'a'.repeat(64);
+    const text = `signing failed for key ${hex}: invalid`;
+    const result = sanitizeGatewayError(text);
+    assert.equal(result, 'signing failed for key [REDACTED]: invalid');
+  });
+
+  it('redacts base58 wallet-address-shaped substrings', () => {
+    // 44-char base58 (typical Solana pubkey length).
+    const wallet = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const text = `payee ${wallet} rejected the deposit`;
+    const result = sanitizeGatewayError(text);
+    assert.equal(result, 'payee [REDACTED] rejected the deposit');
+  });
+
+  it('redacts hex first, then base58 — order matters for correctness', () => {
+    // 64+ hex string is also valid base58 (hex alphabet ⊂ base58 alphabet).
+    // If base58 ran first, it would mask the hex with [REDACTED] before the
+    // hex pass saw it — same visual outcome but the documented-invariant
+    // order is hex → base58.
+    const hex = 'abcdef1234567890'.repeat(4); // 64 chars, all hex
+    const text = `key=${hex}`;
+    const result = sanitizeGatewayError(text);
+    assert.equal(result, 'key=[REDACTED]');
+  });
+
+  it('still redacts payment-signature alongside hex/base58', () => {
+    const wallet = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const text = `error: payment-signatureXYZ from ${wallet} was rejected`;
+    const result = sanitizeGatewayError(text);
+    assert.equal(result, 'error: [redacted] from [REDACTED] was rejected');
   });
 });


### PR DESCRIPTION
## Summary

Fix a PII leak in `signer-core/src/redact.ts:sanitizeGatewayError`. Surfaced during the in-flight #144 review of openclaw-provider — flagged as a downstream-consumer-affected issue rather than a finding to fix in #144.

### The bug

`sanitizeGatewayError(text, maxLen=500)` was claiming to sanitize gateway error bodies for safe inclusion in user-visible error messages. It actually only:

1. Sliced to `maxLen`
2. Replaced `payment-signature[…]` header substrings with `[redacted]`

It did **not** call its own `redactHex` / `redactBase58` helpers. Result: wallet addresses, full base58 tx signatures, and hex-encoded private-key fragments in the gateway error body passed through unredacted into:

- `sdks/mcp/src/client.ts:343, 357`
- `sdks/openclaw-provider/src/index.ts:58, 180` (after #144 lands; the import migration is in flight)

### Fix

Pipeline becomes:

```
slice → strip payment-signature[…] → redactHex → redactBase58
```

Order matters: `redactHex` MUST run before `redactBase58` (the hex alphabet is a subset of base58). The individual helpers already documented this invariant; now enforced for the wrapper too.

```diff
 export function sanitizeGatewayError(text: string, maxLen = 500): string {
-  return text.slice(0, maxLen).replace(/payment-signature[^\s,}"]+/gi, '[redacted]');
+  const sliced = text.slice(0, maxLen).replace(/payment-signature[^\s,}"]+/gi, '[redacted]');
+  return redactBase58(redactHex(sliced));
 }
```

All 3 downstream call sites benefit automatically — no consumer-side changes needed.

### Test changes

Two existing tests used `'a'.repeat(N)` fixtures to verify slicing. Plain `'aaaa…'` now matches the 64+ hex pattern and gets redacted to `[REDACTED]` — that's the correct new behavior, but it broke the length assertions. Switched fixtures to spaces (`' '.repeat(N)`) which match neither redactor.

Added 4 new tests:
- Hex redaction (64 hex chars → `[REDACTED]`)
- Base58 redaction (44-char wallet address → `[REDACTED]`)
- Hex-first-then-base58 ordering invariant
- Payment-signature still redacted alongside hex/base58

## Validation

- [x] `cd sdks/signer-core && npm run build` — clean
- [x] `cd sdks/signer-core && npm test` — 69/69 pass (was 65; +4 new)
- [x] `cd sdks/mcp && npm test` — 69/69 pass (downstream consumer, sanity-check)
- [ ] CI to confirm

## Files

| File | Change |
|---|---|
| `sdks/signer-core/src/redact.ts` | `sanitizeGatewayError` now calls `redactHex` then `redactBase58` after the slice + payment-signature pass |
| `sdks/signer-core/tests/redact.test.ts` | 2 fixtures updated (`'a'.repeat` → `' '.repeat`); 4 new test cases for hex / base58 / ordering / combined-with-payment-signature |
