### PR TITLE
ci(ai-sdk-provider): bump npm audit-level to critical

### DIFF
--- a/.github/workflows/ai-sdk-provider.yml
+++ b/.github/workflows/ai-sdk-provider.yml
@@ -209,4 +209,12 @@ jobs:
         working-directory: sdks/signer-core
         run: npm ci && npm run build
       - run: npm ci
-      - run: npm audit --production --audit-level=high
+      # Audit-level critical (not high) because @solana/spl-token transitively
+      # pulls bigint-buffer, which has a known high-severity CVE
+      # (GHSA-3gc7-fjrx-p6mg) with no upstream fix. Affects the entire Solana
+      # ecosystem. Dependabot security alerts cover the high-severity gap on
+      # the repo level; this job catches CRITICAL regressions in CI.
+      # Mirrors openclaw-provider.yml; signer-core's bs58/web3.js/spl-token
+      # hard-deps reach this audit via signer-core's node_modules after
+      # `npm ci` here builds it as a file: dep above.
+      - run: npm audit --production --audit-level=critical


### PR DESCRIPTION
## Summary

The bigint-buffer high-severity CVE ([GHSA-3gc7-fjrx-p6mg](https://github.com/advisories/GHSA-3gc7-fjrx-p6mg)) reaches the ai-sdk-provider workflow's npm-audit job transitively via:

\`\`\`
@solvela/ai-sdk-provider → @solvela/signer-core (hard dep)
                          → @solana/spl-token (hard dep)
                          → bigint-buffer (vulnerable)
\`\`\`

There is no upstream fix — the issue affects the entire Solana JS ecosystem. As of today (2026-05-07) it is blocking every TS-touching PR's CI; we observed it as a transient \"non-blocking\" failure on #92 (which only avoided it because that PR was Rust-only and its path filters skipped this workflow).

## What's changed

\`.github/workflows/ai-sdk-provider.yml:212\` — \`--audit-level=high\` → \`--audit-level=critical\`, plus the same explanatory comment block that openclaw-provider.yml:161-165 already carries (shipped in #144).

## Why this is the right move

- **Mirrors a precedent.** \`openclaw-provider.yml\` already uses \`audit-level=critical\` for exactly this CVE chain. Bringing ai-sdk-provider into alignment.
- **Dependabot still covers the high-severity class** on the repo level — we don't lose detection, only the CI blocker.
- **Documented in memory.** \`project_solana_ecosystem_audit_blocker.md\` records this exact workaround as the documented path for this CVE class.
- **Cargo-side audit unchanged** — the Rust supply chain doesn't touch bigint-buffer.

## What's not in scope

- Restructuring deps to remove \`@solana/spl-token\` from the transitive tree (would require migrating away from web3.js v1, which is a much larger project).
- Pinning bigint-buffer to a non-vulnerable version (no such version exists).

## Closes / refs

- Memory: \`project_solana_ecosystem_audit_blocker.md\`
- Mirror: \`.github/workflows/openclaw-provider.yml:161-166\` (shipped in #144)

🤖 Generated with [Claude Code](https://claude.com/claude-code)