### PR TITLE
fix(cli-npm): close two real footguns in the @solvela/cli shim

### DIFF
--- a/sdks/cli-npm/bin/solvela.js
+++ b/sdks/cli-npm/bin/solvela.js
@@ -7,6 +7,7 @@
 "use strict";
 
 const { execFileSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 
 // Map Node's process.platform + process.arch to our package naming convention.
@@ -43,7 +44,18 @@ function getBinaryPath(platformPkg) {
     const pkgRoot = path.dirname(
       require.resolve(path.join(platformPkg, "package.json"))
     );
-    return path.join(pkgRoot, "bin", binaryName);
+    const binPath = path.join(pkgRoot, "bin", binaryName);
+    // require.resolve only proves package.json exists — it says nothing about
+    // whether the binary itself was extracted. Two real states leave the bin
+    // missing while package.json is present:
+    //   1. Dev state after `git clone`: platforms/<plat>/bin/ contains only
+    //      .gitkeep until verify-release.sh (or a release build) runs.
+    //   2. Corrupt/interrupted `npm install`: package.json is on disk but the
+    //      bin/ payload was never extracted.
+    // Without this check, execFileSync would throw a generic ENOENT and skip
+    // the actionable "Try: npm install" guidance below.
+    if (!fs.existsSync(binPath)) return null;
+    return binPath;
   } catch (_) {
     return null;
   }

--- a/sdks/cli-npm/package.json
+++ b/sdks/cli-npm/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "solvela": "bin/solvela.js"
   },
+  "scripts": {
+    "publish:prepare": "node scripts/set-private.js false",
+    "publish:cleanup": "node scripts/set-private.js true"
+  },
   "optionalDependencies": {
     "@solvela/cli-linux-x64": "1.0.0-draft",
     "@solvela/cli-win32-x64": "1.0.0-draft",

--- a/sdks/cli-npm/scripts/set-private.js
+++ b/sdks/cli-npm/scripts/set-private.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Toggle the `private` flag on the @solvela/cli root package and all four
+// platform packages in lockstep.
+//
+// Usage:
+//   node scripts/set-private.js true   — set `"private": true` on all 5
+//   node scripts/set-private.js false  — remove `"private": true` from all 5
+//
+// Wired up to npm scripts as `publish:prepare` (false) and `publish:cleanup`
+// (true). The flow is:
+//
+//   npm run publish:prepare        # remove `"private": true` from all 5
+//   npm publish --access public    # then publish each package separately
+//   npm run publish:cleanup        # restore `"private": true` so the working
+//                                  # tree returns to its committed state
+//
+// Why this exists: an `npm publish` against any of these five packages
+// fails with EPRIVATE while `"private": true` is set, but the flag is the
+// only thing keeping the working tree from accidentally publishing during
+// a release rehearsal or a wrong-directory `npm publish` invocation. Hand-
+// editing five files in lockstep is error-prone — one missed flip during
+// publish results in three packages going public and the fourth 404'ing as
+// an optional dep that the shim then fails-soft on.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO = path.resolve(__dirname, "..");
+
+const PACKAGE_FILES = [
+  path.join(REPO, "package.json"),
+  path.join(REPO, "platforms", "linux-x64", "package.json"),
+  path.join(REPO, "platforms", "win32-x64", "package.json"),
+  path.join(REPO, "platforms", "darwin-x64", "package.json"),
+  path.join(REPO, "platforms", "darwin-arm64", "package.json"),
+];
+
+function parseTarget(arg) {
+  if (arg === "true") return true;
+  if (arg === "false") return false;
+  return null;
+}
+
+// Match the literal "private": <bool> field including any inline whitespace,
+// so we can replace just that line without going through JSON.parse +
+// JSON.stringify. A round-trip through the JSON serializer would expand
+// short arrays like `"os": ["darwin"]` onto multiple lines (npm-style
+// 2-space indent always splits arrays), churning ~8 lines per platform
+// file on every publish cycle. String-level replacement keeps the diff
+// surgical: exactly one line changes per file.
+const PRIVATE_LINE_RE = /^([ \t]*"private":[ \t]*)(true|false)([ \t]*,?)$/m;
+
+function applyTarget(file, target) {
+  const raw = fs.readFileSync(file, "utf8");
+
+  // Sanity-check that the field exists in the expected single-line form
+  // before we do any rewriting — guards against unexpectedly-formatted
+  // package.json files that this script wasn't built for.
+  const match = raw.match(PRIVATE_LINE_RE);
+  if (!match) {
+    process.stderr.write(
+      `[set-private] ERROR: ${file} has no \`"private": <bool>\` line in the expected format.\n` +
+        "  This script expects each tracked package.json to declare the field on its own line.\n",
+    );
+    process.exit(1);
+  }
+
+  const before = match[2];
+  const after = target ? "true" : "false";
+
+  if (before === after) {
+    console.log(`  unchanged       ${path.relative(REPO, file)}`);
+    return;
+  }
+
+  // Single-line replace; everything else in the file (object key order,
+  // array compaction, trailing newlines) is left exactly as it was.
+  const updated = raw.replace(PRIVATE_LINE_RE, `$1${after}$3`);
+  fs.writeFileSync(file, updated);
+
+  console.log(`  ${before} -> ${after}    ${path.relative(REPO, file)}`);
+}
+
+function main() {
+  const target = parseTarget(process.argv[2]);
+  if (target === null) {
+    process.stderr.write("Usage: node scripts/set-private.js <true|false>\n");
+    process.exit(1);
+  }
+
+  console.log(
+    `Setting \`private: ${target}\` on ${PACKAGE_FILES.length} package.json files:`,
+  );
+  for (const file of PACKAGE_FILES) {
+    applyTarget(file, target);
+  }
+}
+
+main();


### PR DESCRIPTION
Bundles two SHOULD-FIX findings from a recent code review of \`sdks/cli-npm/\`. The third finding (no linux-arm64) is bigger work and is being tracked separately as a follow-up.

## 1) Verify binary exists before returning the path  (\`bin/solvela.js\`)

\`require.resolve\` in \`getBinaryPath\` only proves \`package.json\` is on disk; it says nothing about the \`bin/<name>\` file itself. Two real states leave the binary missing while \`package.json\` is present:

- **Dev state after \`git clone\`** — \`platforms/<plat>/bin/\` contains only \`.gitkeep\` until \`verify-release.sh\` (or a release build) runs. **Concrete proof on this branch's base:** three of four platform packages locally are in this state — only \`platforms/linux-x64/bin/solvela\` exists.
- **Corrupt or interrupted \`npm install\`** — \`package.json\` lands but the \`bin/\` payload was never extracted.

Without this check, \`execFileSync\` throws a generic \`ENOENT\` and the user never sees the actionable \`[solvela] Could not resolve native binary … Try: npm install\` message that already exists at lines 72-85. Adding an \`fs.existsSync\` gate routes both states through that nice error.

## 2) Automate the \`"private": true\` publish flag  (\`scripts/set-private.js\` + npm scripts)

All five \`package.json\` files (root + four platform packages) declare \`\"private\": true\` to prevent accidental publish during dev. There was **no script that flipped this for an actual release**; the runbook that \`release.yml:126\` cites (\`docs/runbooks/phase-4-publish.md\`) **does not exist on disk** (verified). Hand-editing five files in lockstep at release time is the kind of thing where one missed flip silently 404s an optional dep that the shim then fails-soft on (and end up with three working binaries and one missing — exactly the failure mode the shim's nice-error path can't fully recover from).

Wired up:

\`\`\`bash
npm run publish:prepare         # set \`\"private\": false\` on all 5
npm publish --access public ... # then publish each package
npm run publish:cleanup         # set \`\"private\": true\`  on all 5
\`\`\`

### Why string replacement, not JSON.parse + JSON.stringify

Round-tripping through \`JSON.parse\` / \`JSON.stringify(data, null, 2)\` would expand short arrays like \`\"os\": [\"darwin\"]\` onto multiple lines (npm-style 2-space indent always splits arrays). That would churn ~8 lines per platform file on every publish cycle. The script does a single-line regex replace on the \`\"private\": <bool>\` line, leaving everything else (key order, array compaction, trailing newlines) bit-identical.

### Verified locally

\`\`\`bash
npm run publish:prepare           # all 5 toggle true -> false
git diff --stat platforms/        # diff = exactly 1 line per file (the private boolean)
npm run publish:cleanup           # all 5 toggle false -> true
git diff --stat                   # zero changes on platform files
node bin/solvela.js --version     # solvela 0.1.0  (happy path still works)
\`\`\`

This PR adds a \`scripts\` block to the root \`package.json\` (which had none).

## Out of scope (deferred)

The third finding from the same review — no \`linux-arm64\` (or \`win32-arm64\`) platform package. That requires:

- New \`platforms/linux-arm64/\` directory + \`package.json\` + bin scaffold
- Updating \`PLATFORM_MAP\` in \`bin/solvela.js\`
- Adding \`@solvela/cli-linux-arm64\` to the root \`optionalDependencies\`
- Adding the cross-compile target in \`.github/workflows/release.yml\`

The release-workflow piece is where the actual work is — without it, the package would exist but never get a binary built. Filing as a tracking issue post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)