### PR TITLE
fix(claimer): tighten 0x1 InsufficientFunds match to whole hex tokens (M1)

### DIFF
--- a/crates/x402/src/escrow/claimer.rs
+++ b/crates/x402/src/escrow/claimer.rs
@@ -202,7 +202,27 @@ fn is_insufficient_sol_error(error: &Error) -> bool {
     msg.contains("insufficient lamports")
         || msg.contains("insufficient funds")
         || msg.contains("insufficient sol")
-        || msg.contains("0x1") // InsufficientFunds error code
+        || contains_hex_code(&msg, "0x1") // InsufficientFunds program error code
+}
+
+/// Check whether `msg` contains the hex code `code` as a whole token —
+/// i.e. not followed by another hex digit. Prevents false positives where
+/// `"0x1"` would otherwise match `"0x10"`, `"0x100"`, `"0x1f"`, etc.
+fn contains_hex_code(msg: &str, code: &str) -> bool {
+    let mut search_from = 0;
+    while let Some(rel) = msg[search_from..].find(code) {
+        let abs = search_from + rel;
+        let end = abs + code.len();
+        let next_is_hex = msg[end..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_hexdigit());
+        if !next_is_hex {
+            return true;
+        }
+        search_from = end;
+    }
+    false
 }
 
 /// Submit a claim and return the transaction signature.
@@ -749,6 +769,38 @@ mod tests {
             "Transaction simulation failed".to_string()
         )));
         assert!(!is_insufficient_sol_error(&Error::Rpc("0x2".to_string())));
+    }
+
+    /// Regression: bare substring match on `"0x1"` previously misclassified
+    /// any longer hex code starting with that prefix as InsufficientFunds,
+    /// which would have spuriously drained the fee-payer pool when a
+    /// program returned an unrelated error like `0x10` or `0x1f`.
+    #[test]
+    fn is_insufficient_sol_error_does_not_match_longer_hex_codes() {
+        for code in ["0x10", "0x11", "0x1a", "0x1f", "0x100", "0x1000"] {
+            assert!(
+                !is_insufficient_sol_error(&Error::Rpc(format!("Custom: {code}"))),
+                "code {code} must NOT trigger InsufficientFunds match"
+            );
+        }
+    }
+
+    /// And the genuine `0x1` matches in its various surrounding contexts.
+    #[test]
+    fn is_insufficient_sol_error_still_matches_real_0x1_payloads() {
+        let payloads = [
+            "Custom: 0x1",
+            "Custom: 0x1)",
+            "custom program error: 0x1",
+            "Error processing Instruction 0: custom program error: 0x1",
+            "0x1, somewhere",
+        ];
+        for p in payloads {
+            assert!(
+                is_insufficient_sol_error(&Error::Rpc(p.to_string())),
+                "payload {p:?} must trigger InsufficientFunds match"
+            );
+        }
     }
 
     /// claim_async with a fee-payer pool that has been drained (all wallets


### PR DESCRIPTION
## Summary

PR-C in the x402 follow-up batch. Single-file change, independent of #182/#183/#184.

### M1 — `0x1` substring match was too loose
`is_insufficient_sol_error` previously did `msg.contains("0x1")` to detect Solana's InsufficientFunds program error code. Any longer hex starting with `0x1` (e.g. `0x10`, `0x1a`, `0x1f`, `0x100`) also matched, **falsely classifying unrelated program errors as fee-payer-out-of-SOL**. The caller responds by marking the fee payer unhealthy and starting its cooldown, so repeated false positives across program errors with hex codes like 0x10/0x11/0x1a would silently drain the pool.

**Fix:** small `contains_hex_code` helper that asserts the matched token isn't followed by another hex digit, then call it from the `0x1` arm. Word-boundary at the front isn't needed because `0x1` only appears as a hex literal in Solana error renderings.

## Tests added

- `is_insufficient_sol_error_does_not_match_longer_hex_codes` — asserts `0x10`/`0x11`/`0x1a`/`0x1f`/`0x100`/`0x1000` do NOT match.
- `is_insufficient_sol_error_still_matches_real_0x1_payloads` — asserts documented Solana error renderings still match: `Custom: 0x1`, `Custom: 0x1)`, `custom program error: 0x1`, `Error processing Instruction 0: custom program error: 0x1`.

## Note on M3 (deferred)

M3 (claim transaction's `num_readonly_unsigned` and account layout) was originally planned for this PR. On closer look, the proper fix needs an account reorder to match the on-chain wire format `deposit.rs` already uses (writable non-signers first, then readonly tail). That changes the on-chain transaction's wire format, and the existing test suite doesn't simulate-and-validate the message header against the runtime's classification rules. Splitting M3 into its own PR with a manual on-chain validation step is safer than bundling here.

## Test plan

- [x] `cargo test -p solvela-x402 is_insufficient_sol_error`: 6/6 pass (including 2 new regression tests).
- [x] `cargo test --workspace --all-features` (DATABASE_URL set): 1045+ pass, 0 failed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [ ] CI green
- [ ] Solvela-bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)