### PR TITLE
fix(router): broken haiku alias + load-time pricing validation (R1)

### DIFF
--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -558,43 +558,18 @@ supports_vision = false
         assert!(result.unwrap() > 0, "valid cost should be positive");
     }
 
-    #[test]
-    fn test_estimated_atomic_cost_rejects_nan() {
-        let reg = registry_with_cost(f64::NAN);
-        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
-        // NaN cost_per_million propagates to a NaN total; estimated_atomic_cost
-        // must reject it rather than silently cast NaN→0.
-        match result {
-            Err(e) => assert!(
-                e.contains("non-finite") || e.contains("NaN") || e.contains("failed"),
-                "error should mention non-finite or NaN, got: {e}"
-            ),
-            Ok(v) => panic!("NaN cost must not produce Ok({v})"),
-        }
-    }
-
-    #[test]
-    fn test_estimated_atomic_cost_rejects_positive_infinity() {
-        let reg = registry_with_cost(f64::INFINITY);
-        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
-        match result {
-            Err(e) => assert!(
-                e.contains("non-finite") || e.contains("inf") || e.contains("failed"),
-                "error should mention non-finite or infinity, got: {e}"
-            ),
-            Ok(v) => panic!("INFINITY cost must not produce Ok({v})"),
-        }
-    }
-
-    #[test]
-    fn test_estimated_atomic_cost_rejects_negative_infinity() {
-        let reg = registry_with_cost(f64::NEG_INFINITY);
-        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
-        match result {
-            Err(_) => {} // expected — non-finite or negative check
-            Ok(v) => panic!("-INFINITY cost must not produce Ok({v})"),
-        }
-    }
+    // R1 note: tests asserting NaN/+Inf/-Inf input through `registry_with_cost`
+    // were removed because PR-R1 added a load-time validator in
+    // `solvela_router::models::from_toml` that rejects non-finite and
+    // negative pricing at the source — `registry_with_cost(f64::NAN)` now
+    // panics at the `from_toml(...)` step, so those test inputs are
+    // unreachable at this layer. The router crate carries equivalent
+    // coverage in `from_toml_rejects_nan_negative_and_infinite_pricing`.
+    //
+    // The downstream `estimated_atomic_cost` guard is retained as
+    // defense-in-depth: it still catches the case where finite inputs
+    // produce a non-finite intermediate via arithmetic overflow (the
+    // surviving overflow test below).
 
     #[test]
     fn test_estimated_atomic_cost_rejects_overflow() {

--- a/crates/router/src/models.rs
+++ b/crates/router/src/models.rs
@@ -16,7 +16,12 @@ pub enum ModelRegistryError {
 }
 
 /// TOML-deserialized model entry from `config/models.toml`.
+///
+/// `deny_unknown_fields` catches typos at startup — pre-fix, a typo like
+/// `input_cost_per_milion = 2.50` would silently leave the real field
+/// at its default (zero) and produce a $0 cost quote.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelEntry {
     pub provider: String,
     pub model_id: String,
@@ -42,46 +47,104 @@ pub struct ModelEntry {
 
 /// TOML top-level structure: `[models.<id>]`.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelsConfig {
     pub models: HashMap<String, ModelEntry>,
 }
 
 /// In-memory model registry loaded from TOML config.
+#[derive(Debug)]
 pub struct ModelRegistry {
     models: HashMap<String, ModelInfo>,
 }
 
 impl ModelRegistry {
     /// Load the registry from a TOML string (contents of `config/models.toml`).
+    ///
+    /// Validation pass at load time rejects:
+    /// - Non-finite (`NaN`/`±∞`) or negative `input_cost_per_million` /
+    ///   `output_cost_per_million`. Without this guard, a corrupt TOML
+    ///   entry would silently propagate `NaN` through `estimate_cost` and
+    ///   ultimately result in a `$0` quote (gateway PR #191 fixed the
+    ///   downstream cast in `compute_actual_atomic_cost`; this is the
+    ///   upstream guard at config-load time).
+    /// - Duplicate canonical keys (`provider/model_id`) where the two
+    ///   entries have **different** pricing. Equal-pricing duplicates are
+    ///   allowed because the TOML lets operators name the same underlying
+    ///   provider model under two human-friendly aliases.
     pub fn from_toml(toml_str: &str) -> Result<Self, ModelRegistryError> {
         let config: ModelsConfig =
             toml::from_str(toml_str).map_err(|e| ModelRegistryError::ParseError(e.to_string()))?;
 
-        let models = config
-            .models
-            .into_iter()
-            .flat_map(|(key, entry)| {
-                let id = format!("{}/{}", entry.provider, entry.model_id);
-                let info = ModelInfo {
-                    id: id.clone(),
-                    provider: entry.provider,
-                    model_id: entry.model_id,
-                    display_name: entry.display_name,
-                    input_cost_per_million: entry.input_cost_per_million,
-                    output_cost_per_million: entry.output_cost_per_million,
-                    context_window: entry.context_window,
-                    supports_streaming: entry.supports_streaming,
-                    supports_tools: entry.supports_tools,
-                    supports_vision: entry.supports_vision,
-                    reasoning: entry.reasoning,
-                    supports_structured_output: entry.supports_structured_output,
-                    supports_batch: entry.supports_batch,
-                    max_output_tokens: entry.max_output_tokens,
-                };
-                // Register under both the key and the canonical id
-                vec![(key, info.clone()), (id, info)]
-            })
-            .collect();
+        // Validation pass: every entry must have finite, non-negative pricing.
+        for (key, entry) in &config.models {
+            if !entry.input_cost_per_million.is_finite() || entry.input_cost_per_million < 0.0 {
+                return Err(ModelRegistryError::ParseError(format!(
+                    "model {key:?}: input_cost_per_million must be finite and non-negative, got {}",
+                    entry.input_cost_per_million
+                )));
+            }
+            if !entry.output_cost_per_million.is_finite() || entry.output_cost_per_million < 0.0 {
+                return Err(ModelRegistryError::ParseError(format!(
+                    "model {key:?}: output_cost_per_million must be finite and non-negative, got {}",
+                    entry.output_cost_per_million
+                )));
+            }
+        }
+
+        // Build the registry. Each entry is registered under both its TOML
+        // key and the canonical `provider/model_id`, so a single model is
+        // typically reachable via two lookup keys. Two TOML entries that
+        // reduce to the same canonical key are tolerated only when their
+        // pricing matches — otherwise the silent last-write-wins behavior
+        // of `HashMap::collect` would non-deterministically pick one.
+        let mut models: HashMap<String, ModelInfo> = HashMap::new();
+        for (key, entry) in config.models {
+            let id = format!("{}/{}", entry.provider, entry.model_id);
+            let info = ModelInfo {
+                id: id.clone(),
+                provider: entry.provider,
+                model_id: entry.model_id,
+                display_name: entry.display_name,
+                input_cost_per_million: entry.input_cost_per_million,
+                output_cost_per_million: entry.output_cost_per_million,
+                context_window: entry.context_window,
+                supports_streaming: entry.supports_streaming,
+                supports_tools: entry.supports_tools,
+                supports_vision: entry.supports_vision,
+                reasoning: entry.reasoning,
+                supports_structured_output: entry.supports_structured_output,
+                supports_batch: entry.supports_batch,
+                max_output_tokens: entry.max_output_tokens,
+            };
+
+            // Reject canonical-key collisions only when they would change
+            // the resolved pricing.
+            if let Some(existing) = models.get(&id) {
+                let pricing_matches =
+                    (existing.input_cost_per_million - info.input_cost_per_million).abs()
+                        < f64::EPSILON
+                        && (existing.output_cost_per_million - info.output_cost_per_million).abs()
+                            < f64::EPSILON;
+                if !pricing_matches {
+                    return Err(ModelRegistryError::ParseError(format!(
+                        "duplicate canonical key {id:?} with conflicting pricing: \
+                         entry {key:?} has input={}/output={} but a previous entry \
+                         registered input={}/output={}",
+                        info.input_cost_per_million,
+                        info.output_cost_per_million,
+                        existing.input_cost_per_million,
+                        existing.output_cost_per_million
+                    )));
+                }
+            }
+
+            // TOML key gets its own entry too (legacy). It's expected to be
+            // unique per TOML — `toml::from_str` into HashMap already
+            // enforces that — so no collision check is needed here.
+            models.insert(key, info.clone());
+            models.insert(id, info);
+        }
 
         Ok(Self { models })
     }
@@ -225,5 +288,152 @@ supports_streaming = true
         let registry = ModelRegistry::from_toml(TEST_TOML).unwrap();
         let all = registry.all();
         assert_eq!(all.len(), 2);
+    }
+
+    /// R1 regression: NaN/Infinity/negative pricing must be rejected at
+    /// load time, not silently propagated through `estimate_cost` to the
+    /// chat path's f64-as-u64 saturating cast.
+    #[test]
+    fn from_toml_rejects_nan_negative_and_infinite_pricing() {
+        for (label, body) in [
+            (
+                "NaN input cost",
+                r#"
+[models.bad]
+provider = "test"
+model_id = "bad"
+display_name = "Bad"
+input_cost_per_million = nan
+output_cost_per_million = 1.0
+context_window = 4096
+"#,
+            ),
+            (
+                "Infinity output cost",
+                r#"
+[models.bad]
+provider = "test"
+model_id = "bad"
+display_name = "Bad"
+input_cost_per_million = 1.0
+output_cost_per_million = inf
+context_window = 4096
+"#,
+            ),
+            (
+                "negative input cost",
+                r#"
+[models.bad]
+provider = "test"
+model_id = "bad"
+display_name = "Bad"
+input_cost_per_million = -0.50
+output_cost_per_million = 1.0
+context_window = 4096
+"#,
+            ),
+        ] {
+            let err =
+                ModelRegistry::from_toml(body).expect_err(&format!("{label} must be rejected"));
+            match err {
+                ModelRegistryError::ParseError(msg) => {
+                    assert!(
+                        msg.contains("input_cost_per_million")
+                            || msg.contains("output_cost_per_million"),
+                        "{label}: error must name the offending field, got: {msg}"
+                    );
+                }
+                other => panic!("{label}: expected ParseError, got {other:?}"),
+            }
+        }
+    }
+
+    /// R1 regression: an unknown TOML field (e.g. typo `input_cost_per_milion`)
+    /// must error at load, not silently default the real field to zero.
+    #[test]
+    fn from_toml_rejects_unknown_field_typo() {
+        let body = r#"
+[models.typo]
+provider = "test"
+model_id = "typo"
+display_name = "Typo"
+input_cost_per_milion = 2.50
+output_cost_per_million = 5.00
+context_window = 4096
+"#;
+        let err = ModelRegistry::from_toml(body)
+            .expect_err("unknown field must be rejected by deny_unknown_fields");
+        let msg = match err {
+            ModelRegistryError::ParseError(m) => m,
+            other => panic!("expected ParseError, got {other:?}"),
+        };
+        assert!(
+            msg.contains("unknown") || msg.contains("input_cost_per_milion"),
+            "error must surface the unknown field, got: {msg}"
+        );
+    }
+
+    /// R1 regression: two entries with the same canonical key but
+    /// **different** pricing must be rejected. Equal-pricing duplicates
+    /// are allowed (this is what the production `claude-sonnet-4-6` /
+    /// `claude-sonnet-4-5` pair was relying on; either entry is safe to
+    /// land in the registry first because the resolved pricing is
+    /// identical).
+    #[test]
+    fn from_toml_rejects_canonical_collision_with_conflicting_pricing() {
+        let body = r#"
+[models.first]
+provider = "test"
+model_id = "shared"
+display_name = "First"
+input_cost_per_million = 1.00
+output_cost_per_million = 2.00
+context_window = 4096
+
+[models.second]
+provider = "test"
+model_id = "shared"
+display_name = "Second"
+input_cost_per_million = 9.99
+output_cost_per_million = 2.00
+context_window = 4096
+"#;
+        let err = ModelRegistry::from_toml(body)
+            .expect_err("canonical-key collision with conflicting pricing must error");
+        let msg = match err {
+            ModelRegistryError::ParseError(m) => m,
+            other => panic!("expected ParseError, got {other:?}"),
+        };
+        assert!(
+            msg.contains("duplicate canonical key") && msg.contains("test/shared"),
+            "error must mention the canonical key, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_toml_allows_canonical_collision_with_identical_pricing() {
+        let body = r#"
+[models.first]
+provider = "test"
+model_id = "shared"
+display_name = "First"
+input_cost_per_million = 3.00
+output_cost_per_million = 15.00
+context_window = 4096
+
+[models.second]
+provider = "test"
+model_id = "shared"
+display_name = "Second"
+input_cost_per_million = 3.00
+output_cost_per_million = 15.00
+context_window = 4096
+"#;
+        let registry = ModelRegistry::from_toml(body)
+            .expect("equal-pricing duplicates should load successfully");
+        // Both TOML keys and the shared canonical key all resolve.
+        assert!(registry.get("first").is_some());
+        assert!(registry.get("second").is_some());
+        assert!(registry.get("test/shared").is_some());
     }
 }

--- a/crates/router/src/profiles.rs
+++ b/crates/router/src/profiles.rs
@@ -90,7 +90,12 @@ pub fn resolve_alias(alias: &str) -> Option<&'static str> {
         "gpt5" | "gpt-5" => Some("openai/gpt-5.2"),
         "sonnet" | "claude-sonnet" => Some("anthropic/claude-sonnet-4-20250514"),
         "opus" | "claude-opus" => Some("anthropic/claude-opus-4-20250514"),
-        "haiku" | "claude-haiku" => Some("anthropic/claude-3-5-haiku-20241022"),
+        // The canonical key here MUST match one registered by `from_toml`
+        // — see the cross-check test below. Previously this pointed at
+        // `claude-3-5-haiku-20241022`, which has never been in
+        // `config/models.toml`, so every request using the `haiku`
+        // shorthand returned a 500 (registry lookup miss).
+        "haiku" | "claude-haiku" => Some("anthropic/claude-haiku-4-5-20251001"),
         "gemini" | "gemini-pro" => Some("google/gemini-3.1-pro"),
         "flash" | "gemini-flash" => Some("google/gemini-2.5-flash"),
         "grok" | "grok-fast" => Some("xai/grok-4-fast-reasoning"),
@@ -157,6 +162,72 @@ mod tests {
             resolve_alias("sonnet"),
             Some("anthropic/claude-sonnet-4-20250514")
         );
+        // R1 regression: this used to point at the unregistered
+        // `claude-3-5-haiku-20241022`. The canonical key MUST match a
+        // model registered in `config/models.toml`.
+        assert_eq!(
+            resolve_alias("haiku"),
+            Some("anthropic/claude-haiku-4-5-20251001")
+        );
         assert_eq!(resolve_alias("nonexistent"), None);
+    }
+
+    /// R1 regression guard: every public alias and every profile-tier
+    /// target MUST resolve to a model registered in
+    /// `config/models.toml`. The previous `haiku` alias quietly broke
+    /// this invariant; this test makes the same class of bug a
+    /// compile-then-test failure for any future drift.
+    ///
+    /// The test loads the *production* `models.toml` from the repo root
+    /// (relative to this crate) so it stays in sync as the registry is
+    /// edited.
+    #[test]
+    fn every_alias_and_profile_tier_resolves_to_a_registered_model() {
+        let toml_str = include_str!("../../../config/models.toml");
+        let registry = crate::models::ModelRegistry::from_toml(toml_str)
+            .expect("config/models.toml must parse");
+
+        // Every alias the public `resolve_alias` exposes.
+        let aliases = [
+            "gpt5",
+            "sonnet",
+            "opus",
+            "haiku",
+            "gemini",
+            "flash",
+            "grok",
+            "deepseek",
+            "deepseek-r",
+            "free",
+            "o3-mini",
+            "o4-mini",
+            "gpt4.1",
+            "gpt4.1-mini",
+            "gpt4.1-nano",
+            "sonnet4.5",
+            "grok3",
+            "grok3-mini",
+        ];
+        for alias in aliases {
+            let canonical = resolve_alias(alias)
+                .unwrap_or_else(|| panic!("alias {alias:?} returned None — should resolve"));
+            assert!(
+                registry.get(canonical).is_some(),
+                "alias {alias:?} -> {canonical:?} is not in models.toml — \
+                 the alias either has a typo, references a removed model, \
+                 or was added before the corresponding model entry."
+            );
+        }
+
+        // Every (profile, tier) combination.
+        for profile in [Profile::Eco, Profile::Auto, Profile::Premium, Profile::Free] {
+            for tier in [Tier::Simple, Tier::Medium, Tier::Complex, Tier::Reasoning] {
+                let canonical = resolve_model(profile, tier);
+                assert!(
+                    registry.get(canonical).is_some(),
+                    "profile {profile:?} tier {tier:?} -> {canonical:?} is not in models.toml"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR-R1: first remediation PR for the router crate review. **3 fixes**, 3 commits, single-domain (registry/alias correctness).

| Severity | Finding | Fix | File |
|---|---|---|---|
| **HIGH** | `haiku`/`claude-haiku` alias pointed at unregistered `claude-3-5-haiku-20241022` — every request using the shorthand returned 500 | point alias at the registered `claude-haiku-4-5-20251001`; add cross-check test | `router/profiles.rs` |
| MEDIUM | `from_toml` accepted `NaN`/`±∞`/negative pricing without validation; missing `#[serde(deny_unknown_fields)]` | load-time validator + serde attributes | `router/models.rs` |
| MEDIUM | Two TOML entries with the same `provider/model_id` silently let last-write-win (currently identical pricing, but a maintenance hazard) | reject conflicting-pricing duplicates; allow identical-pricing duplicates | `router/models.rs` |

## Spot-verified before shipping

- The `haiku` alias bug is real: `config/models.toml` has `model_id = "claude-haiku-4-5-20251001"` (not `claude-3-5-haiku-20241022`).
- All other 16 aliases and all 16 (Profile, Tier) targets cross-check cleanly against the registered TOML — only `haiku` was broken.
- The duplicate canonical key for `claude-sonnet-4-{5,6}` exists in production TOML (both have `model_id = "claude-sonnet-4-20250514"` with identical pricing). The new validator allows this case (equal pricing) by design — operators use the dual-name pattern intentionally.

## New regression tests

- **`every_alias_and_profile_tier_resolves_to_a_registered_model`** (profiles.rs) — loads the *production* `config/models.toml` via `include_str!` and verifies every alias and every (Profile, Tier) target resolves to a registered canonical key. This makes the haiku class of bug a test failure for any future drift.
- **`from_toml_rejects_nan_negative_and_infinite_pricing`** — NaN input cost, +∞ output cost, negative input cost all error.
- **`from_toml_rejects_unknown_field_typo`** — `input_cost_per_milion` (missing 'l') errors at startup.
- **`from_toml_rejects_canonical_collision_with_conflicting_pricing`** — divergent-pricing duplicate errors with both values in the message.
- **`from_toml_allows_canonical_collision_with_identical_pricing`** — equal-pricing duplicate (the production sonnet-4-{5,6} pattern) loads successfully.

## Cascading test-fixture cleanup

Three gateway tests in `routes/chat/cost.rs` (`test_estimated_atomic_cost_rejects_nan` and the +∞/-∞ variants) constructed a `ModelRegistry` with NaN/Inf pricing via the test helper `registry_with_cost`. With the new validator, those inputs are now rejected at `from_toml` — the test helper's `.expect("valid test registry TOML")` panicked before the gateway-level guard ran. Tests removed; equivalent coverage exists at the router layer. The gateway's defense-in-depth guard for **arithmetic** overflow (finite input → infinite intermediate) is still tested by the surviving `test_estimated_atomic_cost_rejects_overflow`.

## Tests

- [x] `cargo test --workspace --all-features` (DATABASE_URL set): all green. Router 19/19 (was 14, +5).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.

## Deferred to future cleanup

- **Scorer math indicators** (`scorer.rs:257-269`) — `"-"`/`"+"`/`"/"` fire on hyphenated words and URLs, inflating tier scores for non-math requests. Classification noise, no payment impact (pricing is usage-based, not tier-based). Scope-creep into the cleanup tier.
- **Duplicate `claude-sonnet-4-{5,6}` TOML entries** — kept as-is for now since both have identical pricing and the validator now tolerates this. If desired, the redundant entry can be removed in a follow-up.

## Cumulative pass status

After this PR, the router crate is **complete** for must-ship review. Remaining whole-repo work:
- `crates/protocol/` (`solvela-protocol`) — wire-format types
- `crates/cli/` — `solvela` CLI
- `programs/escrow/` — Anchor program (separate workspace)
- Final medium-tier cleanup PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)