### PR TITLE
ci(mcp): add dedicated workflow

### DIFF
--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -1,0 +1,138 @@
+name: mcp
+
+on:
+  push:
+    paths:
+      - 'sdks/mcp/**'
+      - 'sdks/signer-core/**'
+      - '.github/workflows/mcp.yml'
+  pull_request:
+    paths:
+      - 'sdks/mcp/**'
+      - 'sdks/signer-core/**'
+      - '.github/workflows/mcp.yml'
+
+defaults:
+  run:
+    working-directory: sdks/mcp
+
+jobs:
+  install:
+    name: Install (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Node 22 has --experimental-strip-types enabled by default, which
+        # mcp's `node --test tests/*.ts` runner relies on. Don't drop below
+        # 22 without converting tests to compiled .js or adding a TS loader.
+        node: ['22']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: sdks/mcp/package-lock.json
+      - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
+        working-directory: sdks/signer-core
+        run: npm ci && npm run build
+      - run: npm ci
+
+  build:
+    name: Build (also typechecks)
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/mcp/package-lock.json
+      - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
+        working-directory: sdks/signer-core
+        run: npm ci && npm run build
+      - run: npm ci
+      # `npm run build` is `tsc` — it both typechecks and emits dist/. No
+      # separate typecheck job needed.
+      - run: npm run build
+
+  test:
+    name: Tests (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    needs: install
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: sdks/mcp/package-lock.json
+      - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
+        working-directory: sdks/signer-core
+        run: npm ci && npm run build
+      - run: npm ci
+      - run: npm test
+
+  guard-install-scripts:
+    name: Guard install scripts
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/mcp/package-lock.json
+      - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
+        working-directory: sdks/signer-core
+        run: npm ci && npm run build
+      - run: npm ci
+      - name: Fail if any dependency has postinstall/preinstall/prepublish
+        run: |
+          SCRIPTS=$(npm ls --all --json 2>/dev/null | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          def check(node, path=''):
+              scripts = node.get('scripts', {})
+              bad = [s for s in ['postinstall','preinstall','prepublish'] if s in scripts]
+              if bad:
+                  print(f'{path}: {bad}')
+              for name, child in node.get('dependencies', {}).items():
+                  check(child, name)
+          check(data)
+          ")
+          if [ -n "$SCRIPTS" ]; then
+            echo "ERROR: unexpected install scripts found:"
+            echo "$SCRIPTS"
+            exit 1
+          fi
+          echo "OK: no unexpected install scripts"
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/mcp/package-lock.json
+      - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
+        working-directory: sdks/signer-core
+        run: npm ci && npm run build
+      - run: npm ci
+      # Audit-level critical (not high) because @solana/spl-token transitively
+      # pulls bigint-buffer, which has a known high-severity CVE
+      # (GHSA-3gc7-fjrx-p6mg) with no upstream fix. Affects the entire Solana
+      # ecosystem. Dependabot security alerts cover the high-severity gap on
+      # the repo level; this job catches CRITICAL regressions in CI.
+      # Mirrors openclaw-provider.yml and ai-sdk-provider.yml.
+      - run: npm audit --production --audit-level=critical


### PR DESCRIPTION
## Summary

The mcp package had no dedicated CI workflow until now. The gap let #130's createRequire/ESM bug (a runtime \`ReferenceError\` under \`\"type\": \"module\"\`) sit undetected for 4 days because nothing in CI actually ran mcp's \`tsc\` build or \`node --test\` suite on PR.

This PR adds \`.github/workflows/mcp.yml\` mirroring the openclaw-provider.yml shape (shipped in #144) with three deltas tailored to mcp's specifics.

## Five jobs

1. **install** — \`npm ci\` with signer-core's \`dist/\` pre-built (file: dep)
2. **build (also typechecks)** — \`npm run build\` (which is \`tsc\`)
3. **test** — \`npm test\` (\`node --test tests/*.ts\`)
4. **guard-install-scripts** — fails the build if any dep adds postinstall/preinstall/prepublish scripts (supply-chain hardening, copied from openclaw-provider.yml)
5. **audit** — \`npm audit --production --audit-level=critical\`

## Three deltas vs openclaw-provider.yml

- **Node 22, not 20.** mcp's test script is \`node --test tests/*.ts\`, which relies on Node's \`--experimental-strip-types\` (default-on at 22.6+). Node 20 has no native TS support and would need a loader.
- **Single build job that also serves as typecheck.** mcp's build script is plain \`tsc\` — no separate \`typecheck\`/\`typecheck:tests\` scripts to match the openclaw-provider 8-job split.
- **No publish job.** mcp is \`private: true\` in package.json; no npm registry surface to gate.

## Audit-level rationale

Mirrors the \`--audit-level=critical\` decision from #144 (openclaw-provider) and #152 (ai-sdk-provider): bigint-buffer high-severity CVE (GHSA-3gc7-fjrx-p6mg) reaches every Solana 1.x consumer transitively and has no upstream fix. Resolution path is the @solana/kit migration tracked in SECURITY.md and dependabot.yml.

## Path filter

Triggers on:
- \`sdks/mcp/**\`
- \`sdks/signer-core/**\` (mcp depends on signer-core via \`file:../signer-core\` and would silently break if signer-core's surface changed without exercising mcp)
- \`.github/workflows/mcp.yml\` (so workflow edits exercise themselves)

## Verification

This PR's own CI run will be the first time mcp's build + test gates run on a PR. Local pre-push: \`cd sdks/mcp && npm test\` → 69/69 across 11 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)