### PR TITLE
fix(escrow): enforce provider_ata != agent_ata in claim()

### DIFF
--- a/programs/escrow/src/errors.rs
+++ b/programs/escrow/src/errors.rs
@@ -46,4 +46,13 @@ pub enum EscrowError {
     /// must have a realistic chance to propagate before refund opens.
     #[msg("Expiry slot is too close to now; insufficient claim buffer")]
     ExpiryTooSoon,
+
+    /// `provider_token_account` and `agent_token_account` resolve to the
+    /// same address. Currently unreachable — `deposit` rejects
+    /// `provider == agent` via `InvalidProvider`, so the two ATAs (each
+    /// derived from a distinct authority) cannot collide. Defense-in-depth
+    /// guard so a future change to the deposit-side check, or a different
+    /// deposit code path, doesn't silently re-enable a double-credit drain.
+    #[msg("Provider and agent token accounts must differ")]
+    DuplicateClaimAccounts,
 }

--- a/programs/escrow/src/instructions/claim.rs
+++ b/programs/escrow/src/instructions/claim.rs
@@ -26,6 +26,19 @@ pub fn claim(ctx: Context<Claim>, actual_amount: u64) -> Result<()> {
         Clock::get()?.slot < ctx.accounts.escrow.expiry_slot,
         EscrowError::EscrowExpired,
     );
+    // Defense-in-depth: forbid `provider_token_account == agent_token_account`.
+    // Anchor's account de-dup catches duplicate ACCOUNT-LIST entries, not two
+    // distinct entries that resolve to the same Pubkey. Today the collision
+    // is only reachable if `provider == agent`, which `deposit` already
+    // rejects via `InvalidProvider`. This guard removes the cross-instruction
+    // dependency: if the deposit-side check is ever loosened, the two
+    // `init_if_needed` transfers below would otherwise double-credit the same
+    // ATA and let the provider drain `actual_amount + refund == escrow.amount`
+    // regardless of `actual_amount`.
+    require!(
+        ctx.accounts.provider_token_account.key() != ctx.accounts.agent_token_account.key(),
+        EscrowError::DuplicateClaimAccounts,
+    );
 
     let escrow = &ctx.accounts.escrow;
     let seeds: &[&[u8]] = &[

--- a/programs/escrow/tests/unit.rs
+++ b/programs/escrow/tests/unit.rs
@@ -133,4 +133,14 @@ mod tests {
         assert!(solvela_escrow::MAX_ESCROW_SLOTS >= 100_000);
         assert!(solvela_escrow::MAX_ESCROW_SLOTS <= 1_000_000);
     }
+
+    #[test]
+    fn test_duplicate_claim_accounts_variant_exists() {
+        // Compile-time sentinel for the defense-in-depth guard added to
+        // claim() that rejects `provider_token_account == agent_token_account`.
+        // The full reject path needs LiteSVM (tests/integration.rs); this
+        // test ensures the variant survives a refactor on the default
+        // `cargo test` surface so a regression that removes it is loud.
+        let _err = solvela_escrow::errors::EscrowError::DuplicateClaimAccounts;
+    }
 }


### PR DESCRIPTION
## Summary

Closes the **H4** finding from the 2026-05-08 whole-repo security review.

Anchor's account de-dup catches duplicate **account-list** entries, but it does **not** catch two distinct entries (`provider_token_account` and `agent_token_account`) that resolve to the same `Pubkey`. Today the collision is unreachable because `deposit` rejects `provider == agent` via `InvalidProvider` — but `claim` relies entirely on that **cross-instruction invariant**.

If a future change loosens deposit's `InvalidProvider` check, or adds a different deposit code path, claim's two `init_if_needed` transfers would silently double-credit the same ATA. The provider could drain `actual_amount + refund == escrow.amount` regardless of `actual_amount`. AGENTS.md explicitly mandates this guard pattern for handlers that mutate two ATAs.

This adds the explicit `require!(provider_token_account.key() != agent_token_account.key(), DuplicateClaimAccounts)` at the top of `claim()`, alongside the existing amount / slot-window invariants.

### What changed

- `programs/escrow/src/instructions/claim.rs:30-39` — new `require!` guard at the top of `claim()`, immediately after the existing `EscrowExpired` check.
- `programs/escrow/src/errors.rs` — `DuplicateClaimAccounts` variant **appended at the end** of `EscrowError`. The wire-code stability comment in errors.rs:26-28 explicitly mandates appending only — every existing variant keeps its discriminant, so off-chain decoders are unaffected.
- `programs/escrow/tests/unit.rs` — compile-time sentinel test ensures the variant survives refactors on the default `cargo test` surface.

### Test surface

- **Unit (default `cargo test`):** new `test_duplicate_claim_accounts_variant_exists` — compile-time check that the variant exists and is reachable through the public `errors` module. All 9 unit tests pass (8 existing + 1 new).
- **Integration (LiteSVM, `--features sbf`):** the actual reject path needs `anchor build` to produce `target/deploy/solvela_escrow.so` first. Adding a runtime `claim_with_overlapping_atas_rejected` integration test is an obvious follow-up alongside the next sbf run, but it requires constructing the (currently impossible) overlapping-ATA state, which is what makes this PR a defense-in-depth hardening rather than an exploitable-bug fix.

## Test plan

- [x] `cargo test --manifest-path programs/escrow/Cargo.toml` — 9/9 pass
- [x] `cargo fmt --all -- --check` (in `programs/escrow/`) — clean
- [x] `cargo clippy` — no new warnings introduced (12 pre-existing Anchor macro cfg warnings on main are unchanged)
- [ ] CI green
- [ ] Reviewer confirms `DuplicateClaimAccounts` is **appended** (errors.rs line ~46-54) and no existing variant moved
- [ ] Follow-up: add LiteSVM integration test for the reject path on the next `anchor build` cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)