### PR TITLE
docs(sdks): stop recommending @solvela/sdk until wire format ships

### DIFF
--- a/dashboard/content/docs/sdks/index.mdx
+++ b/dashboard/content/docs/sdks/index.mdx
@@ -27,7 +27,7 @@ The first-party language SDKs each live in their own repository; adapter SDKs li
 - `sdks/ai-sdk-provider/`, `sdks/openclaw-provider/`, `sdks/cli-npm/` — Vercel AI SDK provider, OpenClaw provider, and npm CLI shim (this repo)
 
 <CardGroup>
-  <Card title="TypeScript" description="npm install @solvela/sdk — Node.js and browser compatible" href="/docs/sdks/typescript" />
+  <Card title="TypeScript" description="solvela-ai/solvela-ts (pre-1.0; not yet wire-aligned with prod gateway)" href="/docs/sdks/typescript" />
   <Card title="Python" description="pip install solvela-sdk — sync and async clients via httpx" href="/docs/sdks/python" />
   <Card title="Go" description="go get github.com/solvela-ai/solvela-go — context-aware, goroutine-safe" href="/docs/sdks/go" />
   <Card title="Rust CLI" description="cargo install solvela-cli — interactive chat, model listing, health checks" href="/docs/sdks/rust" />

--- a/dashboard/content/docs/sdks/typescript.mdx
+++ b/dashboard/content/docs/sdks/typescript.mdx
@@ -3,26 +3,30 @@ title: TypeScript SDK
 description: TypeScript/Node.js client for Solvela with automatic x402 payment handling
 ---
 
-The Solvela TypeScript SDK has moved to its own repository:
+The Solvela TypeScript SDK lives in its own repository:
 [**github.com/solvela-ai/solvela-ts**](https://github.com/solvela-ai/solvela-ts).
 
-## Installation
+## Status
 
-```bash
-npm install @solvela/sdk
-```
+The currently-published `@solvela/sdk@0.2.x` on npm is **not yet wire-compatible
+with the production gateway at `api.solvela.ai`**. The `PaymentPayload` envelope
+it emits does not match the shape the gateway deserializes. Track the standalone
+repo for a future release that aligns with the gateway wire format before using
+it for production payments.
+
+If you're building inside this monorepo and need x402 signing today, depend on
+[`@solvela/signer-core`](https://github.com/solvela-ai/solvela/tree/main/sdks/signer-core)
+directly — that's what `sdks/mcp/`, `sdks/openclaw-provider/`, and
+`sdks/ai-sdk-provider/` use to talk to the gateway.
 
 ## Documentation
 
-For the complete API reference, type definitions, examples, and changelog, see:
-
 - **Source:** [github.com/solvela-ai/solvela-ts](https://github.com/solvela-ai/solvela-ts)
-- **npm package:** [@solvela/sdk](https://www.npmjs.com/package/@solvela/sdk)
+- **npm package:** [@solvela/sdk](https://www.npmjs.com/package/@solvela/sdk) (pre-1.0; see status above)
 
 ## What changed
 
 The TypeScript SDK was previously vendored under `sdks/typescript/` in the
 solvela monorepo. That snapshot was retired in favor of a canonical standalone
 repository so SDK fixes (signer hardening, x402 protocol updates, ergonomics)
-ship in lockstep with the npm release. Existing imports of `@solvela/sdk`
-continue to work — only the source location changed.
+can ship in lockstep with the npm release.


### PR DESCRIPTION
## Summary

The published \`@solvela/sdk@0.2.x\` on npm cannot talk to the production gateway at \`api.solvela.ai\` — its \`PaymentPayload\` envelope doesn't match what the Rust gateway in \`crates/protocol/src/payment.rs\` deserializes. Verified yesterday via a serde test. PRs #137 and #144 already dropped \`@solvela/sdk\` from \`dependencies\` in every in-repo TS package in favor of \`@solvela/signer-core\`.

But the public docs at docs.solvela.ai still tell users to \`npm install @solvela/sdk\`, which gives them a broken setup. This PR fixes that.

## What's changed

| File | Change |
|---|---|
| \`dashboard/content/docs/sdks/typescript.mdx\` | Replace \"Installation: npm install @solvela/sdk\" + \"Existing imports continue to work\" with a **Status** section explaining the wire incompat and pointing in-repo consumers at \`@solvela/signer-core\`. Documentation/source links retained. Frontmatter unchanged. |
| \`dashboard/content/docs/sdks/index.mdx\` | TypeScript Card description: \`npm install @solvela/sdk — Node.js and browser compatible\` → \`solvela-ai/solvela-ts (pre-1.0; not yet wire-aligned with prod gateway)\`. \`href\` unchanged. |

## What this is NOT

- Not a code change. No SDK behavior changes.
- Not a peerDep change. \`sdks/ai-sdk-provider/package.json\` still lists \`@solvela/sdk: ^0.2.0\` in \`peerDependencies\`; whether to drop that is a separate decision (it forces consumers to install the wire-incompatible SDK to satisfy the peer, but the impact depends on what consumers expect — leaving it for a follow-up).
- Not the original scope of #134. #134 wanted to **repoint** \`@solvela/sdk\` deps to \`^0.2.0\` plus retire the \`sdks/typescript/\` husk. The husk-retirement work has since landed on \`main\` via #137/#144 and follow-ups, and the dep-repointing direction is the wrong direction per the wire-format finding. Closing #134 in favor of this.

## Test plan

- [x] \`git diff\` reviewed — only the two MDX files touched
- [ ] Reviewer: spot-check rendered output at \`/docs/sdks\` and \`/docs/sdks/typescript\` once deployed (Vercel preview)
- [ ] Reviewer: confirm \`href=\"/docs/sdks/typescript\"\` still resolves (it does — page slug unchanged)

## Related

- #137 — \`feat(signer-core,mcp): absorb x402 signing; drop wire-incompat @solvela/sdk\`
- #144 — \`chore(openclaw-provider): migrate to signer-core; drop @solvela/sdk\`
- #134 — being closed in favor of this

🤖 Generated with [Claude Code](https://claude.com/claude-code)