### PR TITLE
fix(solana): delegate confirmation to shared helper, drop processed status (M7)

### DIFF
--- a/crates/x402/src/solana.rs
+++ b/crates/x402/src/solana.rs
@@ -222,55 +222,6 @@ impl SolanaVerifier {
             })
     }
 
-    /// Poll for transaction confirmation with a timeout and exponential backoff.
-    ///
-    /// Starts polling at 500ms intervals, doubling up to a 4s cap. The overall
-    /// timeout (default 30s) is unchanged — only the inter-poll interval grows.
-    async fn confirm_transaction(&self, signature: &str, timeout_secs: u64) -> Result<(), Error> {
-        let start = std::time::Instant::now();
-        let timeout = std::time::Duration::from_secs(timeout_secs);
-        let mut interval = std::time::Duration::from_millis(500);
-        let max_interval = std::time::Duration::from_secs(4);
-
-        loop {
-            if start.elapsed() > timeout {
-                return Err(Error::Timeout);
-            }
-
-            let result = self
-                .rpc_request("getSignatureStatuses", serde_json::json!([[signature]]))
-                .await?;
-
-            if let Some(value) = result.get("result").and_then(|r| r.get("value")) {
-                if let Some(status) = value.as_array().and_then(|arr| arr.first()) {
-                    if !status.is_null() {
-                        // Check for transaction error
-                        if let Some(err) = status.get("err") {
-                            if !err.is_null() {
-                                return Err(Error::SettlementFailed(format!(
-                                    "transaction failed: {err}"
-                                )));
-                            }
-                        }
-
-                        // Check confirmation status
-                        if let Some(confirmation) =
-                            status.get("confirmationStatus").and_then(|s| s.as_str())
-                        {
-                            if confirmation == "confirmed" || confirmation == "finalized" {
-                                info!(signature, status = confirmation, "transaction confirmed");
-                                return Ok(());
-                            }
-                        }
-                    }
-                }
-            }
-
-            tokio::time::sleep(interval).await;
-            interval = (interval * 2).min(max_interval);
-        }
-    }
-
     /// Send a JSON-RPC request to the Solana cluster.
     async fn rpc_request(
         &self,
@@ -490,8 +441,19 @@ impl PaymentVerifier for SolanaVerifier {
 
         info!(signature = %signature, "transaction sent, waiting for confirmation");
 
-        // Wait for confirmation (30 second timeout)
-        match self.confirm_transaction(&signature, 30).await {
+        // Wait for confirmation (30 second timeout). Delegates to the shared
+        // `solana_rpc::poll_for_confirmation` so SolanaVerifier and
+        // EscrowVerifier converge on identical confirmation semantics
+        // (`confirmed`/`finalized` only — `processed` is not durable enough
+        // for payment settlement).
+        match crate::solana_rpc::poll_for_confirmation(
+            &self.http_client,
+            &self.rpc_url,
+            &signature,
+            std::time::Duration::from_secs(30),
+        )
+        .await
+        {
             Ok(()) => {
                 info!(signature = %signature, "settlement confirmed");
                 Ok(SettlementResult {

--- a/crates/x402/src/solana_rpc.rs
+++ b/crates/x402/src/solana_rpc.rs
@@ -73,17 +73,24 @@ pub fn is_already_processed_error(err: &Error) -> bool {
         || s.contains("-32002")
 }
 
-/// Poll `getSignatureStatuses` until the transaction reaches `processed`,
-/// `confirmed`, or `finalized` status, or until the budget expires.
+/// Poll `getSignatureStatuses` until the transaction reaches `confirmed` or
+/// `finalized` status, or until the budget expires.
 ///
-/// Uses exponential backoff (500ms → 4s cap) matching `SolanaVerifier`'s
-/// existing pattern. Treats transient RPC errors as retryable (does NOT abort
-/// the polling loop on network blips).
+/// `processed` is intentionally NOT accepted: it means the tx has been
+/// observed by a single validator but is not yet in a quorum-voted bank
+/// and can still be rolled back. Accepting `processed` for payment
+/// settlement risks returning success to the gateway before the on-chain
+/// transfer is durable. `confirmed` (2/3 stake voted) is the minimum that
+/// won't roll back under normal cluster operation.
+///
+/// Uses exponential backoff (500ms → 4s cap). Treats transient RPC errors
+/// as retryable (does NOT abort the polling loop on network blips).
 ///
 /// Returns:
-/// - `Ok(())` if confirmed/processed/finalized
+/// - `Ok(())` if confirmed/finalized
 /// - `Err(Error::SettlementFailed)` if the tx landed with an error
-/// - `Err(Error::SettlementFailed("timeout"))` if not confirmed within budget
+/// - `Err(Error::SettlementFailed("not confirmed within ..."))` if not
+///   confirmed within budget
 pub async fn poll_for_confirmation(
     client: &Client,
     rpc_url: &str,
@@ -164,7 +171,7 @@ pub async fn poll_for_confirmation(
 
         if let Some(confirmation) = status.get("confirmationStatus").and_then(|s| s.as_str()) {
             match confirmation {
-                "processed" | "confirmed" | "finalized" => {
+                "confirmed" | "finalized" => {
                     info!(
                         signature = signature_b58,
                         status = confirmation,
@@ -172,6 +179,10 @@ pub async fn poll_for_confirmation(
                         "transaction confirmed"
                     );
                     return Ok(());
+                }
+                "processed" => {
+                    // Tx is in a leader's bank but not yet quorum-voted —
+                    // keep polling until it reaches `confirmed`.
                 }
                 other => {
                     warn!(


### PR DESCRIPTION
## Summary

PR-D in the x402 follow-up batch. Behavior change worth flagging — read the "Behavioral changes" section before approving.

### M7 — Two confirmation loops disagreed on `processed`
`SolanaVerifier::confirm_transaction` and `solana_rpc::poll_for_confirmation` were near-duplicate confirmation polling loops. The shared helper accepted `processed` as final; the in-line verifier did not. Two payment paths (`SolanaVerifier::settle_payment` and `EscrowVerifier::settle_payment`) thus had subtly different durability guarantees.

### Resolution: converge at the stricter standard
1. **Drop `processed` from the shared helper.** `processed` means a single validator has observed the tx but it isn't in a quorum-voted bank — still rollback-eligible. Only `confirmed` (≥2/3 stake voted) and `finalized` are durable enough to claim payment success.
2. **Delete `SolanaVerifier::confirm_transaction`** and have `settle_payment` delegate to the shared helper. Eliminates the duplication.

## Behavioral changes (please review)

- **EscrowVerifier deposit confirmation** previously could return `Ok` at `processed` (~1–3s). Now waits for `confirmed` (~10–15s typical). Small latency increase in exchange for stronger durability — accepting `processed` for payment was a correctness hole, not an intentional optimization.
- **SolanaVerifier settlement** now retries transient RPC errors (network blips, intermittent JSON parse failures) instead of aborting on the first error. Strict improvement for reliability.
- **Timeout error type** changes from `Error::Timeout` to `Error::SettlementFailed("not confirmed within …")`. No callers pattern-match `Error::Timeout` (verified by grep before changing).

## Deferred from this PR

**M2** (`Ok(SettlementResult { success: false })` → `Err`) is intentionally NOT in this PR. The contract change requires updating 4 caller sites in the gateway (chat/mod.rs, proxy.rs, a2a/handler.rs, integration test) and warrants its own scoped review.

## Test plan

- [x] `cargo test --workspace --all-features` (DATABASE_URL set): 1043+ pass, 0 failed.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [ ] Latency regression on devnet/staging — small but real. Worth a quick smoke test before prod merge.
- [ ] CI green
- [ ] Solvela-bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)