### PR TITLE
fix(gateway): financial correctness — close 3 silent revenue gaps

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -160,7 +160,11 @@ async fn handle_new_request(
             data: None,
         })?;
 
-    // Create and save task record
+    // Create and save task record. We persist `max_tokens` so step 3
+    // (payment-submitted) re-applies the same cap to the provider call —
+    // without this, the agent paid for ≤max_tokens output but the provider
+    // would be invoked with max_tokens=None and could return an unbounded
+    // response, leaving the gateway to absorb the overrun.
     let task_id = new_task_id();
     let record = TaskRecord {
         id: task_id.clone(),
@@ -168,6 +172,7 @@ async fn handle_new_request(
         original_message: user_text,
         payment_required: payment_required_json.clone(),
         model: Some(resolved_model.clone()),
+        max_tokens: Some(max_tokens),
         created_at: chrono::Utc::now(),
     };
 
@@ -394,7 +399,7 @@ async fn handle_payment_submitted(
         settlement.tx_signature
     };
 
-    // Build ChatRequest from stored original message
+    // Build ChatRequest from stored original message.
     let model = record.model.unwrap_or_else(|| "auto".to_string());
     let resolved_model = resolve_model(&model, &record.original_message, state)?;
 
@@ -407,6 +412,12 @@ async fn handle_payment_submitted(
             data: None,
         })?;
 
+    // Re-apply the max_tokens cap that was used to compute the quoted cost
+    // in step 2 (handle_new_request). Records persisted before the H1 fix
+    // have `max_tokens = None`; for those we fall back to the historical
+    // 1000-token default so the cap is never silently absent.
+    let enforced_max_tokens = record.max_tokens.unwrap_or(1000);
+
     let chat_req = ChatRequest {
         model: resolved_model.clone(),
         messages: vec![ChatMessage {
@@ -416,7 +427,7 @@ async fn handle_payment_submitted(
             tool_calls: None,
             tool_call_id: None,
         }],
-        max_tokens: None,
+        max_tokens: Some(enforced_max_tokens),
         temperature: None,
         top_p: None,
         stream: false,

--- a/crates/gateway/src/a2a/task_store.rs
+++ b/crates/gateway/src/a2a/task_store.rs
@@ -26,6 +26,15 @@ pub struct TaskRecord {
     pub payment_required: serde_json::Value,
     /// Model hint from the original request (if provided).
     pub model: Option<String>,
+    /// Output-token cap that was used to compute the quoted cost in step 2.
+    /// Step 3 (payment-submitted) MUST re-apply this cap when calling the
+    /// provider so actual output cannot exceed what the agent has already
+    /// paid for. `serde(default)` keeps deserialization backward-compatible
+    /// with task records persisted before this field was added — those
+    /// records will be processed with the call-site fallback rather than
+    /// silently uncapped.
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -155,6 +164,7 @@ mod tests {
             original_message: "Hello, what is Solana?".to_string(),
             payment_required: serde_json::json!({"x402_version": 2}),
             model: Some("auto".to_string()),
+            max_tokens: Some(1000),
             created_at: chrono::Utc::now(),
         };
 
@@ -165,6 +175,7 @@ mod tests {
         assert_eq!(deserialized.state, TaskState::InputRequired);
         assert_eq!(deserialized.original_message, "Hello, what is Solana?");
         assert_eq!(deserialized.model, Some("auto".to_string()));
+        assert_eq!(deserialized.max_tokens, Some(1000));
     }
 
     #[test]
@@ -175,12 +186,36 @@ mod tests {
             original_message: "test".to_string(),
             payment_required: serde_json::json!({}),
             model: None,
+            max_tokens: None,
             created_at: chrono::Utc::now(),
         };
 
         let json = serde_json::to_string(&record).expect("serialize"); // safe: known struct
         let deserialized: TaskRecord = serde_json::from_str(&json).expect("deserialize"); // safe: just serialized
         assert_eq!(deserialized.model, None);
+        assert_eq!(deserialized.max_tokens, None);
         assert_eq!(deserialized.state, TaskState::Completed);
+    }
+
+    /// Regression: TaskRecord JSON written before the H1 fix did not include
+    /// `max_tokens`. Deserialization must succeed with `max_tokens = None`
+    /// rather than failing on an unknown-field/missing-field error, so
+    /// in-flight tasks across a deploy boundary still resolve.
+    #[test]
+    fn test_task_record_legacy_payload_without_max_tokens_deserializes() {
+        let legacy = serde_json::json!({
+            "id": "a2a_legacy",
+            "state": "input-required",
+            "original_message": "hi",
+            "payment_required": {"x402_version": 2},
+            "model": "auto",
+            "created_at": "2026-05-09T00:00:00Z"
+        })
+        .to_string();
+
+        let deserialized: TaskRecord =
+            serde_json::from_str(&legacy).expect("legacy record must deserialize");
+        assert_eq!(deserialized.max_tokens, None);
+        assert_eq!(deserialized.model, Some("auto".to_string()));
     }
 }

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -5,7 +5,73 @@
 
 use tracing::warn;
 
-use solvela_protocol::{ChatRequest, ModelInfo};
+use solvela_protocol::{ChatRequest, ModelInfo, Usage};
+
+/// Hard ceiling on `completion_tokens` when neither the request nor the model
+/// registry declares a tighter cap. Prevents a misbehaving / compromised
+/// provider from inflating `usage.completion_tokens` to something the
+/// gateway cannot have priced for.
+const DEFAULT_COMPLETION_TOKENS_CAP: u32 = 8192;
+
+/// Cap a provider-reported `Usage` to limits the gateway has actually priced
+/// for. Provider responses are trusted today (the gateway speaks
+/// OpenAI-compat to the provider and parses the JSON back), but a compromised
+/// or misbehaving provider could inflate `completion_tokens` to over-bill the
+/// agent, or deflate `prompt_tokens` to under-bill the gateway. Both flow
+/// directly into `compute_actual_atomic_cost` and `state.usage.log_spend`,
+/// so both need bounding before they reach billing.
+///
+/// Caps:
+/// - `completion_tokens` ≤ min(`req.max_tokens`, `model_info.max_output_tokens`,
+///   `DEFAULT_COMPLETION_TOKENS_CAP`). Whichever the gateway treated as the
+///   priceable ceiling at quote time is the right cap; we take the tightest.
+/// - `prompt_tokens` ≤ `model_info.context_window`. The provider cannot have
+///   processed more than the context window without errors, so anything
+///   above is a sign of a corrupt response.
+/// - `total_tokens` is recomputed from the capped components — provider-supplied
+///   totals are not trusted independently.
+pub(crate) fn cap_usage_to_request_limits(
+    usage: &Usage,
+    req: &ChatRequest,
+    model_info: &ModelInfo,
+) -> Usage {
+    let completion_cap = [
+        req.max_tokens,
+        model_info.max_output_tokens,
+        Some(DEFAULT_COMPLETION_TOKENS_CAP),
+    ]
+    .into_iter()
+    .flatten()
+    .min()
+    .unwrap_or(DEFAULT_COMPLETION_TOKENS_CAP);
+
+    let prompt = usage.prompt_tokens.min(model_info.context_window);
+    let completion = usage.completion_tokens.min(completion_cap);
+
+    if completion < usage.completion_tokens {
+        warn!(
+            model = %model_info.model_id,
+            reported = usage.completion_tokens,
+            cap = completion,
+            "provider reported completion_tokens above gateway cap — clamping for billing"
+        );
+    }
+    if prompt < usage.prompt_tokens {
+        warn!(
+            model = %model_info.model_id,
+            reported = usage.prompt_tokens,
+            cap = prompt,
+            "provider reported prompt_tokens above context window — clamping for billing"
+        );
+    }
+
+    let total = prompt.saturating_add(completion);
+    Usage {
+        prompt_tokens: prompt,
+        completion_tokens: completion,
+        total_tokens: total,
+    }
+}
 
 /// Rough token estimate: ~4 chars per token.
 pub(crate) fn estimate_input_tokens(req: &ChatRequest) -> u32 {
@@ -18,15 +84,36 @@ pub(crate) fn estimate_input_tokens(req: &ChatRequest) -> u32 {
 /// Uses integer arithmetic to avoid f64 precision loss on financial amounts.
 /// Cost per million tokens is converted to micro-USDC (atomic units) early,
 /// then all math stays in u128 to prevent overflow on large token counts.
+///
+/// Returns `None` when the model registry's per-million pricing is non-finite
+/// (NaN/Inf) or negative, or when the final atomic total would overflow `u64`.
+/// Rust's `f64 as u128` cast is saturating: `NaN` → 0 and `INFINITY` →
+/// `u128::MAX`. Without this guard, a corrupt `models.toml` entry with `NaN`
+/// pricing would silently quote a $0 cost (escrow claim then no-ops on the
+/// `claim_amount == 0` guard), and an `INFINITY` entry would wrap on the
+/// `* 105 / 100` step. Both are silent revenue gaps.
 pub(crate) fn compute_actual_atomic_cost(
     prompt_tokens: u32,
     completion_tokens: u32,
     model_info: &ModelInfo,
-) -> u64 {
-    // Convert cost-per-million-tokens from USDC (f64) to atomic micro-USDC (u64)
-    // by multiplying by 1_000_000. This is the only f64->int conversion.
-    let input_cost_atomic_per_million = (model_info.input_cost_per_million * 1_000_000.0) as u128;
-    let output_cost_atomic_per_million = (model_info.output_cost_per_million * 1_000_000.0) as u128;
+) -> Option<u64> {
+    let input = model_info.input_cost_per_million;
+    let output = model_info.output_cost_per_million;
+    if !input.is_finite() || !output.is_finite() || input < 0.0 || output < 0.0 {
+        warn!(
+            model = %model_info.model_id,
+            input_cost = input,
+            output_cost = output,
+            "model pricing is non-finite or negative — refusing to compute cost"
+        );
+        return None;
+    }
+
+    // Convert cost-per-million-tokens from USDC (f64) to atomic micro-USDC (u128)
+    // by multiplying by 1_000_000. This is the only f64->int conversion; the
+    // `is_finite` guard above ensures the cast is well-defined.
+    let input_cost_atomic_per_million = (input * 1_000_000.0) as u128;
+    let output_cost_atomic_per_million = (output * 1_000_000.0) as u128;
 
     // tokens * atomic_cost_per_million / 1_000_000 = atomic cost
     let input_atomic = (prompt_tokens as u128) * input_cost_atomic_per_million / 1_000_000;
@@ -36,7 +123,10 @@ pub(crate) fn compute_actual_atomic_cost(
     // 5% platform fee: total = provider * 105 / 100
     let total_atomic = provider_atomic * 105 / 100;
 
-    total_atomic as u64
+    // Final overflow guard: u128 → u64. With sane pricing this never trips,
+    // but guarding here means a pathological combination of huge tokens ×
+    // huge pricing surfaces as None instead of silent wrap.
+    u64::try_from(total_atomic).ok()
 }
 
 /// Upper bound for the `total` USDC cost that `estimated_atomic_cost` will accept.
@@ -311,7 +401,7 @@ mod tests {
         };
 
         let atomic = compute_actual_atomic_cost(1000, 500, &model_info);
-        assert_eq!(atomic, 7875);
+        assert_eq!(atomic, Some(7875));
     }
 
     #[test]
@@ -333,7 +423,7 @@ mod tests {
             max_output_tokens: None,
         };
 
-        assert_eq!(compute_actual_atomic_cost(0, 0, &model_info), 0);
+        assert_eq!(compute_actual_atomic_cost(0, 0, &model_info), Some(0));
     }
 
     #[test]
@@ -363,9 +453,10 @@ supports_vision = false
         // Single 5% fee → 1_050_000. A double-applied fee would yield 1_102_500.
         let atomic = compute_actual_atomic_cost(1_000_000, 0, model_info);
         assert_eq!(
-            atomic, 1_050_000,
-            "expected exactly 1.05x provider cost (single 5% fee); got {atomic}. \
-             1_102_500 here means the fee is being applied twice."
+            atomic,
+            Some(1_050_000),
+            "expected exactly 1.05x provider cost (single 5% fee); got {atomic:?}. \
+             Some(1_102_500) here means the fee is being applied twice."
         );
     }
 
@@ -389,7 +480,141 @@ supports_vision = false
         };
 
         let atomic = compute_actual_atomic_cost(1, 0, &model_info);
-        assert_eq!(atomic, 1_050_000);
+        assert_eq!(atomic, Some(1_050_000));
+    }
+
+    // =========================================================================
+    // cap_usage_to_request_limits — provider-trust bounds (H7)
+    // =========================================================================
+
+    fn test_model_info() -> ModelInfo {
+        ModelInfo {
+            id: "test/model".to_string(),
+            provider: "test".to_string(),
+            model_id: "test-model".to_string(),
+            display_name: "Test".to_string(),
+            input_cost_per_million: 1.0,
+            output_cost_per_million: 1.0,
+            context_window: 4096,
+            supports_streaming: false,
+            supports_tools: false,
+            supports_vision: false,
+            reasoning: false,
+            supports_structured_output: false,
+            supports_batch: false,
+            max_output_tokens: Some(2048),
+        }
+    }
+
+    fn req_with_max_tokens(max: Option<u32>) -> ChatRequest {
+        use solvela_protocol::ChatRequest;
+        ChatRequest {
+            model: "test/model".to_string(),
+            messages: vec![],
+            max_tokens: max,
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        }
+    }
+
+    #[test]
+    fn cap_usage_clamps_completion_to_req_max_tokens() {
+        let model = test_model_info();
+        let req = req_with_max_tokens(Some(500));
+        // Provider claims 9999 completion tokens. Gateway only priced for ≤500.
+        let inflated = solvela_protocol::Usage {
+            prompt_tokens: 100,
+            completion_tokens: 9999,
+            total_tokens: 10099,
+        };
+        let capped = cap_usage_to_request_limits(&inflated, &req, &model);
+        assert_eq!(capped.completion_tokens, 500);
+        assert_eq!(capped.prompt_tokens, 100);
+        assert_eq!(capped.total_tokens, 600);
+    }
+
+    #[test]
+    fn cap_usage_clamps_prompt_to_context_window() {
+        let model = test_model_info(); // context_window = 4096
+        let req = req_with_max_tokens(Some(500));
+        // Provider claims a wildly inflated prompt token count.
+        let inflated = solvela_protocol::Usage {
+            prompt_tokens: 1_000_000,
+            completion_tokens: 100,
+            total_tokens: 1_000_100,
+        };
+        let capped = cap_usage_to_request_limits(&inflated, &req, &model);
+        assert_eq!(capped.prompt_tokens, 4096);
+        assert_eq!(capped.completion_tokens, 100);
+        assert_eq!(capped.total_tokens, 4196);
+    }
+
+    #[test]
+    fn cap_usage_falls_back_to_model_max_output_when_request_uncapped() {
+        let model = test_model_info(); // max_output_tokens = Some(2048)
+        let req = req_with_max_tokens(None); // no req cap
+        let inflated = solvela_protocol::Usage {
+            prompt_tokens: 10,
+            completion_tokens: 9999,
+            total_tokens: 10009,
+        };
+        let capped = cap_usage_to_request_limits(&inflated, &req, &model);
+        // Falls back to model.max_output_tokens (2048), which is tighter
+        // than DEFAULT_COMPLETION_TOKENS_CAP (8192).
+        assert_eq!(capped.completion_tokens, 2048);
+    }
+
+    #[test]
+    fn cap_usage_passes_through_when_within_limits() {
+        let model = test_model_info();
+        let req = req_with_max_tokens(Some(1000));
+        let normal = solvela_protocol::Usage {
+            prompt_tokens: 100,
+            completion_tokens: 500,
+            total_tokens: 600,
+        };
+        let capped = cap_usage_to_request_limits(&normal, &req, &model);
+        assert_eq!(capped.prompt_tokens, 100);
+        assert_eq!(capped.completion_tokens, 500);
+        assert_eq!(capped.total_tokens, 600);
+    }
+
+    /// Regression for the H3 finding: NaN/Inf/negative pricing must return
+    /// None, not silently saturate to 0 or u64::MAX. A corrupt models.toml
+    /// entry must not be a silent revenue gap.
+    #[test]
+    fn test_compute_actual_atomic_cost_rejects_non_finite_pricing() {
+        let mut model_info = ModelInfo {
+            id: "test/model".to_string(),
+            provider: "test".to_string(),
+            model_id: "model".to_string(),
+            display_name: "Test".to_string(),
+            input_cost_per_million: f64::NAN,
+            output_cost_per_million: 1.00,
+            context_window: 128_000,
+            supports_streaming: false,
+            supports_tools: false,
+            supports_vision: false,
+            reasoning: false,
+            supports_structured_output: false,
+            supports_batch: false,
+            max_output_tokens: None,
+        };
+        // NaN input cost
+        assert_eq!(compute_actual_atomic_cost(1000, 500, &model_info), None);
+        // Infinity input cost
+        model_info.input_cost_per_million = f64::INFINITY;
+        assert_eq!(compute_actual_atomic_cost(1000, 500, &model_info), None);
+        // Negative output cost
+        model_info.input_cost_per_million = 1.00;
+        model_info.output_cost_per_million = -0.001;
+        assert_eq!(compute_actual_atomic_cost(1000, 500, &model_info), None);
+        // NaN output cost
+        model_info.output_cost_per_million = f64::NAN;
+        assert_eq!(compute_actual_atomic_cost(1000, 500, &model_info), None);
     }
 
     // =========================================================================

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -32,8 +32,8 @@ use crate::usage::SpendLogEntry;
 use crate::AppState;
 
 use cost::{
-    compute_actual_atomic_cost, estimate_input_tokens, estimated_atomic_cost,
-    usdc_atomic_amount_checked,
+    cap_usage_to_request_limits, compute_actual_atomic_cost, estimate_input_tokens,
+    estimated_atomic_cost, usdc_atomic_amount_checked,
 };
 use payment::{decode_payment_from_header, extract_payment_info, fire_escrow_claim};
 use provider::{ProviderCallContext, ProviderCallError, ProviderCallResult};
@@ -587,6 +587,15 @@ pub async fn chat_completions(
             usage,
             actual_provider,
         }) => {
+            // Cap provider-reported token counts to what the gateway has
+            // actually priced for (req.max_tokens, model context window).
+            // Without this, a misbehaving / compromised provider could
+            // inflate completion_tokens to over-bill the agent, or deflate
+            // prompt_tokens to under-bill the gateway. Both flow into the
+            // escrow claim and spend log below.
+            let usage = usage
+                .as_ref()
+                .map(|u| cap_usage_to_request_limits(u, &req, model_info));
             // Post-response: usage logging, session token, and escrow claims (paid path only)
 
             // Attach session token for paid non-streaming requests
@@ -606,11 +615,12 @@ pub async fn chat_completions(
             // Compute escrow claim amount: prefer actual usage, fall back to estimate
             // E2 FIX: Use minimum 1 atomic unit for streaming when estimation fails
             let claim_atomic = if let Some(ref u) = usage {
-                Some(compute_actual_atomic_cost(
-                    u.prompt_tokens,
-                    u.completion_tokens,
-                    model_info,
-                ))
+                // `compute_actual_atomic_cost` returns `None` when the model
+                // registry pricing is non-finite/negative or the result would
+                // overflow u64. In those cases we skip the claim rather than
+                // firing for a garbage amount; the warn! inside the function
+                // surfaces the corrupt registry entry to operators.
+                compute_actual_atomic_cost(u.prompt_tokens, u.completion_tokens, model_info)
             } else {
                 Some(
                     estimated_atomic_cost(&state.model_registry, &req.model, &req)


### PR DESCRIPTION
## Summary

PR-G3 of the gateway remediation plan. **3 fixes, all close silent revenue gaps**, 2 logical commits (chat cost-path bundle + A2A persistence). Independent of #189 (G1) and #190 (G2) — no file overlap.

| Severity | Finding | Fix | File |
|---|---|---|---|
| **HIGH** | `compute_actual_atomic_cost` saturated `f64 NaN→0` (silent $0 quote) and `Inf→u64::MAX` (overflow) | guard non-finite/negative; return `Option<u64>`; checked u128→u64 | `routes/chat/cost.rs` |
| **HIGH** | A2A quoted with `max_tokens=1000` at step 2 but settled with `None` at step 3 — provider could exceed cap, gateway eats the overrun | persist `max_tokens` in `TaskRecord`; re-apply at settle | `a2a/handler.rs`, `a2a/task_store.rs` |
| **HIGH** | Provider response `usage` trusted without bounds — inflated `completion_tokens` over-bills agent, deflated `prompt_tokens` under-bills gateway | `cap_usage_to_request_limits` helper applied at chat handler | `routes/chat/cost.rs`, `routes/chat/mod.rs` |

### Why bundle the cost-path fixes?
H3 and H7 both protect the same arithmetic in `cost.rs`. They live in the same file, both feed `state.usage.log_spend` and the escrow claim, and the test fixtures share the same `ModelInfo` builder. One PR, two atomic commits.

### Why is A2A separate from chat?
A2A's gap is structurally different: the cap exists at quote time but is *lost* across the two-step persisted flow. The fix lives in the task store schema and round-trip logic, not the cost arithmetic.

## Tests

- [x] `cargo test -p gateway --lib`: 489 pass (was 483 — +6 new regression tests).
- [x] `cargo test --workspace --all-features` (DATABASE_URL set): all green.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.

### New regression tests
- `test_compute_actual_atomic_cost_rejects_non_finite_pricing` — NaN/Inf/negative input + output, all return `None`.
- `cap_usage_clamps_completion_to_req_max_tokens` — provider claiming 9999 tokens against `req.max_tokens=500` clamps to 500.
- `cap_usage_clamps_prompt_to_context_window` — provider claiming 1M prompt tokens clamps to 4096.
- `cap_usage_falls_back_to_model_max_output_when_request_uncapped` — `req.max_tokens=None` falls through to `model_info.max_output_tokens`.
- `cap_usage_passes_through_when_within_limits` — normal usage is not modified.
- `test_task_record_legacy_payload_without_max_tokens_deserializes` — backward-compat: TaskRecord JSON written before this fix deserializes with `max_tokens=None`, in-flight tasks across deploy boundary still resolve.

## Behavioral changes worth knowing

- **`compute_actual_atomic_cost` returns `None` on corrupt model registry pricing** instead of silently saturating. The single caller already binds `Option<u64>`, so this surfaces as `claim_atomic = None` → no escrow claim fired (with a `warn!` line tying it to the model). Operators triaging a "missing claim" alert will see the warn instead of staring at a silent zero.
- **A2A step-3 provider calls now have `max_tokens` set**, where they previously had `None`. Worst-case effect on existing agents: a long-running streamed response that previously kept going until the model decided to stop now truncates at 1000 tokens (the historical quote default). Real impact is likely zero for chat-style A2A workloads but worth flagging.
- **Provider-reported usage is now clamped before billing.** A response claiming `completion_tokens=9999` against `req.max_tokens=500` will be billed for 500. Operators monitoring spend may see a small drop in average billed completion tokens for any provider that was previously inflating counts; that's the correct outcome.

## Remediation plan context

After PR-G3, the must-ship gateway PRs remaining are:
- **G4** — budget enforcement: TOCTOU Lua-atomic + team-budget fail-open + default-budget shared constant.
- **G5** — multi-tenant authz: Admin escalation + 32-byte API keys + query-level org guard + audit actor + nonce/services route auth.
- **G6** (reliability bundle, optional in must-ship): balance_monitor build error + half-open probe gate + rate-limit lock-across-await.

🤖 Generated with [Claude Code](https://claude.com/claude-code)