### PR TITLE
fix(ci): use env-var binding to prevent shell injection in release.yml (M2 SDK)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,20 @@ jobs:
 
       - name: Determine tag
         id: tag
+        # Bind workflow_dispatch input via env: instead of `${{ ... }}`
+        # interpolation directly into the shell. Direct interpolation lets
+        # an attacker who can trigger the workflow inject arbitrary shell
+        # via a tag value containing `$()` / backticks / newlines.
+        # workflow_dispatch is gated to write-permission users today, but
+        # the env-var pattern is the GitHub-recommended hardening regardless.
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "TAG=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "TAG=$TAG_INPUT" >> "$GITHUB_OUTPUT"
           else
-            echo "TAG=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "TAG=$REF_NAME" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create draft GitHub Release


### PR DESCRIPTION
## Summary

Closes the **M2** finding (CI/SDK group) from the 2026-05-08 whole-repo security review.

\`\${{ github.event.inputs.tag }}\` was interpolated directly into the \`run:\` shell of the *Determine tag* step in \`.github/workflows/release.yml\`. A \`workflow_dispatch\` caller who supplied a tag value containing \`\$(...)\`, backticks, or a newline-separated payload could escape the surrounding \`echo\` and execute arbitrary commands in the release runner — which has access to the workflow's secrets and the release-publishing permissions.

## Why now (and why it's medium)

\`workflow_dispatch\` is gated to users with **write** permission on the repo today, so this is **not** remotely reachable. The risk is internal:

- Bot accounts or temporary team memberships that get write access without anyone re-auditing this step
- A future maintainer adding a different trigger (\`pull_request_target\`, \`issue_comment\`, etc.) to the same workflow without realizing the inputs are interpolated unsafely

The env-var binding pattern is the GitHub-recommended hardening regardless and removes the foot-gun.

## Fix

Move both \`github.event.inputs.tag\` and \`github.ref_name\` into the step's \`env:\` block, then reference them as shell variables (\`\$TAG_INPUT\`, \`\$REF_NAME\`) inside \`run:\`. Output is identical — \`\$GITHUB_OUTPUT\` still receives \`TAG=<value>\` for the next step.

## Test plan

- [x] Manual lint review of \`release.yml\` — diff matches the GitHub-recommended pattern (env: + \"\$VAR\")
- [ ] CI on this PR runs the workflow's syntactic-validation steps
- [ ] On next \`workflow_dispatch\`-triggered release, verify the *Determine tag* step still emits \`TAG=v...\` to \`steps.tag.outputs.TAG\` and the downstream *Create draft GitHub Release* step still names the release correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)