### PR TITLE
fix(gateway): recover from mutex poison in fallback replay set

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 > Live shipping status. See [`CHANGELOG.md`](./CHANGELOG.md) for history, [`SECURITY.md`](./SECURITY.md) for disclosure.
 
-_Last refreshed: 2026-04-29 — security audit + hardening pass._
+_Last refreshed: 2026-05-01 — security audit + hardening pass._
 
 ## Shipped
 
@@ -35,6 +35,6 @@ _Last refreshed: 2026-04-29 — security audit + hardening pass._
 
 ## Known follow-ups
 
-- **2 deferred security advisories** — durable-nonce replay (GHSA-fq3f-c8p7-873f), f64 budget bypass (GHSA-86cr-h3rx-vj6j). A scheduled agent opens draft PRs for both 2026-04-29 14:00 UTC.
+- **5 security advisories patched** — GHSA-wc9q-wc6q-gwmq, GHSA-86cr-h3rx-vj6j, GHSA-cgqx-mg48-949v, GHSA-6ggq-cvwx-4f67, GHSA-fq3f-c8p7-873f all fixed in `main` (commits `1e5925e`, `1cd1502`). Advisory records pending publication.
 - **Registry uploads for SDKs** (PyPI, npm, crates.io) — pending operator credentials.
 - **Vercel API token rotation** and **GitHub org 2FA enforcement** — operator-side actions still pending.

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 > Live shipping status. See [`CHANGELOG.md`](./CHANGELOG.md) for history, [`SECURITY.md`](./SECURITY.md) for disclosure.
 
-_Last refreshed: 2026-05-01 — security audit + hardening pass._
+_Last refreshed: 2026-04-29 — security audit + hardening pass._
 
 ## Shipped
 
@@ -35,6 +35,6 @@ _Last refreshed: 2026-05-01 — security audit + hardening pass._
 
 ## Known follow-ups
 
-- **5 security advisories patched** — GHSA-wc9q-wc6q-gwmq, GHSA-86cr-h3rx-vj6j, GHSA-cgqx-mg48-949v, GHSA-6ggq-cvwx-4f67, GHSA-fq3f-c8p7-873f all fixed in `main` (commits `1e5925e`, `1cd1502`). Advisory records pending publication.
+- **2 deferred security advisories** — durable-nonce replay (GHSA-fq3f-c8p7-873f), f64 budget bypass (GHSA-86cr-h3rx-vj6j). A scheduled agent opens draft PRs for both 2026-04-29 14:00 UTC.
 - **Registry uploads for SDKs** (PyPI, npm, crates.io) — pending operator credentials.
 - **Vercel API token rotation** and **GitHub org 2FA enforcement** — operator-side actions still pending.

--- a/crates/gateway/src/cache.rs
+++ b/crates/gateway/src/cache.rs
@@ -276,7 +276,7 @@ impl ResponseCache {
                         let mut cache = self
                             .fallback_replay_set
                             .lock()
-                            .expect("fallback replay set mutex poisoned");
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
                         if cache.get(tx_signature).is_some() {
                             Err(CacheError::Replay)
@@ -303,7 +303,7 @@ impl ResponseCache {
                 let mut cache = self
                     .fallback_replay_set
                     .lock()
-                    .expect("fallback replay set mutex poisoned");
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
 
                 if cache.get(tx_signature).is_some() {
                     // Already seen — replay detected


### PR DESCRIPTION
## Summary

Replacement for #91 (which is broader and bundled with stale relicense duplicates of #94's already-merged work plus pre-#75 STATUS.md state). Cherry-picked just the actual security fix commit (\`a3364f22\`) onto a fresh branch from current main.

## What's changed

\`crates/gateway/src/cache.rs\` — replace \`.expect("fallback replay set mutex poisoned")\` with \`.unwrap_or_else(std::sync::PoisonError::into_inner)\` on both \`fallback_replay_set\` lock sites. A panic on any thread holding the lock would otherwise permanently wedge replay-protection for every subsequent caller.

Same risk class as GHSA-wc9q-wc6q-gwmq (mutex-poisoning DoS). PR #92 (merged as \`53616057\`) closed the same risk on \`crates/gateway/src/routes/proxy.rs\`'s \`replay_set\`. This PR closes it on the \`cache.rs\` \`fallback_replay_set\` — different code path, same bug pattern.

## Surgical scope

Two commits on the branch — squash-merge collapses to one:

- Cherry-pick of \`a3364f22\` (cache.rs + a stale May-1 STATUS.md bump)
- Revert of the STATUS.md bump (six days stale on top of #75 / #94 merges; doc hygiene shouldn't ride on a bug fix)

Net diff: \`crates/gateway/src/cache.rs | 4 ++--\`.

## Verification

\`\`\`
cargo build -p gateway --lib                          # clean
cargo test -p gateway --lib                           # 419/419
cargo clippy -p gateway --lib --all-targets -- -D warnings  # clean
cargo fmt --all -- --check                            # clean
\`\`\`

## Closes / refs

- Replaces #91 (broader scope; this PR carries forward only the security-relevant commit). #91 will be closed in favor of this PR plus the already-merged relicense work in #94.
- Refs #92 (\`53616057\` — same fix pattern on proxy.rs's replay_set).
- Refs #94 (\`90583028\` — relicense work that obsoleted #91's three relicense commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)