### PR TITLE
test(escrow): cover provider == Pubkey::default() rejection (M-3)

### DIFF
--- a/programs/escrow/tests/integration.rs
+++ b/programs/escrow/tests/integration.rs
@@ -3,7 +3,7 @@
 mod helpers;
 
 use helpers::*;
-use solana_sdk::{instruction::AccountMeta, program_pack::Pack, signer::Signer};
+use solana_sdk::{instruction::AccountMeta, program_pack::Pack, pubkey::Pubkey, signer::Signer};
 use spl_associated_token_account::get_associated_token_address;
 
 // ─── Happy Path Tests ──────────────────────────────────────────────────────
@@ -676,6 +676,36 @@ fn test_deposit_with_self_provider_rejected() {
     assert!(
         result.is_err(),
         "deposit with provider == agent must fail (InvalidProvider)"
+    );
+}
+
+#[test]
+fn test_deposit_with_default_provider_rejected() {
+    // Companion to test_deposit_with_self_provider_rejected. The
+    // `InvalidProvider` guard in deposit also rejects `provider ==
+    // Pubkey::default()` (the all-zero key), to prevent escrows from
+    // being created against an unowned/burn key. Without this case
+    // covered, a regression that accidentally narrowed the guard to
+    // only the `provider == agent` check would slip through.
+    let mut ctx = setup();
+    let service_id = [56u8; 32];
+    let amount = 1_000_000u64;
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+
+    let ix = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &Pubkey::default(), // provider == zero key
+        &ctx.usdc_mint,
+        amount,
+        &service_id,
+        500,
+    );
+    let result = send_tx(&mut ctx.svm, &[ix], &ctx.agent, &[&ctx.agent]);
+    assert!(
+        result.is_err(),
+        "deposit with provider == Pubkey::default() must fail (InvalidProvider)"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes the **M-3** finding (escrow group) from the 2026-05-08 whole-repo security review.

The deposit \`InvalidProvider\` guard rejects two cases:

1. \`provider == agent\` — covered by the existing \`test_deposit_with_self_provider_rejected\`
2. \`provider == Pubkey::default()\` — **previously uncovered**

A regression that accidentally narrowed the guard to only the \`provider == agent\` check would slip past the existing test. This PR adds \`test_deposit_with_default_provider_rejected\` immediately alongside the self-provider case so both paths sit together and any future change to the deposit guard has to address both.

## What changed

- \`programs/escrow/tests/integration.rs\` — new \`#[test]\` with the same shape as the self-provider case but passing \`&Pubkey::default()\` for the provider arg.
- One added \`Pubkey\` import to \`use solana_sdk::{...}\`.

## Test plan

- [x] \`cargo check --manifest-path programs/escrow/Cargo.toml --tests\` — clean
- [x] \`cargo check --manifest-path programs/escrow/Cargo.toml --tests --features sbf\` — clean (14 pre-existing Anchor cfg warnings unchanged)
- [ ] Full LiteSVM run on next \`anchor build\`: \`anchor build && cargo test --manifest-path programs/escrow/Cargo.toml --features sbf\` — verifies the new test actually fires the \`InvalidProvider\` reject path on-chain
- [ ] CI green

This is a \`--features sbf\` integration test, so it runs only in the full escrow integration suite (which already requires the compiled \`solvela_escrow.so\` artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)