### PR TITLE
fix(escrow,x402): drain vault residual + enforce minimum expiry buffer (free-service griefing)

### DIFF
--- a/crates/x402/src/escrow/verifier.rs
+++ b/crates/x402/src/escrow/verifier.rs
@@ -43,6 +43,15 @@ fn extract_deposit_amount(message: &ParsedMessage, escrow_program_id: &[u8; 32])
     Some(u64::from_le_bytes(amount_bytes))
 }
 
+/// Minimum number of slots that must remain between the deposit's
+/// `expiry_slot` and the current slot at verification time. Mirrors
+/// `MIN_EXPIRY_BUFFER` in `programs/escrow/src/lib.rs` (on-chain enforcement).
+/// Without this off-chain check, an adversarial agent could deposit with
+/// `expiry_slot = now + 1`, the gateway would deliver the LLM response after
+/// successful verification, and the gateway's claim transaction would fail
+/// to land before refund opens — leaving the agent with free service.
+const MIN_EXPIRY_BUFFER_SLOTS: u64 = 50;
+
 // ---------------------------------------------------------------------------
 // EscrowVerifier
 // ---------------------------------------------------------------------------
@@ -222,6 +231,13 @@ impl PaymentVerifier for EscrowVerifier {
             )
         })?;
 
+        let expiry_bytes: [u8; 8] = deposit_ix.data[48..56].try_into().map_err(|_| {
+            Error::InvalidTransaction(
+                "failed to parse expiry_slot from instruction data".to_string(),
+            )
+        })?;
+        let ix_expiry_slot = u64::from_le_bytes(expiry_bytes);
+
         // Verify amount >= required (gateway-set, never trust client claims)
         if ix_amount < required_amount {
             return Err(Error::InsufficientPayment {
@@ -293,6 +309,26 @@ impl PaymentVerifier for EscrowVerifier {
                 expected: bs58::encode(&vault_ata).into_string(),
                 actual: bs58::encode(&ix_vault).into_string(),
             });
+        }
+
+        // After all offline structural checks pass, verify the deposit's
+        // expiry_slot leaves enough headroom for the gateway's claim
+        // transaction to land. Performed last because it's the only check
+        // that requires an RPC round-trip — keeping malformed-tx tests
+        // offline-only. Without this an adversarial agent could deposit
+        // with `expiry_slot = now + 1`, the gateway would deliver the LLM
+        // response after settle, then the gateway's claim tx would fail
+        // with EscrowExpired and the agent would refund — free service.
+        // The matching on-chain guard (`MIN_EXPIRY_BUFFER` in
+        // `programs/escrow/src/instructions/deposit.rs`) is the backstop.
+        let current_slot =
+            crate::solana_rpc::get_current_slot(&self.http_client, &self.rpc_url).await?;
+        let buffer = ix_expiry_slot.saturating_sub(current_slot);
+        if buffer < MIN_EXPIRY_BUFFER_SLOTS {
+            return Err(Error::InvalidTransaction(format!(
+                "deposit expiry_slot {} is too close to current slot {} (buffer {} < required {})",
+                ix_expiry_slot, current_slot, buffer, MIN_EXPIRY_BUFFER_SLOTS
+            )));
         }
 
         info!(
@@ -551,7 +587,9 @@ mod tests {
             http_client: reqwest::Client::new(),
         };
 
-        // verify_payment doesn't hit the network (only settle_payment does)
+        // verify_payment hits Solana RPC once (`getSlot` for the
+        // expiry-buffer check); this test exercises that RPC call against
+        // devnet. Settlement still only happens in `settle_payment`.
         let result = verifier.verify_payment(&payload).await;
         assert!(
             result.is_ok(),

--- a/crates/x402/src/solana_rpc.rs
+++ b/crates/x402/src/solana_rpc.rs
@@ -185,6 +185,43 @@ pub async fn poll_for_confirmation(
     }
 }
 
+/// Fetch the current confirmed slot via Solana JSON-RPC `getSlot`.
+///
+/// Used by escrow verification to enforce a minimum buffer between the
+/// claimed `expiry_slot` in a deposit instruction and the slot at which
+/// the gateway is verifying — see `EscrowVerifier::verify_payment` and
+/// the matching on-chain `MIN_EXPIRY_BUFFER` guard in
+/// `programs/escrow/src/instructions/deposit.rs`.
+pub async fn get_current_slot(client: &Client, rpc_url: &str) -> Result<u64, Error> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getSlot",
+        "params": [{"commitment": "confirmed"}],
+    });
+
+    let response = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| Error::Rpc(e.to_string()))?;
+
+    let result: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| Error::Rpc(e.to_string()))?;
+
+    if let Some(error) = result.get("error") {
+        return Err(Error::Rpc(error.to_string()));
+    }
+
+    result
+        .get("result")
+        .and_then(|r| r.as_u64())
+        .ok_or_else(|| Error::Rpc("getSlot did not return a u64 result".to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/programs/escrow/src/errors.rs
+++ b/programs/escrow/src/errors.rs
@@ -41,4 +41,9 @@ pub enum EscrowError {
     /// Vault held zero tokens at refund time.
     #[msg("Vault is empty; nothing to refund")]
     EmptyVault,
+
+    /// Expiry slot is too close to current slot — the claim transaction
+    /// must have a realistic chance to propagate before refund opens.
+    #[msg("Expiry slot is too close to now; insufficient claim buffer")]
+    ExpiryTooSoon,
 }

--- a/programs/escrow/src/instructions/claim.rs
+++ b/programs/escrow/src/instructions/claim.rs
@@ -69,6 +69,29 @@ pub fn claim(ctx: Context<Claim>, actual_amount: u64) -> Result<()> {
         token::transfer(cpi_refund, refund)?;
     }
 
+    // Drain any vault residual to agent before close. SPL token's
+    // close_account requires balance == 0, and an attacker (including the
+    // agent themselves) can transfer dust tokens directly to the vault ATA
+    // at any time after deposit confirms — vault is a public address
+    // derivable from on-chain data and SPL transfers don't require
+    // recipient signature. Without this drain, a single dust unit blocks
+    // the entire claim path and forces refund-after-expiry, giving the
+    // agent free service. Reload to read the post-transfer balance.
+    ctx.accounts.vault.reload()?;
+    let surplus = ctx.accounts.vault.amount;
+    if surplus > 0 {
+        let cpi_drain = CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            Transfer {
+                from: ctx.accounts.vault.to_account_info(),
+                to: ctx.accounts.agent_token_account.to_account_info(),
+                authority: ctx.accounts.escrow.to_account_info(),
+            },
+            signer_seeds,
+        );
+        token::transfer(cpi_drain, surplus)?;
+    }
+
     // Close vault ATA (returns rent to agent)
     let cpi_close = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),

--- a/programs/escrow/src/instructions/deposit.rs
+++ b/programs/escrow/src/instructions/deposit.rs
@@ -4,7 +4,7 @@ use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
 
 use crate::errors::EscrowError;
 use crate::state::Escrow;
-use crate::{MAX_ESCROW_SLOTS, USDC_MINT};
+use crate::{MAX_ESCROW_SLOTS, MIN_EXPIRY_BUFFER, USDC_MINT};
 
 /// Deposit USDC into the PDA vault, locking funds for a specific service request.
 ///
@@ -29,6 +29,16 @@ pub fn deposit(
     require!(
         expiry_slot.saturating_sub(now) <= MAX_ESCROW_SLOTS,
         EscrowError::ExpiryTooFar,
+    );
+    // Floor the deposit-to-expiry gap so an adversarial agent can't set
+    // `expiry_slot = now + 1`, receive the LLM response (which the gateway
+    // delivers HTTP-side immediately after settlement), and refund before
+    // the gateway's claim transaction can confirm. ~20 s buffer at
+    // 400ms/slot. The off-chain verifier in
+    // `crates/x402/src/escrow/verifier.rs` enforces an equivalent buffer.
+    require!(
+        expiry_slot.saturating_sub(now) >= MIN_EXPIRY_BUFFER,
+        EscrowError::ExpiryTooSoon,
     );
 
     // Provider field is `UncheckedAccount` (no on-chain owner constraint), so

--- a/programs/escrow/src/lib.rs
+++ b/programs/escrow/src/lib.rs
@@ -54,6 +54,16 @@ pub const USDC_MINT: Pubkey = pubkey!("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDn
 /// clients that would otherwise lock funds for years).
 pub const MAX_ESCROW_SLOTS: u64 = 216_000;
 
+/// Minimum allowed gap between current slot and `expiry_slot` at deposit
+/// time. ~20 s at 400ms/slot — wide enough for any realistic claim
+/// transaction to propagate and confirm, tight enough to reject the
+/// trivially-adversarial `expiry_slot = now + 1` case where an agent
+/// would otherwise receive service from the gateway and refund before
+/// the gateway's claim transaction can land. The off-chain verifier in
+/// `crates/x402/src/escrow/verifier.rs` enforces an equivalent buffer
+/// so the gateway rejects the deposit before delivering a response.
+pub const MIN_EXPIRY_BUFFER: u64 = 50;
+
 declare_id!("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU");
 
 #[program]

--- a/programs/escrow/tests/integration.rs
+++ b/programs/escrow/tests/integration.rs
@@ -705,3 +705,134 @@ fn test_deposit_with_excessive_expiry_rejected() {
         "deposit with excessive expiry_slot must fail (ExpiryTooFar)"
     );
 }
+
+#[test]
+fn test_claim_succeeds_despite_vault_dust() {
+    // H1 regression. SPL token's CloseAccount aborts if the account holds
+    // any non-zero balance, and anyone (including the agent) can transfer
+    // dust into the vault ATA — vault address is publicly derivable, and
+    // SPL transfers require only the sender's signature. Without the
+    // post-transfer drain in claim.rs, a single dust unit blocks every
+    // claim and forces refund-after-expiry, giving the agent free service.
+    let mut ctx = setup();
+    let service_id = [45u8; 32];
+    let amount = 1_000_000u64;
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+    let (escrow_pda, bump) = deposit_helper(&mut ctx, &service_id, amount, 500);
+
+    // Simulate an external dust transfer into the vault. inject_ata
+    // overwrites the existing vault ATA's balance while preserving owner
+    // (= escrow PDA), mint, and rent lamports — equivalent to a
+    // post-deposit SPL transfer of 1 unit from any third party.
+    inject_ata(&mut ctx.svm, &escrow_pda, &ctx.usdc_mint, amount + 1);
+
+    // Full claim. Must succeed despite the dust.
+    let ix = build_claim_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        &service_id,
+        bump,
+        amount,
+    );
+    send_tx(&mut ctx.svm, &[ix], &ctx.provider, &[&ctx.provider])
+        .expect("claim must succeed even when vault holds external dust");
+
+    // Provider got the full claim amount.
+    let provider_ata = get_associated_token_address(&ctx.provider.pubkey(), &ctx.usdc_mint);
+    assert_eq!(read_token_balance(&ctx.svm, &provider_ata), Some(amount));
+
+    // Agent received the dust (drain destination). This preserves the
+    // contract — surplus is unrelated to the contracted payment, so it
+    // returns to the depositor.
+    let agent_ata = get_associated_token_address(&ctx.agent.pubkey(), &ctx.usdc_mint);
+    assert_eq!(
+        read_token_balance(&ctx.svm, &agent_ata),
+        Some(1),
+        "agent should receive the drained dust"
+    );
+
+    // Vault and escrow closed cleanly.
+    let vault = find_vault_ata(&escrow_pda, &ctx.usdc_mint);
+    assert!(!account_exists(&ctx.svm, &vault), "vault should be closed");
+    assert!(
+        !account_exists(&ctx.svm, &escrow_pda),
+        "escrow should be closed"
+    );
+}
+
+#[test]
+fn test_deposit_with_default_provider_rejected() {
+    // M3: deposit.rs:41 explicitly rejects `provider == Pubkey::default()`,
+    // but the path was untested end-to-end. Default-key provider could
+    // never legitimately sign a claim, so deposits naming it would brick
+    // funds until refund.
+    let mut ctx = setup();
+    let service_id = [46u8; 32];
+    let amount = 1_000_000u64;
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+
+    let ix = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &solana_sdk::pubkey::Pubkey::default(), // zero key
+        &ctx.usdc_mint,
+        amount,
+        &service_id,
+        500,
+    );
+    let result = send_tx(&mut ctx.svm, &[ix], &ctx.agent, &[&ctx.agent]);
+    assert!(
+        result.is_err(),
+        "deposit with provider = Pubkey::default() must fail (InvalidProvider)"
+    );
+}
+
+#[test]
+fn test_deposit_max_escrow_slots_boundary() {
+    // M4: exact-boundary regression for the ExpiryTooFar guard. The
+    // `<=` comparison in deposit.rs means `expiry - now == MAX_ESCROW_SLOTS`
+    // must succeed and `+1` must fail. Previously only `u64::MAX` was
+    // tested.
+    let mut ctx = setup();
+    let max = solvela_escrow::MAX_ESCROW_SLOTS;
+    let amount = 1_000_000u64;
+
+    // Sub-test 1: exactly at the boundary — should succeed.
+    let service_id_ok = [47u8; 32];
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+    let now = ctx.svm.get_sysvar::<solana_sdk::clock::Clock>().slot;
+    let ix_ok = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        amount,
+        &service_id_ok,
+        now + max,
+    );
+    send_tx(&mut ctx.svm, &[ix_ok], &ctx.agent, &[&ctx.agent])
+        .expect("deposit at exactly MAX_ESCROW_SLOTS must succeed");
+
+    // Sub-test 2: one slot past the boundary — must fail.
+    let service_id_bad = [48u8; 32];
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+    let now2 = ctx.svm.get_sysvar::<solana_sdk::clock::Clock>().slot;
+    let ix_bad = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        amount,
+        &service_id_bad,
+        now2 + max + 1,
+    );
+    let result = send_tx(&mut ctx.svm, &[ix_bad], &ctx.agent, &[&ctx.agent]);
+    assert!(
+        result.is_err(),
+        "deposit one slot past MAX_ESCROW_SLOTS must fail (ExpiryTooFar)"
+    );
+}

--- a/programs/escrow/tests/integration.rs
+++ b/programs/escrow/tests/integration.rs
@@ -792,6 +792,73 @@ fn test_deposit_with_default_provider_rejected() {
 }
 
 #[test]
+fn test_deposit_expiry_too_soon_fails() {
+    // H2 regression. The previous lower bound on `expiry_slot` was just
+    // `> now`, which let an adversarial agent set `expiry = now + 1`,
+    // receive the LLM response, and refund before the gateway's claim
+    // tx could confirm. The new `MIN_EXPIRY_BUFFER = 50` floor (and the
+    // matching off-chain verifier check in `crates/x402/src/escrow/verifier.rs`)
+    // closes this. Submit a deposit with `expiry = now + 1` — must fail
+    // with ExpiryTooSoon (not InvalidExpiry, which only fires on
+    // expiry <= now).
+    let mut ctx = setup();
+    let service_id = [49u8; 32];
+    let amount = 1_000_000u64;
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+
+    let now = ctx.svm.get_sysvar::<solana_sdk::clock::Clock>().slot;
+    let ix = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        amount,
+        &service_id,
+        now + 1, // passes `> now` but fails `>= now + MIN_EXPIRY_BUFFER`
+    );
+    let result = send_tx(&mut ctx.svm, &[ix], &ctx.agent, &[&ctx.agent]);
+    assert!(
+        result.is_err(),
+        "deposit with expiry_slot = now + 1 must fail (ExpiryTooSoon)"
+    );
+
+    // Also exercise the exact boundary: `now + (MIN_EXPIRY_BUFFER - 1)`
+    // must fail; `now + MIN_EXPIRY_BUFFER` must succeed.
+    let service_id_just_under = [50u8; 32];
+    let now_a = ctx.svm.get_sysvar::<solana_sdk::clock::Clock>().slot;
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+    let ix_under = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        amount,
+        &service_id_just_under,
+        now_a + solvela_escrow::MIN_EXPIRY_BUFFER - 1,
+    );
+    assert!(
+        send_tx(&mut ctx.svm, &[ix_under], &ctx.agent, &[&ctx.agent]).is_err(),
+        "deposit one slot below MIN_EXPIRY_BUFFER must fail"
+    );
+
+    let service_id_at_min = [51u8; 32];
+    let now_b = ctx.svm.get_sysvar::<solana_sdk::clock::Clock>().slot;
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, amount);
+    let ix_min = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        amount,
+        &service_id_at_min,
+        now_b + solvela_escrow::MIN_EXPIRY_BUFFER,
+    );
+    send_tx(&mut ctx.svm, &[ix_min], &ctx.agent, &[&ctx.agent])
+        .expect("deposit at exactly MIN_EXPIRY_BUFFER must succeed");
+}
+
+#[test]
 fn test_deposit_max_escrow_slots_boundary() {
     // M4: exact-boundary regression for the ExpiryTooFar guard. The
     // `<=` comparison in deposit.rs means `expiry - now == MAX_ESCROW_SLOTS`


### PR DESCRIPTION
## Summary
Two cross-layer security fixes for the Anchor escrow program. Both close the same blast radius — agent obtains the LLM response without the gateway being able to settle payment — via different mechanisms.

| Commit | Sev | Mechanism |
|---|---|---|
| `80d01df3` | CRIT | **Vault dust stuffing.** SPL token's CloseAccount aborts on non-zero balance. Anyone (incl. agent) can transfer 1 dust unit into the vault ATA — vault address is publicly derivable, SPL transfers don't require recipient signature. After deposit, the existing claim path transfers the full `escrow.amount` out, but the dust remains, the close CPI fails, the entire claim tx reverts. Provider can never claim. After expiry agent refunds full balance + dust at zero net cost. **Fix:** reload + drain vault residual to agent before close. |
| `3fe42a6b` | CRIT | **Instant-refund window.** Old guard was `expiry_slot > now`. Agent submits with `expiry_slot = now + 1`, gateway's claim tx can't land before slot moves past expiry, claim fails with EscrowExpired, agent refunds. The verifier was already parsing the deposit instruction byte layout but skipping the `expiry_slot` field. **Fix:** new `MIN_EXPIRY_BUFFER = 50` slots (~20 s) on-chain, mirrored in the off-chain verifier with a new `solana_rpc::get_current_slot` helper. |

Both attacks have **zero net cost to the agent** and result in the gateway delivering the LLM response while the provider gets nothing.

## Architecture

**H1 fix (claim.rs):** Inserted between the existing two transfers and the close_account CPI:
```rust
ctx.accounts.vault.reload()?;
let surplus = ctx.accounts.vault.amount;
if surplus > 0 { /* drain to agent_token_account via PDA-signed CPI */ }
```
ClaimEvent schema unchanged — surplus is external dust, not part of the contract.

**H2 fix (two layers):**
- On-chain: `programs/escrow/src/lib.rs` adds `MIN_EXPIRY_BUFFER: u64 = 50`. `deposit.rs` adds a third `require!` after the existing `> now` and `<= MAX_ESCROW_SLOTS` guards. New `ExpiryTooSoon` error variant appended to `errors.rs` (preserves wire codes per the existing comment at line 26-28).
- Off-chain: `crates/x402/src/escrow/verifier.rs` parses `expiry_slot` from `deposit_ix.data[48..56]`, calls new `solana_rpc::get_current_slot`, rejects with `InvalidTransaction` if buffer < 50. The slot check runs LAST so all offline structural checks short-circuit without an RPC round-trip — keeps existing offline-only "rejects malformed" tests independent of network state.

## New tests (integration.rs)
- `test_claim_succeeds_despite_vault_dust` — H1 regression; injects 1 dust unit into vault post-deposit, asserts claim succeeds, agent receives drained dust, vault + escrow close cleanly
- `test_deposit_expiry_too_soon_fails` — H2 regression; covers `now + 1`, `now + (MIN-1)` (must fail), `now + MIN` (must succeed)
- `test_deposit_with_default_provider_rejected` — covers existing `provider != Pubkey::default()` guard (M3 from review)
- `test_deposit_max_escrow_slots_boundary` — exact-boundary regression for the `ExpiryTooFar` guard (M4 from review)

## Out of scope (deferred to cleanup tier)
- **M1**: `Transfer` → `TransferChecked` migration. Mint is pinned via `address = USDC_MINT`, decimals can't drift. Defense-in-depth only.
- **M5**: Anchor 0.31.1 emits 14 `unexpected cfg` warnings under newer Rust. Workspace clippy is unaffected (escrow is excluded from workspace members) but local development hits these.
- **M6**: `--features mainnet` not enforced by any build-pipeline target. Pure documentation gap; cannot be fixed at the program level.

## Test plan
- [x] `cargo build-sbf` rebuilds the .so with H1 + H2 changes
- [x] `cargo test --features sbf` (escrow): 23 integration tests + 8 unit tests pass
- [x] `cargo test -p solvela-x402 --lib`: 122/122 pass with default features
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (workspace; escrow's anchor-cfg warnings aren't in scope)
- [x] Verified `verify_payment` runs the new RPC slot check only after offline checks pass — preserves the offline-only behavior for malformed-tx rejection tests

The 6 `#[sqlx::test]`-annotated DB-bound tests under `--features postgres` fail in this dev environment due to a pre-existing legacy Postgres user config (the same `rcr` auth issue we hit during PR-P1). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)