### PR TITLE
fix(escrow): close two MUST-FIX security gaps + 6 hardening items

### DIFF
--- a/programs/escrow/Cargo.toml
+++ b/programs/escrow/Cargo.toml
@@ -29,6 +29,12 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
+# Selects the mainnet USDC mint (EPjFW…) at compile time. Without this,
+# the program targets the devnet USDC mint (4zMM…). The deployed bytecode
+# at the program ID in lib.rs MUST be built with `--features mainnet` —
+# default builds (e.g. `cargo check --lib`, local-validator tests) target
+# devnet so the same source compiles for both environments without edits.
+mainnet = []
 # Enables the LiteSVM integration tests in tests/integration.rs and
 # tests/helpers.rs. Requires `anchor build` to have produced
 # target/deploy/solvela_escrow.so first; without this feature the

--- a/programs/escrow/src/errors.rs
+++ b/programs/escrow/src/errors.rs
@@ -22,4 +22,23 @@ pub enum EscrowError {
     /// Escrow expiry slot must be in the future.
     #[msg("Expiry slot must be in the future")]
     InvalidExpiry,
+
+    // New variants appended below preserve wire codes for the variants above.
+    // Anchor encodes the error code as the discriminant (declaration order),
+    // so anything inserted earlier would shift the indexed values for clients.
+    /// Escrow has expired; claim is no longer permitted.
+    #[msg("Escrow has expired; claim no longer permitted")]
+    EscrowExpired,
+
+    /// Expiry slot is further in the future than the program permits.
+    #[msg("Expiry slot exceeds the maximum allowed window")]
+    ExpiryTooFar,
+
+    /// Provider key is invalid (zero key, or equal to the agent).
+    #[msg("Provider must be a non-default key distinct from the agent")]
+    InvalidProvider,
+
+    /// Vault held zero tokens at refund time.
+    #[msg("Vault is empty; nothing to refund")]
+    EmptyVault,
 }

--- a/programs/escrow/src/instructions/claim.rs
+++ b/programs/escrow/src/instructions/claim.rs
@@ -17,6 +17,15 @@ pub fn claim(ctx: Context<Claim>, actual_amount: u64) -> Result<()> {
         EscrowError::ClaimExceedsDeposit
     );
     require!(actual_amount > 0, EscrowError::ZeroAmount);
+    // Critical: gate the claim window on `slot < expiry_slot`. Without this,
+    // claim and refund are simultaneously valid once `slot >= expiry_slot`,
+    // and an adversarial provider can race the agent at the boundary. The
+    // entire deterministic-deadline guarantee for the agent depends on this
+    // line. See refund.rs for the matching `slot >= expiry_slot` guard.
+    require!(
+        Clock::get()?.slot < ctx.accounts.escrow.expiry_slot,
+        EscrowError::EscrowExpired,
+    );
 
     let escrow = &ctx.accounts.escrow;
     let seeds: &[&[u8]] = &[
@@ -39,8 +48,14 @@ pub fn claim(ctx: Context<Claim>, actual_amount: u64) -> Result<()> {
     );
     token::transfer(cpi_transfer, actual_amount)?;
 
-    // Refund remainder → agent ATA
-    let refund = escrow.amount - actual_amount;
+    // Refund remainder → agent ATA. The `actual_amount <= escrow.amount`
+    // guard above already prevents underflow, but `checked_sub` makes the
+    // invariant explicit at the call site (and survives a future refactor
+    // that moves or removes the guard).
+    let refund = escrow
+        .amount
+        .checked_sub(actual_amount)
+        .ok_or(EscrowError::ClaimExceedsDeposit)?;
     if refund > 0 {
         let cpi_refund = CpiContext::new_with_signer(
             ctx.accounts.token_program.to_account_info(),
@@ -69,6 +84,7 @@ pub fn claim(ctx: Context<Claim>, actual_amount: u64) -> Result<()> {
     emit!(ClaimEvent {
         agent: escrow.agent,
         provider: escrow.provider,
+        deposited: escrow.amount,
         claimed: actual_amount,
         refunded: refund,
         service_id: escrow.service_id,
@@ -92,8 +108,13 @@ pub struct Claim<'info> {
 
     /// Agent wallet — receives vault rent refund and any token remainder.
     /// Validated via `escrow.agent` address stored on-chain.
+    /// CHECK: `address = escrow.agent` is the only constraint that matters.
+    /// Using `UncheckedAccount` (vs `SystemAccount`) keeps the door open for
+    /// PDA- or program-owned agents (e.g. a future "agent vault" routing
+    /// through CPI). The address constraint above is equivalent in safety
+    /// — it pins the key to whatever was stored at deposit time.
     #[account(mut, address = escrow.agent)]
-    pub agent: SystemAccount<'info>,
+    pub agent: UncheckedAccount<'info>,
 
     /// Provider wallet — must match `escrow.provider`; pays for ATA init.
     #[account(mut)]
@@ -119,9 +140,14 @@ pub struct Claim<'info> {
     )]
     pub provider_token_account: Account<'info, TokenAccount>,
 
-    /// Agent's ATA — receives the refund remainder.
+    /// Agent's ATA — receives the refund remainder. `init_if_needed` so a
+    /// claim still succeeds when the agent has closed their ATA between
+    /// deposit and claim (a normal post-deposit cleanup move that reclaims
+    /// rent). Provider pays for recreation since they're already the
+    /// transaction signer with funds.
     #[account(
-        mut,
+        init_if_needed,
+        payer = provider,
         associated_token::mint = mint,
         associated_token::authority = agent,
     )]
@@ -136,6 +162,9 @@ pub struct Claim<'info> {
 pub struct ClaimEvent {
     pub agent: Pubkey,
     pub provider: Pubkey,
+    /// Original deposit amount. Surfaced so downstream indexers can tell a
+    /// partial claim from a full one without recomputing `claimed + refunded`.
+    pub deposited: u64,
     pub claimed: u64,
     pub refunded: u64,
     pub service_id: [u8; 32],

--- a/programs/escrow/src/instructions/deposit.rs
+++ b/programs/escrow/src/instructions/deposit.rs
@@ -4,7 +4,7 @@ use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
 
 use crate::errors::EscrowError;
 use crate::state::Escrow;
-use crate::USDC_MINT;
+use crate::{MAX_ESCROW_SLOTS, USDC_MINT};
 
 /// Deposit USDC into the PDA vault, locking funds for a specific service request.
 ///
@@ -19,7 +19,32 @@ pub fn deposit(
     expiry_slot: u64,
 ) -> Result<()> {
     require!(amount > 0, EscrowError::ZeroAmount);
-    require!(expiry_slot > Clock::get()?.slot, EscrowError::InvalidExpiry);
+
+    let now = Clock::get()?.slot;
+    require!(expiry_slot > now, EscrowError::InvalidExpiry);
+    // Cap the deposit-to-expiry gap so a buggy or adversarial client can't
+    // pass `expiry_slot = u64::MAX` and lock the agent out of refund forever.
+    // saturating_sub guards against the (already-rejected) `expiry_slot <= now`
+    // case in case of refactor; the `>` check above means subtraction is safe.
+    require!(
+        expiry_slot.saturating_sub(now) <= MAX_ESCROW_SLOTS,
+        EscrowError::ExpiryTooFar,
+    );
+
+    // Provider field is `UncheckedAccount` (no on-chain owner constraint), so
+    // the only on-chain protection a misconfigured client gets is this guard:
+    // a zero-key or self-key provider can never legitimately claim, which
+    // (combined with the expiry guard on claim) would brick the funds. Reject
+    // both at deposit time.
+    let provider_key = ctx.accounts.provider.key();
+    require!(
+        provider_key != Pubkey::default(),
+        EscrowError::InvalidProvider,
+    );
+    require!(
+        provider_key != ctx.accounts.agent.key(),
+        EscrowError::InvalidProvider,
+    );
 
     let escrow = &mut ctx.accounts.escrow;
     escrow.agent = ctx.accounts.agent.key();
@@ -51,7 +76,10 @@ pub fn deposit(
 }
 
 #[derive(Accounts)]
-#[instruction(amount: u64, service_id: [u8; 32])]
+// `amount` is unused in any account constraint — only `service_id` is bound
+// (PDA seeds). Renamed to `_amount` to silence the unused-instruction-arg
+// noise without changing the IX serialization (positional, not by name).
+#[instruction(_amount: u64, service_id: [u8; 32])]
 pub struct Deposit<'info> {
     /// Agent wallet — pays for the transaction and provides the funds.
     #[account(mut)]

--- a/programs/escrow/src/instructions/refund.rs
+++ b/programs/escrow/src/instructions/refund.rs
@@ -26,8 +26,13 @@ pub fn refund(ctx: Context<Refund>) -> Result<()> {
     ];
     let signer_seeds = &[seeds];
 
-    // Return all vault tokens → agent ATA
+    // Return all vault tokens → agent ATA. Reject vault_amount == 0 — it
+    // would emit a RefundEvent with refunded:0 and close the accounts as if
+    // successful, masking any prior state corruption that drained the vault
+    // outside the program's control. Cheap insurance against shipping a
+    // refund that quietly does nothing.
     let vault_amount = ctx.accounts.vault.amount;
+    require!(vault_amount > 0, EscrowError::EmptyVault);
     let cpi_transfer = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
         Transfer {
@@ -89,9 +94,14 @@ pub struct Refund<'info> {
     )]
     pub vault: Account<'info, TokenAccount>,
 
-    /// Agent's ATA — destination for refunded tokens.
+    /// Agent's ATA — destination for refunded tokens. `init_if_needed` so
+    /// refund still succeeds when the agent has closed their ATA between
+    /// deposit and refund (a normal post-deposit cleanup move that reclaims
+    /// rent). Agent is the signer here, so they pay for recreation — same
+    /// pattern as `claim.rs`'s mirror constraint.
     #[account(
-        mut,
+        init_if_needed,
+        payer = agent,
         associated_token::mint = mint,
         associated_token::authority = agent,
     )]

--- a/programs/escrow/src/lib.rs
+++ b/programs/escrow/src/lib.rs
@@ -37,8 +37,22 @@ pub mod state;
 
 use instructions::*;
 
-/// Mainnet USDC-SPL mint address. The escrow only accepts this mint.
+/// USDC-SPL mint address the escrow accepts. Feature-gated so the same
+/// program can be built for mainnet, devnet, or local test validators
+/// without source edits. The deployed mainnet bytecode at the program ID
+/// below MUST be built with `--features mainnet`; default builds (e.g.
+/// `cargo check --lib`, `anchor test` against a local validator) target
+/// the devnet USDC mint.
+#[cfg(feature = "mainnet")]
 pub const USDC_MINT: Pubkey = pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+#[cfg(not(feature = "mainnet"))]
+pub const USDC_MINT: Pubkey = pubkey!("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
+
+/// Maximum allowed gap between current slot and `expiry_slot` at deposit
+/// time. ~1 day at 400ms/slot — generous for any realistic API request
+/// (typical x402 calls resolve in seconds; this only constrains pathological
+/// clients that would otherwise lock funds for years).
+pub const MAX_ESCROW_SLOTS: u64 = 216_000;
 
 declare_id!("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU");
 

--- a/programs/escrow/tests/helpers.rs
+++ b/programs/escrow/tests/helpers.rs
@@ -22,8 +22,12 @@ use spl_token::{
 /// Program ID — must match declare_id!() in lib.rs
 pub const PROGRAM_ID: Pubkey = solana_sdk::pubkey!("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU");
 
-/// Mainnet USDC mint — must match USDC_MINT in lib.rs
-pub const USDC_MINT: Pubkey = solana_sdk::pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+/// USDC mint the program is currently built for. Re-exported from the
+/// program crate so tests automatically follow whichever variant the
+/// `mainnet` feature selects (mainnet `EPjFW…` with `--features mainnet`,
+/// devnet `4zMM…` otherwise). Eliminates the previous "must match lib.rs"
+/// duplication that would silently desync on a feature-gate change.
+pub const USDC_MINT: Pubkey = solvela_escrow::USDC_MINT;
 
 /// Compiled program bytes
 const PROGRAM_SO: &[u8] = include_bytes!("../target/deploy/solvela_escrow.so");
@@ -114,10 +118,7 @@ pub fn inject_ata(svm: &mut LiteSVM, owner: &Pubkey, mint: &Pubkey, amount: u64)
 }
 
 pub fn find_escrow_pda(program_id: &Pubkey, agent: &Pubkey, service_id: &[u8; 32]) -> (Pubkey, u8) {
-    Pubkey::find_program_address(
-        &[b"escrow", agent.as_ref(), service_id],
-        program_id,
-    )
+    Pubkey::find_program_address(&[b"escrow", agent.as_ref(), service_id], program_id)
 }
 
 pub fn find_vault_ata(escrow_pda: &Pubkey, mint: &Pubkey) -> Pubkey {
@@ -153,12 +154,12 @@ pub fn build_deposit_ix(
     Instruction {
         program_id: *program_id,
         accounts: vec![
-            AccountMeta::new(*agent, true),           // agent (signer, mut)
+            AccountMeta::new(*agent, true),              // agent (signer, mut)
             AccountMeta::new_readonly(*provider, false), // provider (unchecked)
-            AccountMeta::new_readonly(*mint, false),   // mint
-            AccountMeta::new(escrow_pda, false),       // escrow (PDA, init)
-            AccountMeta::new(agent_ata, false),        // agent_token_account
-            AccountMeta::new(vault_ata, false),        // vault (init_if_needed)
+            AccountMeta::new_readonly(*mint, false),     // mint
+            AccountMeta::new(escrow_pda, false),         // escrow (PDA, init)
+            AccountMeta::new(agent_ata, false),          // agent_token_account
+            AccountMeta::new(vault_ata, false),          // vault (init_if_needed)
             AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
             AccountMeta::new_readonly(spl_associated_token_account::ID, false),
             AccountMeta::new_readonly(system_program::ID, false),
@@ -188,13 +189,13 @@ pub fn build_claim_ix(
     Instruction {
         program_id: *program_id,
         accounts: vec![
-            AccountMeta::new(escrow_pda, false),       // escrow (PDA, mut, close=agent)
-            AccountMeta::new(*agent, false),            // agent (SystemAccount, mut)
-            AccountMeta::new(*provider, true),          // provider (signer, mut)
-            AccountMeta::new_readonly(*mint, false),    // mint
-            AccountMeta::new(vault_ata, false),         // vault (mut)
-            AccountMeta::new(provider_ata, false),      // provider_token_account (init_if_needed)
-            AccountMeta::new(agent_ata, false),         // agent_token_account (mut)
+            AccountMeta::new(escrow_pda, false), // escrow (PDA, mut, close=agent)
+            AccountMeta::new(*agent, false),     // agent (SystemAccount, mut)
+            AccountMeta::new(*provider, true),   // provider (signer, mut)
+            AccountMeta::new_readonly(*mint, false), // mint
+            AccountMeta::new(vault_ata, false),  // vault (mut)
+            AccountMeta::new(provider_ata, false), // provider_token_account (init_if_needed)
+            AccountMeta::new(agent_ata, false),  // agent_token_account (mut)
             AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
             AccountMeta::new_readonly(spl_associated_token_account::ID, false),
             AccountMeta::new_readonly(system_program::ID, false),
@@ -220,11 +221,11 @@ pub fn build_refund_ix(
     Instruction {
         program_id: *program_id,
         accounts: vec![
-            AccountMeta::new(escrow_pda, false),       // escrow (PDA, mut, close=agent)
-            AccountMeta::new(*agent, true),             // agent (signer, mut)
-            AccountMeta::new_readonly(*mint, false),    // mint
-            AccountMeta::new(vault_ata, false),         // vault (mut)
-            AccountMeta::new(agent_ata, false),         // agent_token_account (mut)
+            AccountMeta::new(escrow_pda, false), // escrow (PDA, mut, close=agent)
+            AccountMeta::new(*agent, true),      // agent (signer, mut)
+            AccountMeta::new_readonly(*mint, false), // mint
+            AccountMeta::new(vault_ata, false),  // vault (mut)
+            AccountMeta::new(agent_ata, false),  // agent_token_account (mut)
             AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
             AccountMeta::new_readonly(spl_associated_token_account::ID, false),
             AccountMeta::new_readonly(system_program::ID, false),

--- a/programs/escrow/tests/integration.rs
+++ b/programs/escrow/tests/integration.rs
@@ -3,11 +3,7 @@
 mod helpers;
 
 use helpers::*;
-use solana_sdk::{
-    instruction::AccountMeta,
-    program_pack::Pack,
-    signer::Signer,
-};
+use solana_sdk::{instruction::AccountMeta, program_pack::Pack, signer::Signer};
 use spl_associated_token_account::get_associated_token_address;
 
 // ─── Happy Path Tests ──────────────────────────────────────────────────────
@@ -25,7 +21,10 @@ fn test_deposit_creates_escrow() {
     let (escrow_pda, _bump) = deposit_helper(&mut ctx, &service_id, amount, expiry_slot);
 
     // Verify escrow PDA exists
-    assert!(account_exists(&ctx.svm, &escrow_pda), "escrow PDA should exist");
+    assert!(
+        account_exists(&ctx.svm, &escrow_pda),
+        "escrow PDA should exist"
+    );
 
     // Verify vault holds the tokens
     let vault = find_vault_ata(&escrow_pda, &ctx.usdc_mint);
@@ -71,11 +70,18 @@ fn test_claim_full_amount() {
     assert_eq!(read_token_balance(&ctx.svm, &provider_ata), Some(amount));
 
     // Escrow PDA closed
-    assert!(!account_exists(&ctx.svm, &escrow_pda), "escrow should be closed");
+    assert!(
+        !account_exists(&ctx.svm, &escrow_pda),
+        "escrow should be closed"
+    );
 
     // Agent ATA unchanged (no refund)
     let agent_ata = get_associated_token_address(&ctx.agent.pubkey(), &ctx.usdc_mint);
-    assert_eq!(read_token_balance(&ctx.svm, &agent_ata), Some(0), "agent should have no refund");
+    assert_eq!(
+        read_token_balance(&ctx.svm, &agent_ata),
+        Some(0),
+        "agent should have no refund"
+    );
 
     // Vault closed
     let vault = find_vault_ata(&escrow_pda, &ctx.usdc_mint);
@@ -90,7 +96,12 @@ fn test_claim_partial_with_refund() {
     let claim_amount = 600_000u64;
     let refund_amount = deposit_amount - claim_amount;
 
-    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, deposit_amount);
+    inject_ata(
+        &mut ctx.svm,
+        &ctx.agent.pubkey(),
+        &ctx.usdc_mint,
+        deposit_amount,
+    );
     let (escrow_pda, bump) = deposit_helper(&mut ctx, &service_id, deposit_amount, 500);
 
     let ix = build_claim_ix(
@@ -102,18 +113,28 @@ fn test_claim_partial_with_refund() {
         bump,
         claim_amount,
     );
-    send_tx(&mut ctx.svm, &[ix], &ctx.provider, &[&ctx.provider]).expect("partial claim should succeed");
+    send_tx(&mut ctx.svm, &[ix], &ctx.provider, &[&ctx.provider])
+        .expect("partial claim should succeed");
 
     // Provider got claim amount
     let provider_ata = get_associated_token_address(&ctx.provider.pubkey(), &ctx.usdc_mint);
-    assert_eq!(read_token_balance(&ctx.svm, &provider_ata), Some(claim_amount));
+    assert_eq!(
+        read_token_balance(&ctx.svm, &provider_ata),
+        Some(claim_amount)
+    );
 
     // Agent got refund
     let agent_ata = get_associated_token_address(&ctx.agent.pubkey(), &ctx.usdc_mint);
-    assert_eq!(read_token_balance(&ctx.svm, &agent_ata), Some(refund_amount));
+    assert_eq!(
+        read_token_balance(&ctx.svm, &agent_ata),
+        Some(refund_amount)
+    );
 
     // Escrow closed
-    assert!(!account_exists(&ctx.svm, &escrow_pda), "escrow should be closed");
+    assert!(
+        !account_exists(&ctx.svm, &escrow_pda),
+        "escrow should be closed"
+    );
 
     // Vault closed
     let vault = find_vault_ata(&escrow_pda, &ctx.usdc_mint);
@@ -147,7 +168,10 @@ fn test_refund_after_expiry() {
     assert_eq!(read_token_balance(&ctx.svm, &agent_ata), Some(amount));
 
     // Escrow closed
-    assert!(!account_exists(&ctx.svm, &escrow_pda), "escrow should be closed");
+    assert!(
+        !account_exists(&ctx.svm, &escrow_pda),
+        "escrow should be closed"
+    );
 
     // Vault closed
     let vault = find_vault_ata(&escrow_pda, &ctx.usdc_mint);
@@ -163,7 +187,12 @@ fn test_multiple_escrows_same_agent() {
     let amount_b = 2_000_000u64;
 
     // Fund agent with enough for both deposits
-    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount_a + amount_b);
+    inject_ata(
+        &mut ctx.svm,
+        &ctx.agent.pubkey(),
+        &ctx.usdc_mint,
+        amount_a + amount_b,
+    );
 
     // Two separate deposits
     let (_escrow_a, bump_a) = deposit_helper(&mut ctx, &service_id_a, amount_a, 500);
@@ -183,10 +212,16 @@ fn test_multiple_escrows_same_agent() {
 
     // Escrow A closed
     let (pda_a, _) = find_escrow_pda(&ctx.program_id, &ctx.agent.pubkey(), &service_id_a);
-    assert!(!account_exists(&ctx.svm, &pda_a), "escrow A should be closed");
+    assert!(
+        !account_exists(&ctx.svm, &pda_a),
+        "escrow A should be closed"
+    );
 
     // Escrow B still exists with funds
-    assert!(account_exists(&ctx.svm, &escrow_b), "escrow B should still exist");
+    assert!(
+        account_exists(&ctx.svm, &escrow_b),
+        "escrow B should still exist"
+    );
     let vault_b = find_vault_ata(&escrow_b, &ctx.usdc_mint);
     assert_eq!(read_token_balance(&ctx.svm, &vault_b), Some(amount_b));
 }
@@ -283,7 +318,9 @@ fn test_claim_wrong_provider_fails() {
     let mut ctx = setup();
     let service_id = [24u8; 32];
     let wrong_provider = solana_sdk::signature::Keypair::new();
-    ctx.svm.airdrop(&wrong_provider.pubkey(), 10_000_000_000).unwrap();
+    ctx.svm
+        .airdrop(&wrong_provider.pubkey(), 10_000_000_000)
+        .unwrap();
 
     inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, 1_000_000);
     let (_escrow, _bump) = deposit_helper(&mut ctx, &service_id, 1_000_000, 500);
@@ -343,7 +380,9 @@ fn test_refund_wrong_agent_fails() {
     let mut ctx = setup();
     let service_id = [26u8; 32];
     let wrong_agent = solana_sdk::signature::Keypair::new();
-    ctx.svm.airdrop(&wrong_agent.pubkey(), 10_000_000_000).unwrap();
+    ctx.svm
+        .airdrop(&wrong_agent.pubkey(), 10_000_000_000)
+        .unwrap();
 
     inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, 1_000_000);
     let (_escrow, _bump) = deposit_helper(&mut ctx, &service_id, 1_000_000, 100);
@@ -419,7 +458,9 @@ fn test_deposit_wrong_mint_fails() {
         .set_account(
             fake_mint,
             solana_sdk::account::Account {
-                lamports: ctx.svm.minimum_balance_for_rent_exemption(spl_token::state::Mint::LEN),
+                lamports: ctx
+                    .svm
+                    .minimum_balance_for_rent_exemption(spl_token::state::Mint::LEN),
                 data: mint_data,
                 owner: spl_token::ID,
                 executable: false,
@@ -443,4 +484,224 @@ fn test_deposit_wrong_mint_fails() {
     );
     let result = send_tx(&mut ctx.svm, &[ix], &ctx.agent, &[&ctx.agent]);
     assert!(result.is_err(), "deposit with wrong mint should fail");
+}
+
+// ─── Hardening regressions (post-review) ──────────────────────────────────
+//
+// These tests cover the failure modes flagged by the 2026-05-07 review:
+//   - claim must be gated on slot < expiry_slot (race with refund)
+//   - refund must survive a closed agent ATA (init_if_needed)
+//   - claim's refund leg must do the same
+//   - deposit must reject self-provider and excessive expiry
+
+#[test]
+fn test_claim_after_expiry_fails() {
+    let mut ctx = setup();
+    let service_id = [40u8; 32];
+    let amount = 1_000_000u64;
+    let expiry_slot = 100u64;
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+    let (_pda, bump) = deposit_helper(&mut ctx, &service_id, amount, expiry_slot);
+
+    // Warp to the expiry boundary itself — claim must be rejected here, not
+    // just after. The guard is `slot < expiry_slot` (strict inequality).
+    warp_and_refresh(&mut ctx.svm, expiry_slot);
+
+    let ix = build_claim_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        &service_id,
+        bump,
+        amount,
+    );
+    let result = send_tx(&mut ctx.svm, &[ix], &ctx.provider, &[&ctx.provider]);
+    assert!(
+        result.is_err(),
+        "claim at expiry boundary must fail (EscrowExpired)"
+    );
+
+    // And a slot beyond expiry, to be belt-and-braces.
+    warp_and_refresh(&mut ctx.svm, expiry_slot + 100);
+    let ix2 = build_claim_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        &service_id,
+        bump,
+        amount,
+    );
+    let result2 = send_tx(&mut ctx.svm, &[ix2], &ctx.provider, &[&ctx.provider]);
+    assert!(
+        result2.is_err(),
+        "claim past expiry must fail (EscrowExpired)"
+    );
+}
+
+#[test]
+fn test_refund_after_agent_ata_closed_succeeds() {
+    let mut ctx = setup();
+    let service_id = [41u8; 32];
+    let amount = 1_000_000u64;
+    let expiry_slot = 100u64;
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+    let (_pda, bump) = deposit_helper(&mut ctx, &service_id, amount, expiry_slot);
+
+    // Close the agent's ATA between deposit and refund — normal post-deposit
+    // cleanup move that reclaims rent. Pre-fix this would brick the funds in
+    // the vault PDA forever; with init_if_needed the refund instruction
+    // recreates the ATA and refunds normally.
+    let agent_ata = get_associated_token_address(&ctx.agent.pubkey(), &ctx.usdc_mint);
+    let close_ix = spl_token::instruction::close_account(
+        &spl_token::ID,
+        &agent_ata,
+        &ctx.agent.pubkey(),
+        &ctx.agent.pubkey(),
+        &[],
+    )
+    .expect("build close_account ix");
+    send_tx(&mut ctx.svm, &[close_ix], &ctx.agent, &[&ctx.agent])
+        .expect("close empty agent ATA should succeed");
+    assert!(
+        !account_exists(&ctx.svm, &agent_ata),
+        "agent ATA should be closed before refund"
+    );
+
+    // Warp to expiry and refund.
+    warp_and_refresh(&mut ctx.svm, expiry_slot + 1);
+    let ix = build_refund_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.usdc_mint,
+        &service_id,
+        bump,
+    );
+    send_tx(&mut ctx.svm, &[ix], &ctx.agent, &[&ctx.agent])
+        .expect("refund should succeed even after agent ATA was closed");
+
+    // ATA should be re-created and hold the refunded amount.
+    assert_eq!(
+        read_token_balance(&ctx.svm, &agent_ata),
+        Some(amount),
+        "agent ATA should be re-created with the full refund"
+    );
+}
+
+#[test]
+fn test_claim_after_agent_ata_closed_succeeds() {
+    let mut ctx = setup();
+    let service_id = [42u8; 32];
+    let deposit_amount = 1_000_000u64;
+    let claim_amount = 600_000u64; // partial — exercises the refund leg
+
+    inject_ata(
+        &mut ctx.svm,
+        &ctx.agent.pubkey(),
+        &ctx.usdc_mint,
+        deposit_amount,
+    );
+    let (_pda, bump) = deposit_helper(&mut ctx, &service_id, deposit_amount, 500);
+
+    // Close the agent's ATA after deposit. Pre-fix this would brick the
+    // claim's refund leg (and therefore the entire claim) on a partial
+    // claim. With init_if_needed the provider pays for the recreation.
+    let agent_ata = get_associated_token_address(&ctx.agent.pubkey(), &ctx.usdc_mint);
+    let close_ix = spl_token::instruction::close_account(
+        &spl_token::ID,
+        &agent_ata,
+        &ctx.agent.pubkey(),
+        &ctx.agent.pubkey(),
+        &[],
+    )
+    .expect("build close_account ix");
+    send_tx(&mut ctx.svm, &[close_ix], &ctx.agent, &[&ctx.agent])
+        .expect("close empty agent ATA should succeed");
+    assert!(
+        !account_exists(&ctx.svm, &agent_ata),
+        "agent ATA should be closed before claim"
+    );
+
+    let ix = build_claim_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        &service_id,
+        bump,
+        claim_amount,
+    );
+    send_tx(&mut ctx.svm, &[ix], &ctx.provider, &[&ctx.provider])
+        .expect("claim should succeed even after agent ATA was closed");
+
+    // Provider received their portion; agent ATA was re-created with the
+    // refund (deposit_amount - claim_amount).
+    let provider_ata = get_associated_token_address(&ctx.provider.pubkey(), &ctx.usdc_mint);
+    assert_eq!(
+        read_token_balance(&ctx.svm, &provider_ata),
+        Some(claim_amount),
+        "provider should receive the claim amount"
+    );
+    assert_eq!(
+        read_token_balance(&ctx.svm, &agent_ata),
+        Some(deposit_amount - claim_amount),
+        "agent ATA should be re-created with the refund remainder"
+    );
+}
+
+#[test]
+fn test_deposit_with_self_provider_rejected() {
+    let mut ctx = setup();
+    let service_id = [43u8; 32];
+    let amount = 1_000_000u64;
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+
+    // Build a deposit IX where provider == agent. Pre-fix this would create
+    // an escrow that only the agent (acting as provider) could claim, which
+    // combined with the no-claim-expiry-guard bug would brick refund.
+    let ix = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.agent.pubkey(), // provider == agent
+        &ctx.usdc_mint,
+        amount,
+        &service_id,
+        500,
+    );
+    let result = send_tx(&mut ctx.svm, &[ix], &ctx.agent, &[&ctx.agent]);
+    assert!(
+        result.is_err(),
+        "deposit with provider == agent must fail (InvalidProvider)"
+    );
+}
+
+#[test]
+fn test_deposit_with_excessive_expiry_rejected() {
+    let mut ctx = setup();
+    let service_id = [44u8; 32];
+    let amount = 1_000_000u64;
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+
+    // MAX_ESCROW_SLOTS in lib.rs is 216_000. Anything beyond `now + that`
+    // must be rejected so a buggy/adversarial client can't lock funds for
+    // years (and combined with the no-expiry-claim-guard bug, exploit it).
+    let ix = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        amount,
+        &service_id,
+        u64::MAX, // adversarial maximum
+    );
+    let result = send_tx(&mut ctx.svm, &[ix], &ctx.agent, &[&ctx.agent]);
+    assert!(
+        result.is_err(),
+        "deposit with excessive expiry_slot must fail (ExpiryTooFar)"
+    );
 }

--- a/programs/escrow/tests/unit.rs
+++ b/programs/escrow/tests/unit.rs
@@ -10,8 +10,8 @@
 #[cfg(test)]
 mod tests {
     use anchor_lang::Space;
-    use solvela_escrow::state::Escrow;
     use solana_sdk::pubkey::Pubkey;
+    use solvela_escrow::state::Escrow;
 
     // Expected space: 8 (discriminator) + InitSpace
     // Escrow fields:
@@ -106,5 +106,31 @@ mod tests {
             expiry_slot: 0,
             bump: 0,
         };
+    }
+
+    #[test]
+    fn test_claim_event_includes_deposited() {
+        // Compile-time sentinel for the `deposited` field on ClaimEvent —
+        // added in this PR so downstream indexers can tell partial vs full
+        // claims without reconstructing `claimed + refunded`. If this test
+        // fails to compile, the field was renamed or removed and any
+        // indexer/UI that reads it will silently break.
+        let _e = solvela_escrow::instructions::ClaimEvent {
+            agent: Pubkey::default(),
+            provider: Pubkey::default(),
+            deposited: 100,
+            claimed: 60,
+            refunded: 40,
+            service_id: [0u8; 32],
+        };
+    }
+
+    #[test]
+    fn test_max_escrow_slots_is_sane() {
+        // ~1 day at 400ms/slot. Doc-checked sanity bound — if someone bumps
+        // it beyond a few days, that's a separate decision (would interact
+        // with the agent's deadline guarantee).
+        assert!(solvela_escrow::MAX_ESCROW_SLOTS >= 100_000);
+        assert!(solvela_escrow::MAX_ESCROW_SLOTS <= 1_000_000);
     }
 }


### PR DESCRIPTION
Closes both MUST-FIX issues from the 2026-05-07 escrow review plus 6 of 7 SHOULD-FIX items. **Verified zero on-chain usage** (\`getProgramAccounts\` against \`9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU\` returned no accounts) — no funds at risk during the disclosure window. Source-fix lands here; redeployment is a separate operational step (see bottom).

## MUST FIX

### 1. \`claim\` now requires \`Clock::slot < expiry_slot\`
Pre-fix, claim and refund were simultaneously valid once \`slot >= expiry_slot\`, and an adversarial provider could race the agent at the boundary. The deterministic-deadline guarantee for the agent depended on this single \`require!\`.

### 2. \`claim\` and \`refund\` make \`agent_token_account\` \`init_if_needed\`
Pre-fix, an agent who closed their ATA after deposit (a normal post-deposit cleanup move that reclaims rent) would brick BOTH the standalone \`refund\` AND the claim's refund leg — funds permanently stuck in the vault PDA. The reviewer flagged \`refund\`; \`claim\`'s refund leg has the identical constraint shape, so it's fixed in lockstep.
- \`refund\`: agent (signer) pays for ATA recreation
- \`claim\`: provider (signer) pays for ATA recreation

## SHOULD FIX

| # | Site | Change |
|---|---|---|
| 3 | \`lib.rs\` USDC mint | Feature-gated. \`--features mainnet\` selects \`EPjFW…\`; default targets devnet \`4zMM…\`. Deployed mainnet bytecode MUST be built with \`--features mainnet\`. |
| 4 | \`deposit.rs\` provider | Rejects \`provider == agent\` and \`provider == Pubkey::default()\`. UncheckedAccount kept (intentional design); just adds the obviously-bad-cases gate. |
| 5 | \`deposit.rs\` expiry | Caps \`expiry_slot - now\` at \`MAX_ESCROW_SLOTS\` (216_000 = ~1 day at 400ms). Combined with #1, bounds the claim window. |
| 6 | \`claim.rs\` agent | \`SystemAccount\` → \`UncheckedAccount\` with the existing \`address = escrow.agent\`. Same safety; unblocks future PDA-/program-owned agents. |
| 7 | \`claim.rs\` event | \`ClaimEvent\` gains \`deposited\` field for indexer disambiguation. |
| 8 | \`refund.rs\` + \`claim.rs\` math | \`refund\` rejects \`vault_amount == 0\`; \`claim\` uses \`checked_sub\`; \`deposit\` \`#[instruction]\` arg renamed \`_amount\`. |

### Out of scope (filed as note in commit body)

The reviewer's \`dep:\`-namespaced \`sbf\` features bonus NIT — Cargo doesn't allow \`optional = true\` on \`[dev-dependencies]\`, so the proposed pattern doesn't compile. The "cuts cold cargo check time" benefit needs a different mechanism. Left as-is.

## New error variants

Appended at the end of \`EscrowError\` so existing wire codes are preserved: \`EscrowExpired\`, \`ExpiryTooFar\`, \`InvalidProvider\`, \`EmptyVault\`.

## New tests (7 total)

| Test | Covers |
|---|---|
| \`test_claim_after_expiry_fails\` | MUST FIX 1 — boundary AND past-expiry |
| \`test_refund_after_agent_ata_closed_succeeds\` | MUST FIX 2 — refund instruction |
| \`test_claim_after_agent_ata_closed_succeeds\` | MUST FIX 2 — claim's refund leg |
| \`test_deposit_with_self_provider_rejected\` | SHOULD FIX 4 |
| \`test_deposit_with_excessive_expiry_rejected\` | SHOULD FIX 5 |
| \`test_claim_event_includes_deposited\` (unit) | SHOULD FIX 7 — compile-time field sentinel |
| \`test_max_escrow_slots_is_sane\` (unit) | SHOULD FIX 5 — bound sanity |

## Verified locally

\`\`\`
cargo test --test unit                          # 8/8
cargo build-sbf                                 # solvela_escrow.so 308KB
cargo test --features sbf --test integration    # 19/19  (14 prior + 5 new)
cargo check --lib --features mainnet            # clean
cargo fmt --all -- --check                      # clean
\`\`\`

## Redeployment — separate operational step

This PR is the source-fix only. Every active escrow opened against the deployed bytecode at \`9neD…tHLU\` will continue to have the bugs until the program is redeployed. Steps once this lands:

1. \`anchor build -- --features mainnet\` (or \`cargo build-sbf --features mainnet\`)
2. Verify the new \`solvela_escrow.so\` matches the expected bytecode hash
3. \`anchor upgrade\` against the program authority for \`9neD…tHLU\` — **the local \`target/deploy/*-keypair.json\` files are NOT this authority**; they're auto-generated build artifacts. The real upgrade-authority key lives outside the repo (hardware wallet / ledger / dedicated keypair file).
4. Sanity-check on-chain (e.g. invoke \`deposit\` with adversarial inputs that the new tests cover, observe the new \`Escrow*\` error codes return).

No funds-at-risk pressure: \`getProgramAccounts 9neD…tHLU\` returned zero accounts at PR time, so there are no in-flight escrows that need to be drained or migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)