### PR TITLE
fix(protocol): forward-compat Role + safe Usage + deny_unknown_fields on x402 payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,7 +2631,6 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/gateway/src/providers/anthropic.rs
+++ b/crates/gateway/src/providers/anthropic.rs
@@ -165,11 +165,15 @@ fn from_anthropic_response(resp: AnthropicResponse, original_model: &str) -> Cha
             },
             finish_reason,
         }],
-        usage: Some(Usage {
-            prompt_tokens: resp.usage.input_tokens,
-            completion_tokens: resp.usage.output_tokens,
-            total_tokens: resp.usage.input_tokens + resp.usage.output_tokens,
-        }),
+        // `Usage::new` does the saturating add for total_tokens. A plain
+        // `prompt + completion` panics in debug builds on overflow and
+        // silently wraps in release; the gateway billing path
+        // (`cap_usage_to_request_limits`) reads `total_tokens` directly,
+        // so a wrapped value would propagate into spend tracking.
+        usage: Some(Usage::new(
+            resp.usage.input_tokens,
+            resp.usage.output_tokens,
+        )),
     }
 }
 

--- a/crates/gateway/src/providers/google.rs
+++ b/crates/gateway/src/providers/google.rs
@@ -119,13 +119,14 @@ fn to_gemini_request(req: &ChatRequest) -> GeminiRequest {
     let contents: Vec<GeminiContent> = req
         .messages
         .iter()
-        .filter(|m| m.role != Role::System && m.role != Role::Developer)
+        .filter(|m| m.role != Role::System && m.role != Role::Developer && m.role != Role::Unknown)
         .map(|m| GeminiContent {
             role: Some(match m.role {
                 Role::User => "user".to_string(),
                 Role::Assistant => "model".to_string(),
                 Role::System | Role::Developer => "user".to_string(), // filtered above, but safe fallback
                 Role::Tool => "user".to_string(), // Gemini uses "user" for tool results
+                Role::Unknown => "user".to_string(), // filtered above; safe fallback for forward-compat
             }),
             parts: vec![GeminiPart {
                 text: m.content.clone(),

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -13,4 +13,3 @@ categories = ["api-bindings"]
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "2"

--- a/crates/protocol/src/chat.rs
+++ b/crates/protocol/src/chat.rs
@@ -3,6 +3,15 @@ use serde::{Deserialize, Serialize};
 use crate::tools::{ToolCall, ToolDefinition};
 
 /// Role of a message participant.
+///
+/// `Unknown` is a forward-compat catch-all on the **deserialize** side: a
+/// provider response that carries a role string we haven't enumerated
+/// (e.g., a future OpenAI-introduced variant) lands as `Role::Unknown`
+/// instead of failing the whole message parse and surfacing a 500.
+/// `#[serde(other)]` only affects deserialization; serialization of
+/// `Role::Unknown` produces the literal `"unknown"` string. Provider
+/// adapters should not emit `Unknown` to upstream APIs — translate it
+/// to a sensible default (typically `"user"`) before serializing.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
@@ -11,6 +20,8 @@ pub enum Role {
     Assistant,
     Tool,
     Developer,
+    #[serde(other)]
+    Unknown,
 }
 
 /// A single message in a chat conversation.
@@ -51,6 +62,27 @@ pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+}
+
+impl Usage {
+    /// Construct a `Usage` from prompt and completion counts, computing
+    /// `total_tokens = prompt_tokens.saturating_add(completion_tokens)`.
+    ///
+    /// Provider adapters should prefer this constructor over building the
+    /// struct directly: a plain `prompt + completion` panics in debug
+    /// builds on overflow and silently wraps in release. Even though
+    /// today's models stay well below `u32::MAX` (Claude 3.5's 200K
+    /// context + 8K output is ~0.005% of `u32::MAX`), keeping the
+    /// arithmetic saturating means the gateway billing path
+    /// (`cap_usage_to_request_limits` in `routes/chat/cost.rs`) never
+    /// reads a wrapped value.
+    pub fn new(prompt_tokens: u32, completion_tokens: u32) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens.saturating_add(completion_tokens),
+        }
+    }
 }
 
 /// A single choice in a chat completion response.

--- a/crates/protocol/src/payment.rs
+++ b/crates/protocol/src/payment.rs
@@ -3,7 +3,14 @@ use serde::{Deserialize, Serialize};
 use crate::cost::CostBreakdown;
 
 /// Describes a resource that requires payment.
+///
+/// `deny_unknown_fields`: the field set is fully owned by this codebase
+/// and the x402 spec; rejecting unknown keys at parse time prevents
+/// clients from stuffing extra metadata into the inbound
+/// `PaymentPayload.resource` where the gateway might later start reading
+/// it without realizing it's unvalidated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Resource {
     /// The URL path of the resource.
     pub url: String,
@@ -13,6 +20,7 @@ pub struct Resource {
 
 /// Describes an accepted payment method.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PaymentAccept {
     /// Payment scheme (e.g., "exact", "escrow").
     pub scheme: String,
@@ -34,6 +42,7 @@ pub struct PaymentAccept {
 
 /// The full 402 Payment Required response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PaymentRequired {
     pub x402_version: u8,
     pub resource: Resource,
@@ -44,13 +53,24 @@ pub struct PaymentRequired {
 
 /// Solana-specific payment data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SolanaPayload {
     /// Base64-encoded signed versioned transaction.
     pub transaction: String,
 }
 
 /// Escrow-specific payment payload (scheme = "escrow").
+///
+/// `deny_unknown_fields` interacts with the parent `PayloadData` enum's
+/// `untagged` deserialization to reject ambiguous payloads: a client that
+/// sends both `transaction` (Direct's field) and `deposit_tx` (Escrow's
+/// fields) used to silently deserialize as `Escrow` because Escrow had
+/// all required fields. With `deny_unknown_fields` Escrow now rejects
+/// the extra `transaction` key, and untagged falls through to Direct
+/// (which then rejects the extra `deposit_tx`), so the ambiguous case
+/// errors out at parse time instead of silently picking one variant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EscrowPayload {
     /// Base64-encoded signed deposit transaction (Solana versioned tx).
     pub deposit_tx: String,
@@ -73,6 +93,7 @@ pub enum PayloadData {
 
 /// The payment payload sent in the `PAYMENT-SIGNATURE` header.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PaymentPayload {
     pub x402_version: u8,
     pub resource: Resource,

--- a/crates/protocol/src/vision.rs
+++ b/crates/protocol/src/vision.rs
@@ -1,3 +1,21 @@
+//! Multimodal content wire-format types.
+//!
+//! **Status: defined but unreachable.** `ChatMessage::content` is currently
+//! `String`, so a multipart payload from a client never lands as a
+//! `Vec<ContentPart>` — the request would fail to deserialize against
+//! `ChatRequest` before reaching any provider adapter. None of the
+//! provider adapters (OpenAI / Anthropic / Google / xAI / DeepSeek)
+//! consume `ContentPart` either; image inputs are dropped on the floor
+//! today.
+//!
+//! Wiring this up requires a coordinated change: introduce a
+//! `MessageContent` enum (`String(String) | Parts(Vec<ContentPart>)`) on
+//! `ChatMessage`, then update each provider adapter's request
+//! translation. That's a separate PR worth its own review (multimodal
+//! cost accounting, image-bytes counting for usage reporting, model
+//! capability gating in `models.toml`). Tracking it here so the next
+//! reviewer doesn't assume vision works.
+
 use serde::{Deserialize, Serialize};
 
 /// An image URL with optional detail level.
@@ -9,6 +27,8 @@ pub struct ImageUrl {
 }
 
 /// A single part of multi-modal content (text or image).
+///
+/// Currently unreachable — see the module-level doc comment.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentPart {


### PR DESCRIPTION
## Summary
Three protocol-crate hardenings surfaced by the review pass on `crates/protocol/`:

- **Role::Unknown catch-all** — `Role` gets a `#[serde(other)]` unit variant so a provider response carrying an enum we haven't enumerated (future OpenAI variant, vendor extension) deserializes cleanly instead of failing the whole message and surfacing a 500. Provider adapters translate Unknown -> "user" before serializing upstream.
- **`Usage::new` saturating constructor** — replaces `prompt + completion` arithmetic that panics in debug / wraps in release. The gateway billing path reads `total_tokens` directly via `cap_usage_to_request_limits`, so a wrapped value would silently propagate into spend tracking. Wired through the Anthropic adapter; today's models are nowhere near `u32::MAX` but the saturating add costs nothing.
- **`#[serde(deny_unknown_fields)]` on every x402 payment-payload type** — Resource, PaymentAccept, PaymentRequired, SolanaPayload, EscrowPayload, PaymentPayload. The PAYMENT-SIGNATURE header is the primary trust boundary for client-supplied data; silently discarding unknown keys was letting clients smuggle unvalidated fields. Side benefit: resolves an ambiguity in the untagged `PayloadData` union (a payload with both `transaction` and `deposit_tx` used to silently pick Escrow; now errors out at parse time).

Plus two small chores in the same crate:
- Drop unused `thiserror` dep from `crates/protocol/Cargo.toml` (no `.rs` file uses it).
- Module-level doc comment on `vision.rs` flagging `ContentPart`/`ImageUrl` as defined-but-unreachable so the next reviewer doesn't assume multimodal works (`ChatMessage::content` is `String`; no provider adapter consumes it; image inputs are dropped on the floor today).

## Out of scope (deferred to a future PR)
The actual multimodal plumbing — `ChatMessage::content` -> `MessageContent { String | Parts }`, plus per-provider request translation across all five adapters, plus image-bytes cost accounting and `models.toml` capability gating — is a coordinated change that wants its own review. Flagged in `vision.rs` doc.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p solvela-protocol` — 18 passed
- [x] `cargo test -p gateway --lib` — 483 passed
- [x] `cargo test -p solvela-x402 -p solvela-router` — 14 + 122 passed

DB-bound integration tests under `crates/gateway/tests/escrow_queue.rs` were skipped locally because they require a live Postgres at the legacy `rcr` user — pre-existing env config issue unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)