### PR TITLE
fix(gateway): reliability bundle — build-error propagation + probe gate + rate-limit lock ordering

### DIFF
--- a/crates/gateway/src/balance_monitor.rs
+++ b/crates/gateway/src/balance_monitor.rs
@@ -93,17 +93,23 @@ pub struct BalanceMonitor {
 
 impl BalanceMonitor {
     /// Create a new monitor for the given wallet pubkeys.
-    pub fn new(config: MonitorConfig, wallet_pubkeys: Vec<String>) -> Self {
+    ///
+    /// Returns `Err(reqwest::Error)` if the HTTP client fails to build —
+    /// previously we silently fell back to `Client::default()` (no
+    /// timeout), which under unusual TLS-init conditions could leave
+    /// `fetch_balance` hanging indefinitely and block graceful shutdown.
+    /// Failing startup is the correct response: no balance monitoring is
+    /// better than a stuck-forever monitoring task.
+    pub fn new(config: MonitorConfig, wallet_pubkeys: Vec<String>) -> Result<Self, reqwest::Error> {
         let http_client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
-            .build()
-            .unwrap_or_default();
+            .build()?;
 
-        Self {
+        Ok(Self {
             config,
             wallet_pubkeys,
             http_client,
-        }
+        })
     }
 
     /// Returns the number of wallets being monitored.
@@ -315,7 +321,7 @@ mod tests {
             check_interval_secs: 300,
             rpc_url: "https://api.devnet.solana.com".to_string(),
         };
-        BalanceMonitor::new(config, vec![])
+        BalanceMonitor::new(config, vec![]).expect("test client builds")
     }
 
     #[test]

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Context;
 use tracing::{info, warn};
 
 /// Read an environment variable with dual-prefix support.
@@ -587,7 +588,10 @@ async fn main() -> anyhow::Result<()> {
                 monitor_config.rpc_url = app_config.solana.rpc_url.clone();
             }
 
-            let monitor = Arc::new(BalanceMonitor::new(monitor_config, wallet_pubkeys));
+            let monitor = Arc::new(
+                BalanceMonitor::new(monitor_config, wallet_pubkeys)
+                    .context("failed to build balance monitor HTTP client")?,
+            );
             info!(
                 wallets = monitor.wallet_count(),
                 interval_secs = app_config.monitor.check_interval_secs,

--- a/crates/gateway/src/middleware/rate_limit.rs
+++ b/crates/gateway/src/middleware/rate_limit.rs
@@ -78,24 +78,22 @@ impl RateLimiter {
     /// When `client_id` is `"unknown"`, applies the stricter
     /// `unknown_max_requests` limit instead of the normal `max_requests`.
     pub async fn check(&self, client_id: &str) -> Result<u32, ()> {
-        let mut entries = self.entries.lock().await;
-
-        // Emergency cleanup: if the map has grown too large, evict expired
-        // entries — but only if at least 60 seconds have passed since the last
-        // emergency cleanup to prevent cleanup storms under sustained load.
-        if entries.len() > 100_000 {
-            let mut last = self.last_emergency_cleanup.lock().await;
-            let should_cleanup = last.is_none_or(|t| t.elapsed() >= Duration::from_secs(60));
-            if should_cleanup {
-                *last = Some(Instant::now());
-                drop(last);
-                let now = Instant::now();
-                entries.retain(|_, entry| {
-                    now.duration_since(entry.window_start) < self.config.window * 2
-                });
-            }
+        // Decide whether emergency cleanup is needed under a SHORT lock
+        // on `entries`. Previously this function held `entries` for its
+        // entire body — including across the nested
+        // `last_emergency_cleanup.lock().await` and the O(N) `retain` —
+        // so under DDoS (the exact moment `len > 100k` triggers) every
+        // other request blocked on `entries` for the full duration. The
+        // cleanup is now out-of-band and takes locks one at a time.
+        let needs_cleanup = {
+            let entries = self.entries.lock().await;
+            entries.len() > 100_000
+        };
+        if needs_cleanup {
+            self.maybe_emergency_cleanup().await;
         }
 
+        let mut entries = self.entries.lock().await;
         let now = Instant::now();
 
         let entry = entries
@@ -128,6 +126,30 @@ impl RateLimiter {
 
     /// Periodically clean up expired entries to prevent memory leaks.
     pub async fn cleanup(&self) {
+        let mut entries = self.entries.lock().await;
+        let now = Instant::now();
+        entries.retain(|_, entry| now.duration_since(entry.window_start) < self.config.window * 2);
+    }
+
+    /// Emergency cleanup path used when `entries.len() > 100_000`.
+    ///
+    /// Acquires `last_emergency_cleanup` first (cheap; deflects redundant
+    /// callers when the gate fired in the last 60s), drops it, then
+    /// re-acquires `entries` only for the retain. Each lock is held for
+    /// a single short critical section — never across an `.await` for
+    /// another lock — so the hot path's brief `entries` read at the top
+    /// of `check()` doesn't queue behind the cleanup.
+    async fn maybe_emergency_cleanup(&self) {
+        // Cleanup-gate check + claim under its own short lock.
+        {
+            let mut last = self.last_emergency_cleanup.lock().await;
+            if last.is_some_and(|t| t.elapsed() < Duration::from_secs(60)) {
+                return; // Recent cleanup; skip.
+            }
+            *last = Some(Instant::now());
+        }
+
+        // Now perform the retain under a fresh `entries` lock.
         let mut entries = self.entries.lock().await;
         let now = Instant::now();
         entries.retain(|_, entry| now.duration_since(entry.window_start) < self.config.window * 2);

--- a/crates/gateway/src/providers/health.rs
+++ b/crates/gateway/src/providers/health.rs
@@ -62,6 +62,14 @@ struct ProviderHealth {
     ewma_latency_ms: f64,
     /// EWMA alpha (smoothing factor).
     ewma_alpha: f64,
+    /// `true` while a half-open probe request is in flight. The classic
+    /// half-open invariant is "exactly one probe at a time"; without this
+    /// flag, multiple concurrent callers all observe `HalfOpen` at once,
+    /// `is_available()` returns `true` to each of them, and a recovering
+    /// provider gets hammered with N concurrent requests the moment
+    /// cooldown expires. Cleared by the next `record_success` or
+    /// `record_failure` (closed-on-success or reopened-on-failure).
+    probe_in_flight: bool,
 }
 
 impl ProviderHealth {
@@ -72,6 +80,7 @@ impl ProviderHealth {
             opened_at: None,
             ewma_latency_ms: 0.0,
             ewma_alpha: 0.2, // ~10s window with 2s avg request time
+            probe_in_flight: false,
         }
     }
 }
@@ -121,6 +130,11 @@ impl ProviderHealthTracker {
             health.opened_at = None;
         }
 
+        // Clear the probe slot regardless of state — a concurrent caller
+        // that was previously deflected can now retry against the fresh
+        // closed/half-open state.
+        health.probe_in_flight = false;
+
         self.cleanup_old_outcomes(health);
     }
 
@@ -143,8 +157,18 @@ impl ProviderHealthTracker {
             info!(provider, "circuit breaker: half-open → open (probe failed)");
             health.state = CircuitState::Open;
             health.opened_at = Some(now);
+            // Probe slot is released when the circuit reopens — the next
+            // half-open transition (after a fresh cooldown) will claim a
+            // new probe slot via is_available.
+            health.probe_in_flight = false;
             return;
         }
+
+        // Defensive clear in case a probe-claimed call somehow took the
+        // closed/open path (shouldn't happen given the above transitions,
+        // but cheap insurance against future refactors leaving the flag
+        // stuck true).
+        health.probe_in_flight = false;
 
         self.cleanup_old_outcomes(health);
         self.evaluate_circuit(provider, health);
@@ -160,7 +184,19 @@ impl ProviderHealthTracker {
 
         match health.state {
             CircuitState::Closed => true,
-            CircuitState::HalfOpen => true, // Allow probe request
+            CircuitState::HalfOpen => {
+                // Half-open allows exactly ONE probe at a time. If another
+                // caller already grabbed the probe slot, this caller must
+                // wait — return false so the fallback chain tries the
+                // next provider instead of stacking concurrent probes on
+                // a recovering upstream.
+                if health.probe_in_flight {
+                    false
+                } else {
+                    health.probe_in_flight = true;
+                    true
+                }
+            }
             CircuitState::Open => {
                 // Check if cooldown has elapsed
                 if let Some(opened_at) = health.opened_at {
@@ -170,6 +206,11 @@ impl ProviderHealthTracker {
                             "circuit breaker: open → half-open (cooldown elapsed)"
                         );
                         health.state = CircuitState::HalfOpen;
+                        // Claim the probe slot for the caller that
+                        // triggered the transition. Subsequent concurrent
+                        // callers will see `probe_in_flight = true` and
+                        // be deflected.
+                        health.probe_in_flight = true;
                         true
                     } else {
                         false
@@ -247,6 +288,9 @@ impl ProviderHealthTracker {
                 health.opened_at = None;
             }
 
+            // Release the model-level probe slot — see ProviderHealth doc.
+            health.probe_in_flight = false;
+
             self.cleanup_old_outcomes(health);
         }
         // Cascade to provider level (models lock is dropped)
@@ -277,11 +321,15 @@ impl ProviderHealthTracker {
                 );
                 health.state = CircuitState::Open;
                 health.opened_at = Some(now);
+                health.probe_in_flight = false;
                 // Drop lock before cascading, then cascade
                 drop(models);
                 self.record_failure(provider, latency_ms).await;
                 return;
             }
+
+            // Defensive clear (mirrors record_failure provider-level).
+            health.probe_in_flight = false;
 
             self.cleanup_old_outcomes(health);
             self.evaluate_model_circuit(provider, model, health);
@@ -301,7 +349,15 @@ impl ProviderHealthTracker {
 
         match health.state {
             CircuitState::Closed => true,
-            CircuitState::HalfOpen => true,
+            CircuitState::HalfOpen => {
+                // One probe at a time — see is_available for rationale.
+                if health.probe_in_flight {
+                    false
+                } else {
+                    health.probe_in_flight = true;
+                    true
+                }
+            }
             CircuitState::Open => {
                 if let Some(opened_at) = health.opened_at {
                     if opened_at.elapsed() >= self.config.cooldown {
@@ -310,6 +366,7 @@ impl ProviderHealthTracker {
                             model, "model circuit breaker: open → half-open (cooldown elapsed)"
                         );
                         health.state = CircuitState::HalfOpen;
+                        health.probe_in_flight = true;
                         true
                     } else {
                         false
@@ -640,5 +697,44 @@ mod tests {
             (rate - 0.75).abs() < 0.01,
             "expected 75% failure rate at provider level, got {rate}"
         );
+    }
+
+    /// H6 regression: when the circuit transitions to half-open, exactly
+    /// ONE caller may probe; subsequent concurrent callers must be
+    /// deflected (return false from `is_available`). Pre-fix, all
+    /// concurrent callers saw `HalfOpen` and `is_available` returned
+    /// `true` to each, hammering the recovering provider.
+    #[tokio::test]
+    async fn half_open_admits_only_one_concurrent_probe() {
+        let tracker = ProviderHealthTracker::new(test_config());
+
+        // Force the circuit open: enough failures to exceed min_requests
+        // and trip the threshold.
+        for _ in 0..10 {
+            tracker.record_failure("openai", 500).await;
+        }
+        assert_eq!(tracker.get_state("openai").await, CircuitState::Open);
+
+        // Wait for cooldown to elapse so the next is_available()
+        // transitions Open → HalfOpen.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        // First caller: takes the probe slot, returns true.
+        assert!(tracker.is_available("openai").await);
+        assert_eq!(tracker.get_state("openai").await, CircuitState::HalfOpen);
+
+        // Second concurrent caller while still half-open: must be
+        // deflected because the probe is in flight.
+        assert!(
+            !tracker.is_available("openai").await,
+            "second half-open caller must be deflected (probe slot already claimed)"
+        );
+
+        // After the probe completes (success here), the slot reopens
+        // and the circuit closes. A subsequent caller should be allowed
+        // through normally.
+        tracker.record_success("openai", 100).await;
+        assert_eq!(tracker.get_state("openai").await, CircuitState::Closed);
+        assert!(tracker.is_available("openai").await);
     }
 }


### PR DESCRIPTION
## Summary

PR-G6 of the gateway remediation plan. **Reliability bundle**: 3 independent fixes (1 CRITICAL, 1 HIGH, 1 HIGH), one commit each. Independent of #189–#193.

| Severity | Finding | Fix | File |
|---|---|---|---|
| **CRITICAL** | `BalanceMonitor::new` silently dropped HTTP timeout via `unwrap_or_default()` — could hang shutdown | propagate build error; fail startup | `balance_monitor.rs`, `main.rs` |
| **HIGH** | Provider half-open circuit breaker allowed unlimited concurrent probes — recovering provider hammered | `probe_in_flight` flag; one probe at a time | `providers/health.rs` |
| **HIGH** | Rate-limiter held `entries` mutex across nested cleanup-gate acquire + O(N) retain — self-amplifying under DDoS | restructure to drop entries before nested lock; new `maybe_emergency_cleanup` helper | `middleware/rate_limit.rs` |

## C3 — `balance_monitor` build-error propagation

`BalanceMonitor::new` previously called `reqwest::Client::builder().timeout(...).build().unwrap_or_default()`. On the rare path where the builder fails (TLS-init edge cases), `unwrap_or_default()` returns `Client::new()` — a client with **no timeout**. Combined with the monitor running inside `tokio::select!` against the shutdown signal, a stuck request would block graceful shutdown for the OS-default connection timeout (minutes).

**Fix:** return `Result<Self, reqwest::Error>`; `main.rs` propagates with `.context(...)?`. Failing startup is the right answer — no monitoring is better than monitoring that can hang shutdown.

## H6 — Half-open probe gate

Classic circuit-breaker invariant: exactly one probe at a time. Pre-fix, all concurrent callers observed `HalfOpen` simultaneously, `is_available()` returned `true` to each, and a recovering provider got hammered with N concurrent requests at the cooldown moment.

**Fix:** add `probe_in_flight: bool` to `ProviderHealth`. `is_available()` claims the slot atomically (when state transitions Open → HalfOpen, or when already HalfOpen and slot is free). `record_success`/`record_failure` (and model-level variants) release the slot. New regression test `half_open_admits_only_one_concurrent_probe` proves the second concurrent caller is deflected.

## H5 — Rate-limit lock ordering

`check()` previously held `entries` for the whole function, including across the nested `last_emergency_cleanup.lock().await` and the O(N) `entries.retain` walk inside the `len() > 100_000` branch. Under sustained DDoS — the exact moment that branch triggers — every other `check()` call blocked on `entries` for the full nested-acquire + retain duration.

**Fix:** check `len()` under a short read of `entries`, drop, call `maybe_emergency_cleanup` helper out-of-band (which takes locks one at a time), then re-acquire `entries` for the rate-limit increment as normal.

## Tests

- [x] `cargo test --workspace --all-features` (DATABASE_URL set): all green.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] **New `half_open_admits_only_one_concurrent_probe`** — trips circuit Open, waits for cooldown, asserts first `is_available` call gets the probe slot and second concurrent call is deflected.

## After G6

Gateway crate is **complete** for must-ship review. Remaining whole-repo work:
- `crates/router/` — 15-dimension request scorer + routing profiles + model registry
- `crates/protocol/` (`solvela-protocol`) — wire-format types
- `crates/cli/` — `solvela` CLI
- `programs/escrow/` — Anchor program (NOT a workspace member; build separately)
- Medium-tier cleanup PR (~30 small items batched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)