### PR TITLE
fix(cli): typed WalletData with redacted Debug + zeroize derived secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,6 +2623,7 @@ dependencies = [
  "tracing",
  "url",
  "wiremock",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,6 +37,7 @@ url = { workspace = true }
 getrandom = { version = "0.4", features = ["std"] }
 hdrhistogram = "7"
 secrecy = "0.10"
+zeroize = { workspace = true }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -5,6 +5,7 @@ use sha2::{Digest, Sha256};
 use solvela_x402::types::{
     PaymentAccept, PaymentPayload, PaymentRequired, Resource, SolanaPayload,
 };
+use zeroize::Zeroizing;
 
 use crate::commands::wallet::load_wallet;
 
@@ -175,13 +176,22 @@ pub async fn run(
             .await
             .context("failed to build escrow deposit transaction")?;
 
-            // Derive agent pubkey from keypair.
-            let key_bytes = bs58::decode(private_key_b58)
-                .into_vec()
-                .context("keypair decode")?;
-            let seed: [u8; 32] = key_bytes[..32]
-                .try_into()
-                .map_err(|_| anyhow::anyhow!("bad seed"))?;
+            // Derive agent pubkey from keypair. Both `key_bytes` (Vec<u8>
+            // holding seed||pubkey) and `seed` ([u8; 32], the raw ed25519
+            // secret scalar) are wrapped in `Zeroizing` so the buffers are
+            // scrubbed when this scope exits. `agent_pubkey` is the
+            // public verifying key — non-secret, no wrap needed.
+            let key_bytes = Zeroizing::new(
+                bs58::decode(private_key_b58)
+                    .into_vec()
+                    .context("keypair decode")?,
+            );
+            let mut seed = Zeroizing::new([0u8; 32]);
+            seed.copy_from_slice(
+                key_bytes
+                    .get(..32)
+                    .ok_or_else(|| anyhow::anyhow!("bad seed"))?,
+            );
             let agent_pubkey = ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key();
             let agent_pubkey_b58 = bs58::encode(agent_pubkey.as_bytes()).into_string();
 

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
 use solvela_x402::types::{
     PaymentAccept, PaymentPayload, PaymentRequired, Resource, SolanaPayload,
@@ -121,11 +122,11 @@ pub async fn run(
         }
     }
 
-    // Load wallet.
+    // Load wallet. `expose_secret()` is the documented escape hatch for
+    // SecretString — every site that pulls the raw key is greppable for
+    // future reviewers.
     let wallet = load_wallet()?;
-    let private_key_b58 = wallet["private_key"]
-        .as_str()
-        .context("wallet missing private_key field")?;
+    let private_key_b58: &str = wallet.private_key.expose_secret();
 
     // Select the preferred payment scheme (escrow > exact, or override).
     let accepted = select_payment_scheme(&payment_required.accepts, scheme)?.clone();

--- a/crates/cli/src/commands/mcp/mod.rs
+++ b/crates/cli/src/commands/mcp/mod.rs
@@ -299,16 +299,13 @@ pub async fn run_install(args: InstallArgs) -> Result<()> {
         Some(w)
     } else {
         match load_wallet() {
-            Ok(wallet) => match wallet["address"].as_str() {
-                Some(addr) => Some(validate_wallet(addr).map_err(|e| {
-                    anyhow::anyhow!(
-                        "wallet.json contains an invalid address: {}. \
-                         Re-run 'solvela wallet init' or pass --wallet=<pubkey> explicitly.",
-                        e
-                    )
-                })?),
-                None => None,
-            },
+            Ok(wallet) => Some(validate_wallet(&wallet.address).map_err(|e| {
+                anyhow::anyhow!(
+                    "wallet.json contains an invalid address: {}. \
+                     Re-run 'solvela wallet init' or pass --wallet=<pubkey> explicitly.",
+                    e
+                )
+            })?),
             Err(_) => {
                 eprintln!(
                     "Note: no wallet found at ~/.solvela/wallet.json. \

--- a/crates/cli/src/commands/recover.rs
+++ b/crates/cli/src/commands/recover.rs
@@ -10,6 +10,7 @@
 use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use secrecy::ExposeSecret;
+use zeroize::Zeroizing;
 
 use crate::commands::wallet::load_wallet;
 
@@ -84,18 +85,25 @@ pub async fn run(
     let wallet = load_wallet()?;
     let private_key_b58: &str = wallet.private_key.expose_secret();
 
-    let key_bytes = bs58::decode(private_key_b58)
-        .into_vec()
-        .context("failed to decode private key from base58")?;
+    // `Zeroizing` scrubs the byte buffers when the function returns so a
+    // process memory dump (crash, /proc/pid/mem scan from a sibling with
+    // ptrace, or a core file) doesn't yield the raw secret. The
+    // `signing_key` value lives until the end of `run` — refunds use it
+    // to sign tx; ed25519_dalek::SigningKey already implements Drop +
+    // Zeroize internally.
+    let key_bytes = Zeroizing::new(
+        bs58::decode(private_key_b58)
+            .into_vec()
+            .context("failed to decode private key from base58")?,
+    );
     if key_bytes.len() != 64 {
         return Err(anyhow!(
             "private key must be 64 bytes (seed || pubkey), got {}",
             key_bytes.len()
         ));
     }
-    let seed: [u8; 32] = key_bytes[..32]
-        .try_into()
-        .map_err(|_| anyhow!("failed to slice seed from keypair bytes"))?;
+    let mut seed = Zeroizing::new([0u8; 32]);
+    seed.copy_from_slice(&key_bytes[..32]);
     let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
     let agent_pubkey: [u8; 32] = signing_key.verifying_key().to_bytes();
     let agent_pubkey_b58 = bs58::encode(agent_pubkey).into_string();

--- a/crates/cli/src/commands/recover.rs
+++ b/crates/cli/src/commands/recover.rs
@@ -9,6 +9,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use secrecy::ExposeSecret;
 
 use crate::commands::wallet::load_wallet;
 
@@ -81,9 +82,7 @@ pub async fn run(
 
     // --- Load wallet ---
     let wallet = load_wallet()?;
-    let private_key_b58 = wallet["private_key"]
-        .as_str()
-        .context("wallet missing private_key field")?;
+    let private_key_b58: &str = wallet.private_key.expose_secret();
 
     let key_bytes = bs58::decode(private_key_b58)
         .into_vec()

--- a/crates/cli/src/commands/wallet.rs
+++ b/crates/cli/src/commands/wallet.rs
@@ -2,6 +2,25 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use secrecy::{ExposeSecret, SecretString};
+
+/// Typed wallet contents with the private key wrapped in `SecretString`.
+///
+/// Replaces the previous raw `serde_json::Value` return from `load_wallet()`
+/// to (a) enforce field presence at parse time rather than panic-prone
+/// `wallet["..."].as_str().unwrap()` chains scattered across callers, and
+/// (b) ensure any caller that `{:?}`-formats the wallet in an error chain
+/// or trace doesn't dump the private key. `SecretString` provides
+/// `Debug` that redacts the inner string; the derived `Debug` on this
+/// struct inherits the redaction.
+///
+/// `created_at` from the on-disk JSON is intentionally not threaded through
+/// — no caller reads it and dropping it keeps the in-memory surface tight.
+#[derive(Debug)]
+pub struct WalletData {
+    pub address: String,
+    pub private_key: SecretString,
+}
 
 fn wallet_dir() -> PathBuf {
     home_dir().join(".solvela")
@@ -66,7 +85,7 @@ pub async fn init() -> Result<()> {
 
 pub async fn status(api_url: &str) -> Result<()> {
     let wallet = load_wallet()?;
-    let address = wallet["address"].as_str().unwrap_or("unknown");
+    let address = &wallet.address;
 
     println!("Wallet Address: {}", address);
     println!("Gateway:        {}", api_url);
@@ -103,14 +122,17 @@ pub async fn status(api_url: &str) -> Result<()> {
 
 pub fn export() -> Result<()> {
     let wallet = load_wallet()?;
-    let key = wallet["private_key"].as_str().unwrap_or("not found");
     eprintln!("WARNING: Keep this key secret! Anyone with this key controls your funds.");
     eprintln!();
-    println!("{}", key);
+    // Explicit `expose_secret()` keeps the unwrap path documented at the
+    // single point where the secret legitimately leaves the SecretString
+    // — there's no other way to extract the inner value, so any future
+    // reviewer can grep for `expose_secret` to find every use site.
+    println!("{}", wallet.private_key.expose_secret());
     Ok(())
 }
 
-pub(crate) fn load_wallet() -> Result<serde_json::Value> {
+pub(crate) fn load_wallet() -> Result<WalletData> {
     let path = wallet_file();
     if !path.exists() {
         anyhow::bail!(
@@ -119,7 +141,24 @@ pub(crate) fn load_wallet() -> Result<serde_json::Value> {
         );
     }
     let data = fs::read_to_string(&path).context("failed to read wallet file")?;
-    serde_json::from_str(&data).context("wallet file is corrupted")
+    let parsed: serde_json::Value =
+        serde_json::from_str(&data).context("wallet file is corrupted")?;
+
+    let address = parsed
+        .get("address")
+        .and_then(|v| v.as_str())
+        .context("wallet file missing 'address' field")?
+        .to_string();
+    let private_key = parsed
+        .get("private_key")
+        .and_then(|v| v.as_str())
+        .context("wallet file missing 'private_key' field")?
+        .to_string();
+
+    Ok(WalletData {
+        address,
+        private_key: SecretString::from(private_key),
+    })
 }
 
 #[cfg(test)]
@@ -192,8 +231,29 @@ mod tests {
         .expect("write file");
 
         let wallet = load_wallet().expect("load should succeed");
-        assert_eq!(wallet["address"], "def");
-        assert_eq!(wallet["private_key"], "abc");
+        assert_eq!(wallet.address, "def");
+        assert_eq!(wallet.private_key.expose_secret(), "abc");
+    }
+
+    #[tokio::test]
+    async fn test_wallet_data_debug_redacts_private_key() {
+        // Defense-in-depth: any future caller that {:?}-formats a
+        // WalletData (e.g. inside an anyhow .context() chain) must NOT
+        // expose the private key. SecretString redacts itself; this test
+        // pins that contract.
+        let wallet = WalletData {
+            address: "AddressVisible".to_string(),
+            private_key: SecretString::from("secret-key-must-not-leak".to_string()),
+        };
+        let debug_output = format!("{:?}", wallet);
+        assert!(
+            !debug_output.contains("secret-key-must-not-leak"),
+            "Debug must not expose private key: {debug_output}"
+        );
+        assert!(
+            debug_output.contains("AddressVisible"),
+            "Debug should expose non-secret fields: {debug_output}"
+        );
     }
 
     #[tokio::test]
@@ -210,10 +270,9 @@ mod tests {
         );
 
         let wallet = load_wallet().expect("should load created wallet");
-        let address = wallet["address"].as_str().expect("address field");
-        assert!(!address.is_empty(), "address should not be empty");
+        assert!(!wallet.address.is_empty(), "address should not be empty");
         assert!(
-            wallet["private_key"].as_str().is_some(),
+            !wallet.private_key.expose_secret().is_empty(),
             "private_key should be present"
         );
     }
@@ -230,7 +289,7 @@ mod tests {
         let wallet2 = load_wallet().expect("load after second init");
 
         assert_eq!(
-            wallet1["address"], wallet2["address"],
+            wallet1.address, wallet2.address,
             "second init should not overwrite existing wallet"
         );
     }
@@ -258,8 +317,8 @@ mod tests {
         init().await.expect("init");
 
         let wallet = load_wallet().expect("load");
-        let address = wallet["address"].as_str().expect("address");
-        let private_key = wallet["private_key"].as_str().expect("private_key");
+        let address = &wallet.address;
+        let private_key = wallet.private_key.expose_secret();
 
         // Address should be base58 (32-44 chars for Solana pubkeys)
         assert!(
@@ -280,7 +339,7 @@ mod tests {
         assert_eq!(key_bytes.len(), 64, "private key should be 64 bytes");
         let derived_address = bs58::encode(&key_bytes[32..]).into_string();
         assert_eq!(
-            derived_address, address,
+            &derived_address, address,
             "address should match pubkey from private key"
         );
     }

--- a/crates/cli/src/commands/wallet.rs
+++ b/crates/cli/src/commands/wallet.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use secrecy::{ExposeSecret, SecretString};
+use zeroize::Zeroizing;
 
 /// Typed wallet contents with the private key wrapped in `SecretString`.
 ///
@@ -49,17 +50,25 @@ pub async fn init() -> Result<()> {
     // Generate a real ed25519 keypair using the same library the gateway uses
     // for signature verification. The 32-byte secret scalar is the private key;
     // the corresponding 32-byte verifying key is the Solana public key.
-    let mut seed = [0u8; 32];
-    getrandom::fill(&mut seed).context("failed to generate random seed")?;
+    //
+    // `Zeroizing<[u8; 32]>` and `Zeroizing<[u8; 64]>` scrub the byte arrays
+    // when the function returns, so a process memory dump (crash, /proc/pid/mem
+    // scan from a sibling process with ptrace, or a core file written to
+    // disk) doesn't yield the raw secret. The base58 String we emit to disk
+    // is also derived from these bytes, but it's brief — `serde_json::json!`
+    // consumes `private_key_b58` immediately and the in-memory buffer is
+    // only live for microseconds.
+    let mut seed = Zeroizing::new([0u8; 32]);
+    getrandom::fill(&mut *seed).context("failed to generate random seed")?;
 
     let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
     let verifying_key = signing_key.verifying_key();
 
     // Solana wallet convention: private key = seed || pubkey bytes (64 bytes total), base58-encoded
-    let mut full_key = [0u8; 64];
-    full_key[..32].copy_from_slice(&seed);
+    let mut full_key = Zeroizing::new([0u8; 64]);
+    full_key[..32].copy_from_slice(&*seed);
     full_key[32..].copy_from_slice(verifying_key.as_bytes());
-    let private_key_b58 = bs58::encode(&full_key).into_string();
+    let private_key_b58 = bs58::encode(&*full_key).into_string();
     let address = bs58::encode(verifying_key.as_bytes()).into_string();
 
     let wallet_data = serde_json::json!({


### PR DESCRIPTION
## Summary
The two defense-in-depth secret-hygiene findings deferred from PR-CLI1 (#197). Both close the customer-facing private-key handling story.

| Commit | Sev | Topic |
|---|---|---|
| `e4dbd8d1` | H2 | Typed `WalletData { address, private_key: SecretString }` replaces raw `serde_json::Value` return from `load_wallet()`. Derived `Debug` redacts private_key (SecretString prints `Secret([REDACTED ...])`). Eliminates the panic-prone `wallet["..."].as_str().unwrap()` chains scattered across 4 callers and removes any future risk of `tracing::error!(?wallet, ...)` or `.context(format!("{:?}", wallet))` dumping the keypair to stderr/logs. |
| `e41a919f` | H1 | `seed: [u8; 32]`, `full_key: [u8; 64]`, and `key_bytes: Vec<u8>` in `wallet::init` / `chat::run` (escrow leg) / `recover::run` are wrapped in `zeroize::Zeroizing<>` so Drop scrubs the buffers on function exit. Closes the process-memory-dump exposure window where a /proc/pid/mem scan or a core file would yield the raw ed25519 secret. The `secrecy` crate was already a dep but only `loadtest::payment` was using it — production paths are now consistent. |

## Architecture

**H2:** New struct `WalletData` in `wallet.rs` with `#[derive(Debug)]`. The `secrecy::SecretString` field provides redacted Debug; the derived Debug on the wrapper inherits it. `load_wallet()` parses the on-disk JSON into typed fields with `.context()` errors on missing required fields (no more silent `as_str().unwrap_or("not found")`). Every read of the inner key string goes through `expose_secret()` — grep-able for future reviewers.

`created_at` from the on-disk JSON is intentionally not threaded through — no caller reads it and dropping it keeps the in-memory surface tight.

**H1:** `Zeroizing<T>` from the `zeroize` crate is a thin wrapper that calls `Zeroize::zeroize` on Drop. Wraps three call sites: the random seed + derived 64-byte buffer in `wallet::init`, and the bs58-decoded keypair + sliced seed in both `chat::run` and `recover::run`. The base58-encoded String emitted to disk in `init` is brief (consumed by `serde_json::json!` immediately) and the on-disk JSON is already protected by the chmod-0600 atomic write from PR-CLI1.

## Surface touched
- `wallet.rs` — new struct, redacted-debug test, refactored `load_wallet`, updated `status`/`export`, Zeroizing wraps in `init`
- `chat.rs` — typed access to wallet, Zeroizing wraps on the escrow-leg derivation
- `recover.rs` — typed access, Zeroizing wraps
- `mcp/mod.rs` — `Some(wallet.address)` replaces `wallet["address"].as_str().map(...)`
- `Cargo.toml` — new `zeroize = { workspace = true }` (already in workspace deps for x402)

## Merge note
This branch is based off pre-CLI1 main. PR-CLI1's H4 fix (the `validate_wallet` re-validation on the disk-loaded address in `mcp/mod.rs`) touches the same lines this PR changes. Whichever PR merges second will have a small conflict; resolution is `Some(validate_wallet(&wallet.address)?)` — both fixes are independently correct and combine without semantic conflict.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p solvela-cli --all-targets -- -D warnings`
- [x] `cargo check -p solvela-cli`
- [x] `cargo test -p solvela-cli` — 185 passed (184 pre-existing + 1 new redaction test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)