### PR TITLE
fix(gateway): error/log info-leak cluster — sanitize 5 leak surfaces

### DIFF
--- a/crates/gateway/src/balance_monitor.rs
+++ b/crates/gateway/src/balance_monitor.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use metrics::gauge;
 use serde::Deserialize;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Lamports per SOL (1 SOL = 1_000_000_000 lamports).
 const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
@@ -184,7 +184,14 @@ impl BalanceMonitor {
                     );
                 }
                 AlertLevel::Healthy => {
-                    info!(
+                    // `debug!` (not `info!`): with a 5-minute check interval,
+                    // an INFO line per wallet streams the entire fee-payer
+                    // pool composition to log aggregators / SIEMs forever.
+                    // Solana pubkeys aren't secrets in isolation, but the
+                    // operator's full pool composition is sensitive infra
+                    // info. Warning/Critical branches stay at their current
+                    // levels — operators need those.
+                    debug!(
                         wallet = %result.wallet_pubkey,
                         balance_sol = %result.balance_sol,
                         lamports = result.lamports,

--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -18,6 +18,19 @@ pub enum GatewayError {
     #[error("payment required")]
     PaymentRequired,
 
+    /// Inner string is forwarded to the client verbatim in the 402 response
+    /// body — used for both user-friendly error messages ("transaction has
+    /// already been used", "Payment verification failed", etc.) and the
+    /// serialized `PaymentRequired` challenge payload.
+    ///
+    /// Constructors MUST NOT pass through:
+    /// - raw provider/facilitator/RPC error bodies (those go through
+    ///   `ProviderError`/`SettlementFailed` which sanitize),
+    /// - internal hostnames/URLs,
+    /// - parser exception details that fingerprint the implementation.
+    ///
+    /// When in doubt, log the internal detail at `warn!` and return a
+    /// static safe-to-forward message here.
     #[error("invalid payment: {0}")]
     InvalidPayment(String),
 

--- a/crates/gateway/src/middleware/x402.rs
+++ b/crates/gateway/src/middleware/x402.rs
@@ -13,12 +13,38 @@ use solvela_x402::types::PaymentPayload;
 use crate::AppState;
 
 /// Decoded payment information stored in request extensions.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is implemented manually to redact the raw signed-transaction
+/// payload. The default derive would expose the full base64 transaction
+/// (and any embedded signatures) any time this struct is formatted via
+/// `{:?}` — e.g. through `tracing::debug!(?ext, ...)` on request
+/// extensions. Routes/handlers should never need the raw transaction in
+/// logs; if they do, log the parsed payload's fields explicitly.
+#[derive(Clone)]
 pub struct PaymentInfo {
     /// The decoded payment payload from the PAYMENT-SIGNATURE header.
     pub payload: PaymentPayload,
     /// The raw header value (for re-encoding if needed).
     pub raw_header: String,
+}
+
+impl std::fmt::Debug for PaymentInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Show enough metadata to be useful for debugging (network, scheme,
+        // resource URL) while redacting the raw transaction. The first 8
+        // chars of `raw_header` are kept as a correlation prefix so log
+        // entries can be matched up without exposing the full payload.
+        let raw_prefix: String = self.raw_header.chars().take(8).collect();
+        f.debug_struct("PaymentInfo")
+            .field("network", &self.payload.accepted.network)
+            .field("scheme", &self.payload.accepted.scheme)
+            .field("resource", &self.payload.resource.url)
+            .field(
+                "raw_header",
+                &format_args!("{raw_prefix}…[{} bytes redacted]", self.raw_header.len()),
+            )
+            .finish()
+    }
 }
 
 /// x402 payment extraction middleware.
@@ -195,5 +221,32 @@ mod tests {
             PayloadData::Direct(p) => assert_eq!(p.transaction, "base64encodedtx"),
             PayloadData::Escrow(_) => panic!("expected Direct variant"),
         }
+    }
+
+    /// Regression: `Debug` on `PaymentInfo` must redact the raw signed
+    /// transaction. The previous `#[derive(Debug)]` exposed the full
+    /// base64 transaction (including signatures) any time the struct was
+    /// formatted via `{:?}`.
+    #[test]
+    fn payment_info_debug_redacts_raw_header() {
+        let secret_tx = "AAAAAAAAAAAAAAAAAAAAAAA_super_secret_signed_tx_payload_AAAAAAAAAA";
+        let info = PaymentInfo {
+            payload: sample_payload(),
+            raw_header: secret_tx.to_string(),
+        };
+        let debug = format!("{info:?}");
+        assert!(
+            !debug.contains("super_secret_signed_tx_payload"),
+            "Debug output must NOT contain full raw_header: {debug}"
+        );
+        let expected_marker = format!("[{} bytes redacted]", secret_tx.len());
+        assert!(
+            debug.contains(&expected_marker),
+            "Debug output must indicate redaction with byte count {expected_marker:?}: {debug}"
+        );
+        // Useful metadata IS shown.
+        assert!(debug.contains("network"));
+        assert!(debug.contains("resource"));
+        assert!(debug.contains("/v1/chat/completions"));
     }
 }

--- a/crates/gateway/src/providers/google.rs
+++ b/crates/gateway/src/providers/google.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use solvela_protocol::{
     ChatChoice, ChatMessage, ChatRequest, ChatResponse, ModelInfo, Role, Usage,
@@ -270,11 +270,20 @@ impl LLMProvider for GoogleProvider {
         let response = response.error_for_status()?;
         let body_text = response.text().await?;
         let gemini_resp: GeminiResponse = serde_json::from_str(&body_text).map_err(|e| {
+            // The full body can contain user-prompt-derived content (PII,
+            // confidential business data, safety-filtered fragments). Log
+            // only structural metadata at WARN; full preview at DEBUG so it
+            // is suppressed at default production log levels.
             warn!(
                 model = %original_model,
                 error = %e,
-                body_preview = %&body_text[..body_text.len().min(500)],
+                body_len = body_text.len(),
                 "failed to parse Gemini response"
+            );
+            debug!(
+                model = %original_model,
+                body_preview = %&body_text[..body_text.len().min(500)],
+                "Gemini response body preview (debug only)"
             );
             e
         })?;

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -239,9 +239,14 @@ pub async fn proxy_service(
     // Step 4: Payment present — decode and verify
     let raw_header = payment_header.expect("checked above");
     let payload = decode_payment_header(raw_header).map_err(|e| {
-        GatewayError::InvalidPayment(format!(
-            "PAYMENT-SIGNATURE header could not be decoded: {e}"
-        ))
+        // Don't echo the parser error — log it internally and return a
+        // sanitized message. See `GatewayError::InvalidPayment` doc.
+        warn!(error = %e, "PAYMENT-SIGNATURE header decode failed (proxy)");
+        GatewayError::InvalidPayment(
+            "PAYMENT-SIGNATURE header could not be decoded. \
+             Encode a valid PaymentPayload as standard base64 JSON."
+                .to_string(),
+        )
     })?;
 
     // Validate resource URL matches this proxy endpoint

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -181,6 +181,16 @@ impl UsageTracker {
         let id = Uuid::new_v4();
         let created_at = Utc::now();
 
+        // Session tokens are bearer-equivalent: anyone with a leaked log line
+        // can replay session-authenticated requests without paying. Log only
+        // an 8-char correlation prefix so entries can be matched without
+        // exposing the full token. Wallet pubkey, request_id, and tx_signature
+        // remain in full — they're public on-chain or correlation-only.
+        let session_prefix = entry
+            .session_id
+            .as_deref()
+            .map(|s| s.chars().take(8).collect::<String>())
+            .unwrap_or_else(|| "none".to_string());
         info!(
             wallet = %entry.wallet_address,
             model = %entry.model,
@@ -190,7 +200,7 @@ impl UsageTracker {
             cost_usdc = entry.cost_usdc,
             tx_signature = entry.tx_signature.as_deref().unwrap_or("none"),
             request_id = entry.request_id.as_deref().unwrap_or("none"),
-            session_id = entry.session_id.as_deref().unwrap_or("none"),
+            session_prefix = %session_prefix,
             "spend logged"
         );
 


### PR DESCRIPTION
## Summary

PR-G2 of the gateway remediation plan. **5 fixes, single domain (info leaks via error responses and logs)**, one commit per fix, all with regression tests where applicable. Independent of PR-G1 (#189) — no file overlap.

| Severity | Finding | Fix | File |
|---|---|---|---|
| **HIGH** | `proxy.rs:242` echoed `decode_payment_header` parser errors verbatim to client | sanitize like chat handler; warn! internally | `error.rs`, `routes/proxy.rs` |
| **HIGH** | `PaymentInfo` derived `Debug` exposing full signed-tx via `{:?}` | custom redacting `Debug` with 8-char correlation prefix + byte count | `middleware/x402.rs` |
| **HIGH** | `usage.rs:184` logged full `session_id` (bearer-equiv) at INFO on every spend | rename field to `session_prefix`, log first 8 chars only | `usage.rs` |
| **HIGH** | `balance_monitor.rs:186` logged every healthy fee-payer pubkey at INFO each cycle | demote `Healthy` arm to `debug!` | `balance_monitor.rs` |
| MEDIUM | `providers/google.rs:276` logged up to 500 bytes of Gemini body at WARN | split into structural `warn!` + body-preview `debug!` | `providers/google.rs` |

### Reframing the original CRITICAL classification

The pass-4 review flagged `error.rs::IntoResponse` for `InvalidPayment` returning the inner string verbatim as **CRITICAL**. Verifying against current call sites: every existing `InvalidPayment(...)` constructor already passes a sanitized user-facing string OR the intentional `serde_json::to_string(&PaymentRequired)` 402-challenge body. **No caller currently leaks raw provider/RPC errors.** The risk was a future contributor adding such a call.

This PR keeps the `InvalidPayment(String)` shape intact (since some uses are intentional 402-challenge JSON) and instead:
1. Adds an explicit doc comment to the variant declaring what callers MUST NOT pass through (raw provider/facilitator/RPC bodies, internal hostnames, parser exception details).
2. Tightens the one existing leaky caller (`proxy.rs:242` was the only `format!("...{e}")` over an internal error string) to follow the chat-handler pattern: `warn!` internally, return a static safe-to-forward string.

Splitting `InvalidPayment` into a sanitized variant + a separate `PaymentChallenge` variant is the proper architectural fix but needs ~12 caller updates and is deferred to a future cleanup PR if reviewers want it.

## Tests

- [x] `cargo test -p gateway --lib`: 484/484 pass (was 483 — +1 new regression test).
- [x] `cargo test --workspace --all-features` (DATABASE_URL set): 1043+ pass, 0 failed.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] New regression test: `middleware::x402::tests::payment_info_debug_redacts_raw_header` — verifies the secret raw_header substring does NOT appear in `{:?}` output and the redaction marker is present with the correct byte count.

## Behavioral changes worth knowing

- **Logs at default INFO level lose** per-wallet fee-payer healthy lines (now DEBUG), session_id full values (now 8-char prefix), and Gemini body previews on parse failure (now DEBUG). Operators who need any of these can opt in via `RUST_LOG=gateway::balance_monitor=debug` etc.
- **Client-visible 402 responses** for proxy decode failures change from `"PAYMENT-SIGNATURE header could not be decoded: <parser-error>"` to a fixed sanitized string. Internal warn! preserves the original error for ops debugging.
- **`PaymentInfo` `{:?}` output** changes shape (now shows only `network`, `scheme`, `resource`, and a redacted `raw_header`). No production code uses `{:?}` on `PaymentInfo` today (verified by grep), but if any tests/downstream code did, they'd see the new format.

## Remediation plan context

After PR-G2, the must-ship gateway PRs remaining are:
- **G3** — financial correctness: cost.rs NaN/Inf guard + A2A max_tokens persistence + provider usage cross-validation.
- **G4** — budget enforcement: TOCTOU Lua atomic + team-budget fail-open + default-budget shared constant.
- **G5** — multi-tenant authz: Admin escalation + 32-byte API keys + query-level org guard + audit actor identity + nonce/services route auth.
- **G6** (reliability bundle, optional): balance_monitor build error + half-open probe gate + rate-limit lock-across-await.

🤖 Generated with [Claude Code](https://claude.com/claude-code)