### PR TITLE
fix(mcp): parseFloat -> Number, signingMode cast, refund-clamp guards

### DIFF
--- a/sdks/mcp/src/client.ts
+++ b/sdks/mcp/src/client.ts
@@ -233,7 +233,17 @@ export class GatewayClient {
       // HF5: parse402 throws instead of returning null.
       const paymentInfo = parse402(await resp.text());
 
-      const cost = parseFloat(paymentInfo.cost_breakdown.total);
+      // Defense-in-depth: parse402 also validates this field, but using Number()
+      // (vs parseFloat) here means trailing-garbage like "0.001SOL" is rejected
+      // even if the upstream validator regresses or a third party generates the
+      // body. The check matters because `cost` drives both a budget mutation
+      // and a signed transaction below.
+      const cost = Number(paymentInfo.cost_breakdown.total);
+      if (!Number.isFinite(cost) || cost < 0) {
+        throw new Error(
+          `Gateway returned invalid total cost: ${paymentInfo.cost_breakdown.total}`,
+        );
+      }
 
       // T1-H: Atomic budget reservation — both check and increment must be in the same
       // critical section to prevent two parallel calls from both passing the budget check.
@@ -263,10 +273,12 @@ export class GatewayClient {
         });
       } else {
         // Filter accepts by signing mode before handing off to the SDK signer.
-        const filteredAccepts = filterAccepts(
-          paymentInfo.accepts,
-          this.signingMode as 'auto' | 'escrow' | 'direct',
-        );
+        // Bind to a typed local so TS verifies the narrowing produced by the
+        // `signingMode === 'off'` check above — replaces the previous `as` cast
+        // that silently masked the 'off' branch and would have lied if the
+        // if-ladder above were ever refactored.
+        const mode: 'auto' | 'escrow' | 'direct' = this.signingMode;
+        const filteredAccepts = filterAccepts(paymentInfo.accepts, mode);
         const filteredPaymentInfo = { ...paymentInfo, accepts: filteredAccepts };
         const privateKey = process.env['SOLANA_WALLET_KEY'];
 
@@ -277,10 +289,13 @@ export class GatewayClient {
           // HF2: Refund the reserved budget — signer never succeeded.
           await this.budgetMutex.runExclusive(async () => {
             const before = this.sessionSpentMicro;
-            if (before > 0 && before < costMicro) {
-              // Math.max(0, ...) would clamp — indicates a race condition in budget accounting.
+            // Warn whenever Math.max(0, ...) below would clamp. Dropping the
+            // prior `before > 0` guard means `before === 0` also surfaces a
+            // warning — that case implies a parallel refund already zeroed the
+            // counter (double-refund / race), which silently no-op'd before.
+            if (before < costMicro) {
               process.stderr.write(
-                `[solvela-mcp] WARN: budget refund clamped to 0 (before=${before}, costMicro=${costMicro}) — possible race condition\n`,
+                `[solvela-mcp] WARN: budget refund clamped (before=${before}, costMicro=${costMicro}). Possible double-refund or race.\n`,
               );
             }
             this.sessionSpentMicro = Math.max(0, this.sessionSpentMicro - costMicro);
@@ -442,10 +457,14 @@ export class GatewayClient {
       // Phase 3-refund: reservation never landed on-chain; roll back.
       await this.budgetMutex.runExclusive(async () => {
         const before = this.escrowDepositsSessionMicro;
-        if (before > 0 && before < amountMicro) {
+        // Warn whenever Math.max(0, ...) below would clamp. Dropping the prior
+        // `before > 0` guard means `before === 0` also surfaces a warning —
+        // that case implies a parallel refund already zeroed the counter
+        // (double-refund / race), which silently no-op'd before.
+        if (before < amountMicro) {
           process.stderr.write(
             `[solvela-mcp] WARN: escrow refund clamped (before=$${(before / 1_000_000).toFixed(6)}, refund=$${amount.toFixed(6)}). ` +
-            `Possible race condition.\n`,
+            `Possible double-refund or race.\n`,
           );
         }
         this.escrowDepositsSessionMicro = Math.max(0, this.escrowDepositsSessionMicro - amountMicro);

--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -57,7 +57,9 @@ const signingMode = rawSigningMode as 'auto' | 'escrow' | 'direct' | 'off';
 const budgetStr = process.env['SOLVELA_SESSION_BUDGET'] ?? process.env['RCR_SESSION_BUDGET']; // compat
 let sessionBudget: number | undefined;
 if (budgetStr !== undefined) {
-  const parsed = parseFloat(budgetStr);
+  // Number() (vs parseFloat) rejects trailing-garbage like "5USD" — parseFloat
+  // would silently coerce to 5, bypassing the positive-number guard below.
+  const parsed = Number(budgetStr);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     process.stderr.write(
       `[solvela-mcp] Fatal: SOLVELA_SESSION_BUDGET='${budgetStr}' is not a positive number.\n`,
@@ -101,7 +103,8 @@ const escrowRecipientWallet = process.env['SOLVELA_RECIPIENT_WALLET'] ?? '';
 const maxEscrowDepositStr = process.env['SOLVELA_MAX_ESCROW_DEPOSIT'];
 let maxEscrowDeposit = 5.0;
 if (maxEscrowDepositStr !== undefined) {
-  const parsed = parseFloat(maxEscrowDepositStr);
+  // Number() rejects trailing-garbage like "5USD" — see SOLVELA_SESSION_BUDGET above.
+  const parsed = Number(maxEscrowDepositStr);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     process.stderr.write(
       `[solvela-mcp] Fatal: SOLVELA_MAX_ESCROW_DEPOSIT='${maxEscrowDepositStr}' is not a positive number.\n`,
@@ -115,7 +118,8 @@ if (maxEscrowDepositStr !== undefined) {
 const maxEscrowSessionStr = process.env['SOLVELA_MAX_ESCROW_SESSION'];
 let maxEscrowSession = 20.0;
 if (maxEscrowSessionStr !== undefined) {
-  const parsed = parseFloat(maxEscrowSessionStr);
+  // Number() rejects trailing-garbage like "20USD" — see SOLVELA_SESSION_BUDGET above.
+  const parsed = Number(maxEscrowSessionStr);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     process.stderr.write(
       `[solvela-mcp] Fatal: SOLVELA_MAX_ESCROW_SESSION='${maxEscrowSessionStr}' is not a positive number.\n`,


### PR DESCRIPTION
## Summary

Picks up the still-applicable fixes from #130 (the createRequire/ESM fix and the refund-clamp WARN logging both already landed on \`main\` via other PRs since #130 was opened) and folds in the \`parseFloat\` env-var sites in \`index.ts\` that were not in #130's original scope but share the same bug class — per the \"fully green, not narrow scope\" pattern.

## What's changed

| File:Line | Change | Rationale |
|---|---|---|
| \`client.ts:236\` | \`parseFloat(...)\` → \`Number(...)\` + explicit \`isFinite && >= 0\` throw on \`paymentInfo.cost_breakdown.total\` | \`parseFloat(\"0.001SOL\")\` returns 0.001; \`Number\` returns NaN. \`cost\` drives a budget mutation and signed transaction. |
| \`client.ts:268\` | \`this.signingMode as 'auto'\|'escrow'\|'direct'\` → typed local \`const mode: 'auto'\|'escrow'\|'direct' = this.signingMode\` | The \`as\` cast silently masked the \`'off'\` variant. The typed local relies on TS narrowing from the \`signingMode === 'off'\` check earlier in the same block — TypeScript will catch a refactor that breaks the narrowing. |
| \`client.ts:283\` | Drop \`before > 0 &&\` guard from budget-refund-clamp WARN | With the guard, \`before === 0\` (parallel refund already zeroed the counter — i.e. double-refund or race) silently no-op'd. Now it surfaces a WARN. |
| \`client.ts:447\` | Same fix on the escrow-refund-clamp site | Same reasoning. |
| \`index.ts:60\` | \`parseFloat(SOLVELA_SESSION_BUDGET)\` → \`Number(...)\` | Same bug class — \`parseFloat(\"5USD\")\` silently accepted by the existing \`isFinite && >0\` guard. |
| \`index.ts:104\` | \`parseFloat(SOLVELA_MAX_ESCROW_DEPOSIT)\` → \`Number(...)\` | Same. |
| \`index.ts:118\` | \`parseFloat(SOLVELA_MAX_ESCROW_SESSION)\` → \`Number(...)\` | Same. |

## What's NOT in scope

- The TS18046 narrowing fix from #133 — already self-resolved by #137 (verified \`npx tsc --noEmit\` clean).
- The \`sanitizeGatewayError\` redaction fix from #124 — already on main via #145.
- The \`createRequire\` ESM fix from #130 — already on main (no \`createRequire\` calls remain in either file).
- The refund-clamp WARN logging from #130 — already on main (only the \`before > 0 &&\` guard around the WARN was missed; this PR drops it).
- The \`parseInt\` site at \`index.ts:74\` for \`SOLVELA_TIMEOUT_MS\` — same bug class but rarer footgun (env var typically lacks units); leaving for a separate decision.

## Test plan

\`\`\`bash
cd sdks/mcp
npx tsc --noEmit       # clean
npm test               # 69/69 across 11 suites
grep -n parseFloat src/client.ts src/index.ts   # only mentions left are in explanatory comments
\`\`\`

No public-API change. No behavior change on well-formed input. Two intended behavior changes:

1. \`createPaymentHeader\` is now never called with a NaN \`cost\` — instead an explicit \`Error\` is thrown earlier with a clearer message.
2. Double-refund / race conditions that previously silently no-op'd now WARN to stderr.

## Closes / refs

- Closes #130 (replaced by this narrowed scope; the obsolete fixes from #130 already landed on main).
- Refs #137 (made #133 obsolete), #144 (parallel migration), #145 (made #124 obsolete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)