### PR TITLE
fix(gateway): truncate attacker-controlled tx_raw in replay logs (M4)

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -346,7 +346,7 @@ async fn handle_payment_submitted(
             } else {
                 set.put(tx_raw.to_string(), now);
                 warn!(
-                    tx = %tx_raw,
+                    tx_prefix = &tx_raw[..tx_raw.len().min(88)],
                     "A2A payment accepted under degraded in-memory replay protection (no Redis)"
                 );
                 false

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -458,7 +458,7 @@ pub async fn chat_completions(
                 } else {
                     replay_set.put(tx_raw.to_string(), now);
                     warn!(
-                        tx = %tx_raw,
+                        tx_prefix = &tx_raw[..tx_raw.len().min(88)],
                         "payment accepted under degraded in-memory replay protection (no Redis)"
                     );
                     false
@@ -468,7 +468,10 @@ pub async fn chat_completions(
             if replay_detected {
                 counter!("solvela_replay_rejections_total").increment(1);
                 counter!("solvela_payments_total", "status" => "failed").increment(1);
-                warn!(tx = %tx_raw, "replay attack detected — transaction already used");
+                warn!(
+                    tx_prefix = &tx_raw[..tx_raw.len().min(88)],
+                    "replay attack detected — transaction already used"
+                );
                 return Err(GatewayError::InvalidPayment(
                     "transaction has already been used; each payment signature may only be submitted once".to_string()
                 ));

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -370,7 +370,7 @@ pub async fn proxy_service(
         } else {
             replay_set.put(tx_raw.to_string(), now);
             warn!(
-                tx = %tx_raw,
+                tx_prefix = &tx_raw[..tx_raw.len().min(88)],
                 "payment accepted under degraded in-memory replay protection (no Redis)"
             );
             false
@@ -380,7 +380,10 @@ pub async fn proxy_service(
     if replay_detected {
         counter!("solvela_replay_rejections_total").increment(1);
         counter!("solvela_payments_total", "status" => "failed").increment(1);
-        warn!(tx = %tx_raw, "replay attack detected — transaction already used");
+        warn!(
+            tx_prefix = &tx_raw[..tx_raw.len().min(88)],
+            "replay attack detected — transaction already used"
+        );
         return Err(GatewayError::InvalidPayment(
             "transaction has already been used; each payment signature may only be submitted once"
                 .to_string(),


### PR DESCRIPTION
## Summary

Closes the **M4** finding from the 2026-05-08 whole-repo security review.

\`tx_raw\` is the base64 transaction payload taken straight from the attacker-controlled \`PAYMENT-SIGNATURE\` header. Five \`tracing::warn!\` sites in chat/mod.rs, proxy.rs, and a2a/handler.rs were emitting it in full via \`tx = %tx_raw\`:

- on the **accepted-under-degraded-replay** path (when Redis is unavailable and the gateway falls back to in-memory replay protection)
- on the **replay-detected** path

Two issues with that:

1. **Log pipeline cost amplification** — a 50 KB transaction (allowable via current header decoding) gets stored five paths up the tracing → logging → storage stack on every adversarial probe.
2. **Log injection / search noise** — base64 padding is ASCII-safe but a malicious agent can pump arbitrarily long unique values, fanning out across log indices and bloating retention.

## Fix

The neighbouring durable-nonce denial paths (\`chat/mod.rs:426\`, \`a2a/handler.rs:313\`, \`proxy.rs:341\`) already use the convention \`tx_prefix = &tx_raw[..tx_raw.len().min(88)]\` — 88 chars is enough to identify a tx by its prefix while bounding worst-case log size.

This PR applies the same convention to the five remaining sites so every place we log a payment header value uses the same bounded form.

## Files changed

- \`crates/gateway/src/routes/chat/mod.rs\` — 2 sites (degraded-replay + replay-detected)
- \`crates/gateway/src/routes/proxy.rs\` — 2 sites (degraded-replay + replay-detected)
- \`crates/gateway/src/a2a/handler.rs\` — 1 site (degraded-replay; the A2A error response already uses a generic message and never echoed \`tx_raw\`)

Note: this is a **structured-log field rename** (\`tx\` → \`tx_prefix\`). Log-shipping pipelines that key off the \`tx\` field name will need to update; the new name matches what the durable-nonce paths already emit.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo test -p gateway\` — 544 pass (no behavioural change; tests don't assert on log field names)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green
- [ ] Reviewer confirms: each affected log site is paired with a matching \`tx_prefix = &tx_raw[..tx_raw.len().min(88)]\` and no other place still emits the full payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)