### PR TITLE
fix(x402/escrow): two critical fixes from review (sysvar + provider check)

### DIFF
--- a/crates/x402/src/escrow/claimer.rs
+++ b/crates/x402/src/escrow/claimer.rs
@@ -508,7 +508,11 @@ pub(crate) async fn do_claim(params: &ClaimParams) -> Result<String, Error> {
 // ---------------------------------------------------------------------------
 
 /// SysvarRecentBlockhashes pubkey (used in AdvanceNonceAccount instruction).
-const SYSVAR_RECENT_BLOCKHASHES_ID: &str = "SysvarRecentB1teleworLdhashes11111111111111";
+///
+/// Source of truth: `solana-sdk-ids` crate, `sysvar::recent_blockhashes::ID`.
+/// Must decode to exactly 32 bytes — guarded by
+/// `tests::sysvar_recent_blockhashes_id_decodes_to_32_bytes`.
+const SYSVAR_RECENT_BLOCKHASHES_ID: &str = "SysvarRecentB1ockHashes11111111111111111111";
 
 /// Data needed to build an AdvanceNonceAccount instruction.
 struct NonceAdvanceInfo {
@@ -590,6 +594,24 @@ mod tests {
     use super::*;
     use crate::fee_payer::FeePayerPool;
     use crate::nonce_pool::NoncePool;
+
+    /// Regression guard: `SYSVAR_RECENT_BLOCKHASHES_ID` must decode to a 32-byte
+    /// pubkey. A previous typo silently broke durable-nonce claims because the
+    /// decode failure was swallowed by `try_fetch_nonce`'s fallback path.
+    #[test]
+    fn sysvar_recent_blockhashes_id_decodes_to_32_bytes() {
+        let bytes = bs58::decode(SYSVAR_RECENT_BLOCKHASHES_ID)
+            .into_vec()
+            .expect("SYSVAR_RECENT_BLOCKHASHES_ID must be valid base58");
+        assert_eq!(
+            bytes.len(),
+            32,
+            "SYSVAR_RECENT_BLOCKHASHES_ID must decode to 32 bytes (got {})",
+            bytes.len()
+        );
+        decode_bs58_pubkey(SYSVAR_RECENT_BLOCKHASHES_ID)
+            .expect("SYSVAR_RECENT_BLOCKHASHES_ID must round-trip through decode_bs58_pubkey");
+    }
 
     /// Generate a deterministic valid base58-encoded ed25519 keypair (64 bytes)
     fn test_keypair_b58(seed: u8) -> String {

--- a/crates/x402/src/escrow/verifier.rs
+++ b/crates/x402/src/escrow/verifier.rs
@@ -264,6 +264,21 @@ impl PaymentVerifier for EscrowVerifier {
             ));
         }
 
+        // Position 1: provider (must equal the gateway's recipient_wallet).
+        // The on-chain program stores `escrow.provider = ctx.accounts.provider.key()`,
+        // and `claim` requires `has_one = provider`. If we accept a deposit whose
+        // provider is not us, verification passes but the claim later fails with
+        // ConstraintHasOne — gateway eats the LLM cost with no recoverable revenue.
+        let recipient_bytes = decode_bs58_pubkey(&self.recipient_wallet)
+            .map_err(|e| Error::InvalidTransaction(format!("recipient_wallet config: {e}")))?;
+        let ix_provider = get_key(1)?;
+        if ix_provider != recipient_bytes {
+            return Err(Error::WrongRecipient {
+                expected: self.recipient_wallet.clone(),
+                actual: bs58::encode(&ix_provider).into_string(),
+            });
+        }
+
         // Position 2: mint (must be the configured USDC mint)
         let usdc_mint_bytes = decode_bs58_pubkey(&self.usdc_mint)
             .map_err(|e| Error::InvalidTransaction(format!("usdc_mint config: {e}")))?;
@@ -693,6 +708,74 @@ mod tests {
                 assert_eq!(actual, 1000);
             }
             other => panic!("expected InsufficientPayment, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_escrow_verifier_rejects_wrong_provider() {
+        use crate::escrow::deposit::{build_deposit_tx, DepositParams};
+        use base64::Engine;
+
+        // Tx encodes provider = attacker wallet, but verifier expects gateway wallet.
+        // Without the provider check, this passes verification, the gateway serves
+        // the LLM response, then the on-chain claim fails ConstraintHasOne and the
+        // revenue is unrecoverable. Regression guard for that path.
+        let attacker_provider = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+        let seed = [42u8; 32];
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let verifying_key = signing_key.verifying_key();
+        let mut full = [0u8; 64];
+        full[..32].copy_from_slice(&seed);
+        full[32..].copy_from_slice(verifying_key.as_bytes());
+        let agent_keypair_b58 = bs58::encode(&full).into_string();
+        let agent_pubkey_b58 = bs58::encode(verifying_key.as_bytes()).into_string();
+
+        let service_id = [7u8; 32];
+        let params = DepositParams {
+            agent_keypair_b58,
+            provider_wallet_b58: attacker_provider.to_string(),
+            usdc_mint_b58: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            escrow_program_id_b58: "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string(),
+            amount: 5000,
+            service_id,
+            expiry_slot: 999_999_999,
+            recent_blockhash: [0u8; 32],
+        };
+        let deposit_tx_b64 = build_deposit_tx(&params).expect("tx build");
+        let service_id_b64 = base64::engine::general_purpose::STANDARD.encode(service_id);
+
+        let payload = PaymentPayload {
+            x402_version: 2,
+            resource: Resource {
+                url: "/v1/chat/completions".to_string(),
+                method: "POST".to_string(),
+            },
+            accepted: PaymentAccept {
+                scheme: "escrow".to_string(),
+                network: SOLANA_NETWORK.to_string(),
+                amount: "5000".to_string(),
+                asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                pay_to: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string(),
+                max_timeout_seconds: 300,
+                escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
+            },
+            payload: PayloadData::Escrow(EscrowPayload {
+                deposit_tx: deposit_tx_b64,
+                service_id: service_id_b64,
+                agent_pubkey: agent_pubkey_b58,
+            }),
+        };
+
+        // Verifier configured with the canonical gateway provider — must reject.
+        let result = make_verifier().verify_payment(&payload).await;
+        assert!(result.is_err(), "expected error for wrong provider");
+        match result.unwrap_err() {
+            Error::WrongRecipient { expected, actual } => {
+                assert_eq!(expected, "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+                assert_eq!(actual, attacker_provider);
+            }
+            other => panic!("expected WrongRecipient, got: {other}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Two CRITICAL fixes surfaced during the x402 review pass. Each is a small, isolated commit with a regression test.

### C1 — Corrupted `SysvarRecentBlockhashes` constant (`escrow/claimer.rs`)
The const literal was `"SysvarRecentB1teleworLdhashes11111111111111"` — 43 chars of gibberish containing the typo `"telewor"`. `decode_bs58_pubkey` rejected it, the `Err` was swallowed by `try_fetch_nonce`'s fallback path, and **every claim silently used a recent blockhash instead of the durable nonce**. The `NoncePool` was wired up, costs SOL to fund nonce accounts, and had no effect.

Fix: replace with the canonical value from `solana-sdk-ids` (`sysvar::recent_blockhashes::ID`) and add a unit test asserting the constant decodes to exactly 32 bytes.

### C2 — Verifier didn't check the deposit's `provider` account (`escrow/verifier.rs`)
The Anchor program stores `escrow.provider = ctx.accounts.provider.key()` at deposit and enforces `has_one = provider` on claim. The verifier checked positions 0 (agent), 2 (mint), 3 (escrow PDA), 5 (vault) but **skipped position 1 (provider)**.

An agent could submit a deposit pointing `provider` at any wallet: `verify_payment` returned `Ok`, the gateway served the LLM response and enqueued a claim, then the on-chain claim later failed `ConstraintHasOne` and the upstream LLM cost was unrecoverable. Funds weren't lost (vault stays locked until refund timeout) but revenue was.

Fix: add the missing check ahead of the mint check, returning `Error::WrongRecipient` on mismatch. Negative test builds a deposit with an attacker-controlled provider and asserts the verifier rejects it before any settlement attempt.

## Test plan

- [x] `cargo test -p solvela-x402` — 124 passed (was 122; +1 for C1, +1 for C2)
- [x] `cargo clippy -p solvela-x402 --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -p solvela-x402 -- --check` — clean
- [x] `cargo check --workspace --all-targets` — clean
- [ ] Solvela-bot review (auto)
- [ ] CI green

## Notes

- Existing positive tests still pass because `make_verifier()` and `build_test_tx` happened to use matching provider/recipient values.
- No public API change; `EscrowVerifier::verify_payment` adds one more rejection case using the existing `Error::WrongRecipient` variant.
- `SYSVAR_RECENT_BLOCKHASHES_ID` is module-private; no external surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)