### PR TITLE
fix(gateway): SSRF cluster — close 4 paths around the proxy + service marketplace

### DIFF
--- a/crates/gateway/src/providers/google.rs
+++ b/crates/gateway/src/providers/google.rs
@@ -93,6 +93,28 @@ struct GeminiUsageMetadata {
 // Format translation
 // ---------------------------------------------------------------------------
 
+/// Validate that a Gemini model name is safe to interpolate into the
+/// generative-language API URL.
+///
+/// The handler builds
+/// `https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`
+/// — without this guard, an attacker-controlled `req.model` containing `/`,
+/// `?`, `#`, or `:` would manipulate the request path, query, or action verb.
+/// Gemini model IDs in practice are ASCII alphanumerics plus `-`, `.`, `_`
+/// (e.g. `gemini-2.5-flash`, `gemini-1.5-pro-002`).
+fn validate_gemini_model_name(model: &str) -> Result<(), String> {
+    if model.is_empty() {
+        return Err("google model name must not be empty".to_string());
+    }
+    if !model
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_')
+    {
+        return Err(format!("invalid google model id: {model:?}"));
+    }
+    Ok(())
+}
+
 fn to_gemini_request(req: &ChatRequest) -> GeminiRequest {
     // Extract system instruction
     let system_instruction: Option<GeminiContent> = {
@@ -246,6 +268,11 @@ impl LLMProvider for GoogleProvider {
         // Extract Gemini model name (e.g., "google/gemini-2.5-flash" → "gemini-2.5-flash")
         let model_name = req.model.strip_prefix("google/").unwrap_or(&req.model);
 
+        // Allowlist the model-name characters before URL interpolation —
+        // see `validate_gemini_model_name` for rationale.
+        validate_gemini_model_name(model_name)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
+
         // API key sent as a header (not a URL query param) to prevent key leakage
         // in server logs, proxy logs, and browser history.
         let url = format!(
@@ -398,5 +425,45 @@ mod tests {
         assert_eq!(chat_resp.choices[0].message.content, "Hi there!");
         assert_eq!(chat_resp.choices[0].finish_reason, Some("stop".to_string()));
         assert_eq!(chat_resp.usage.as_ref().unwrap().total_tokens, 8);
+    }
+
+    // ---------------------------------------------------------------------
+    // validate_gemini_model_name (URL-injection allowlist)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn validate_gemini_model_name_accepts_real_model_ids() {
+        for ok in [
+            "gemini-2.5-flash",
+            "gemini-1.5-pro-002",
+            "gemini-2.0-flash-exp",
+            "gemini_pro_v1",
+            "AcceptedAlnum123",
+        ] {
+            assert!(
+                validate_gemini_model_name(ok).is_ok(),
+                "model id {ok:?} must validate"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_gemini_model_name_rejects_url_injection() {
+        // Each of these would otherwise alter the request URL.
+        for bad in [
+            "",
+            "gemini/../../../etc/passwd",
+            "gemini-2.5-flash:streamGenerateContent",
+            "gemini-2.5-flash?api_key=stolen",
+            "gemini-2.5-flash#fragment",
+            "gemini 2.5 flash",
+            "gemini\nflash",
+            "../../models/private",
+        ] {
+            assert!(
+                validate_gemini_model_name(bad).is_err(),
+                "model id {bad:?} must be rejected"
+            );
+        }
     }
 }

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -468,8 +468,15 @@ pub async fn proxy_service(
 
     // Build a per-request client that pins the validated DNS resolution,
     // preventing DNS rebinding between the SSRF check and the connection.
+    //
+    // `redirect::Policy::none()` is critical: reqwest's default policy follows
+    // up to 10 redirects, each with a fresh DNS lookup that bypasses the
+    // `.resolve()` pin AND `resolve_and_validate_endpoint`. Without this,
+    // a `302 Location: http://169.254.169.254/...` from a registered upstream
+    // would land us inside cloud metadata or other internal infrastructure.
     let pinned_client = reqwest::Client::builder()
         .resolve(&validated_host, validated_addr)
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| GatewayError::Internal(format!("HTTP client error: {e}")))?;
 
@@ -977,11 +984,18 @@ mod tests {
         use solvela_x402::facilitator::Facilitator;
 
         let mut reg = ServiceRegistry::empty();
+        // Endpoint shape must match the validator's rule: internal services
+        // use a relative path; external services use an absolute https URL.
+        let endpoint = if internal {
+            "/v1/test".to_string()
+        } else {
+            "https://test.example.com/api".to_string()
+        };
         reg.register(ServiceEntry {
             id: "test-svc".to_string(),
             name: "Test Service".to_string(),
             category: "test".to_string(),
-            endpoint: "https://test.example.com/api".to_string(),
+            endpoint,
             x402_enabled,
             internal,
             description: None,

--- a/crates/gateway/src/security.rs
+++ b/crates/gateway/src/security.rs
@@ -149,16 +149,23 @@ fn is_private_ip(ip: IpAddr) -> bool {
             || (octets[0] == 172 && (16..=31).contains(&octets[1]))
             // 192.168.0.0/16 — private
             || (octets[0] == 192 && octets[1] == 168)
-            // 169.254.0.0/16 — link-local (cloud metadata)
+            // 169.254.0.0/16 — link-local (cloud metadata, e.g. AWS IMDS)
             || (octets[0] == 169 && octets[1] == 254)
             // 0.0.0.0/8 — "this" network
             || octets[0] == 0
+            // 100.64.0.0/10 — RFC 6598 carrier-grade NAT shared address space.
+            // Many cloud providers route this to internal/customer infra.
+            || (octets[0] == 100 && (octets[1] & 0xc0) == 64)
         }
         IpAddr::V6(v6) => {
             // ::1 — IPv6 loopback
             v6 == std::net::Ipv6Addr::LOCALHOST
             // fe80::/10 — IPv6 link-local
             || (v6.segments()[0] & 0xffc0) == 0xfe80
+            // ::ffff:0:0/96 — IPv4-mapped IPv6. Recurse through the V4 arm
+            // so private IPv4 ranges (e.g. ::ffff:10.0.0.1) are caught here
+            // rather than slipping through as "public IPv6".
+            || v6.to_ipv4_mapped().is_some_and(|v4| is_private_ip(IpAddr::V4(v4)))
         }
     }
 }
@@ -262,6 +269,30 @@ mod tests {
     #[test]
     fn test_public_v6() {
         assert!(!is_private_ip("2607:f8b0:4004:800::200e".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_cgnat_100_64() {
+        // RFC 6598 — 100.64.0.0/10. Boundaries:
+        // 100.64.0.0 through 100.127.255.255 must be treated as private.
+        assert!(is_private_ip("100.64.0.0".parse().unwrap()));
+        assert!(is_private_ip("100.64.0.1".parse().unwrap()));
+        assert!(is_private_ip("100.96.0.1".parse().unwrap()));
+        assert!(is_private_ip("100.127.255.255".parse().unwrap()));
+        // Just outside the /10 — must remain public.
+        assert!(!is_private_ip("100.63.255.255".parse().unwrap()));
+        assert!(!is_private_ip("100.128.0.0".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_ipv4_mapped_ipv6_private_addresses_caught() {
+        // ::ffff:10.0.0.1 must be classified the same as 10.0.0.1 (private).
+        assert!(is_private_ip("::ffff:10.0.0.1".parse().unwrap()));
+        assert!(is_private_ip("::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_private_ip("::ffff:169.254.169.254".parse().unwrap()));
+        assert!(is_private_ip("::ffff:100.64.0.1".parse().unwrap()));
+        // ::ffff:8.8.8.8 maps to public 8.8.8.8 — must remain public.
+        assert!(!is_private_ip("::ffff:8.8.8.8".parse().unwrap()));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/gateway/src/services.rs
+++ b/crates/gateway/src/services.rs
@@ -17,6 +17,13 @@ use thiserror::Error;
 pub enum ServiceRegistryError {
     #[error("failed to parse services.toml: {0}")]
     ParseError(#[from] toml::de::Error),
+
+    #[error("invalid service entry '{id}': {source}")]
+    InvalidEntry {
+        id: String,
+        #[source]
+        source: RegistrationError,
+    },
 }
 
 /// Errors returned by `ServiceRegistry::register()`.
@@ -126,14 +133,19 @@ impl ServiceRegistry {
     }
 
     /// Parse a TOML string (content of `services.toml`) into a registry.
+    ///
+    /// Each entry is validated through the same checks `register()` enforces
+    /// (id format, name/category bounds, endpoint scheme, positive price).
+    /// A malformed entry causes the whole load to fail with
+    /// `ServiceRegistryError::InvalidEntry` — fail-closed beats serving an
+    /// unsafe registry.
     pub fn from_toml(toml_str: &str) -> Result<Self, ServiceRegistryError> {
         let raw: RawServices = toml::from_str(toml_str)?;
 
-        let mut services: Vec<ServiceEntry> = raw
-            .services
-            .into_iter()
-            .map(|(id, raw)| ServiceEntry {
-                id,
+        let mut services: Vec<ServiceEntry> = Vec::with_capacity(raw.services.len());
+        for (id, raw) in raw.services {
+            let entry = ServiceEntry {
+                id: id.clone(),
                 name: raw.name,
                 category: raw.category,
                 endpoint: raw.endpoint,
@@ -147,8 +159,13 @@ impl ServiceRegistry {
                 source: "config".to_string(),
                 healthy: None,
                 price_per_request_usdc: raw.price_per_request_usdc,
-            })
-            .collect();
+            };
+            validate_entry(&entry).map_err(|source| ServiceRegistryError::InvalidEntry {
+                id: id.clone(),
+                source,
+            })?;
+            services.push(entry);
+        }
 
         // Stable alphabetical order so response is deterministic.
         services.sort_by(|a, b| a.id.cmp(&b.id));
@@ -181,41 +198,11 @@ impl ServiceRegistry {
     /// Validates the entry and inserts it into the registry. Returns
     /// `Err(RegistrationError)` if validation fails or the ID is taken.
     pub fn register(&mut self, entry: ServiceEntry) -> Result<(), RegistrationError> {
-        // Validate id: non-empty, max 64, [a-z0-9\-] only
-        if entry.id.is_empty()
-            || entry.id.len() > 64
-            || !entry
-                .id
-                .chars()
-                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-        {
-            return Err(RegistrationError::InvalidId);
-        }
+        validate_entry(&entry)?;
 
-        // Check uniqueness
+        // Check uniqueness against the current registry.
         if self.services.iter().any(|s| s.id == entry.id) {
             return Err(RegistrationError::DuplicateId(entry.id));
-        }
-
-        // Validate name
-        if entry.name.is_empty() || entry.name.len() > 128 {
-            return Err(RegistrationError::InvalidName);
-        }
-
-        // Validate category
-        if entry.category.is_empty() || entry.category.len() > 32 {
-            return Err(RegistrationError::InvalidCategory);
-        }
-
-        // Validate endpoint
-        if !entry.endpoint.starts_with("https://") {
-            return Err(RegistrationError::InvalidEndpoint);
-        }
-
-        // Validate price
-        match entry.price_per_request_usdc {
-            Some(price) if price > 0.0 => {}
-            _ => return Err(RegistrationError::InvalidPrice),
         }
 
         self.services.push(entry);
@@ -224,7 +211,62 @@ impl ServiceRegistry {
 
         Ok(())
     }
+}
 
+/// Validate a `ServiceEntry`'s field values without checking uniqueness.
+///
+/// Single source of truth for both `from_toml` (load-time) and `register()`
+/// (runtime registration) so a malformed `services.toml` cannot bypass the
+/// checks runtime registration enforces.
+///
+/// Internal services (`internal == true`) use relative paths like
+/// `/v1/chat/completions` for their `endpoint`; external services must use
+/// HTTPS absolute URLs.
+fn validate_entry(entry: &ServiceEntry) -> Result<(), RegistrationError> {
+    // id: non-empty, max 64, [a-z0-9-] only
+    if entry.id.is_empty()
+        || entry.id.len() > 64
+        || !entry
+            .id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(RegistrationError::InvalidId);
+    }
+
+    // name
+    if entry.name.is_empty() || entry.name.len() > 128 {
+        return Err(RegistrationError::InvalidName);
+    }
+
+    // category
+    if entry.category.is_empty() || entry.category.len() > 32 {
+        return Err(RegistrationError::InvalidCategory);
+    }
+
+    // endpoint — HTTPS-only for external; relative path for internal.
+    if entry.internal {
+        if !entry.endpoint.starts_with('/') {
+            return Err(RegistrationError::InvalidEndpoint);
+        }
+    } else if !entry.endpoint.starts_with("https://") {
+        return Err(RegistrationError::InvalidEndpoint);
+    }
+
+    // Price — only required for external services. Internal services are
+    // billed per-token via the chat pipeline, so `price_per_request_usdc`
+    // is optional for them.
+    if !entry.internal {
+        match entry.price_per_request_usdc {
+            Some(price) if price > 0.0 => {}
+            _ => return Err(RegistrationError::InvalidPrice),
+        }
+    }
+
+    Ok(())
+}
+
+impl ServiceRegistry {
     /// Update the health status for a service by ID.
     ///
     /// Returns `true` if the service was found (and updated), `false` otherwise.
@@ -480,5 +522,91 @@ internal = true
             registry.register(entry),
             Err(RegistrationError::InvalidPrice)
         );
+    }
+
+    /// Regression for the SSRF gap where `from_toml` skipped validation:
+    /// loading a `services.toml` with an `http://` endpoint for an
+    /// external service must now fail, not be silently accepted.
+    #[test]
+    fn from_toml_rejects_external_service_with_http_endpoint() {
+        let bad = r#"
+[services.bad-external]
+name = "Bad External"
+endpoint = "http://10.0.0.1/internal"
+category = "data"
+x402_enabled = true
+internal = false
+pricing_label = "$0.001"
+price_per_request_usdc = 0.001
+"#;
+        let err = ServiceRegistry::from_toml(bad).expect_err("must reject http external endpoint");
+        match err {
+            ServiceRegistryError::InvalidEntry { id, source } => {
+                assert_eq!(id, "bad-external");
+                assert_eq!(source, RegistrationError::InvalidEndpoint);
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_toml_rejects_external_service_with_zero_price() {
+        let bad = r#"
+[services.zero-price]
+name = "Zero Price"
+endpoint = "https://example.com/api"
+category = "data"
+x402_enabled = true
+internal = false
+pricing_label = "$0"
+price_per_request_usdc = 0.0
+"#;
+        let err = ServiceRegistry::from_toml(bad).expect_err("must reject zero price");
+        match err {
+            ServiceRegistryError::InvalidEntry { id, source } => {
+                assert_eq!(id, "zero-price");
+                assert_eq!(source, RegistrationError::InvalidPrice);
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_toml_rejects_invalid_id_charset() {
+        // Capital letters and other non-allowlist chars must be rejected.
+        let bad = r#"
+[services."BadId"]
+name = "Bad"
+endpoint = "https://example.com/api"
+category = "data"
+x402_enabled = true
+internal = false
+pricing_label = "$0.001"
+price_per_request_usdc = 0.001
+"#;
+        let err = ServiceRegistry::from_toml(bad).expect_err("must reject invalid id");
+        match err {
+            ServiceRegistryError::InvalidEntry { source, .. } => {
+                assert_eq!(source, RegistrationError::InvalidId);
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_toml_accepts_internal_service_without_price() {
+        // Internal services are billed per-token via the chat pipeline; their
+        // `price_per_request_usdc` is optional and a missing field must NOT
+        // cause from_toml to reject the entry.
+        let ok = r#"
+[services.llm-gateway]
+name = "LLM Intelligence"
+endpoint = "/v1/chat/completions"
+category = "intelligence"
+x402_enabled = true
+internal = true
+"#;
+        let registry = ServiceRegistry::from_toml(ok).expect("internal-without-price must load");
+        assert_eq!(registry.all().len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

PR-G1 of the gateway remediation plan from the ongoing whole-repo review. **Single security domain** (SSRF / proxy attack surface), **4 fixes** that all narrow the same blast radius. Each fix has dedicated regression tests.

| Severity | Finding | Fix | File(s) |
|---|---|---|---|
| **CRITICAL** | Proxy redirect-following bypassed DNS pin + SSRF guard | `redirect::Policy::none()` | `routes/proxy.rs` |
| **CRITICAL** | `services.toml` skipped runtime validation | Shared `validate_entry()` for both `from_toml` and `register()` | `services.rs`, `routes/proxy.rs` (test fixture) |
| **CRITICAL** | Google provider URL injection via `req.model` | Allowlist regex in `validate_gemini_model_name` | `providers/google.rs` |
| **HIGH** | `is_private_ip` missed CGNAT (RFC 6598) and IPv4-mapped IPv6 | Add `100.64.0.0/10` + `Ipv6Addr::to_ipv4_mapped()` recursion | `security.rs` |

### Why bundle them?
All four narrow the same SSRF attack surface. Shipping them together eliminates the cluster in one review cycle rather than running four separate reviews on overlapping code.

### Note on commit titles
The branch has 3 commits (the proxy redirect-policy fix got bundled into the services-validation commit when I staged both files). What's actually in each commit:

- `60dd3503` — services.rs validator + proxy.rs redirect policy + proxy test fixture (covers both the C1 redirect fix and the C2 services validation fix)
- `26ef62ff` — security.rs (CGNAT + IPv4-mapped IPv6). Title accidentally got swapped during a mid-edit `--amend`; **content is correct**, label says "fix(services,proxy)" but only contains security.rs changes.
- `2314c86e` — providers/google.rs (Gemini URL allowlist)

I'll squash-merge or fix titles before merge if you'd prefer cleaner labels in the history.

## Tests

- [x] Workspace tests: all pass (491 in gateway lib + 1043 across other crates).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] New regression tests:
  - `services::tests::from_toml_rejects_external_service_with_http_endpoint`
  - `services::tests::from_toml_rejects_external_service_with_zero_price`
  - `services::tests::from_toml_rejects_invalid_id_charset`
  - `services::tests::from_toml_accepts_internal_service_without_price`
  - `security::tests::test_cgnat_100_64`
  - `security::tests::test_ipv4_mapped_ipv6_private_addresses_caught`
  - `providers::google::tests::validate_gemini_model_name_accepts_real_model_ids`
  - `providers::google::tests::validate_gemini_model_name_rejects_url_injection`

## Behavioral changes worth knowing

- **`from_toml` now rejects malformed `services.toml` entries** instead of silently skipping. If `config/services.toml` ever had an invalid entry that "happened to work" before, gateway startup will now fail with a descriptive error. The actual deployed `services.toml` is mostly commented out today, so I expect zero impact in prod, but worth noting for any private staging configs.
- **Google provider rejects model names with `:`, `/`, `?`, `#`, etc.** — only `[a-zA-Z0-9._-]` allowed. All real Gemini model IDs match this pattern (`gemini-2.5-flash`, `gemini-1.5-pro-002`).
- **CGNAT and IPv4-mapped IPv6 ranges now block as private** — services registered to addresses in 100.64.0.0/10 or `::ffff:<private-v4>` will be rejected by the SSRF guard.

## Remediation plan context

This is PR-G1 of 5 must-ship gateway PRs (G1–G5) plus a reliability bundle (G6). After G1:
- **G2** — error / log info leaks (InvalidPayment sanitization, session_id log, balance pool log, PaymentInfo Debug)
- **G3** — financial correctness (cost.rs NaN/Inf, A2A max_tokens persistence, provider usage trust)
- **G4** — budget enforcement (TOCTOU Lua atomic, team-budget fail-open, default divergence)
- **G5** — multi-tenant authz (Admin escalation, key entropy, query-level org guard, audit actor, nonce/services auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)