### PR TITLE
chore(audit): suppress unreachable RUSTSEC-2023-0071 (rsa via sqlx-mysql) (M4)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,29 @@
+# cargo-audit configuration
+# https://docs.rs/cargo-audit/latest/cargo_audit/
+
+[advisories]
+# Ignore advisories that are known to be unreachable in our build.
+# Each entry MUST include a notes block in this file's comments
+# explaining why the advisory does not affect us, and how to verify
+# the unreachability claim.
+ignore = [
+    # RUSTSEC-2023-0071 — Marvin Attack timing sidechannel in `rsa 0.9.x`.
+    #
+    # Path: rsa <- sqlx-mysql <- sqlx-macros-core <- sqlx-macros <- sqlx
+    #
+    # We use sqlx with `default-features = false, features = ["postgres", ...]`
+    # (see workspace Cargo.toml). `sqlx-macros-core 0.8.6` declares
+    # `sqlx-mysql` as an OPTIONAL dependency (gated behind the `mysql`
+    # feature, which we do not enable). cargo-audit reads `Cargo.lock`
+    # without applying feature gates, so it reports `sqlx-mysql` (and
+    # transitively `rsa`) as present even though they are never compiled.
+    #
+    # Verify: `find target/{debug,release}/deps -name '*sqlx_mysql*'` is
+    # empty in any of our builds. No `rsa` symbol appears in the gateway
+    # binary.
+    #
+    # If sqlx upstream stops listing `sqlx-mysql` unconditionally in
+    # `sqlx-macros-core`'s deps block (or releases an `rsa` upgrade),
+    # remove this ignore.
+    "RUSTSEC-2023-0071",
+]


### PR DESCRIPTION
## Summary

PR-F (final in the x402 follow-up batch). Documentation + cargo-audit config only — no code changes.

### M4 — Unreachable RUSTSEC-2023-0071 was noisy in CI

`cargo audit` flags RUSTSEC-2023-0071 (rsa 0.9.x Marvin Attack timing sidechannel, CVSS 5.9) reachable through:

```
rsa <- sqlx-mysql <- sqlx-macros-core <- sqlx-macros <- sqlx
```

The workspace builds sqlx with `default-features = false, features = ["postgres", ...]`. The `mysql` feature is **not** enabled, so `sqlx-mysql` (and transitively `rsa`) are never compiled. Verified by:

```bash
find target/debug/deps target/release/deps -name '*sqlx_mysql*' 2>/dev/null
# (empty)
```

cargo-audit flags it anyway because `sqlx-macros-core 0.8.6` declares `sqlx-mysql` as an OPTIONAL dep, and cargo-audit reads `Cargo.lock` without applying feature gates (known cargo-audit limitation, issue #563). No `rsa` upgrade is available and no upstream sqlx fix yet — `.cargo/audit.toml` ignore is the canonical workaround.

### What this PR does

Creates `.cargo/audit.toml` with one ignore entry for RUSTSEC-2023-0071, **with a 14-line comment block recording**:
- The exact dependency path
- Why the advisory does not affect us (feature gating)
- How to verify the unreachability claim (find deps + binary check)
- When to remove the ignore (sqlx upstream fix or rsa upgrade)

The comment is the load-bearing part. Adding ignores without documented reasons is what makes ignore-lists rot. Future contributors should be able to grep this file, see the verification recipe, and decide whether the ignore is still load-bearing.

## Note on the 8 Dependabot vulns flagged on push

These are reported by GitHub Dependabot on `main` independently of `cargo audit`. They probably overlap with this rsa entry (the moderate ones likely) — separate cleanup pass would be a worthwhile follow-up.

## Test plan

- [x] `cargo audit`: exit 0, no vulnerabilities reported (was: 1 vulnerability found).
- [x] `cargo build`: unchanged (no compile-time impact).
- [x] `cargo test --workspace --all-features`: unchanged.
- [ ] CI green
- [ ] Solvela-bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)