### PR TITLE
chore: cleanup-tier MEDIUMs from review pass — 8 fixes across cli + escrow

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -95,7 +95,16 @@ pub async fn run(
 
     // --- 402 Payment Required ---
     let error_body: serde_json::Value = resp.json().await?;
-    let error_msg = error_body["error"]["message"].as_str().unwrap_or("");
+    // Surface a clear actionable error when `error.message` is missing or
+    // non-string. Otherwise the empty-string fallback flowed straight into
+    // serde_json::from_str("") which returns "EOF while parsing a value"
+    // — accurate but useless for the user trying to debug a malformed
+    // 402 response from the gateway.
+    let error_msg = error_body["error"]["message"].as_str().ok_or_else(|| {
+        anyhow::anyhow!(
+            "gateway 402 response missing error.message field; raw body: {error_body}"
+        )
+    })?;
 
     let payment_required: PaymentRequired = serde_json::from_str(error_msg)
         .context("failed to parse PaymentRequired from 402 response")?;

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -101,9 +101,7 @@ pub async fn run(
     // — accurate but useless for the user trying to debug a malformed
     // 402 response from the gateway.
     let error_msg = error_body["error"]["message"].as_str().ok_or_else(|| {
-        anyhow::anyhow!(
-            "gateway 402 response missing error.message field; raw body: {error_body}"
-        )
+        anyhow::anyhow!("gateway 402 response missing error.message field; raw body: {error_body}")
     })?;
 
     let payment_required: PaymentRequired = serde_json::from_str(error_msg)

--- a/crates/cli/src/commands/mcp/mod.rs
+++ b/crates/cli/src/commands/mcp/mod.rs
@@ -379,7 +379,13 @@ pub async fn run_install(args: InstallArgs) -> Result<()> {
         }
         _ => {
             let home = home_dir()?;
-            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            // `cwd` resolves the project-scope `.mcp.json` location. A
+            // silent fallback to `.` would mask EACCES/ENOENT (cwd
+            // deleted out from under us, or permission lost) and write
+            // the config to a path the user didn't expect — bail with
+            // a clear error instead.
+            let cwd = std::env::current_dir()
+                .context("failed to read current working directory; project-scope mcp install requires a readable cwd")?;
             let path = config_path(&host, &scope, &home, &cwd).ok_or_else(|| {
                 anyhow::anyhow!("internal: host {} has no config path (bug)", host)
             })?;
@@ -441,7 +447,13 @@ pub async fn run_uninstall(args: UninstallArgs) -> Result<()> {
         }
         _ => {
             let home = home_dir()?;
-            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            // `cwd` resolves the project-scope `.mcp.json` location. A
+            // silent fallback to `.` would mask EACCES/ENOENT (cwd
+            // deleted out from under us, or permission lost) and write
+            // the config to a path the user didn't expect — bail with
+            // a clear error instead.
+            let cwd = std::env::current_dir()
+                .context("failed to read current working directory; project-scope mcp install requires a readable cwd")?;
             let path = config_path(&host, &scope, &home, &cwd).ok_or_else(|| {
                 anyhow::anyhow!("internal: host {} has no config path (bug)", host)
             })?;

--- a/crates/cli/src/commands/models.rs
+++ b/crates/cli/src/commands/models.rs
@@ -1,7 +1,14 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 pub async fn list(api_url: &str) -> Result<()> {
-    let resp = reqwest::get(format!("{}/v1/models", api_url)).await?;
+    // Match the timeout posture of `wallet::status` and `health::check`
+    // — bare `reqwest::get(...)` has no timeout, so a stalled gateway
+    // would hang the CLI indefinitely on a read-only listing.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .context("failed to build HTTP client")?;
+    let resp = client.get(format!("{}/v1/models", api_url)).send().await?;
     let body: serde_json::Value = resp.json().await?;
 
     if let Some(data) = body["data"].as_array() {

--- a/crates/cli/src/commands/recover.rs
+++ b/crates/cli/src/commands/recover.rs
@@ -206,10 +206,17 @@ pub async fn run(
         return Ok(());
     }
 
-    // Pre-balance
-    let pre_balance = fetch_sol_balance(&rpc_url, &agent_pubkey_b58, &client)
-        .await
-        .unwrap_or(0);
+    // Pre-balance. Display-only — log RPC failures so the user can tell a
+    // genuine "0 lamports" wallet apart from a network error masquerading
+    // as zero. Either way we proceed with refund attempts; the value is
+    // not load-bearing.
+    let pre_balance = match fetch_sol_balance(&rpc_url, &agent_pubkey_b58, &client).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to fetch pre-refund SOL balance; displaying 0");
+            0
+        }
+    };
     println!("Pre-refund SOL balance : {pre_balance} lamports");
 
     // Confirmation prompt
@@ -269,10 +276,16 @@ pub async fn run(
         }
     }
 
-    // Post-balance
-    let post_balance = fetch_sol_balance(&rpc_url, &agent_pubkey_b58, &client)
-        .await
-        .unwrap_or(0);
+    // Post-balance — same display-only treatment as the pre-balance
+    // above. A failure here would otherwise mask a successful refund as
+    // "0 lamports recovered" in the summary line.
+    let post_balance = match fetch_sol_balance(&rpc_url, &agent_pubkey_b58, &client).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to fetch post-refund SOL balance; displaying 0");
+            0
+        }
+    };
     println!();
     println!("Post-refund SOL balance: {post_balance} lamports");
     println!("Recovery complete: {success} succeeded, {failure} failed");

--- a/crates/cli/src/commands/solana_tx.rs
+++ b/crates/cli/src/commands/solana_tx.rs
@@ -211,7 +211,14 @@ pub async fn build_usdc_transfer(
         .parse()
         .context("invalid recipient wallet address")?;
 
-    let usdc_mint: Pubkey = USDC_MINT.parse().expect("USDC_MINT constant is valid");
+    // USDC_MINT is a hardcoded literal in this file, so the parse is
+    // infallible in practice. `?` rather than `.expect()` keeps the
+    // CLAUDE.md "no expect/unwrap in non-test code" rule honest — if a
+    // future refactor swaps the constant to something env-derived, the
+    // error path is already in place.
+    let usdc_mint: Pubkey = USDC_MINT
+        .parse()
+        .with_context(|| format!("USDC_MINT constant '{USDC_MINT}' did not parse as a Pubkey"))?;
     let token_program = Pubkey::TOKEN_PROGRAM_ID;
 
     // --- 3. Derive ATAs ---

--- a/programs/escrow/AGENTS.md
+++ b/programs/escrow/AGENTS.md
@@ -46,10 +46,43 @@ OPENSSL_NO_PKG_CONFIG=1 OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu OPENSSL_INCLUD
 ```
 Prefer LiteSVM for fast deterministic tests; use Surfpool/mainnet-fork only when you need real-account behaviour.
 
+### Build Fallback
+If `anchor build` exits silently without producing `target/deploy/solvela_escrow.so` (a known foot-gun on some toolchain combinations — Anchor 0.31.1 vs newer cargo), use the underlying SBF builder directly:
+
+```bash
+cd programs/escrow && cargo build-sbf
+```
+
+This produces the same `.so` artifact and runs the same SBF compilation pipeline that `anchor build` invokes — just without Anchor's outer wrapping. Verified to produce a valid program in this repo's tooling configuration.
+
+### Deployment Checklist
+The `mainnet` feature flag selects which USDC mint the deployed program accepts at compile time. **Mainnet deploys MUST be built with `--features mainnet`** — without it, the program targets the devnet USDC mint and would silently reject all mainnet USDC deposits with `mint mismatch`.
+
+```bash
+# Mainnet deploy — selects EPjFW…USDC mint
+cargo build-sbf -- --features mainnet
+
+# Devnet / local-validator deploy (default) — selects 4zMM…USDC mint
+cargo build-sbf
+```
+
+Before invoking `solana program deploy`, verify the resulting `.so` is the right variant by inspecting the constants:
+
+```bash
+cargo expand --features mainnet | grep 'USDC_MINT.*=' | head -1
+# Expect: pub const USDC_MINT: Pubkey = pubkey!("EPjFW…");
+```
+
+There is no on-chain self-check for which mint the deployed bytecode references — the program would happily accept the configured-at-compile-time mint, mainnet or devnet. The discipline lives in this checklist.
+
+### Lint Notes (informational)
+`cargo clippy --all-targets -- -D warnings` against this crate emits ~14 `unexpected cfg condition value` warnings on newer Rust toolchains. These originate inside Anchor 0.31.1's macro-generated code (`#[program]`, `#[derive(Accounts)]`) and don't reflect any issue with this program's source. Workspace clippy (`cargo clippy --workspace`) doesn't surface them because escrow is not a workspace member. Either tolerate the noise locally, or add `RUSTFLAGS="--cap-lints=warn"` to your dev shell.
+
 ### Common Patterns
 - `#[error_code]` enum with `#[msg("…")]` on every variant.
 - CPI with PDA signer using `CpiContext::new_with_signer` (see root AGENTS.md for the canonical snippet).
 - Require-guards: `require!(cond, EscrowError::Foo);`.
+- Token transfers use `TransferChecked` (mint + decimals validated at the SPL token program level), not bare `Transfer`.
 
 ## Dependencies
 
@@ -57,6 +90,6 @@ Prefer LiteSVM for fast deterministic tests; use Surfpool/mainnet-fork only when
 - Client-side counterpart in `crates/x402/src/escrow/`.
 
 ### External
-- `anchor-lang`, `anchor-spl` (for `token::transfer` CPIs), `solana-program`.
+- `anchor-lang`, `anchor-spl` (for `token::transfer_checked` CPIs), `solana-program`.
 
 <!-- MANUAL: -->

--- a/programs/escrow/src/instructions/claim.rs
+++ b/programs/escrow/src/instructions/claim.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
-use anchor_spl::token::{self, CloseAccount, Mint, Token, TokenAccount, Transfer};
+use anchor_spl::token::{self, CloseAccount, Mint, Token, TokenAccount, TransferChecked};
 
 use crate::errors::EscrowError;
 use crate::state::Escrow;
@@ -36,17 +36,21 @@ pub fn claim(ctx: Context<Claim>, actual_amount: u64) -> Result<()> {
     ];
     let signer_seeds = &[seeds];
 
-    // Transfer actual_amount → provider ATA
+    // Transfer actual_amount → provider ATA. `TransferChecked` validates
+    // the mint and decimals at the SPL token program level — defense-in-
+    // depth over the existing `has_one = mint` constraint on the escrow.
+    let mint_decimals = ctx.accounts.mint.decimals;
     let cpi_transfer = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
-        Transfer {
+        TransferChecked {
             from: ctx.accounts.vault.to_account_info(),
+            mint: ctx.accounts.mint.to_account_info(),
             to: ctx.accounts.provider_token_account.to_account_info(),
             authority: ctx.accounts.escrow.to_account_info(),
         },
         signer_seeds,
     );
-    token::transfer(cpi_transfer, actual_amount)?;
+    token::transfer_checked(cpi_transfer, actual_amount, mint_decimals)?;
 
     // Refund remainder → agent ATA. The `actual_amount <= escrow.amount`
     // guard above already prevents underflow, but `checked_sub` makes the
@@ -59,14 +63,15 @@ pub fn claim(ctx: Context<Claim>, actual_amount: u64) -> Result<()> {
     if refund > 0 {
         let cpi_refund = CpiContext::new_with_signer(
             ctx.accounts.token_program.to_account_info(),
-            Transfer {
+            TransferChecked {
                 from: ctx.accounts.vault.to_account_info(),
+                mint: ctx.accounts.mint.to_account_info(),
                 to: ctx.accounts.agent_token_account.to_account_info(),
                 authority: ctx.accounts.escrow.to_account_info(),
             },
             signer_seeds,
         );
-        token::transfer(cpi_refund, refund)?;
+        token::transfer_checked(cpi_refund, refund, mint_decimals)?;
     }
 
     // Drain any vault residual to agent before close. SPL token's
@@ -82,14 +87,15 @@ pub fn claim(ctx: Context<Claim>, actual_amount: u64) -> Result<()> {
     if surplus > 0 {
         let cpi_drain = CpiContext::new_with_signer(
             ctx.accounts.token_program.to_account_info(),
-            Transfer {
+            TransferChecked {
                 from: ctx.accounts.vault.to_account_info(),
+                mint: ctx.accounts.mint.to_account_info(),
                 to: ctx.accounts.agent_token_account.to_account_info(),
                 authority: ctx.accounts.escrow.to_account_info(),
             },
             signer_seeds,
         );
-        token::transfer(cpi_drain, surplus)?;
+        token::transfer_checked(cpi_drain, surplus, mint_decimals)?;
     }
 
     // Close vault ATA (returns rent to agent)

--- a/programs/escrow/src/instructions/deposit.rs
+++ b/programs/escrow/src/instructions/deposit.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
-use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
+use anchor_spl::token::{self, Mint, Token, TokenAccount, TransferChecked};
 
 use crate::errors::EscrowError;
 use crate::state::Escrow;
@@ -65,14 +65,21 @@ pub fn deposit(
     escrow.expiry_slot = expiry_slot;
     escrow.bump = ctx.bumps.escrow;
 
-    // Transfer USDC from agent's ATA → vault ATA
-    let cpi_accounts = Transfer {
+    // Transfer USDC from agent's ATA → vault ATA. `TransferChecked`
+    // (over plain `Transfer`) passes the mint and its decimals through
+    // to the SPL token program for in-CPI validation. Mint is already
+    // pinned via `address = USDC_MINT` on the Accounts struct so this
+    // is strict defense-in-depth — but if a future refactor weakens
+    // the binding, `transfer_checked` would still reject a mismatched
+    // mint and the wrong decimals.
+    let cpi_accounts = TransferChecked {
         from: ctx.accounts.agent_token_account.to_account_info(),
+        mint: ctx.accounts.mint.to_account_info(),
         to: ctx.accounts.vault.to_account_info(),
         authority: ctx.accounts.agent.to_account_info(),
     };
     let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), cpi_accounts);
-    token::transfer(cpi_ctx, amount)?;
+    token::transfer_checked(cpi_ctx, amount, ctx.accounts.mint.decimals)?;
 
     emit!(DepositEvent {
         agent: escrow.agent,

--- a/programs/escrow/src/instructions/refund.rs
+++ b/programs/escrow/src/instructions/refund.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
-use anchor_spl::token::{self, CloseAccount, Mint, Token, TokenAccount, Transfer};
+use anchor_spl::token::{self, CloseAccount, Mint, Token, TokenAccount, TransferChecked};
 
 use crate::errors::EscrowError;
 use crate::state::Escrow;
@@ -33,16 +33,20 @@ pub fn refund(ctx: Context<Refund>) -> Result<()> {
     // refund that quietly does nothing.
     let vault_amount = ctx.accounts.vault.amount;
     require!(vault_amount > 0, EscrowError::EmptyVault);
+    // `TransferChecked` validates mint + decimals at the SPL token program
+    // level — defense-in-depth over the `has_one = mint` constraint on the
+    // escrow account.
     let cpi_transfer = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
-        Transfer {
+        TransferChecked {
             from: ctx.accounts.vault.to_account_info(),
+            mint: ctx.accounts.mint.to_account_info(),
             to: ctx.accounts.agent_token_account.to_account_info(),
             authority: ctx.accounts.escrow.to_account_info(),
         },
         signer_seeds,
     );
-    token::transfer(cpi_transfer, vault_amount)?;
+    token::transfer_checked(cpi_transfer, vault_amount, ctx.accounts.mint.decimals)?;
 
     // Close vault ATA (returns rent to agent)
     let cpi_close = CpiContext::new_with_signer(


### PR DESCRIPTION
## Summary
First wave of the cleanup-tier batch deferred from the must-ship review pass (#182–#199). All MEDIUM severity, no security-critical changes. Each fix is a focused commit so reviewers can drop or amend any individual item.

## Commits (in order)

| Commit | ID | Topic |
|---|---|---|
| `b515464f` | CLI M1 | 10s HTTP timeout on `models.rs` `/v1/models` listing — bare `reqwest::get` had no timeout |
| `e646b40b` | CLI M2 | Replace `.expect()` on USDC_MINT parse in `solana_tx.rs` with `?` + context |
| `8956a755` | CLI M4 | Log RPC failures on display-only SOL balance fetches in `recover.rs` (was silent `.unwrap_or(0)`) |
| `8ca7da2c` | CLI M5 | Clearer error when 402 response lacks `error.message` field — was producing "EOF while parsing" |
| `5c526298` | CLI M6 | Bail on cwd failure in `mcp::run_install` / `run_uninstall` instead of silent fallback to `.` |
| `70d75924` | Escrow M1 | Migrate all 5 token transfers from `Transfer` → `TransferChecked` (mint + decimals validated in-CPI) |
| `b7c0ceba` | Escrow M5+M6 | Deployment checklist + `cargo build-sbf` fallback + clippy notes in `programs/escrow/AGENTS.md` |

## Already moot (no commit)

- **CLI M3** (silent `"not found"` fallback in `wallet::export`) was already eliminated by PR-CLI2's typed `WalletData` refactor — `private_key` is now a required `SecretString` field with a clear error if missing from the on-disk JSON.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (escrow excluded from workspace; its anchor cfg warnings are documented in commit `b7c0ceba`)
- [x] `cargo test -p solvela-cli` — 189 passed
- [x] `cargo test -p solvela-x402 --lib` — 132 passed
- [x] `cargo test -p gateway --lib` — 497 passed
- [x] `cargo test -p solvela-router` — 19 passed
- [x] `cargo test -p solvela-protocol` — 18 passed
- [x] `cargo build-sbf && cargo test --features sbf` against `programs/escrow/` — 23 integration + 8 unit tests pass with `TransferChecked` migration

## Out of scope
The original review-pass agent reports flagged additional MEDIUMs in x402, gateway, router, and protocol crates. Those weren't in detailed scope at the time of this PR — they can be a second cleanup wave once the dust settles from this one. Reach out if you'd like me to expand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)