### PR TITLE
fix(cli): security hardening — wallet write race + payment timeouts + escrow math + URL/wallet validation

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -49,7 +49,16 @@ pub async fn run(
     yes: bool,
     scheme: Option<&str>,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    // Single client serves the gateway round-trip (which proxies LLM
+    // completions, ~30-90 s typical) and the Solana RPC calls
+    // (`solana_tx::*` helpers; ~1-5 s typical). The 180 s safety-net
+    // covers the slowest legitimate path. Without a timeout, a stalled
+    // gateway or RPC hangs the process indefinitely after the keypair
+    // has already been loaded and the transaction signed.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(180))
+        .build()
+        .context("failed to build HTTP client")?;
 
     let body = serde_json::json!({
         "model": model,

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -154,8 +154,10 @@ pub async fn run(
             let current_slot = crate::commands::solana_tx::fetch_current_slot(&rpc_url, &client)
                 .await
                 .context("failed to fetch current slot for escrow expiry")?;
-            let timeout_slots = (accepted.max_timeout_seconds * 1000) / 400;
-            let expiry_slot = current_slot + timeout_slots;
+            let expiry_slot = crate::commands::util::escrow_expiry_slot(
+                current_slot,
+                accepted.max_timeout_seconds,
+            );
             let deposit_tx = crate::commands::solana_tx::build_escrow_deposit(
                 private_key_b58,
                 &accepted.pay_to,

--- a/crates/cli/src/commands/loadtest/payment.rs
+++ b/crates/cli/src/commands/loadtest/payment.rs
@@ -254,8 +254,10 @@ impl PaymentStrategy for EscrowPaymentStrategy {
         let current_slot = fetch_current_slot(&self.rpc_url, &self.rpc_client)
             .await
             .context("failed to fetch current slot for escrow expiry")?;
-        let timeout_slots = (accepted.max_timeout_seconds * 1000) / 400;
-        let expiry_slot = current_slot + timeout_slots;
+        let expiry_slot = crate::commands::util::escrow_expiry_slot(
+            current_slot,
+            accepted.max_timeout_seconds,
+        );
 
         // Build and sign the escrow deposit transaction.
         let deposit_tx = build_escrow_deposit(

--- a/crates/cli/src/commands/loadtest/payment.rs
+++ b/crates/cli/src/commands/loadtest/payment.rs
@@ -254,10 +254,8 @@ impl PaymentStrategy for EscrowPaymentStrategy {
         let current_slot = fetch_current_slot(&self.rpc_url, &self.rpc_client)
             .await
             .context("failed to fetch current slot for escrow expiry")?;
-        let expiry_slot = crate::commands::util::escrow_expiry_slot(
-            current_slot,
-            accepted.max_timeout_seconds,
-        );
+        let expiry_slot =
+            crate::commands::util::escrow_expiry_slot(current_slot, accepted.max_timeout_seconds);
 
         // Build and sign the escrow deposit transaction.
         let deposit_tx = build_escrow_deposit(

--- a/crates/cli/src/commands/mcp/merge.rs
+++ b/crates/cli/src/commands/mcp/merge.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::io::Write as IoWrite;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -109,50 +108,11 @@ pub fn read_entry(path: &Path) -> Result<Option<Value>> {
         .cloned())
 }
 
-/// Atomically write `value` as pretty JSON to `path`:
-/// 1. Write to a temp file in the same directory (same filesystem → rename is atomic).
-/// 2. Rename temp file over the target path.
-/// 3. On Unix, chmod 0600.
+/// Atomically write `value` as pretty JSON to `path`. Thin wrapper over the
+/// shared `crate::commands::util::write_atomic_json` helper so MCP host
+/// configs share the same chmod-before-rename guarantees the wallet file gets.
 pub fn write_atomic(path: &Path, value: &Value) -> Result<()> {
-    let parent = path
-        .parent()
-        .with_context(|| format!("no parent directory for {}", path.display()))?;
-
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create directory {}", parent.display()))?;
-
-    let json = serde_json::to_string_pretty(value).context("failed to serialize JSON")?;
-
-    // Write to temp file in same directory for atomic rename.
-    let mut tmp = tempfile::NamedTempFile::new_in(parent)
-        .context("failed to create temp file for atomic write")?;
-    tmp.write_all(json.as_bytes())
-        .context("failed to write to temp file")?;
-    tmp.write_all(b"\n")
-        .context("failed to write newline to temp file")?;
-    tmp.flush().context("failed to flush temp file")?;
-
-    // Set 0600 permissions on the tempfile FD BEFORE the atomic rename so the
-    // file is never visible on disk with wider permissions (no race window).
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        tmp.as_file()
-            .set_permissions(fs::Permissions::from_mode(0o600))
-            .context("failed to set permissions on temp file")?;
-    }
-
-    tmp.persist(path)
-        .with_context(|| format!("failed to persist temp file to {}", path.display()))?;
-
-    // Belt-and-braces: re-apply after rename in case of cross-filesystem fallback.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("failed to set permissions on {}", path.display()))?;
-    }
-
+    crate::commands::util::write_atomic_json(path, value)?;
     tracing::info!("wrote config to {}", path.display());
     Ok(())
 }

--- a/crates/cli/src/commands/mcp/mod.rs
+++ b/crates/cli/src/commands/mcp/mod.rs
@@ -53,17 +53,7 @@ pub enum McpAction {
     Uninstall(UninstallArgs),
 }
 
-/// Validate a gateway URL: must parse as http or https.
-fn validate_gateway_url(s: &str) -> Result<String, String> {
-    let parsed = url::Url::parse(s).map_err(|e| format!("invalid URL '{}': {}", s, e))?;
-    if parsed.scheme() != "http" && parsed.scheme() != "https" {
-        return Err(format!(
-            "gateway URL must use http or https scheme, got '{}'",
-            parsed.scheme()
-        ));
-    }
-    Ok(s.to_owned())
-}
+use crate::commands::util::validate_gateway_url;
 
 /// Validate a Solana wallet pubkey: base58 chars only, length 32–44.
 fn validate_wallet(s: &str) -> Result<String, String> {

--- a/crates/cli/src/commands/mcp/mod.rs
+++ b/crates/cli/src/commands/mcp/mod.rs
@@ -287,12 +287,28 @@ pub async fn run_install(args: InstallArgs) -> Result<()> {
         );
     }
 
-    // Resolve wallet address: explicit arg > wallet.json > emit a note
+    // Resolve wallet address: explicit arg > wallet.json > emit a note.
+    //
+    // The explicit `--wallet` flag is already gated by `value_parser =
+    // validate_wallet`; the on-disk path was not. Re-validate the loaded
+    // address before it flows into `claude mcp add -e SOLANA_WALLET_ADDRESS=...`
+    // — a hand-edited or attacker-placed wallet file with an embedded
+    // newline would otherwise smuggle an extra `-e` env var into the
+    // child process and could persist into the user's Claude Code config.
     let wallet_address = if let Some(w) = args.wallet {
         Some(w)
     } else {
         match load_wallet() {
-            Ok(wallet) => wallet["address"].as_str().map(str::to_owned),
+            Ok(wallet) => match wallet["address"].as_str() {
+                Some(addr) => Some(validate_wallet(addr).map_err(|e| {
+                    anyhow::anyhow!(
+                        "wallet.json contains an invalid address: {}. \
+                         Re-run 'solvela wallet init' or pass --wallet=<pubkey> explicitly.",
+                        e
+                    )
+                })?),
+                None => None,
+            },
             Err(_) => {
                 eprintln!(
                     "Note: no wallet found at ~/.solvela/wallet.json. \

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -7,4 +7,5 @@ pub mod models;
 pub mod recover;
 pub(crate) mod solana_tx;
 pub mod stats;
+pub(crate) mod util;
 pub mod wallet;

--- a/crates/cli/src/commands/recover.rs
+++ b/crates/cli/src/commands/recover.rs
@@ -118,7 +118,12 @@ pub async fn run(
         .unwrap_or(ESCROW_PROGRAM_ID)
         .to_string();
 
-    let client = reqwest::Client::new();
+    // RPC-only client. 30 s safety-net so a stalled RPC node fails fast
+    // instead of hanging the recovery flow after the user has typed `--execute`.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("failed to build HTTP client")?;
 
     // --- Discover escrows owned by the local wallet ---
     let escrows = discover_escrows(&rpc_url, &program_id_str, &agent_pubkey, &client)

--- a/crates/cli/src/commands/util.rs
+++ b/crates/cli/src/commands/util.rs
@@ -60,6 +60,25 @@ pub(crate) fn write_atomic_json(path: &Path, value: &Value) -> Result<()> {
     Ok(())
 }
 
+/// Validate a gateway URL: must parse as `http://...` or `https://...`.
+///
+/// Used by clap as `value_parser` on every CLI argument that accepts a
+/// gateway URL — both the global `--api-url` (which is the trust anchor
+/// for the entire payment flow) and the `mcp install --gateway-url`
+/// sub-argument. Without this, a user (or a poisoned `SOLVELA_API_URL`
+/// env var) could point the CLI at `file:///etc/passwd` or any other
+/// scheme reqwest happens to support.
+pub(crate) fn validate_gateway_url(s: &str) -> Result<String, String> {
+    let parsed = url::Url::parse(s).map_err(|e| format!("invalid URL '{}': {}", s, e))?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(format!(
+            "gateway URL must use http or https scheme, got '{}'",
+            parsed.scheme()
+        ));
+    }
+    Ok(s.to_owned())
+}
+
 /// Hard upper bound on how many Solana slots into the future an escrow's
 /// expiry may be set, as seen from the CLI's perspective. Solana slots are
 /// ~400 ms each, so 10_000 slots ≈ 66 minutes — comfortably above any

--- a/crates/cli/src/commands/util.rs
+++ b/crates/cli/src/commands/util.rs
@@ -1,0 +1,61 @@
+//! Shared CLI helpers reused across multiple subcommands.
+//!
+//! This module exists so commands like `wallet init` and `mcp install` can
+//! share a single atomic-write implementation that gets the file-permission
+//! bits right (chmod the tempfile FD *before* the rename — never leave a
+//! key-bearing file readable on disk between syscalls).
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+/// Atomically write `value` as pretty JSON to `path`:
+/// 1. Write to a temp file in the same directory (same filesystem → rename is atomic).
+/// 2. Chmod 0600 on the tempfile FD before the rename so the file is never
+///    visible on disk with wider permissions.
+/// 3. Rename temp file over the target path.
+/// 4. Re-apply 0600 after rename in case of cross-filesystem fallback (belt-and-braces).
+pub(crate) fn write_atomic_json(path: &Path, value: &Value) -> Result<()> {
+    let parent = path
+        .parent()
+        .with_context(|| format!("no parent directory for {}", path.display()))?;
+
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create directory {}", parent.display()))?;
+
+    let json = serde_json::to_string_pretty(value).context("failed to serialize JSON")?;
+
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .context("failed to create temp file for atomic write")?;
+    tmp.write_all(json.as_bytes())
+        .context("failed to write to temp file")?;
+    tmp.write_all(b"\n")
+        .context("failed to write newline to temp file")?;
+    tmp.flush().context("failed to flush temp file")?;
+
+    // Set 0600 on the tempfile FD BEFORE the rename — closes the race window
+    // where `fs::write` followed by `fs::set_permissions` would briefly leave
+    // a key-bearing file world-readable.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tmp.as_file()
+            .set_permissions(fs::Permissions::from_mode(0o600))
+            .context("failed to set permissions on temp file")?;
+    }
+
+    tmp.persist(path)
+        .with_context(|| format!("failed to persist temp file to {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/util.rs
+++ b/crates/cli/src/commands/util.rs
@@ -59,3 +59,64 @@ pub(crate) fn write_atomic_json(path: &Path, value: &Value) -> Result<()> {
 
     Ok(())
 }
+
+/// Hard upper bound on how many Solana slots into the future an escrow's
+/// expiry may be set, as seen from the CLI's perspective. Solana slots are
+/// ~400 ms each, so 10_000 slots ≈ 66 minutes — comfortably above any
+/// legitimate `max_timeout_seconds` the gateway should advertise (the
+/// gateway-side ceiling is 300 s ≈ 750 slots) while still rejecting
+/// malicious or misconfigured responses that would push the expiry far
+/// enough out to be effectively never.
+const MAX_ESCROW_EXPIRY_SLOTS_AHEAD: u64 = 10_000;
+
+/// Compute the Solana slot at which an escrow PDA created now should expire.
+///
+/// The intermediate `(seconds * 1000) / 400` arithmetic operates on `u64`
+/// and a hostile or buggy gateway returning a `max_timeout_seconds` near
+/// `u64::MAX / 1000` would silently wrap in release mode, producing a tiny
+/// or zero `timeout_slots` and a near-`current_slot` `expiry_slot`. That
+/// makes the deposited PDA refundable almost immediately, opening a
+/// reverse-the-payment race against the gateway's claim.
+///
+/// Saturating arithmetic plus the `MAX_ESCROW_EXPIRY_SLOTS_AHEAD` cap
+/// closes both the wrap-to-zero case and the unbounded-future case.
+pub(crate) fn escrow_expiry_slot(current_slot: u64, max_timeout_seconds: u64) -> u64 {
+    let timeout_slots = max_timeout_seconds
+        .saturating_mul(1000)
+        .saturating_div(400)
+        .min(MAX_ESCROW_EXPIRY_SLOTS_AHEAD);
+    current_slot.saturating_add(timeout_slots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escrow_expiry_typical_300s() {
+        // 300 s × 2.5 slots/s = 750 slots ahead.
+        assert_eq!(escrow_expiry_slot(1_000_000, 300), 1_000_750);
+    }
+
+    #[test]
+    fn escrow_expiry_clamps_huge_values() {
+        // u64::MAX seconds would wrap without saturation; with the cap it
+        // tops out at MAX_ESCROW_EXPIRY_SLOTS_AHEAD slots ahead.
+        assert_eq!(
+            escrow_expiry_slot(1_000_000, u64::MAX),
+            1_000_000 + MAX_ESCROW_EXPIRY_SLOTS_AHEAD,
+        );
+    }
+
+    #[test]
+    fn escrow_expiry_zero_seconds() {
+        assert_eq!(escrow_expiry_slot(1_000_000, 0), 1_000_000);
+    }
+
+    #[test]
+    fn escrow_expiry_saturates_current_slot_overflow() {
+        // Even with a near-u64::MAX current_slot, saturating_add prevents
+        // wrap-to-zero (which would also produce an instantly-refundable PDA).
+        assert_eq!(escrow_expiry_slot(u64::MAX - 100, 300), u64::MAX);
+    }
+}

--- a/crates/cli/src/commands/wallet.rs
+++ b/crates/cli/src/commands/wallet.rs
@@ -49,15 +49,11 @@ pub async fn init() -> Result<()> {
         "created_at": chrono::Utc::now().to_rfc3339(),
     });
 
-    fs::write(wallet_file(), serde_json::to_string_pretty(&wallet_data)?)
+    // Atomic write: chmod 0600 happens on the tempfile FD before the rename,
+    // closing the race window where the previous fs::write + set_permissions
+    // pair would briefly leave the key file world-readable.
+    crate::commands::util::write_atomic_json(&wallet_file(), &wallet_data)
         .context("failed to write wallet file")?;
-
-    // Restrict file permissions to owner-only on Unix
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(wallet_file(), fs::Permissions::from_mode(0o600))?;
-    }
 
     println!("Wallet created!");
     println!("Address:   {}", address);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,7 +15,12 @@ pub(crate) static ENV_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_
 #[command(version)]
 struct Cli {
     /// Gateway API URL
-    #[arg(long, env = "SOLVELA_API_URL", default_value = "http://localhost:8402")]
+    #[arg(
+        long,
+        env = "SOLVELA_API_URL",
+        default_value = "http://localhost:8402",
+        value_parser = commands::util::validate_gateway_url,
+    )]
     api_url: String,
 
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
First must-ship batch from the CLI review pass. Five focused fixes (3 CRITICAL + 2 HIGH) packaged as separate commits.

| Commit | Severity | Topic |
|---|---|---|
| `eade4f92` | C1 | Wallet `fs::write` + chmod race — key file briefly readable on disk between syscalls. Hoist `write_atomic` into `commands::util::write_atomic_json`; chmod the tempfile FD before the rename. |
| `810092b7` | C2 | `chat.rs` and `recover.rs` HTTP clients had no timeout. Stalled gateway/RPC = process hangs after the keypair is decrypted and the tx signed. 180 s for chat, 30 s for recover. |
| `b1e5b952` | C3 | `(max_timeout_seconds * 1000) / 400` raw `u64` multiply wraps in release on huge values, producing a near-zero `expiry_slot` and an immediately-refundable escrow PDA. Saturating math + 10,000-slot cap (≈66 min wall clock; gateway ceiling is 300 s ≈ 750 slots). |
| `15f5ec36` | H3 | Global `--api-url` had no `value_parser`. `file://`, `ftp://`, etc. were accepted. Hoist `validate_gateway_url` into `commands::util` and apply to `Cli::api_url`. |
| `37df60d4` | H4 | `mcp install` was reading `wallet["address"]` from disk and `format!`-injecting it into `claude mcp add -e SOLANA_WALLET_ADDRESS=...` without re-validation. A hand-edited wallet file with an embedded newline could smuggle an extra `-e` env var. Re-run `validate_wallet` on the disk-loaded path. |

## Out of scope (deferred to PR-CLI2)
The defense-in-depth secret-hygiene fixes from the same review:
- **H1**: zeroize seed/key arrays in `wallet.rs` / `chat.rs` / `recover.rs` (`secrecy = "0.10"` is already a dep but unused on customer paths)
- **H2**: typed `WalletData` return from `load_wallet()` with redacted `Debug` (currently `serde_json::Value` would print the private key if any caller `{:?}`-formats it)

These touch type signatures across 4-5 files and benefit from being reviewed independently.

The 6 MEDIUM findings (silent error swallows, stray `.expect()`, no-timeout `models.rs`, etc.) go to a future cleanup-tier PR after all crates are reviewed.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- [x] `cargo test -p solvela-cli` — 188 passed (includes 4 new `escrow_expiry_slot` unit tests)
- [x] `cargo check -p solvela-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)