### PR TITLE
docs(status): note 2026-05-08 escrow redeploy + refresh follow-ups

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,13 +2,13 @@
 
 > Live shipping status. See [`CHANGELOG.md`](./CHANGELOG.md) for history, [`SECURITY.md`](./SECURITY.md) for disclosure.
 
-_Last refreshed: 2026-04-29 — security audit + hardening pass._
+_Last refreshed: 2026-05-08 — escrow program upgraded with hardened bytecode._
 
 ## Shipped
 
 - **Gateway** — Axum HTTP server with chat completions, image generation, A2A protocol, model registry, escrow endpoints, enterprise org/team/audit/budget endpoints, Prometheus metrics. 5 LLM providers (OpenAI, Anthropic, Google, xAI, DeepSeek).
 - **Protocol** — `solvela-protocol`, `solvela-x402`, `solvela-router`, `solvela-cli` published to crates.io. v0.1.1 was published with mixed/MIT metadata; v0.2.0 corrects this and aligns with the per-component split (gateway BUSL-1.1, libraries MIT, SDKs MIT). `cargo install solvela-cli` works.
-- **Escrow program** — Anchor / USDC-SPL trustless escrow. Deployed to Solana mainnet at `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`.
+- **Escrow program** — Anchor / USDC-SPL trustless escrow. Deployed to Solana mainnet at `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`. Upgraded 2026-05-08 (slot 418438627, tx `2Rp69yKfyxeeawrFRPZbLma9NytxEXSz8PeWPdNYzWm4e3Fr2xihP3T23PiwDB9xYbnUwN8kmsnrgBKjP2dbBbuE`, bytecode SHA-256 `2293edfce3a0e7b1b0332bc32d9f7a9e58105a2a3f825ee05d8a4f7fbf57bf26`) to close two MUST-FIX security gaps (claim expiry race, closed-ATA refund deadlock) and six SHOULD-FIX hardening items per PR #160. Verified zero on-chain accounts at upgrade time — no funds at risk during the disclosure window.
 - **SDKs** — Python, TypeScript, Go, and a wallet-client (Rust) SDK in separate repos: `solvela-python` (v0.1.0), `solvela-ts` (v0.2.0), `solvela-go` (v0.1.0), `solvela-client` (v0.2.0). Tagged + GitHub Released 2026-04-29 as the security-hardening release; Go is live via the module proxy, PyPI/npm/crates.io uploads pending operator credentials.
 - **Dashboard + Docs** — Next.js app serving `solvela.ai`, `app.solvela.ai`, `docs.solvela.ai` via subdomain middleware. `www.solvela.ai` 308-redirects to apex.
 
@@ -35,6 +35,7 @@ _Last refreshed: 2026-04-29 — security audit + hardening pass._
 
 ## Known follow-ups
 
-- **2 deferred security advisories** — durable-nonce replay (GHSA-fq3f-c8p7-873f), f64 budget bypass (GHSA-86cr-h3rx-vj6j). A scheduled agent opens draft PRs for both 2026-04-29 14:00 UTC.
 - **Registry uploads for SDKs** (PyPI, npm, crates.io) — pending operator credentials.
 - **Vercel API token rotation** and **GitHub org 2FA enforcement** — operator-side actions still pending.
+- **Anchor 0.31 → 1.0 migration on the escrow program** (#155 / #156) — coordinated bump alongside the broader Solana 1.x → @solana/kit ecosystem migration. Not security-critical now that the deployed bytecode is hardened.
+- **Dedicated escrow CI workflow** (#162) — `programs/escrow/` opts out of the workspace and isn't covered by the cross-cutting Rust job. Cargo build-sbf + LiteSVM integration tests should run on every escrow-touching PR.


### PR DESCRIPTION
Bookkeeping after #160's source fix landed and the deployed bytecode at \`9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU\` was upgraded earlier today (issue #161).

## What changed

- **Date bump**: \`Last refreshed\` 2026-04-29 → 2026-05-08.
- **Escrow Shipped entry** gains the audit trail: upgrade slot \`418438627\`, tx \`2Rp69yKfyxeeawrFRPZbLma9NytxEXSz8PeWPdNYzWm4e3Fr2xihP3T23PiwDB9xYbnUwN8kmsnrgBKjP2dbBbuE\`, bytecode SHA-256 \`2293edfce3a0e7b1b0332bc32d9f7a9e58105a2a3f825ee05d8a4f7fbf57bf26\`, source PR #160. Notes verified zero on-chain accounts at upgrade time.
- **Drop stale follow-up**: the "2 deferred security advisories" bullet from 2026-04-29. Both GHSAs (\`GHSA-fq3f-c8p7-873f\` durable-nonce replay, \`GHSA-86cr-h3rx-vj6j\` f64 budget bypass) were patched in earlier commits — \`.github/dependabot.yml\` already documents all 5 GHSAs as resolved.
- **Add two real open items**: anchor 0.31 → 1.0 migration on the escrow program (#155 / #156) and dedicated escrow CI workflow (#162).

## Verification

The redeploy itself (Step 1 + Step 2 from #161) ran successfully earlier today. Bytecode hash on-chain matches the local source build:

\`\`\`
$ solana program dump 9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU /tmp/deployed.so
Wrote program to /tmp/deployed.so
$ head -c 308032 /tmp/deployed.so | sha256sum
2293edfce3a0e7b1b0332bc32d9f7a9e58105a2a3f825ee05d8a4f7fbf57bf26  -
$ sha256sum programs/escrow/target/deploy/solvela_escrow.so
2293edfce3a0e7b1b0332bc32d9f7a9e58105a2a3f825ee05d8a4f7fbf57bf26  programs/escrow/target/deploy/solvela_escrow.so
\`\`\`

Final wallet balance after the upgrade: 2.7837 SOL (started 3.133, net spend 0.349 SOL = ~50 KB of permanent ProgramData rent + chunked-tx fees; buffer-account rent refunded on the atomic swap as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)