### PR TITLE
test(coverage): raise workspace coverage from 74% to 80%+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,34 @@ jobs:
     name: Rust (fmt, clippy, test)
     runs-on: ubuntu-latest
 
+    # Postgres + Redis are required by the workspace's `#[sqlx::test]` and
+    # Redis-backed integration tests under crates/gateway/tests/. The user
+    # (`solvela`) is created as a superuser by the postgres image, which is
+    # needed so sqlx::test can `CREATE DATABASE` for per-test isolation.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: solvela
+          POSTGRES_PASSWORD: solvela
+          POSTGRES_DB: solvela_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U solvela"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -30,6 +58,9 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
+        env:
+          DATABASE_URL: postgres://solvela:solvela@localhost:5432/solvela_test
+          REDIS_URL: redis://localhost:6379
         run: cargo test --all
 
   audit:

--- a/crates/gateway/src/cache.rs
+++ b/crates/gateway/src/cache.rs
@@ -506,6 +506,143 @@ mod tests {
         assert!(config.enabled);
     }
 
+    /// CLAUDE.md rule #16: cache keys are wallet-agnostic. Two payers with
+    /// identical (model, messages, temperature) MUST produce the same key,
+    /// regardless of any other field on the request. We prove this structurally
+    /// by varying every non-key field and asserting the hash is unchanged.
+    #[test]
+    fn cache_key_ignores_non_key_request_fields() {
+        let base = make_request("openai/gpt-4o", vec![user_message("Hello")], Some(0.7));
+        let key_base = ResponseCache::cache_key(&base);
+
+        // max_tokens differs — must not affect the key.
+        let mut variant = base.clone();
+        variant.max_tokens = Some(2048);
+        assert_eq!(
+            ResponseCache::cache_key(&variant),
+            key_base,
+            "max_tokens must not be part of the cache key"
+        );
+
+        // top_p differs — must not affect the key.
+        let mut variant = base.clone();
+        variant.top_p = Some(0.9);
+        assert_eq!(
+            ResponseCache::cache_key(&variant),
+            key_base,
+            "top_p must not be part of the cache key"
+        );
+
+        // stream differs — cache_key itself ignores it (the get/set methods
+        // gate on stream separately).
+        let mut variant = base.clone();
+        variant.stream = true;
+        assert_eq!(
+            ResponseCache::cache_key(&variant),
+            key_base,
+            "stream flag must not be part of the cache key"
+        );
+    }
+
+    /// Message order is part of the conversation; two prompts with the same
+    /// content in different order are NOT the same prompt.
+    #[test]
+    fn cache_key_is_sensitive_to_message_order() {
+        let req_a = make_request(
+            "openai/gpt-4o",
+            vec![user_message("first"), user_message("second")],
+            Some(0.7),
+        );
+        let req_b = make_request(
+            "openai/gpt-4o",
+            vec![user_message("second"), user_message("first")],
+            Some(0.7),
+        );
+        assert_ne!(
+            ResponseCache::cache_key(&req_a),
+            ResponseCache::cache_key(&req_b),
+            "message order must affect the cache key"
+        );
+    }
+
+    /// Adding a message must produce a different key.
+    #[test]
+    fn cache_key_is_sensitive_to_message_count() {
+        let req_a = make_request("openai/gpt-4o", vec![user_message("Hello")], Some(0.7));
+        let req_b = make_request(
+            "openai/gpt-4o",
+            vec![user_message("Hello"), user_message("again")],
+            Some(0.7),
+        );
+        assert_ne!(
+            ResponseCache::cache_key(&req_a),
+            ResponseCache::cache_key(&req_b),
+            "additional messages must affect the cache key"
+        );
+    }
+
+    /// `from_client` accepts an already-opened Redis client without making any
+    /// network round-trip. Used by `main.rs` after a connectivity probe.
+    #[test]
+    fn from_client_constructs_without_connecting() {
+        let client =
+            redis::Client::open("redis://127.0.0.1:1").expect("client open should not connect");
+        let _cache = ResponseCache::from_client(client, CacheConfig::default())
+            .expect("from_client should not connect");
+    }
+
+    /// `set` early-exits for streaming requests without spawning a Redis writer.
+    /// We use a bogus Redis URL — if `set` tried to connect, the spawned task
+    /// would log a warning, but the function itself must return immediately.
+    #[tokio::test]
+    async fn set_short_circuits_for_streaming_requests() {
+        let cache = ResponseCache::new("redis://127.0.0.1:1", CacheConfig::default())
+            .expect("client creation should not connect");
+
+        let req = ChatRequest {
+            model: "openai/gpt-4o".to_string(),
+            messages: vec![user_message("Hello")],
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            stream: true,
+            tools: None,
+            tool_choice: None,
+        };
+        let response = ChatResponse {
+            id: "test".to_string(),
+            object: "chat.completion".to_string(),
+            created: 0,
+            model: "gpt-4o".to_string(),
+            choices: vec![],
+            usage: None,
+        };
+        // Should return without panic; nothing to assert besides "doesn't try to connect".
+        cache.set(&req, &response).await;
+    }
+
+    /// `set` early-exits when caching is disabled.
+    #[tokio::test]
+    async fn set_short_circuits_when_disabled() {
+        let config = CacheConfig {
+            default_ttl_secs: 600,
+            enabled: false,
+        };
+        let cache = ResponseCache::new("redis://127.0.0.1:1", config)
+            .expect("client creation should not connect");
+
+        let req = make_request("openai/gpt-4o", vec![user_message("Hello")], None);
+        let response = ChatResponse {
+            id: "test".to_string(),
+            object: "chat.completion".to_string(),
+            created: 0,
+            model: "gpt-4o".to_string(),
+            choices: vec![],
+            usage: None,
+        };
+        cache.set(&req, &response).await;
+    }
+
     #[test]
     fn test_cache_error_display() {
         let err = CacheError::Connection("refused".to_string());

--- a/crates/gateway/src/providers/deepseek.rs
+++ b/crates/gateway/src/providers/deepseek.rs
@@ -4,6 +4,9 @@ use solvela_protocol::{ChatRequest, ChatResponse, ModelInfo};
 
 use super::{ChatStream, LLMProvider, ProviderError};
 
+const DEEPSEEK_PREFIX: &str = "deepseek/";
+const DEEPSEEK_URL: &str = "https://api.deepseek.com/chat/completions";
+
 /// DeepSeek provider adapter.
 ///
 /// DeepSeek's API is OpenAI-compatible — requests pass through with
@@ -19,6 +22,25 @@ impl DeepSeekProvider {
     }
 }
 
+fn strip_model_prefix(model: &str) -> String {
+    model
+        .strip_prefix(DEEPSEEK_PREFIX)
+        .unwrap_or(model)
+        .to_string()
+}
+
+fn build_chat_body(req: &ChatRequest) -> Result<serde_json::Value, serde_json::Error> {
+    let mut req = req.clone();
+    req.model = strip_model_prefix(&req.model);
+    serde_json::to_value(&req)
+}
+
+fn build_stream_body(req: &ChatRequest) -> Result<serde_json::Value, serde_json::Error> {
+    let mut body = build_chat_body(req)?;
+    body["stream"] = serde_json::Value::Bool(true);
+    Ok(body)
+}
+
 #[async_trait]
 impl LLMProvider for DeepSeekProvider {
     fn name(&self) -> &str {
@@ -31,17 +53,12 @@ impl LLMProvider for DeepSeekProvider {
 
     async fn chat_completion(
         &self,
-        mut req: ChatRequest,
+        req: ChatRequest,
     ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
-        req.model = req
-            .model
-            .strip_prefix("deepseek/")
-            .unwrap_or(&req.model)
-            .to_string();
-        let req_body = serde_json::to_value(&req)?;
+        let req_body = build_chat_body(&req)?;
         let response = super::retry_with_backoff(2, || {
             self.client
-                .post("https://api.deepseek.com/chat/completions")
+                .post(DEEPSEEK_URL)
                 .timeout(std::time::Duration::from_secs(90))
                 .bearer_auth(&self.api_key)
                 .json(&req_body)
@@ -53,21 +70,12 @@ impl LLMProvider for DeepSeekProvider {
         Ok(body)
     }
 
-    async fn chat_completion_stream(
-        &self,
-        mut req: ChatRequest,
-    ) -> Result<ChatStream, ProviderError> {
-        req.model = req
-            .model
-            .strip_prefix("deepseek/")
-            .unwrap_or(&req.model)
-            .to_string();
-        let mut body = serde_json::to_value(&req)?;
-        body["stream"] = serde_json::Value::Bool(true);
+    async fn chat_completion_stream(&self, req: ChatRequest) -> Result<ChatStream, ProviderError> {
+        let body = build_stream_body(&req)?;
 
         let response = self
             .client
-            .post("https://api.deepseek.com/chat/completions")
+            .post(DEEPSEEK_URL)
             .timeout(std::time::Duration::from_secs(90))
             .bearer_auth(&self.api_key)
             .json(&body)
@@ -76,5 +84,92 @@ impl LLMProvider for DeepSeekProvider {
             .error_for_status()?;
 
         Ok(super::spawn_openai_sse_parser(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solvela_protocol::{ChatMessage, Role};
+
+    fn sample_request(model: &str) -> ChatRequest {
+        ChatRequest {
+            model: model.to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: "hi".to_string(),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(64),
+            temperature: Some(0.7),
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        }
+    }
+
+    #[test]
+    fn strip_model_prefix_removes_known_prefix() {
+        assert_eq!(
+            strip_model_prefix("deepseek/deepseek-chat"),
+            "deepseek-chat"
+        );
+    }
+
+    #[test]
+    fn strip_model_prefix_leaves_other_models_unchanged() {
+        assert_eq!(strip_model_prefix("deepseek-reasoner"), "deepseek-reasoner");
+        assert_eq!(strip_model_prefix("openai/gpt-4o"), "openai/gpt-4o");
+    }
+
+    #[test]
+    fn strip_model_prefix_handles_empty_remainder() {
+        assert_eq!(strip_model_prefix("deepseek/"), "");
+    }
+
+    #[test]
+    fn build_chat_body_strips_prefix_and_serializes() {
+        let req = sample_request("deepseek/deepseek-chat");
+        let body = build_chat_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "deepseek-chat");
+        assert_eq!(body["messages"][0]["content"], "hi");
+        assert!(body.get("stream").is_none() || body["stream"] == serde_json::Value::Bool(false));
+    }
+
+    #[test]
+    fn build_chat_body_preserves_unprefixed_model() {
+        let req = sample_request("deepseek-reasoner");
+        let body = build_chat_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "deepseek-reasoner");
+    }
+
+    #[test]
+    fn build_stream_body_injects_stream_true() {
+        let req = sample_request("deepseek/deepseek-chat");
+        let body = build_stream_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "deepseek-chat");
+        assert_eq!(body["stream"], serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn build_stream_body_does_not_mutate_caller() {
+        let req = sample_request("deepseek/deepseek-chat");
+        let _ = build_stream_body(&req).expect("body must serialize");
+        assert_eq!(req.model, "deepseek/deepseek-chat");
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let provider = DeepSeekProvider::new(reqwest::Client::new(), "ds-test".to_string());
+        assert_eq!(provider.name(), "deepseek");
+    }
+
+    #[test]
+    fn supported_models_is_empty_by_design() {
+        let provider = DeepSeekProvider::new(reqwest::Client::new(), "ds-test".to_string());
+        assert!(provider.supported_models().is_empty());
     }
 }

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -4,6 +4,9 @@ use solvela_protocol::{ChatRequest, ChatResponse, ModelInfo};
 
 use super::{ChatStream, LLMProvider, ProviderError};
 
+const OPENAI_PREFIX: &str = "openai/";
+const OPENAI_URL: &str = "https://api.openai.com/v1/chat/completions";
+
 /// OpenAI provider adapter.
 ///
 /// OpenAI's API is the baseline format — requests are passed through
@@ -19,6 +22,25 @@ impl OpenAIProvider {
     }
 }
 
+fn strip_model_prefix(model: &str) -> String {
+    model
+        .strip_prefix(OPENAI_PREFIX)
+        .unwrap_or(model)
+        .to_string()
+}
+
+fn build_chat_body(req: &ChatRequest) -> Result<serde_json::Value, serde_json::Error> {
+    let mut req = req.clone();
+    req.model = strip_model_prefix(&req.model);
+    serde_json::to_value(&req)
+}
+
+fn build_stream_body(req: &ChatRequest) -> Result<serde_json::Value, serde_json::Error> {
+    let mut body = build_chat_body(req)?;
+    body["stream"] = serde_json::Value::Bool(true);
+    Ok(body)
+}
+
 #[async_trait]
 impl LLMProvider for OpenAIProvider {
     fn name(&self) -> &str {
@@ -32,17 +54,12 @@ impl LLMProvider for OpenAIProvider {
 
     async fn chat_completion(
         &self,
-        mut req: ChatRequest,
+        req: ChatRequest,
     ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
-        req.model = req
-            .model
-            .strip_prefix("openai/")
-            .unwrap_or(&req.model)
-            .to_string();
-        let req_body = serde_json::to_value(&req)?;
+        let req_body = build_chat_body(&req)?;
         let response = super::retry_with_backoff(2, || {
             self.client
-                .post("https://api.openai.com/v1/chat/completions")
+                .post(OPENAI_URL)
                 .timeout(std::time::Duration::from_secs(90))
                 .bearer_auth(&self.api_key)
                 .json(&req_body)
@@ -54,21 +71,12 @@ impl LLMProvider for OpenAIProvider {
         Ok(body)
     }
 
-    async fn chat_completion_stream(
-        &self,
-        mut req: ChatRequest,
-    ) -> Result<ChatStream, ProviderError> {
-        req.model = req
-            .model
-            .strip_prefix("openai/")
-            .unwrap_or(&req.model)
-            .to_string();
-        let mut body = serde_json::to_value(&req)?;
-        body["stream"] = serde_json::Value::Bool(true);
+    async fn chat_completion_stream(&self, req: ChatRequest) -> Result<ChatStream, ProviderError> {
+        let body = build_stream_body(&req)?;
 
         let response = self
             .client
-            .post("https://api.openai.com/v1/chat/completions")
+            .post(OPENAI_URL)
             .timeout(std::time::Duration::from_secs(90))
             .bearer_auth(&self.api_key)
             .json(&body)
@@ -77,5 +85,92 @@ impl LLMProvider for OpenAIProvider {
             .error_for_status()?;
 
         Ok(super::spawn_openai_sse_parser(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solvela_protocol::{ChatMessage, Role};
+
+    fn sample_request(model: &str) -> ChatRequest {
+        ChatRequest {
+            model: model.to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: "hi".to_string(),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(64),
+            temperature: Some(0.7),
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        }
+    }
+
+    #[test]
+    fn strip_model_prefix_removes_known_prefix() {
+        assert_eq!(strip_model_prefix("openai/gpt-4o"), "gpt-4o");
+    }
+
+    #[test]
+    fn strip_model_prefix_leaves_other_models_unchanged() {
+        assert_eq!(strip_model_prefix("gpt-4o-mini"), "gpt-4o-mini");
+        assert_eq!(strip_model_prefix("anthropic/claude"), "anthropic/claude");
+    }
+
+    #[test]
+    fn strip_model_prefix_handles_empty_remainder() {
+        // Defensive: a bare prefix should produce an empty model name rather than panic.
+        assert_eq!(strip_model_prefix("openai/"), "");
+    }
+
+    #[test]
+    fn build_chat_body_strips_prefix_and_serializes() {
+        let req = sample_request("openai/gpt-4o");
+        let body = build_chat_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "gpt-4o");
+        assert_eq!(body["messages"][0]["content"], "hi");
+        // Non-streaming bodies must not set stream=true (would corrupt downstream parsing).
+        assert!(body.get("stream").is_none() || body["stream"] == serde_json::Value::Bool(false));
+    }
+
+    #[test]
+    fn build_chat_body_preserves_unprefixed_model() {
+        let req = sample_request("gpt-4o-mini");
+        let body = build_chat_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "gpt-4o-mini");
+    }
+
+    #[test]
+    fn build_stream_body_injects_stream_true() {
+        let req = sample_request("openai/gpt-4o");
+        let body = build_stream_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "gpt-4o");
+        assert_eq!(body["stream"], serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn build_stream_body_does_not_mutate_caller() {
+        let req = sample_request("openai/gpt-4o");
+        let _ = build_stream_body(&req).expect("body must serialize");
+        // The original request still carries the prefixed model — proves we cloned.
+        assert_eq!(req.model, "openai/gpt-4o");
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let provider = OpenAIProvider::new(reqwest::Client::new(), "sk-test".to_string());
+        assert_eq!(provider.name(), "openai");
+    }
+
+    #[test]
+    fn supported_models_is_empty_by_design() {
+        let provider = OpenAIProvider::new(reqwest::Client::new(), "sk-test".to_string());
+        assert!(provider.supported_models().is_empty());
     }
 }

--- a/crates/gateway/src/providers/xai.rs
+++ b/crates/gateway/src/providers/xai.rs
@@ -4,6 +4,9 @@ use solvela_protocol::{ChatRequest, ChatResponse, ModelInfo};
 
 use super::{ChatStream, LLMProvider, ProviderError};
 
+const XAI_PREFIX: &str = "xai/";
+const XAI_URL: &str = "https://api.x.ai/v1/chat/completions";
+
 /// xAI (Grok) provider adapter.
 ///
 /// xAI's API is OpenAI-compatible — requests pass through with
@@ -19,6 +22,22 @@ impl XAIProvider {
     }
 }
 
+fn strip_model_prefix(model: &str) -> String {
+    model.strip_prefix(XAI_PREFIX).unwrap_or(model).to_string()
+}
+
+fn build_chat_body(req: &ChatRequest) -> Result<serde_json::Value, serde_json::Error> {
+    let mut req = req.clone();
+    req.model = strip_model_prefix(&req.model);
+    serde_json::to_value(&req)
+}
+
+fn build_stream_body(req: &ChatRequest) -> Result<serde_json::Value, serde_json::Error> {
+    let mut body = build_chat_body(req)?;
+    body["stream"] = serde_json::Value::Bool(true);
+    Ok(body)
+}
+
 #[async_trait]
 impl LLMProvider for XAIProvider {
     fn name(&self) -> &str {
@@ -32,17 +51,12 @@ impl LLMProvider for XAIProvider {
 
     async fn chat_completion(
         &self,
-        mut req: ChatRequest,
+        req: ChatRequest,
     ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
-        req.model = req
-            .model
-            .strip_prefix("xai/")
-            .unwrap_or(&req.model)
-            .to_string();
-        let req_body = serde_json::to_value(&req)?;
+        let req_body = build_chat_body(&req)?;
         let response = super::retry_with_backoff(2, || {
             self.client
-                .post("https://api.x.ai/v1/chat/completions")
+                .post(XAI_URL)
                 .timeout(std::time::Duration::from_secs(90))
                 .bearer_auth(&self.api_key)
                 .json(&req_body)
@@ -54,21 +68,12 @@ impl LLMProvider for XAIProvider {
         Ok(body)
     }
 
-    async fn chat_completion_stream(
-        &self,
-        mut req: ChatRequest,
-    ) -> Result<ChatStream, ProviderError> {
-        req.model = req
-            .model
-            .strip_prefix("xai/")
-            .unwrap_or(&req.model)
-            .to_string();
-        let mut body = serde_json::to_value(&req)?;
-        body["stream"] = serde_json::Value::Bool(true);
+    async fn chat_completion_stream(&self, req: ChatRequest) -> Result<ChatStream, ProviderError> {
+        let body = build_stream_body(&req)?;
 
         let response = self
             .client
-            .post("https://api.x.ai/v1/chat/completions")
+            .post(XAI_URL)
             .timeout(std::time::Duration::from_secs(90))
             .bearer_auth(&self.api_key)
             .json(&body)
@@ -77,5 +82,89 @@ impl LLMProvider for XAIProvider {
             .error_for_status()?;
 
         Ok(super::spawn_openai_sse_parser(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solvela_protocol::{ChatMessage, Role};
+
+    fn sample_request(model: &str) -> ChatRequest {
+        ChatRequest {
+            model: model.to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: "hi".to_string(),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(64),
+            temperature: Some(0.7),
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        }
+    }
+
+    #[test]
+    fn strip_model_prefix_removes_known_prefix() {
+        assert_eq!(strip_model_prefix("xai/grok-4"), "grok-4");
+    }
+
+    #[test]
+    fn strip_model_prefix_leaves_other_models_unchanged() {
+        assert_eq!(strip_model_prefix("grok-4-fast"), "grok-4-fast");
+        assert_eq!(strip_model_prefix("openai/gpt-4o"), "openai/gpt-4o");
+    }
+
+    #[test]
+    fn strip_model_prefix_handles_empty_remainder() {
+        assert_eq!(strip_model_prefix("xai/"), "");
+    }
+
+    #[test]
+    fn build_chat_body_strips_prefix_and_serializes() {
+        let req = sample_request("xai/grok-4");
+        let body = build_chat_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "grok-4");
+        assert_eq!(body["messages"][0]["content"], "hi");
+        assert!(body.get("stream").is_none() || body["stream"] == serde_json::Value::Bool(false));
+    }
+
+    #[test]
+    fn build_chat_body_preserves_unprefixed_model() {
+        let req = sample_request("grok-4-fast");
+        let body = build_chat_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "grok-4-fast");
+    }
+
+    #[test]
+    fn build_stream_body_injects_stream_true() {
+        let req = sample_request("xai/grok-4");
+        let body = build_stream_body(&req).expect("body must serialize");
+        assert_eq!(body["model"], "grok-4");
+        assert_eq!(body["stream"], serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn build_stream_body_does_not_mutate_caller() {
+        let req = sample_request("xai/grok-4");
+        let _ = build_stream_body(&req).expect("body must serialize");
+        assert_eq!(req.model, "xai/grok-4");
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let provider = XAIProvider::new(reqwest::Client::new(), "xai-test".to_string());
+        assert_eq!(provider.name(), "xai");
+    }
+
+    #[test]
+    fn supported_models_is_empty_by_design() {
+        let provider = XAIProvider::new(reqwest::Client::new(), "xai-test".to_string());
+        assert!(provider.supported_models().is_empty());
     }
 }

--- a/crates/gateway/tests/orgs_queries.rs
+++ b/crates/gateway/tests/orgs_queries.rs
@@ -1,0 +1,490 @@
+//! Integration tests for `gateway::orgs::queries` against a real Postgres.
+//!
+//! Each `#[sqlx::test]` creates a fresh, isolated database, runs the workspace
+//! migrations against it, and tears it down afterwards. Requires the workspace
+//! `DATABASE_URL` env var to point at a Postgres where the connecting user can
+//! `CREATE DATABASE` (the docker-compose `solvela` superuser satisfies this).
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use gateway::orgs::models::{
+    AddMemberRequest, AssignWalletRequest, CreateApiKeyRequest, CreateOrgRequest,
+    CreateTeamRequest, OrgRole,
+};
+use gateway::orgs::queries::{
+    add_member, assign_wallet, create_api_key, create_org, create_team, generate_api_key, get_org,
+    hash_api_key, list_api_keys, list_members, list_orgs_for_wallet, list_team_wallets, list_teams,
+    revoke_api_key, verify_api_key,
+};
+
+const OWNER_WALLET: &str = "DZNuWFpYwzEAcyaMQzqgbxA4d1f4Yq8EU2YbLPLYxNTw";
+const SECOND_WALLET: &str = "GbZ6oTmEa9PEd6FGQEmTm3GbXCQkAGqNGGJYXrW8oQte";
+
+fn make_create_request(slug: &str) -> CreateOrgRequest {
+    CreateOrgRequest {
+        name: format!("Org {slug}"),
+        slug: slug.to_string(),
+    }
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_org_inserts_org_and_owner_member(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create_org should succeed");
+
+    assert_eq!(org.name, "Org acme");
+    assert_eq!(org.slug, "acme");
+    assert_eq!(org.owner_wallet, OWNER_WALLET);
+
+    let members = list_members(&pool, org.id)
+        .await
+        .expect("list_members should succeed");
+    assert_eq!(members.len(), 1, "owner must be auto-enrolled");
+    assert_eq!(members[0].wallet_address, OWNER_WALLET);
+    assert_eq!(members[0].role, OrgRole::Owner);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_org_rolls_back_on_duplicate_slug(pool: PgPool) {
+    create_org(&pool, make_create_request("dup"), OWNER_WALLET.to_string())
+        .await
+        .expect("first insert succeeds");
+
+    let result = create_org(&pool, make_create_request("dup"), SECOND_WALLET.to_string()).await;
+    assert!(result.is_err(), "duplicate slug must reject");
+
+    // Transactional guarantee: no orphan org_members row from the failed second attempt.
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM org_members")
+        .fetch_one(&pool)
+        .await
+        .expect("count members");
+    assert_eq!(count, 1, "rolled-back tx must leave no orphan members");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_org_returns_some_for_known_id_and_none_for_unknown(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create");
+
+    let found = get_org(&pool, org.id).await.expect("query");
+    assert!(found.is_some(), "should find existing org");
+    assert_eq!(found.unwrap().id, org.id);
+
+    let missing = get_org(&pool, Uuid::new_v4()).await.expect("query");
+    assert!(missing.is_none(), "unknown id returns None");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn list_orgs_for_wallet_returns_orgs_in_creation_order(pool: PgPool) {
+    let _org_a = create_org(
+        &pool,
+        make_create_request("first"),
+        OWNER_WALLET.to_string(),
+    )
+    .await
+    .expect("create first");
+
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    let _org_b = create_org(
+        &pool,
+        make_create_request("second"),
+        OWNER_WALLET.to_string(),
+    )
+    .await
+    .expect("create second");
+
+    let orgs = list_orgs_for_wallet(&pool, OWNER_WALLET)
+        .await
+        .expect("list");
+    assert_eq!(orgs.len(), 2);
+    assert!(
+        orgs[0].created_at <= orgs[1].created_at,
+        "ordering must be ASC by created_at"
+    );
+
+    let none = list_orgs_for_wallet(&pool, "unknown_wallet")
+        .await
+        .expect("list empty");
+    assert!(none.is_empty(), "non-member wallet sees no orgs");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_and_list_teams(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+
+    let team_a = create_team(
+        &pool,
+        org.id,
+        CreateTeamRequest {
+            name: "Engineering".to_string(),
+        },
+    )
+    .await
+    .expect("create team");
+    assert_eq!(team_a.org_id, org.id);
+
+    let team_b = create_team(
+        &pool,
+        org.id,
+        CreateTeamRequest {
+            name: "Marketing".to_string(),
+        },
+    )
+    .await
+    .expect("create second team");
+    assert_ne!(team_a.id, team_b.id);
+
+    let teams = list_teams(&pool, org.id).await.expect("list teams");
+    assert_eq!(teams.len(), 2);
+
+    let empty = list_teams(&pool, Uuid::new_v4()).await.expect("list empty");
+    assert!(empty.is_empty());
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn add_member_defaults_role_to_member_when_unset(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create");
+
+    let member = add_member(
+        &pool,
+        org.id,
+        AddMemberRequest {
+            wallet_address: SECOND_WALLET.to_string(),
+            role: None,
+        },
+    )
+    .await
+    .expect("add_member");
+    assert_eq!(member.role, OrgRole::Member);
+    assert_eq!(member.wallet_address, SECOND_WALLET);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn add_member_honors_explicit_admin_role(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create");
+
+    let member = add_member(
+        &pool,
+        org.id,
+        AddMemberRequest {
+            wallet_address: SECOND_WALLET.to_string(),
+            role: Some(OrgRole::Admin),
+        },
+    )
+    .await
+    .expect("add_member");
+    assert_eq!(member.role, OrgRole::Admin);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn add_member_rejects_duplicate_wallet_in_same_org(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create");
+
+    // Owner is already a member; re-adding the same wallet must violate UNIQUE.
+    let result = add_member(
+        &pool,
+        org.id,
+        AddMemberRequest {
+            wallet_address: OWNER_WALLET.to_string(),
+            role: None,
+        },
+    )
+    .await;
+    assert!(result.is_err(), "duplicate (org, wallet) must reject");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn assign_and_list_team_wallets(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+    let team = create_team(
+        &pool,
+        org.id,
+        CreateTeamRequest {
+            name: "Engineering".to_string(),
+        },
+    )
+    .await
+    .expect("create team");
+
+    assign_wallet(
+        &pool,
+        team.id,
+        &AssignWalletRequest {
+            wallet_address: SECOND_WALLET.to_string(),
+        },
+    )
+    .await
+    .expect("assign");
+
+    let wallets = list_team_wallets(&pool, team.id)
+        .await
+        .expect("list wallets");
+    assert_eq!(wallets.len(), 1);
+    assert_eq!(wallets[0].wallet_address, SECOND_WALLET);
+    assert_eq!(wallets[0].team_id, team.id);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_api_key_returns_plaintext_once_and_persists_hash(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+
+    let created = create_api_key(
+        &pool,
+        org.id,
+        CreateApiKeyRequest {
+            name: "ci-runner".to_string(),
+            role: Some(OrgRole::Admin),
+            expires_in_days: Some(30),
+        },
+    )
+    .await
+    .expect("create_api_key");
+
+    assert!(created.key.starts_with("solvela_k_"));
+    assert_eq!(created.key.len(), 42);
+    assert_eq!(created.role, OrgRole::Admin);
+    assert!(
+        created.expires_at.is_some(),
+        "expires_in_days should populate expires_at"
+    );
+
+    let stored_hash: Option<String> =
+        sqlx::query_scalar("SELECT key_hash FROM api_keys WHERE id = $1")
+            .bind(created.id)
+            .fetch_optional(&pool)
+            .await
+            .expect("query hash");
+    assert_eq!(stored_hash, Some(hash_api_key(&created.key)));
+
+    // The plaintext itself does not appear anywhere in the api_keys row.
+    let any_plaintext: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::BIGINT FROM api_keys WHERE key_hash = $1 OR key_prefix = $1 OR name = $1",
+    )
+    .bind(&created.key)
+    .fetch_one(&pool)
+    .await
+    .expect("query plaintext leak");
+    assert_eq!(
+        any_plaintext, 0,
+        "raw plaintext must never appear in stored columns"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_api_key_without_expiry_leaves_expires_at_null(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+
+    let created = create_api_key(
+        &pool,
+        org.id,
+        CreateApiKeyRequest {
+            name: "permanent".to_string(),
+            role: None,
+            expires_in_days: None,
+        },
+    )
+    .await
+    .expect("create_api_key");
+
+    assert!(created.expires_at.is_none());
+    assert_eq!(created.role, OrgRole::Member, "role defaults to member");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn verify_api_key_returns_some_for_valid_key(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+    let created = create_api_key(
+        &pool,
+        org.id,
+        CreateApiKeyRequest {
+            name: "ci".to_string(),
+            role: None,
+            expires_in_days: None,
+        },
+    )
+    .await
+    .expect("create");
+
+    let verified = verify_api_key(&pool, &created.key)
+        .await
+        .expect("verify")
+        .expect("must verify a freshly-created key");
+    assert_eq!(verified.0.id, created.id);
+    assert_eq!(verified.1, org.id);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn verify_api_key_returns_none_for_unknown_key(pool: PgPool) {
+    let unknown = generate_api_key();
+    let result = verify_api_key(&pool, &unknown).await.expect("verify");
+    assert!(result.is_none(), "unknown key returns None");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn verify_api_key_returns_none_for_revoked_key(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+    let created = create_api_key(
+        &pool,
+        org.id,
+        CreateApiKeyRequest {
+            name: "to-revoke".to_string(),
+            role: None,
+            expires_in_days: None,
+        },
+    )
+    .await
+    .expect("create");
+
+    let updated = revoke_api_key(&pool, created.id, org.id)
+        .await
+        .expect("revoke");
+    assert!(updated, "first revoke returns true");
+
+    let result = verify_api_key(&pool, &created.key).await.expect("verify");
+    assert!(result.is_none(), "revoked key must not verify");
+
+    let second = revoke_api_key(&pool, created.id, org.id)
+        .await
+        .expect("second revoke");
+    assert!(!second, "second revoke returns false");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn verify_api_key_returns_none_for_expired_key(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+
+    // Insert an expired key directly so we don't have to wait.
+    let key = generate_api_key();
+    let key_hash = hash_api_key(&key);
+    sqlx::query(
+        r#"INSERT INTO api_keys (id, org_id, key_prefix, key_hash, name, role, expires_at, created_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(org.id)
+    .bind(&key[..14])
+    .bind(&key_hash)
+    .bind("expired")
+    .bind(OrgRole::Member)
+    .bind(chrono::Utc::now() - chrono::Duration::days(1))
+    .bind(chrono::Utc::now() - chrono::Duration::days(2))
+    .execute(&pool)
+    .await
+    .expect("insert expired key");
+
+    let result = verify_api_key(&pool, &key).await.expect("verify");
+    assert!(result.is_none(), "expired key must not verify");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn list_api_keys_filters_revoked(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+
+    let active = create_api_key(
+        &pool,
+        org.id,
+        CreateApiKeyRequest {
+            name: "active".to_string(),
+            role: None,
+            expires_in_days: None,
+        },
+    )
+    .await
+    .expect("create active");
+
+    let to_revoke = create_api_key(
+        &pool,
+        org.id,
+        CreateApiKeyRequest {
+            name: "to-revoke".to_string(),
+            role: None,
+            expires_in_days: None,
+        },
+    )
+    .await
+    .expect("create to-revoke");
+
+    revoke_api_key(&pool, to_revoke.id, org.id)
+        .await
+        .expect("revoke");
+
+    let listed = list_api_keys(&pool, org.id).await.expect("list");
+    assert_eq!(listed.len(), 1, "revoked keys are filtered out");
+    assert_eq!(listed[0].id, active.id);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn revoke_api_key_returns_false_for_unknown_id(pool: PgPool) {
+    let org = create_org(&pool, make_create_request("acme"), OWNER_WALLET.to_string())
+        .await
+        .expect("create org");
+
+    let updated = revoke_api_key(&pool, Uuid::new_v4(), org.id)
+        .await
+        .expect("revoke unknown");
+    assert!(!updated, "revoking a non-existent key returns false");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn revoke_api_key_scopes_to_org(pool: PgPool) {
+    let org_a = create_org(&pool, make_create_request("a"), OWNER_WALLET.to_string())
+        .await
+        .expect("create a");
+    let org_b = create_org(&pool, make_create_request("b"), SECOND_WALLET.to_string())
+        .await
+        .expect("create b");
+
+    let created = create_api_key(
+        &pool,
+        org_a.id,
+        CreateApiKeyRequest {
+            name: "for-a".to_string(),
+            role: None,
+            expires_in_days: None,
+        },
+    )
+    .await
+    .expect("create");
+
+    // Org B must NOT be able to revoke org A's key.
+    let cross = revoke_api_key(&pool, created.id, org_b.id)
+        .await
+        .expect("attempt cross-org revoke");
+    assert!(
+        !cross,
+        "revoke must scope to (org_id, key_id) — cross-org revoke must not flip the row"
+    );
+
+    // The key still verifies.
+    let verified = verify_api_key(&pool, &created.key).await.expect("verify");
+    assert!(
+        verified.is_some(),
+        "key targeted by a cross-org revoke must remain valid"
+    );
+}

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -1,0 +1,638 @@
+//! HTTP-level integration tests for the org-management routes.
+//!
+//! Builds a minimal `Router` per test with `db_pool: Some(pool)` (from
+//! `#[sqlx::test]`) and exercises the admin-token happy path of each
+//! handler via `tower::ServiceExt::oneshot`. Auth-rejection paths are
+//! already covered by inline tests in `src/routes/orgs/*`.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::{delete, get, post, put};
+use axum::Router;
+use http_body_util::BodyExt;
+use serde_json::Value;
+use sqlx::PgPool;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use gateway::config::AppConfig;
+use gateway::providers::health::{CircuitBreakerConfig, ProviderHealthTracker};
+use gateway::providers::ProviderRegistry;
+use gateway::routes::orgs::{
+    add_member, assign_wallet, create_api_key, create_org, create_team, get_org, get_org_stats,
+    get_team_budget, get_team_stats, get_wallet_budget, list_api_keys, list_audit_logs,
+    list_members, list_orgs, list_team_wallets, list_teams, revoke_api_key, set_team_budget,
+    set_wallet_budget,
+};
+use gateway::services::ServiceRegistry;
+use gateway::usage::UsageTracker;
+use gateway::AppState;
+use solvela_router::models::ModelRegistry;
+
+const ADMIN_TOKEN: &str = "test-admin-token";
+const TEST_MODELS_TOML: &str = r#"
+[models.openai-gpt-4o]
+provider = "openai"
+model_id = "gpt-4o"
+display_name = "GPT-4o"
+input_cost_per_million = 2.50
+output_cost_per_million = 10.00
+context_window = 128000
+supports_streaming = true
+supports_tools = true
+supports_vision = true
+"#;
+
+/// Build a Router with the org routes wired up against the supplied
+/// per-test Postgres pool. Mirrors the production registration in `lib.rs`.
+fn router_with_pool(pool: PgPool) -> Router {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).expect("models toml");
+    let service_registry = ServiceRegistry::empty();
+    let facilitator = solvela_x402::facilitator::Facilitator::new(vec![]);
+
+    let state = Arc::new(AppState {
+        config: AppConfig::default(),
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: ProviderRegistry::from_env(reqwest::Client::new()),
+        facilitator,
+        usage: UsageTracker::noop(),
+        cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: Some(pool),
+        session_secret: vec![0u8; 32],
+        replay_set: AppState::new_replay_set(),
+        http_client: reqwest::Client::new(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(ADMIN_TOKEN.to_string()),
+        prometheus_handle: None,
+        dev_bypass_payment: false,
+    });
+
+    Router::new()
+        .route("/v1/orgs", post(create_org).get(list_orgs))
+        .route("/v1/orgs/{id}", get(get_org))
+        .route("/v1/orgs/{id}/teams", post(create_team).get(list_teams))
+        .route("/v1/orgs/{id}/members", post(add_member).get(list_members))
+        .route(
+            "/v1/orgs/{id}/teams/{tid}/wallets",
+            post(assign_wallet).get(list_team_wallets),
+        )
+        .route(
+            "/v1/orgs/{id}/api-keys",
+            post(create_api_key).get(list_api_keys),
+        )
+        .route("/v1/orgs/{id}/api-keys/{kid}", delete(revoke_api_key))
+        .route("/v1/orgs/{id}/audit-logs", get(list_audit_logs))
+        .route(
+            "/v1/orgs/{id}/teams/{tid}/budget",
+            put(set_team_budget).get(get_team_budget),
+        )
+        .route(
+            "/v1/wallets/{wallet}/budget",
+            put(set_wallet_budget).get(get_wallet_budget),
+        )
+        .route("/v1/orgs/{id}/teams/{tid}/stats", get(get_team_stats))
+        .route("/v1/orgs/{id}/stats", get(get_org_stats))
+        .with_state(state)
+}
+
+fn auth_header() -> (&'static str, String) {
+    ("authorization", format!("Bearer {ADMIN_TOKEN}"))
+}
+
+fn json_request(method: &str, uri: &str, body: &str) -> Request<Body> {
+    let (k, v) = auth_header();
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header(k, v)
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn bare_request(method: &str, uri: &str) -> Request<Body> {
+    let (k, v) = auth_header();
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(k, v)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn body_to_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).expect("body must be JSON")
+}
+
+async fn create_test_org(app: &Router, slug: &str) -> Uuid {
+    let body = format!(r#"{{"name":"Org {slug}","slug":"{slug}","owner_wallet":"owner-{slug}"}}"#);
+    let resp = app
+        .clone()
+        .oneshot(json_request("POST", "/v1/orgs", &body))
+        .await
+        .expect("create_org");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "create_org must succeed"
+    );
+    let json = body_to_json(resp).await;
+    Uuid::parse_str(json["id"].as_str().expect("id field")).expect("uuid")
+}
+
+// ---------------------------------------------------------------------------
+// /v1/orgs CRUD
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_org_returns_201_with_id(pool: PgPool) {
+    let app = router_with_pool(pool);
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/v1/orgs",
+            r#"{"name":"Acme","slug":"acme","owner_wallet":"acmewallet"}"#,
+        ))
+        .await
+        .expect("call");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let json = body_to_json(resp).await;
+    assert_eq!(json["name"], "Acme");
+    assert_eq!(json["slug"], "acme");
+    assert_eq!(json["owner_wallet"], "acmewallet");
+    assert!(Uuid::parse_str(json["id"].as_str().unwrap()).is_ok());
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_org_rejects_invalid_slug(pool: PgPool) {
+    let app = router_with_pool(pool);
+
+    let resp = app
+        .oneshot(json_request(
+            "POST",
+            "/v1/orgs",
+            r#"{"name":"Acme","slug":"bad_slug","owner_wallet":"acmewallet"}"#,
+        ))
+        .await
+        .expect("call");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_org_rejects_oversized_wallet(pool: PgPool) {
+    let app = router_with_pool(pool);
+
+    let big_wallet = "a".repeat(65);
+    let body = format!(r#"{{"name":"Acme","slug":"acme","owner_wallet":"{big_wallet}"}}"#);
+
+    let resp = app
+        .oneshot(json_request("POST", "/v1/orgs", &body))
+        .await
+        .expect("call");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn list_orgs_returns_admin_view(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let _id_a = create_test_org(&app, "first").await;
+    let _id_b = create_test_org(&app, "second").await;
+
+    let resp = app
+        .oneshot(bare_request("GET", "/v1/orgs"))
+        .await
+        .expect("call");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    let arr = json.as_array().expect("array");
+    assert_eq!(arr.len(), 2);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_org_returns_existing(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}")))
+        .await
+        .expect("call");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    assert_eq!(json["id"].as_str().unwrap(), org_id.to_string());
+    assert_eq!(json["slug"], "acme");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_org_returns_404_for_unknown(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let bogus = Uuid::new_v4();
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{bogus}")))
+        .await
+        .expect("call");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------------
+// teams + members + team wallets
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_and_list_teams_via_http(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams"),
+            r#"{"name":"Engineering"}"#,
+        ))
+        .await
+        .expect("create team");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let team_json = body_to_json(resp).await;
+    assert_eq!(team_json["name"], "Engineering");
+    let team_id = Uuid::parse_str(team_json["id"].as_str().unwrap()).expect("uuid");
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams"),
+            r#"{"name":"Marketing"}"#,
+        ))
+        .await
+        .expect("second team");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/teams")))
+        .await
+        .expect("list teams");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    let teams = json.as_array().expect("array");
+    assert_eq!(teams.len(), 2);
+    assert!(teams
+        .iter()
+        .any(|t| t["id"].as_str().unwrap() == team_id.to_string()));
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_team_rejects_blank_name(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams"),
+            r#"{"name":""}"#,
+        ))
+        .await
+        .expect("call");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn add_and_list_members_via_http(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/members"),
+            r#"{"wallet_address":"alice","role":"admin"}"#,
+        ))
+        .await
+        .expect("add member");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let json = body_to_json(resp).await;
+    assert_eq!(json["wallet_address"], "alice");
+    assert_eq!(json["role"], "admin");
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/members")))
+        .await
+        .expect("list members");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    let members = json.as_array().unwrap();
+    // Owner (auto-enrolled) + alice
+    assert_eq!(members.len(), 2);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn assign_wallet_404s_when_team_not_in_org(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+    let bogus_team = Uuid::new_v4();
+
+    let resp = app
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams/{bogus_team}/wallets"),
+            r#"{"wallet_address":"alice"}"#,
+        ))
+        .await
+        .expect("call");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn assign_and_list_team_wallets_via_http(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams"),
+            r#"{"name":"Eng"}"#,
+        ))
+        .await
+        .expect("team");
+    let team_json = body_to_json(resp).await;
+    let team_id = Uuid::parse_str(team_json["id"].as_str().unwrap()).expect("uuid");
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/wallets"),
+            r#"{"wallet_address":"alice"}"#,
+        ))
+        .await
+        .expect("assign wallet");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let resp = app
+        .oneshot(bare_request(
+            "GET",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/wallets"),
+        ))
+        .await
+        .expect("list");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["wallet_address"], "alice");
+}
+
+// ---------------------------------------------------------------------------
+// /v1/orgs/:id/api-keys
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_list_revoke_api_key_round_trip(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/api-keys"),
+            r#"{"name":"ci-runner","role":"admin"}"#,
+        ))
+        .await
+        .expect("create");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let json = body_to_json(resp).await;
+    assert_eq!(json["name"], "ci-runner");
+    assert_eq!(json["role"], "admin");
+    let key_id = Uuid::parse_str(json["id"].as_str().unwrap()).expect("uuid");
+    assert!(json["key"].as_str().unwrap().starts_with("solvela_k_"));
+
+    let resp = app
+        .clone()
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/api-keys")))
+        .await
+        .expect("list");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"].as_str().unwrap(), key_id.to_string());
+
+    let resp = app
+        .clone()
+        .oneshot(bare_request(
+            "DELETE",
+            &format!("/v1/orgs/{org_id}/api-keys/{key_id}"),
+        ))
+        .await
+        .expect("revoke");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    assert_eq!(json["revoked"], true);
+
+    let resp = app
+        .clone()
+        .oneshot(bare_request(
+            "DELETE",
+            &format!("/v1/orgs/{org_id}/api-keys/{key_id}"),
+        ))
+        .await
+        .expect("second revoke");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/api-keys")))
+        .await
+        .expect("list after revoke");
+    let json = body_to_json(resp).await;
+    assert_eq!(json.as_array().unwrap().len(), 0);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_api_key_rejects_blank_name(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/api-keys"),
+            r#"{"name":"   "}"#,
+        ))
+        .await
+        .expect("call");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// budgets
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn set_and_get_team_budget_via_http(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams"),
+            r#"{"name":"Eng"}"#,
+        ))
+        .await
+        .expect("team");
+    let team_id = Uuid::parse_str(body_to_json(resp).await["id"].as_str().unwrap()).expect("uuid");
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "PUT",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/budget"),
+            r#"{"hourly":1.0,"daily":10.0,"monthly":100.0}"#,
+        ))
+        .await
+        .expect("set budget");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = app
+        .oneshot(bare_request(
+            "GET",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/budget"),
+        ))
+        .await
+        .expect("get budget");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    assert_eq!(json["hourly_limit"], 1.0);
+    assert_eq!(json["daily_limit"], 10.0);
+    assert_eq!(json["monthly_limit"], 100.0);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn set_team_budget_rejects_negative_value(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams"),
+            r#"{"name":"Eng"}"#,
+        ))
+        .await
+        .expect("team");
+    let team_id = Uuid::parse_str(body_to_json(resp).await["id"].as_str().unwrap()).expect("uuid");
+
+    let resp = app
+        .oneshot(json_request(
+            "PUT",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/budget"),
+            r#"{"daily":-1.0}"#,
+        ))
+        .await
+        .expect("call");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn set_team_budget_404s_when_team_not_in_org(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+    let bogus_team = Uuid::new_v4();
+
+    let resp = app
+        .oneshot(json_request(
+            "PUT",
+            &format!("/v1/orgs/{org_id}/teams/{bogus_team}/budget"),
+            r#"{"daily":1.0}"#,
+        ))
+        .await
+        .expect("call");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn set_and_get_wallet_budget_via_http(pool: PgPool) {
+    let app = router_with_pool(pool);
+
+    let wallet = "alice";
+
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "PUT",
+            &format!("/v1/wallets/{wallet}/budget"),
+            r#"{"hourly":0.5,"daily":5.0,"monthly":50.0}"#,
+        ))
+        .await
+        .expect("set");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/wallets/{wallet}/budget")))
+        .await
+        .expect("get");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    assert_eq!(json["hourly_limit"], 0.5);
+    assert_eq!(json["daily_limit"], 5.0);
+    assert_eq!(json["monthly_limit"], 50.0);
+    assert_eq!(json["hourly_spend"], 0.0);
+    assert_eq!(json["daily_spend"], 0.0);
+    assert_eq!(json["monthly_spend"], 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// audit logs + stats (smoke: handler reaches DB and returns JSON shape)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn audit_logs_endpoint_returns_json_array(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .oneshot(bare_request(
+            "GET",
+            &format!("/v1/orgs/{org_id}/audit-logs?limit=10"),
+        ))
+        .await
+        .expect("audit logs");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+    assert!(json.is_array(), "audit-logs response must be an array");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn org_stats_endpoint_returns_200(pool: PgPool) {
+    let app = router_with_pool(pool);
+    let org_id = create_test_org(&app, "acme").await;
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/stats")))
+        .await
+        .expect("org stats");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let _json = body_to_json(resp).await;
+}

--- a/crates/gateway/tests/usage_integration.rs
+++ b/crates/gateway/tests/usage_integration.rs
@@ -1,0 +1,350 @@
+//! Integration tests for `gateway::usage` against a real Postgres.
+//!
+//! Covers the DB-backed and fully-pure paths of `UsageTracker` and the
+//! free-standing stats functions. Redis-backed budget enforcement paths
+//! are left for a follow-up — they require a fresh Redis instance per test
+//! and a different fixture story.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use gateway::usage::{
+    get_stats_by_day, get_stats_by_model, get_wallet_stats, BudgetConfig, SpendLogEntry,
+    UsageError, UsageTracker,
+};
+
+const WALLET_A: &str = "DZNuWFpYwzEAcyaMQzqgbxA4d1f4Yq8EU2YbLPLYxNTw";
+const WALLET_B: &str = "GbZ6oTmEa9PEd6FGQEmTm3GbXCQkAGqNGGJYXrW8oQte";
+
+/// Seed N spend rows directly via SQL — bypassing `log_spend`'s `tokio::spawn`
+/// so the read-side tests are deterministic.
+async fn seed_spend(pool: &PgPool, wallet: &str, rows: &[(&str, &str, i32, i32, f64)]) {
+    for (model, provider, input_tokens, output_tokens, cost) in rows {
+        sqlx::query(
+            r#"INSERT INTO spend_logs (id, wallet_address, model, provider,
+                input_tokens, output_tokens, cost_usdc, created_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())"#,
+        )
+        .bind(Uuid::new_v4())
+        .bind(wallet)
+        .bind(model)
+        .bind(provider)
+        .bind(input_tokens)
+        .bind(output_tokens)
+        .bind(cost)
+        .execute(pool)
+        .await
+        .expect("seed spend_logs insert");
+    }
+}
+
+#[test]
+fn budget_config_default_uses_100_dollar_daily_cap() {
+    let cfg = BudgetConfig::default();
+    assert!(cfg.hourly.is_none(), "default has no hourly cap");
+    assert_eq!(
+        cfg.daily,
+        Some(100.0),
+        "default daily cap matches DEFAULT_DAILY_LIMIT_USDC"
+    );
+    assert!(cfg.monthly.is_none(), "default has no monthly cap");
+}
+
+#[test]
+fn usage_error_display_matches_thiserror_format() {
+    let err = UsageError::Database("connection refused".into());
+    assert_eq!(err.to_string(), "database error: connection refused");
+
+    let err = UsageError::Redis("timeout".into());
+    assert_eq!(err.to_string(), "redis error: timeout");
+
+    let err = UsageError::NotConfigured;
+    assert_eq!(err.to_string(), "not configured");
+
+    let err = UsageError::BudgetExceeded {
+        wallet: "WALLET".into(),
+        limit: 1.0,
+        spent: 1.5,
+    };
+    let s = err.to_string();
+    assert!(s.contains("WALLET"), "wallet must appear: {s}");
+    assert!(
+        s.contains("$1.5000"),
+        "spent must format with 4 decimals: {s}"
+    );
+    assert!(
+        s.contains("$1.00"),
+        "limit must format with 2 decimals: {s}"
+    );
+}
+
+#[tokio::test]
+async fn noop_tracker_has_no_backends() {
+    let tracker = UsageTracker::noop();
+    assert!(
+        tracker.redis_client().is_none(),
+        "noop tracker exposes no redis client"
+    );
+}
+
+#[tokio::test]
+async fn check_budget_without_redis_applies_one_dollar_per_request_cap() {
+    let tracker = UsageTracker::noop();
+
+    // Below the cap — allowed.
+    tracker
+        .check_budget(WALLET_A, 0.50)
+        .await
+        .expect("0.50 USDC must be within the no-Redis cap");
+
+    // At the cap — allowed (boundary).
+    tracker
+        .check_budget(WALLET_A, 1.00)
+        .await
+        .expect("$1.00 USDC must be at-or-below the cap");
+
+    // Above the cap — denied.
+    let err = tracker
+        .check_budget(WALLET_A, 1.01)
+        .await
+        .expect_err("anything above $1 must be rejected without Redis");
+    match err {
+        UsageError::BudgetExceeded {
+            wallet,
+            limit,
+            spent,
+        } => {
+            assert_eq!(wallet, WALLET_A);
+            assert_eq!(limit, 1.0);
+            assert_eq!(spent, 1.01);
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn get_summary_without_db_returns_not_configured() {
+    let tracker = UsageTracker::noop();
+    let result = tracker.get_summary(WALLET_A).await;
+    assert!(matches!(result, Err(UsageError::NotConfigured)));
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_summary_aggregates_spend_logs(pool: PgPool) {
+    seed_spend(
+        &pool,
+        WALLET_A,
+        &[
+            ("openai/gpt-4o", "openai", 100, 200, 0.0050),
+            ("openai/gpt-4o", "openai", 50, 150, 0.0025),
+            ("anthropic/claude-3.5", "anthropic", 200, 400, 0.0080),
+        ],
+    )
+    .await;
+    // Other wallet must not pollute results.
+    seed_spend(
+        &pool,
+        WALLET_B,
+        &[("openai/gpt-4o", "openai", 999, 999, 9.99)],
+    )
+    .await;
+
+    let tracker = UsageTracker::new(Some(pool.clone()), None);
+    let summary = tracker.get_summary(WALLET_A).await.expect("summary");
+
+    assert_eq!(summary.wallet_address, WALLET_A);
+    assert_eq!(summary.total_requests, 3);
+    assert_eq!(summary.total_input_tokens, 350);
+    assert_eq!(summary.total_output_tokens, 750);
+    assert!(
+        (summary.total_cost_usdc - 0.0155).abs() < 1e-9,
+        "summed cost must be 0.0155, got {}",
+        summary.total_cost_usdc
+    );
+    // daily/monthly Redis aggregations are stubbed at 0 in the source.
+    assert_eq!(summary.daily_cost_usdc, 0.0);
+    assert_eq!(summary.monthly_cost_usdc, 0.0);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_persists_row_when_db_configured(pool: PgPool) {
+    let tracker = UsageTracker::new(Some(pool.clone()), None);
+
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: WALLET_A.to_string(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 12,
+        output_tokens: 34,
+        cost_usdc: 0.0009,
+        tx_signature: Some("tx-test-sig".to_string()),
+        request_id: Some("req-abc".to_string()),
+        session_id: None,
+    });
+
+    // Fire-and-forget: poll briefly for the row to land.
+    let mut found = false;
+    for _ in 0..50 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM spend_logs WHERE wallet_address = $1")
+                .bind(WALLET_A)
+                .fetch_one(&pool)
+                .await
+                .expect("count");
+        if count == 1 {
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "log_spend should have persisted exactly one row within 1s"
+    );
+
+    let row: (
+        String,
+        String,
+        i32,
+        i32,
+        f64,
+        Option<String>,
+        Option<String>,
+    ) = sqlx::query_as(
+        r#"SELECT model, provider, input_tokens, output_tokens,
+                  cost_usdc::DOUBLE PRECISION, tx_signature, request_id
+           FROM spend_logs WHERE wallet_address = $1"#,
+    )
+    .bind(WALLET_A)
+    .fetch_one(&pool)
+    .await
+    .expect("read back");
+
+    assert_eq!(row.0, "openai/gpt-4o");
+    assert_eq!(row.1, "openai");
+    assert_eq!(row.2, 12);
+    assert_eq!(row.3, 34);
+    assert!((row.4 - 0.0009).abs() < 1e-9);
+    assert_eq!(row.5.as_deref(), Some("tx-test-sig"));
+    assert_eq!(row.6.as_deref(), Some("req-abc"));
+}
+
+#[tokio::test]
+async fn log_spend_with_no_backends_does_not_panic() {
+    // Pure smoke: emits a tracing event without touching DB or Redis.
+    let tracker = UsageTracker::noop();
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: WALLET_A.to_string(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 1,
+        output_tokens: 2,
+        cost_usdc: 0.0001,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+    });
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_wallet_stats_aggregates_within_window(pool: PgPool) {
+    seed_spend(
+        &pool,
+        WALLET_A,
+        &[
+            ("openai/gpt-4o", "openai", 100, 200, 0.005),
+            ("openai/gpt-4o", "openai", 50, 100, 0.002),
+        ],
+    )
+    .await;
+
+    let stats = get_wallet_stats(&pool, WALLET_A, 7).await.expect("stats");
+    assert_eq!(stats.total_requests, 2);
+    assert!((stats.total_cost - 0.007).abs() < 1e-9);
+    assert_eq!(stats.total_input, 150);
+    assert_eq!(stats.total_output, 300);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_wallet_stats_returns_zeros_for_unknown_wallet(pool: PgPool) {
+    let stats = get_wallet_stats(&pool, "no-such-wallet", 7)
+        .await
+        .expect("stats");
+    assert_eq!(stats.total_requests, 0);
+    assert_eq!(stats.total_cost, 0.0);
+    assert_eq!(stats.total_input, 0);
+    assert_eq!(stats.total_output, 0);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_stats_by_model_groups_and_orders_by_cost_desc(pool: PgPool) {
+    seed_spend(
+        &pool,
+        WALLET_A,
+        &[
+            ("openai/gpt-4o", "openai", 100, 200, 0.001),
+            ("openai/gpt-4o", "openai", 100, 200, 0.002),
+            ("anthropic/claude-3.5", "anthropic", 50, 50, 0.010),
+        ],
+    )
+    .await;
+
+    let rows = get_stats_by_model(&pool, WALLET_A, 7)
+        .await
+        .expect("by_model");
+    assert_eq!(rows.len(), 2);
+    // Ordered by total cost DESC — anthropic ($0.010) outranks openai ($0.003).
+    assert_eq!(rows[0].model, "anthropic/claude-3.5");
+    assert!((rows[0].cost - 0.010).abs() < 1e-9);
+    assert_eq!(rows[0].requests, 1);
+
+    assert_eq!(rows[1].model, "openai/gpt-4o");
+    assert!((rows[1].cost - 0.003).abs() < 1e-9);
+    assert_eq!(rows[1].requests, 2);
+    assert_eq!(rows[1].input_tokens, 200);
+    assert_eq!(rows[1].output_tokens, 400);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_stats_by_day_groups_today(pool: PgPool) {
+    seed_spend(
+        &pool,
+        WALLET_A,
+        &[
+            ("openai/gpt-4o", "openai", 100, 200, 0.005),
+            ("openai/gpt-4o", "openai", 50, 100, 0.002),
+        ],
+    )
+    .await;
+
+    let rows = get_stats_by_day(&pool, WALLET_A, 7).await.expect("by_day");
+    // Both rows seeded NOW() so they collapse into a single day bucket.
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].requests, 2);
+    assert!((rows[0].cost - 0.007).abs() < 1e-9);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_stats_filters_outside_window(pool: PgPool) {
+    // Seed a row dated 30 days ago — outside the 7-day window.
+    sqlx::query(
+        r#"INSERT INTO spend_logs (id, wallet_address, model, provider,
+            input_tokens, output_tokens, cost_usdc, created_at)
+           VALUES ($1, $2, 'old-model', 'old', 1, 1, 99.99, NOW() - INTERVAL '30 days')"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(WALLET_A)
+    .execute(&pool)
+    .await
+    .expect("seed old row");
+
+    // And one row inside the window.
+    seed_spend(&pool, WALLET_A, &[("openai/gpt-4o", "openai", 1, 1, 0.001)]).await;
+
+    let stats = get_wallet_stats(&pool, WALLET_A, 7).await.expect("stats");
+    assert_eq!(
+        stats.total_requests, 1,
+        "30-day-old row must be filtered out by the 7-day window"
+    );
+    assert!((stats.total_cost - 0.001).abs() < 1e-9);
+}

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -1,0 +1,685 @@
+//! Redis-backed integration tests for `gateway::usage`.
+//!
+//! These exercise the hot-path counters in `log_spend`, the Redis
+//! happy-path of `check_budget`, the cache-then-DB helpers
+//! (`get_wallet_budget_config`, `get_team_for_wallet`,
+//! `get_team_budget_config`), and team-level enforcement.
+//!
+//! Per-test isolation: each test generates a UUID-prefixed wallet address.
+//! Spend, budget-config, and team-membership keys all embed the wallet,
+//! so two parallel tests never collide. Postgres isolation comes from
+//! `#[sqlx::test]` (fresh DB per test).
+
+use chrono::Utc;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use gateway::usage::{get_redis_spend, SpendLogEntry, UsageError, UsageTracker};
+
+const REDIS_URL: &str = "redis://127.0.0.1:6379";
+
+fn redis_client() -> redis::Client {
+    redis::Client::open(REDIS_URL).expect("local Redis must be reachable")
+}
+
+/// Generate a per-test wallet so spend / budget_config / team_member
+/// keys are isolated even when tests run in parallel.
+fn unique_wallet() -> String {
+    format!("test_w_{}", Uuid::new_v4().simple())
+}
+
+/// Wait for a Redis key to materialize (set by `tokio::spawn` inside `log_spend`).
+/// Polls every 20ms for up to 1s.
+async fn wait_for_key(client: &redis::Client, key: &str) -> Option<String> {
+    for _ in 0..50 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("redis conn");
+        if let Ok(Some(val)) = redis::cmd("GET")
+            .arg(key)
+            .query_async::<Option<String>>(&mut conn)
+            .await
+        {
+            return Some(val);
+        }
+    }
+    None
+}
+
+/// Best-effort cleanup of test keys.
+async fn redis_del(client: &redis::Client, keys: &[&str]) {
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("redis conn");
+    for key in keys {
+        let _: Result<i64, _> = redis::cmd("DEL").arg(*key).query_async(&mut conn).await;
+    }
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_writes_redis_hourly_daily_monthly_counters(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 100,
+        output_tokens: 200,
+        cost_usdc: 0.0050,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+    });
+
+    let hour_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H"));
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let month_key = format!("spend:{}:{}", wallet, now.format("%Y-%m"));
+
+    let hour_val = wait_for_key(&client, &hour_key)
+        .await
+        .expect("hourly counter must appear");
+    assert_eq!(hour_val.parse::<f64>().unwrap_or(0.0), 0.005);
+
+    let day_val = wait_for_key(&client, &day_key)
+        .await
+        .expect("daily counter must appear");
+    assert_eq!(day_val.parse::<f64>().unwrap_or(0.0), 0.005);
+
+    let month_val = wait_for_key(&client, &month_key)
+        .await
+        .expect("monthly counter must appear");
+    assert_eq!(month_val.parse::<f64>().unwrap_or(0.0), 0.005);
+
+    let via_helper = get_redis_spend(&client, &hour_key)
+        .await
+        .expect("get_redis_spend");
+    assert_eq!(via_helper, 0.005);
+
+    redis_del(&client, &[&hour_key, &day_key, &month_key]).await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_accumulates_across_calls(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    let entry = SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 1,
+        output_tokens: 1,
+        cost_usdc: 0.001,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+    };
+    tracker.log_spend(entry.clone());
+    tracker.log_spend(entry.clone());
+    tracker.log_spend(entry);
+
+    let mut total: f64 = 0.0;
+    for _ in 0..100 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        if let Ok(val) = get_redis_spend(&client, &day_key).await {
+            total = val;
+            if (total - 0.003).abs() < 1e-9 {
+                break;
+            }
+        }
+    }
+    assert!(
+        (total - 0.003).abs() < 1e-9,
+        "three log_spend calls of 0.001 must accumulate to 0.003, got {total}"
+    );
+
+    redis_del(&client, &[&day_key]).await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_passes_when_under_default_daily_limit(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    tracker
+        .check_budget(&wallet, 0.50)
+        .await
+        .expect("default budget must allow $0.50");
+
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let cache_key = format!("budget_config:{wallet}");
+    let cached: Option<String> = redis::cmd("GET")
+        .arg(&cache_key)
+        .query_async(&mut conn)
+        .await
+        .expect("get cache");
+    assert!(
+        cached.is_some(),
+        "wallet budget config must be cached after the first lookup"
+    );
+
+    redis_del(&client, &[&cache_key, &format!("team_member:{wallet}")]).await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_rejects_when_daily_limit_would_be_exceeded(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    sqlx::query("INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 1.00)")
+        .bind(&wallet)
+        .execute(&pool)
+        .await
+        .expect("seed wallet_budget");
+
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&day_key)
+        .arg("0.95")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed spend");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    tracker
+        .check_budget(&wallet, 0.04)
+        .await
+        .expect("$0.04 must fit");
+
+    let err = tracker
+        .check_budget(&wallet, 0.10)
+        .await
+        .expect_err("must reject when over the daily limit");
+    match err {
+        UsageError::BudgetExceeded {
+            wallet: w,
+            limit,
+            spent,
+        } => {
+            assert_eq!(w, wallet);
+            assert_eq!(limit, 1.0);
+            assert!((spent - 1.05).abs() < 1e-9);
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del(
+        &client,
+        &[
+            &day_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+        ],
+    )
+    .await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_rejects_when_hourly_limit_would_be_exceeded(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    sqlx::query("INSERT INTO wallet_budgets (wallet_address, hourly_limit_usdc) VALUES ($1, 0.50)")
+        .bind(&wallet)
+        .execute(&pool)
+        .await
+        .expect("seed");
+
+    let hour_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H"));
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&hour_key)
+        .arg("0.49")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    let err = tracker
+        .check_budget(&wallet, 0.10)
+        .await
+        .expect_err("over hourly cap");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => assert_eq!(limit, 0.5),
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del(
+        &client,
+        &[
+            &hour_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+        ],
+    )
+    .await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_rejects_when_monthly_limit_would_be_exceeded(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, monthly_limit_usdc) VALUES ($1, 5.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed");
+
+    let month_key = format!("spend:{}:{}", wallet, now.format("%Y-%m"));
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&month_key)
+        .arg("4.99")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    let err = tracker
+        .check_budget(&wallet, 0.10)
+        .await
+        .expect_err("over monthly cap");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => assert_eq!(limit, 5.0),
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del(
+        &client,
+        &[
+            &month_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+        ],
+    )
+    .await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_caches_team_membership_as_none_for_non_members(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    tracker
+        .check_budget(&wallet, 0.10)
+        .await
+        .expect("default $100/day must allow $0.10");
+
+    let cache_key = format!("team_member:{wallet}");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let cached: Option<String> = redis::cmd("GET")
+        .arg(&cache_key)
+        .query_async(&mut conn)
+        .await
+        .expect("get cache");
+    assert_eq!(
+        cached.as_deref(),
+        Some("none"),
+        "non-member wallets should be cached as 'none' to avoid repeated DB misses"
+    );
+
+    redis_del(&client, &[&cache_key, &format!("budget_config:{wallet}")]).await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_uses_pre_populated_redis_cache(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    // Pre-populate cache with a tight $0.05/day cap. NO matching DB row,
+    // so reaching the DB would yield the default $100. Exceeding the
+    // cached $0.05 proves the cache (not the default) was consulted.
+    let cache_key = format!("budget_config:{wallet}");
+    let cached_config = r#"{"hourly":null,"daily":0.05,"monthly":null}"#;
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&cache_key)
+        .arg(cached_config)
+        .arg("EX")
+        .arg(60)
+        .query_async(&mut conn)
+        .await
+        .expect("prime cache");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    tracker
+        .check_budget(&wallet, 0.04)
+        .await
+        .expect("$0.04 fits under cached cap");
+
+    let err = tracker
+        .check_budget(&wallet, 0.06)
+        .await
+        .expect_err("must reject under the cached cap");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => {
+            assert!(
+                (limit - 0.05).abs() < 1e-9,
+                "limit must be cached 0.05, got {limit}"
+            );
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del(&client, &[&cache_key, &format!("team_member:{wallet}")]).await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_falls_through_to_db_when_cache_is_corrupt(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    sqlx::query("INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 1.00)")
+        .bind(&wallet)
+        .execute(&pool)
+        .await
+        .expect("seed");
+
+    let cache_key = format!("budget_config:{wallet}");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&cache_key)
+        .arg("not-valid-json")
+        .arg("EX")
+        .arg(60)
+        .query_async(&mut conn)
+        .await
+        .expect("prime corrupt cache");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    tracker
+        .check_budget(&wallet, 0.50)
+        .await
+        .expect("must use DB after detecting corrupt cache");
+
+    redis_del(&client, &[&cache_key, &format!("team_member:{wallet}")]).await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_writes_team_counters_when_wallet_in_team(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    let owner_wallet = format!("test_owner_{}", Uuid::new_v4().simple());
+    let org_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO organizations (name, slug, owner_wallet) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind("test-org")
+    .bind(format!("slug-{}", Uuid::new_v4().simple()))
+    .bind(&owner_wallet)
+    .fetch_one(&pool)
+    .await
+    .expect("create org");
+
+    let team_id: Uuid =
+        sqlx::query_scalar("INSERT INTO teams (org_id, name) VALUES ($1, $2) RETURNING id")
+            .bind(org_id)
+            .bind(format!("team-{}", Uuid::new_v4().simple()))
+            .fetch_one(&pool)
+            .await
+            .expect("create team");
+
+    sqlx::query("INSERT INTO team_wallets (team_id, wallet_address) VALUES ($1, $2)")
+        .bind(team_id)
+        .bind(&wallet)
+        .execute(&pool)
+        .await
+        .expect("assign wallet");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 1,
+        output_tokens: 1,
+        cost_usdc: 0.0025,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+    });
+
+    let now = Utc::now();
+    let team_day_key = format!("team_spend:{}:{}", team_id, now.format("%Y-%m-%d"));
+
+    let val = wait_for_key(&client, &team_day_key)
+        .await
+        .expect("team_spend key must appear");
+    assert_eq!(val.parse::<f64>().unwrap_or(0.0), 0.0025);
+
+    redis_del(
+        &client,
+        &[
+            &team_day_key,
+            &format!("team_spend:{}:{}", team_id, now.format("%Y-%m-%dT%H")),
+            &format!("team_spend:{}:{}", team_id, now.format("%Y-%m")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%d")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m")),
+            &format!("team_member:{wallet}"),
+            &format!("team_budget:{team_id}"),
+        ],
+    )
+    .await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_enforces_team_daily_limit(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    let owner_wallet = format!("test_owner_{}", Uuid::new_v4().simple());
+    let org_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO organizations (name, slug, owner_wallet) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind("test-org")
+    .bind(format!("slug-{}", Uuid::new_v4().simple()))
+    .bind(&owner_wallet)
+    .fetch_one(&pool)
+    .await
+    .expect("org");
+
+    let team_id: Uuid =
+        sqlx::query_scalar("INSERT INTO teams (org_id, name) VALUES ($1, $2) RETURNING id")
+            .bind(org_id)
+            .bind(format!("team-{}", Uuid::new_v4().simple()))
+            .fetch_one(&pool)
+            .await
+            .expect("team");
+
+    sqlx::query("INSERT INTO team_wallets (team_id, wallet_address) VALUES ($1, $2)")
+        .bind(team_id)
+        .bind(&wallet)
+        .execute(&pool)
+        .await
+        .expect("assign");
+
+    sqlx::query("INSERT INTO team_budgets (team_id, daily_limit_usdc) VALUES ($1, 0.10)")
+        .bind(team_id)
+        .execute(&pool)
+        .await
+        .expect("team_budget");
+
+    let now = Utc::now();
+    let team_day_key = format!("team_spend:{}:{}", team_id, now.format("%Y-%m-%d"));
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&team_day_key)
+        .arg("0.09")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // Wallet's per-wallet cap is the default $100/day; team cap is $0.10.
+    // $0.05 pushes team total to $0.14 — exceeds team cap.
+    let err = tracker
+        .check_budget(&wallet, 0.05)
+        .await
+        .expect_err("team daily cap must enforce");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => {
+            assert!(
+                (limit - 0.10).abs() < 1e-9,
+                "limit must be team 0.10, got {limit}"
+            );
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del(
+        &client,
+        &[
+            &team_day_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+            &format!("team_budget:{team_id}"),
+        ],
+    )
+    .await;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_redis_get_failure_fails_closed(pool: PgPool) {
+    // Garbage in the spend key forces the GET-as-f64 decode to fail.
+    // The check_budget code path treats any GET error as a Redis error
+    // and must deny the request (fail-closed).
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&day_key)
+        .arg("not-a-number")
+        .arg("EX")
+        .arg(60)
+        .query_async(&mut conn)
+        .await
+        .expect("seed garbage");
+
+    sqlx::query("INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 1.00)")
+        .bind(&wallet)
+        .execute(&pool)
+        .await
+        .expect("seed budget");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    let err = tracker
+        .check_budget(&wallet, 0.10)
+        .await
+        .expect_err("garbage in Redis must fail closed");
+    match err {
+        UsageError::Redis(_) => {}
+        other => panic!("expected Redis error, got {other:?}"),
+    }
+
+    redis_del(
+        &client,
+        &[
+            &day_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn get_redis_spend_returns_zero_for_missing_key() {
+    let client = redis_client();
+    let key = format!("nonexistent:{}", Uuid::new_v4().simple());
+
+    let val = get_redis_spend(&client, &key)
+        .await
+        .expect("missing key must return Ok(0.0)");
+    assert_eq!(val, 0.0);
+}
+
+#[tokio::test]
+async fn get_redis_spend_returns_value_for_present_key() {
+    let client = redis_client();
+    let key = format!("test:get_redis_spend:{}", Uuid::new_v4().simple());
+
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&key)
+        .arg("0.42")
+        .arg("EX")
+        .arg(60)
+        .query_async(&mut conn)
+        .await
+        .expect("set");
+
+    let val = get_redis_spend(&client, &key)
+        .await
+        .expect("present key must return its value");
+    assert!((val - 0.42).abs() < 1e-9);
+
+    redis_del(&client, &[&key]).await;
+}

--- a/crates/x402/src/spl_transfer.rs
+++ b/crates/x402/src/spl_transfer.rs
@@ -122,3 +122,379 @@ pub(crate) fn extract_spl_transfer(message: &ParsedMessage) -> Result<SplTransfe
         "no SPL Token transfer instruction found".to_string(),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solana_types::{CompiledInstruction, MessageHeader};
+
+    fn pubkey_from_byte(byte: u8) -> Pubkey {
+        let mut bytes = [0u8; 32];
+        bytes[0] = byte;
+        Pubkey(bytes)
+    }
+
+    fn empty_message_with(
+        account_keys: Vec<Pubkey>,
+        instructions: Vec<CompiledInstruction>,
+    ) -> ParsedMessage {
+        ParsedMessage {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            account_keys,
+            recent_blockhash: [0u8; 32],
+            instructions,
+            is_v0: false,
+        }
+    }
+
+    fn transfer_data(amount: u64) -> Vec<u8> {
+        let mut data = vec![3];
+        data.extend_from_slice(&amount.to_le_bytes());
+        data
+    }
+
+    fn transfer_checked_data(amount: u64, decimals: u8) -> Vec<u8> {
+        let mut data = vec![12];
+        data.extend_from_slice(&amount.to_le_bytes());
+        data.push(decimals);
+        data
+    }
+
+    #[test]
+    fn extracts_transfer_amount_and_destination() {
+        let source = pubkey_from_byte(1);
+        let destination = pubkey_from_byte(2);
+        let authority = pubkey_from_byte(3);
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+
+        let message = empty_message_with(
+            vec![source, destination, authority, token_program],
+            vec![CompiledInstruction {
+                program_id_index: 3,
+                accounts: vec![0, 1, 2],
+                data: transfer_data(1_000_000),
+            }],
+        );
+
+        let info = extract_spl_transfer(&message).expect("transfer must parse");
+        assert_eq!(info.amount, 1_000_000);
+        assert_eq!(info.destination, destination);
+        assert!(info.mint.is_none(), "Transfer has no mint field");
+    }
+
+    #[test]
+    fn extracts_transfer_checked_amount_destination_and_mint() {
+        let source = pubkey_from_byte(1);
+        let mint = pubkey_from_byte(2);
+        let destination = pubkey_from_byte(3);
+        let authority = pubkey_from_byte(4);
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+
+        let message = empty_message_with(
+            vec![source, mint, destination, authority, token_program],
+            vec![CompiledInstruction {
+                program_id_index: 4,
+                accounts: vec![0, 1, 2, 3],
+                data: transfer_checked_data(2_500_000, 6),
+            }],
+        );
+
+        let info = extract_spl_transfer(&message).expect("transfer-checked must parse");
+        assert_eq!(info.amount, 2_500_000);
+        assert_eq!(info.destination, destination);
+        assert_eq!(info.mint, Some(mint));
+    }
+
+    #[test]
+    fn accepts_transfer_checked_from_token_2022_program() {
+        let source = pubkey_from_byte(1);
+        let mint = pubkey_from_byte(2);
+        let destination = pubkey_from_byte(3);
+        let authority = pubkey_from_byte(4);
+        let token2022_program = Pubkey::TOKEN_2022_PROGRAM_ID;
+
+        let message = empty_message_with(
+            vec![source, mint, destination, authority, token2022_program],
+            vec![CompiledInstruction {
+                program_id_index: 4,
+                accounts: vec![0, 1, 2, 3],
+                data: transfer_checked_data(7, 9),
+            }],
+        );
+
+        let info = extract_spl_transfer(&message).expect("token-2022 transfer must parse");
+        assert_eq!(info.amount, 7);
+        assert_eq!(info.mint, Some(mint));
+    }
+
+    #[test]
+    fn skips_non_spl_token_program_instructions() {
+        let source = pubkey_from_byte(1);
+        let destination = pubkey_from_byte(2);
+        let authority = pubkey_from_byte(3);
+        let other_program = pubkey_from_byte(99);
+
+        let message = empty_message_with(
+            vec![source, destination, authority, other_program],
+            vec![CompiledInstruction {
+                program_id_index: 3,
+                accounts: vec![0, 1, 2],
+                data: transfer_data(1),
+            }],
+        );
+
+        let err = extract_spl_transfer(&message).expect_err("must reject non-token program");
+        match err {
+            Error::InvalidTransaction(msg) => {
+                assert!(msg.contains("no SPL Token transfer"), "wrong error: {msg}")
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skips_empty_instruction_data() {
+        let source = pubkey_from_byte(1);
+        let destination = pubkey_from_byte(2);
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+
+        let message = empty_message_with(
+            vec![source, destination, token_program],
+            vec![CompiledInstruction {
+                program_id_index: 2,
+                accounts: vec![0, 1],
+                data: vec![],
+            }],
+        );
+
+        let err = extract_spl_transfer(&message).expect_err("empty data must not match");
+        assert!(matches!(err, Error::InvalidTransaction(_)));
+    }
+
+    #[test]
+    fn skips_out_of_bounds_program_id_index() {
+        let source = pubkey_from_byte(1);
+        let destination = pubkey_from_byte(2);
+
+        let message = empty_message_with(
+            vec![source, destination],
+            vec![CompiledInstruction {
+                program_id_index: 99,
+                accounts: vec![0, 1],
+                data: transfer_data(1),
+            }],
+        );
+
+        let err = extract_spl_transfer(&message).expect_err("oob program index must not match");
+        assert!(matches!(err, Error::InvalidTransaction(_)));
+    }
+
+    #[test]
+    fn rejects_transfer_with_truncated_data() {
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+        let message = empty_message_with(
+            vec![pubkey_from_byte(1), pubkey_from_byte(2), token_program],
+            vec![CompiledInstruction {
+                program_id_index: 2,
+                accounts: vec![0, 1],
+                data: vec![3, 0, 0],
+            }],
+        );
+
+        let err = extract_spl_transfer(&message).expect_err("truncated data must error");
+        match err {
+            Error::InvalidTransaction(msg) => assert!(msg.contains("too short"), "msg: {msg}"),
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_transfer_with_missing_accounts() {
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+        let message = empty_message_with(
+            vec![pubkey_from_byte(1), token_program],
+            vec![CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: transfer_data(100),
+            }],
+        );
+
+        let err = extract_spl_transfer(&message).expect_err("missing accounts must error");
+        match err {
+            Error::InvalidTransaction(msg) => {
+                assert!(msg.contains("missing accounts"), "msg: {msg}")
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_transfer_with_oob_destination_index() {
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+        let message = empty_message_with(
+            vec![pubkey_from_byte(1), pubkey_from_byte(2), token_program],
+            vec![CompiledInstruction {
+                program_id_index: 2,
+                accounts: vec![0, 99, 1],
+                data: transfer_data(100),
+            }],
+        );
+
+        let err = extract_spl_transfer(&message).expect_err("oob destination must error");
+        match err {
+            Error::InvalidTransaction(msg) => {
+                assert!(msg.contains("destination account index"), "msg: {msg}")
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_transfer_checked_with_truncated_data() {
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+        let message = empty_message_with(
+            vec![pubkey_from_byte(1), pubkey_from_byte(2), token_program],
+            vec![CompiledInstruction {
+                program_id_index: 2,
+                accounts: vec![0, 1, 0],
+                data: vec![12, 0, 0],
+            }],
+        );
+
+        let err =
+            extract_spl_transfer(&message).expect_err("truncated transfer-checked must error");
+        match err {
+            Error::InvalidTransaction(msg) => assert!(msg.contains("too short"), "msg: {msg}"),
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_transfer_checked_with_missing_accounts() {
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+        let message = empty_message_with(
+            vec![pubkey_from_byte(1), pubkey_from_byte(2), token_program],
+            vec![CompiledInstruction {
+                program_id_index: 2,
+                accounts: vec![0, 1],
+                data: transfer_checked_data(100, 6),
+            }],
+        );
+
+        let err = extract_spl_transfer(&message)
+            .expect_err("missing accounts in transfer-checked must error");
+        match err {
+            Error::InvalidTransaction(msg) => {
+                assert!(msg.contains("missing accounts"), "msg: {msg}")
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_transfer_checked_with_oob_mint_index() {
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+        let message = empty_message_with(
+            vec![
+                pubkey_from_byte(1),
+                pubkey_from_byte(2),
+                pubkey_from_byte(3),
+                token_program,
+            ],
+            vec![CompiledInstruction {
+                program_id_index: 3,
+                accounts: vec![0, 99, 2, 0],
+                data: transfer_checked_data(100, 6),
+            }],
+        );
+
+        let err = extract_spl_transfer(&message).expect_err("oob mint must error");
+        match err {
+            Error::InvalidTransaction(msg) => {
+                assert!(msg.contains("mint account index"), "msg: {msg}")
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_transfer_checked_with_oob_destination_index() {
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+        let message = empty_message_with(
+            vec![
+                pubkey_from_byte(1),
+                pubkey_from_byte(2),
+                pubkey_from_byte(3),
+                token_program,
+            ],
+            vec![CompiledInstruction {
+                program_id_index: 3,
+                accounts: vec![0, 1, 99, 0],
+                data: transfer_checked_data(100, 6),
+            }],
+        );
+
+        let err = extract_spl_transfer(&message).expect_err("oob destination must error");
+        match err {
+            Error::InvalidTransaction(msg) => {
+                assert!(msg.contains("destination account index"), "msg: {msg}")
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skips_unknown_discriminators() {
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+        let message = empty_message_with(
+            vec![pubkey_from_byte(1), pubkey_from_byte(2), token_program],
+            vec![CompiledInstruction {
+                program_id_index: 2,
+                accounts: vec![0, 1],
+                data: vec![7, 0, 0, 0, 0, 0, 0, 0, 0],
+            }],
+        );
+
+        let err = extract_spl_transfer(&message)
+            .expect_err("non-transfer discriminator must produce 'no transfer found'");
+        match err {
+            Error::InvalidTransaction(msg) => {
+                assert!(msg.contains("no SPL Token transfer"), "msg: {msg}")
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finds_transfer_after_skipping_non_token_instruction() {
+        let source = pubkey_from_byte(1);
+        let destination = pubkey_from_byte(2);
+        let other_program = pubkey_from_byte(99);
+        let token_program = Pubkey::TOKEN_PROGRAM_ID;
+
+        let message = empty_message_with(
+            vec![source, destination, other_program, token_program],
+            vec![
+                CompiledInstruction {
+                    program_id_index: 2,
+                    accounts: vec![],
+                    data: vec![1, 2, 3],
+                },
+                CompiledInstruction {
+                    program_id_index: 3,
+                    accounts: vec![0, 1, 0],
+                    data: transfer_data(42),
+                },
+            ],
+        );
+
+        let info = extract_spl_transfer(&message).expect("must find the second instruction");
+        assert_eq!(info.amount, 42);
+        assert_eq!(info.destination, destination);
+    }
+}


### PR DESCRIPTION
## Summary

Raises Rust workspace coverage past the 80% threshold on every `cargo llvm-cov` metric:

| metric | before | after | Δ |
|---|---:|---:|---:|
| lines | 74.41% | **80.35%** | +5.94 |
| functions | 77.18% | **81.41%** | +4.23 |
| regions | 77.15% | **81.90%** | +4.75 |

Adds **113 tests across 9 files**, all green. Source changes are minimal: only the three OpenAI-compatible provider stubs (openai/xai/deepseek) get an extract-method refactor (`build_chat_body` / `build_stream_body`) so prefix-stripping and stream-flag injection are testable without HTTP mocks. Behaviour is unchanged.

### What's tested now that wasn't before

- **Provider stubs (0% → 87%)**: openai/xai/deepseek prefix stripping, body construction, stream-flag injection.
- **`x402::spl_transfer` (61% → 95%)**: Transfer + TransferChecked parsing, Token-2022 acceptance, every malformed-input rejection branch.
- **`gateway::cache` (50% → 64%)**: wallet-agnostic key invariant per CLAUDE.md rule #16; order/count sensitivity; short-circuit paths.
- **`gateway::orgs::queries` (8% → 99%)**: full CRUD coverage via `#[sqlx::test]` against per-test Postgres DBs; cross-org scoping; expiry/revocation.
- **`gateway::usage` (38% → 90%)**: DB-backed `get_summary`/`log_spend`/stats fns; Redis hot-path counters; `check_budget` happy + reject paths (hourly/daily/monthly + team-level); cache-hit/cache-corrupt/cache-miss; fail-closed Redis errors.
- **`routes/orgs/*` (org HTTP handlers)**: `crud.rs` 17% → 66%, `teams.rs` 39% → 75%, `api_keys.rs` 64% → 84%, `budget.rs` 49% → 78%, `audit.rs` 65% → 88% — exercised via `tower::ServiceExt::oneshot` against per-test Postgres pools.

### Test layout

| File | Tests |
|---|---:|
| `crates/gateway/src/providers/{openai,xai,deepseek}.rs` (inline) | 27 |
| `crates/gateway/src/cache.rs` (inline) | 7 |
| `crates/x402/src/spl_transfer.rs` (inline) | 15 |
| `crates/gateway/tests/orgs_queries.rs` | 18 |
| `crates/gateway/tests/usage_integration.rs` | 13 |
| `crates/gateway/tests/usage_redis.rs` | 14 |
| `crates/gateway/tests/orgs_routes.rs` | 19 |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test -p gateway --test orgs_queries` (DATABASE_URL set) — 18/18 ✓
- [x] `cargo test -p gateway --test usage_integration` (DATABASE_URL set) — 13/13 ✓
- [x] `cargo test -p gateway --test usage_redis` (DATABASE_URL set, Redis up) — 14/14 ✓
- [x] `cargo test -p gateway --test orgs_routes` (DATABASE_URL set) — 19/19 ✓
- [x] `cargo test -p gateway --lib -- providers cache` — 43/43 ✓
- [x] `cargo test -p solvela-x402 --lib -- spl_transfer` — 15/15 ✓
- [x] `DATABASE_URL=… cargo llvm-cov --workspace --summary-only` — 80.35% lines / 81.41% funcs / 81.90% regions

### CI requirements for the new integration tests

The four `tests/*.rs` integration files use `#[sqlx::test(migrations = "../../migrations")]`, which needs:

1. `DATABASE_URL` exported (Postgres where the user can `CREATE DATABASE`)
2. `docker compose up -d` (or equivalent) for the `usage_redis` tests to reach Redis on `127.0.0.1:6379`

The pattern matches the existing `tests/migrations.rs` opt-in flow. CI may need a `services:` section if it doesn't already provision Postgres + Redis for tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)