### PR TITLE
fix(escrow): atomic claim queue with FOR UPDATE SKIP LOCKED (H1/H2/M6)

### DIFF
--- a/crates/gateway/tests/escrow_queue.rs
+++ b/crates/gateway/tests/escrow_queue.rs
@@ -230,8 +230,11 @@ async fn fetch_pending_claims_returns_pending_rows_in_creation_order(pool: PgPoo
     assert_eq!(claim_a.agent_pubkey, AGENT_A);
     assert_eq!(claim_a.claim_amount, 100);
     assert_eq!(claim_a.deposited_amount, None);
-    assert_eq!(claim_a.status, ClaimStatus::Pending);
-    assert_eq!(claim_a.attempts, 0);
+    // fetch_pending_claims atomically marks rows in_progress and increments
+    // attempts (FOR UPDATE SKIP LOCKED), so post-fetch status is InProgress
+    // and attempts is 1, not the pre-fetch (Pending, 0) values.
+    assert_eq!(claim_a.status, ClaimStatus::InProgress);
+    assert_eq!(claim_a.attempts, 1);
     assert_eq!(&claim_a.service_id[..], &SERVICE_ID_A[..]);
 
     let claim_b = &claims[1];
@@ -271,6 +274,50 @@ async fn fetch_pending_claims_skips_completed_and_failed(pool: PgPool) {
         .expect("fetch_pending_claims");
     assert_eq!(claims.len(), 1, "completed claim must be excluded");
     assert_eq!(claims[0].id, id_pending);
+}
+
+/// Regression: two concurrent `fetch_pending_claims` calls must each return a
+/// disjoint subset of rows (no duplicates), via PostgreSQL row-level
+/// `FOR UPDATE SKIP LOCKED`. Without that lock, both calls would observe the
+/// same rows and the second worker would re-run a claim the first is
+/// already processing, double-submitting on-chain.
+#[sqlx::test(migrations = "../../migrations")]
+async fn fetch_pending_claims_skip_locked_avoids_double_claim(pool: PgPool) {
+    // Enqueue 4 distinct rows.
+    let mut ids = Vec::with_capacity(4);
+    for n in 0..4u8 {
+        let mut sid = [0u8; 32];
+        sid[0] = n + 1;
+        let id = enqueue_claim(&pool, &sid, AGENT_A, 100, None)
+            .await
+            .expect("enqueue");
+        ids.push(id);
+    }
+
+    // Two concurrent fetchers, each asking for up to 4 rows.
+    let p1 = pool.clone();
+    let p2 = pool.clone();
+    let (a, b) = tokio::join!(
+        async move { fetch_pending_claims(&p1, 4).await.expect("fetch 1") },
+        async move { fetch_pending_claims(&p2, 4).await.expect("fetch 2") },
+    );
+
+    // Combined, the two fetches should cover all 4 rows with no overlap.
+    let total = a.len() + b.len();
+    assert_eq!(
+        total, 4,
+        "all 4 rows should be claimed exactly once across the two fetches"
+    );
+
+    let mut seen = std::collections::HashSet::new();
+    for c in a.iter().chain(b.iter()) {
+        assert!(
+            seen.insert(c.id.clone()),
+            "row {} returned twice — SKIP LOCKED is not preventing double-claim",
+            c.id
+        );
+    }
+    assert_eq!(seen.len(), 4, "every enqueued row must appear exactly once");
 }
 
 #[sqlx::test(migrations = "../../migrations")]

--- a/crates/x402/src/escrow/claim_processor.rs
+++ b/crates/x402/src/escrow/claim_processor.rs
@@ -284,8 +284,14 @@ async fn process_pending_claims(
     }
 
     for entry in &pending {
-        // Skip claims that have exceeded max attempts (mark as failed)
-        if entry.attempts >= MAX_CLAIM_ATTEMPTS {
+        // Skip claims that have exceeded max attempts (mark as failed).
+        // `entry.attempts` is post-increment from `fetch_pending_claims`, so
+        // `> MAX_CLAIM_ATTEMPTS` here preserves the "up to MAX attempts"
+        // semantic — the MAX-th attempt is still made on the claim path
+        // below, after which `mark_attempt_failed` flips status to 'failed'.
+        // Rows can only land here with `attempts > MAX` via stale recovery
+        // of an `in_progress` row that crashed mid-attempt.
+        if entry.attempts > MAX_CLAIM_ATTEMPTS {
             let error_msg = format!("exceeded maximum retry attempts ({MAX_CLAIM_ATTEMPTS})");
             warn!(
                 claim_id = %entry.id,
@@ -310,15 +316,9 @@ async fn process_pending_claims(
             continue;
         }
 
-        // Mark in-progress before attempting
-        if let Err(e) = claim_queue::mark_in_progress(pool, &entry.id).await {
-            warn!(
-                claim_id = %entry.id,
-                error = %e,
-                "failed to mark claim in_progress, skipping"
-            );
-            continue;
-        }
+        // Note: `fetch_pending_claims` already marked this row in_progress and
+        // incremented `attempts` atomically, so `entry.attempts` is the
+        // post-increment value (no separate `mark_in_progress` call needed).
 
         // Decode agent pubkey from base58
         let agent_bytes = match decode_bs58_pubkey(&entry.agent_pubkey) {
@@ -326,13 +326,17 @@ async fn process_pending_claims(
             Err(e) => {
                 let error_msg = format!("invalid agent pubkey: {e}");
                 warn!(claim_id = %entry.id, error = %error_msg, "skipping claim");
-                let _ = claim_queue::mark_attempt_failed(
-                    pool,
-                    &entry.id,
-                    &error_msg,
-                    entry.attempts + 1,
-                )
-                .await;
+                if let Err(db_err) =
+                    claim_queue::mark_attempt_failed(pool, &entry.id, &error_msg, entry.attempts)
+                        .await
+                {
+                    warn!(
+                        claim_id = %entry.id,
+                        error = %db_err,
+                        "failed to record bs58-invalid claim failure — \
+                         row may stay in_progress until 5-minute stale recovery"
+                    );
+                }
                 circuit_breaker.record_failure();
                 counter!("solvela_escrow_claims_total", "result" => "failure").increment(1);
                 if let Some(m) = metrics {
@@ -370,17 +374,13 @@ async fn process_pending_claims(
                 warn!(
                     claim_id = %entry.id,
                     error = %error_msg,
-                    attempt = entry.attempts + 1,
+                    attempt = entry.attempts,
                     max_attempts = MAX_CLAIM_ATTEMPTS,
                     "escrow claim attempt failed"
                 );
-                if let Err(db_err) = claim_queue::mark_attempt_failed(
-                    pool,
-                    &entry.id,
-                    &error_msg,
-                    entry.attempts + 1,
-                )
-                .await
+                if let Err(db_err) =
+                    claim_queue::mark_attempt_failed(pool, &entry.id, &error_msg, entry.attempts)
+                        .await
                 {
                     warn!(
                         claim_id = %entry.id,
@@ -392,8 +392,8 @@ async fn process_pending_claims(
                 counter!("solvela_escrow_claims_total", "result" => "failure").increment(1);
                 if let Some(m) = metrics {
                     // If this claim has exceeded max attempts, count as permanently failed.
-                    // Otherwise, it's a retry.
-                    if entry.attempts + 1 >= MAX_CLAIM_ATTEMPTS {
+                    // Otherwise, it's a retry. `entry.attempts` is post-increment.
+                    if entry.attempts >= MAX_CLAIM_ATTEMPTS {
                         m.claims_failed.fetch_add(1, Ordering::Relaxed);
                     } else {
                         m.claims_retried.fetch_add(1, Ordering::Relaxed);
@@ -689,8 +689,9 @@ mod tests {
             .await
             .expect("enqueue");
         // Force attempts = MAX while keeping status='pending' so fetch_pending_claims
-        // picks the row up. (mark_in_progress would flip status to 'in_progress' and
-        // the recent updated_at would exclude it from the next poll.)
+        // picks the row up. fetch atomically increments attempts to MAX+1 and marks
+        // it in_progress, then the entry-guard (`attempts > MAX`) fires and the row
+        // is marked permanently failed.
         sqlx::query("UPDATE escrow_claim_queue SET attempts = $1 WHERE id = $2::uuid")
             .bind(MAX_CLAIM_ATTEMPTS)
             .bind(&id)
@@ -738,10 +739,10 @@ mod tests {
         .await
         .expect("read");
 
-        // After mark_in_progress(+1) + mark_attempt_failed(invalid bs58),
+        // After fetch_pending_claims (atomic +1) + mark_attempt_failed(invalid bs58),
         // status returns to pending (under MAX) and error_message is set.
         assert_eq!(status, "pending");
-        assert_eq!(attempts, 1, "mark_in_progress must have incremented");
+        assert_eq!(attempts, 1, "fetch_pending_claims must have incremented");
         let msg = error_message.expect("error_message must be set");
         assert!(msg.contains("invalid agent pubkey"), "msg: {msg}");
 
@@ -774,7 +775,7 @@ mod tests {
         .await
         .expect("read");
 
-        // mark_in_progress (+1) → submission Err → mark_attempt_failed → pending again.
+        // fetch_pending_claims (atomic +1) → submission Err → mark_attempt_failed → pending again.
         assert_eq!(status, "pending");
         assert_eq!(attempts, 1);
         let msg = error_message.expect("error_message must be set");
@@ -794,15 +795,17 @@ mod tests {
     async fn process_pending_claims_counts_failure_when_attempts_at_max_after_increment(
         pool: PgPool,
     ) {
-        // After mark_in_progress, attempts becomes MAX_CLAIM_ATTEMPTS exactly.
-        // The submission errors, mark_attempt_failed marks the row failed,
+        // After fetch_pending_claims's atomic +1, attempts becomes MAX_CLAIM_ATTEMPTS
+        // exactly. The submission errors, mark_attempt_failed marks the row failed,
         // and metrics must increment claims_failed (not claims_retried).
         let id = claim_queue::enqueue_claim(&pool, &[1u8; 32], VALID_AGENT_B58, 1_000, None)
             .await
             .expect("enqueue");
-        // Force attempts = MAX-1 while keeping status='pending' so the row passes
-        // the entry guard (entry.attempts < MAX_CLAIM_ATTEMPTS) and the
-        // post-increment value (entry.attempts + 1) hits MAX exactly.
+        // Force attempts = MAX-1 while keeping status='pending'. fetch_pending_claims
+        // atomically increments to MAX, the entry guard (`attempts > MAX`) misses,
+        // the claim is attempted, and on Err the row hits MAX exactly so
+        // mark_attempt_failed flips status to 'failed' and metric routing
+        // (`attempts >= MAX`) counts it as a permanent failure.
         sqlx::query("UPDATE escrow_claim_queue SET attempts = $1 WHERE id = $2::uuid")
             .bind(MAX_CLAIM_ATTEMPTS - 1)
             .bind(&id)

--- a/crates/x402/src/escrow/claim_queue.rs
+++ b/crates/x402/src/escrow/claim_queue.rs
@@ -95,6 +95,14 @@ pub async fn enqueue_claim(
 
 /// Mark a claim as in-progress (being submitted). Increments the attempt
 /// counter and records the timestamp.
+///
+/// As of the H1 fix, the main processor loop no longer calls this — rows
+/// are atomically claimed by `fetch_pending_claims`. Kept public for tests
+/// and any explicit-transition needs.
+///
+/// Relies on the `trg_escrow_claim_queue_updated_at` trigger (migration 008)
+/// to maintain `updated_at`; the stale-`in_progress` recovery in
+/// `fetch_pending_claims` depends on that trigger being present.
 pub async fn mark_in_progress(pool: &sqlx::PgPool, id: &str) -> Result<(), sqlx::Error> {
     sqlx::query(
         "UPDATE escrow_claim_queue
@@ -108,6 +116,9 @@ pub async fn mark_in_progress(pool: &sqlx::PgPool, id: &str) -> Result<(), sqlx:
 }
 
 /// Mark a claim as completed with the on-chain transaction signature.
+///
+/// `updated_at` is maintained by the `trg_escrow_claim_queue_updated_at`
+/// trigger (migration 008), not by this query.
 pub async fn mark_completed(
     pool: &sqlx::PgPool,
     id: &str,
@@ -160,10 +171,19 @@ pub async fn mark_attempt_failed(
     Ok(())
 }
 
-/// Fetch pending claims ordered by creation time (oldest first).
+/// Atomically claim and mark up to `limit` pending rows as `in_progress`.
 ///
-/// Also recovers stale `in_progress` claims that have been stuck for more
-/// than 5 minutes (likely abandoned due to a crash or SIGTERM).
+/// Uses `FOR UPDATE SKIP LOCKED` so concurrent workers (multiple gateway
+/// instances, or a crash-restart racing the previous loop) cannot pick up
+/// the same row. Also recovers stale `in_progress` rows that have been
+/// stuck for more than 5 minutes (abandoned by a crash or SIGTERM); the
+/// 5-minute boundary uses `updated_at`, maintained by the
+/// `trg_escrow_claim_queue_updated_at` trigger from migration 008.
+///
+/// Returned rows are already marked `in_progress` with `attempts`
+/// post-incremented — callers must NOT call `mark_in_progress` again on
+/// them. Treat `entry.attempts` as the post-increment value when deciding
+/// retry vs permanent-failure routing.
 pub async fn fetch_pending_claims(
     pool: &sqlx::PgPool,
     limit: i64,
@@ -182,13 +202,23 @@ pub async fn fetch_pending_claims(
             Option<String>,
         ),
     >(
-        "SELECT id::text, service_id, agent_pubkey, claim_amount, deposited_amount,
-                status, attempts, tx_signature, error_message
-         FROM escrow_claim_queue
-         WHERE (status = 'pending' AND (next_retry_at IS NULL OR next_retry_at <= NOW()))
-            OR (status = 'in_progress' AND updated_at < NOW() - INTERVAL '5 minutes')
-         ORDER BY created_at ASC
-         LIMIT $1",
+        "WITH locked AS (
+             SELECT id
+             FROM escrow_claim_queue
+             WHERE (status = 'pending' AND (next_retry_at IS NULL OR next_retry_at <= NOW()))
+                OR (status = 'in_progress' AND updated_at < NOW() - INTERVAL '5 minutes')
+             ORDER BY created_at ASC
+             LIMIT $1
+             FOR UPDATE SKIP LOCKED
+         )
+         UPDATE escrow_claim_queue q
+         SET status = 'in_progress',
+             attempts = q.attempts + 1,
+             last_attempt_at = NOW()
+         FROM locked
+         WHERE q.id = locked.id
+         RETURNING q.id::text, q.service_id, q.agent_pubkey, q.claim_amount, q.deposited_amount,
+                   q.status, q.attempts, q.tx_signature, q.error_message",
     )
     .bind(limit)
     .fetch_all(pool)


### PR DESCRIPTION
## Summary

Three related fixes from the x402 review (PR-A in the follow-up batch). All concentrated in the escrow claim queue path. Independent of #182 — no file overlap.

### H1 — `FOR UPDATE SKIP LOCKED` (real, not cosmetic)
Previously `fetch_pending_claims` was a plain SELECT. The row-level lock was effectively never held across the `mark_in_progress` UPDATE, so two concurrent workers (multi-instance, rolling deploy, crash + restart) could fetch and process the same row and double-submit on-chain.

Refactored to a single CTE + UPDATE RETURNING statement that locks rows with `FOR UPDATE SKIP LOCKED`, marks them `in_progress`, and returns them — atomic in one round-trip. The processor's separate `mark_in_progress` call is removed (rows arrive already marked); `entry.attempts` is now post-increment, so the entry guard relaxes from `>= MAX` to `> MAX` to preserve the "up to MAX attempts" semantic.

`mark_in_progress` is kept public for tests and explicit-transition needs.

### H2 — `let _ = mark_attempt_failed(...)` swallowed rollback errors
The bs58-invalid arm already marked the row in_progress (pre-H1) or fetch had done so (post-H1). If the rollback `mark_attempt_failed` call then failed, the row was silently stuck in_progress until the 5-minute stale-recovery sweep, with no log line to point at the cause. Replaced with `if let Err(db_err) = ... { warn!(...) }` matching the pattern used in the claim-error arm.

### M6 — Document the `updated_at` trigger coupling
`mark_in_progress`, `mark_completed`, and `fetch_pending_claims`'s stale-recovery branch all rely on `trg_escrow_claim_queue_updated_at` (migration 008) to maintain `updated_at`. A future migration that drops the trigger would silently break stale recovery. Doc comments now name the trigger so the coupling is grep-able.

## Behavior change to be aware of

After this PR, `fetch_pending_claims` returns rows already marked `in_progress` with `attempts` post-incremented. Two integration tests were updated:

- `fetch_pending_claims_returns_pending_rows_in_creation_order` now asserts `status=InProgress, attempts=1` (was `Pending, 0`).
- New: `fetch_pending_claims_skip_locked_avoids_double_claim` runs two concurrent fetchers against 4 rows and asserts disjoint coverage with no duplicates.

## Test plan

- [x] `cargo test --workspace --all-features` (DATABASE_URL set): 1043+ tests pass, 1 ignored, 0 failed.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] New SKIP LOCKED regression test passes (proves no double-claim under two concurrent fetchers).
- [ ] CI green
- [ ] Solvela-bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)