### PR TITLE
docs: record 2026-05-10 escrow redeploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to Solvela (formerly RustyClawRouter), in reverse chronological order.
 
+## 2026-05-10 — Escrow program redeploy
+
+Escrow bytecode redeployed to mainnet at `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU` on slot 418832804 (tx `58ud2vrh8KsiwST8AsA9qUE7kJpN1NTDvaz8TfzqbG9RRkHM64tUMD974efAigzktVPg5DWXrbE6GWQd6wjFNkxb`, bytecode SHA-256 `5fb8e7548f0653a165803523c322b8d19eab06310462d8621c7250e912bf16c9`, 310,360 bytes). Closes the disclosure caveat from the 2026-05-09 review pass — the two CRIT-class escrow footguns ([#198](https://github.com/solvela-ai/solvela/pull/198): vault dust stuffing + instant-refund window) and the `Transfer` → `TransferChecked` defense-in-depth migration ([#200](https://github.com/solvela-ai/solvela/pull/200)) are now live in deployed bytecode. `getProgramAccounts` returned zero at redeploy time; transition was zero-impact. Authority unchanged (`EDM9pao5miQdJYfzCtZii9cVn5ZHTBJq84Y9yyqZbsr4`); fee paid by gateway hot wallet `B7reP7…`.
+
 ## 2026-05-09 — Whole-repo security review pass
 
-Internal review-pass across all 6 workspace crates plus the standalone Anchor escrow program. 18 must-ship PRs ([#182](https://github.com/solvela-ai/solvela/pull/182)–[#199](https://github.com/solvela-ai/solvela/pull/199)) landed on `main`; cleanup-tier wave 1 ([#200](https://github.com/solvela-ai/solvela/pull/200)) open with 8 deferred MEDIUMs. All HIGH/CRITICAL findings closed in source. The deployed mainnet escrow bytecode does not yet include the 2026-05-09 escrow source fixes — a redeploy is tracked in `STATUS.md` follow-ups. `getProgramAccounts` returned zero accounts when the new findings landed — both newly-discovered escrow footguns were latent and unexploited.
+Internal review-pass across all 6 workspace crates plus the standalone Anchor escrow program. 18 must-ship PRs ([#182](https://github.com/solvela-ai/solvela/pull/182)–[#199](https://github.com/solvela-ai/solvela/pull/199)) landed on `main`; cleanup-tier wave 1 ([#200](https://github.com/solvela-ai/solvela/pull/200)) followed with 8 deferred MEDIUMs. All HIGH/CRITICAL findings closed in source. Mainnet redeploy completed 2026-05-10 (see entry above). `getProgramAccounts` returned zero accounts when the new findings landed — both newly-discovered escrow footguns were latent and unexploited.
 
 ### x402 protocol library — 7 PRs ([#182–#188](https://github.com/solvela-ai/solvela/pull/182))
 
@@ -41,7 +45,7 @@ Two CRIT-class footguns closed; both result in the same blast radius (free servi
 - **Vault dust stuffing** — `spl-token`'s `CloseAccount` aborts on any non-zero balance. Vault ATA address is publicly derivable and SPL transfers don't require recipient signature, so anyone (incl. the agent) could transfer 1 dust unit into the vault and brick the provider's claim path. After expiry the agent refunds full amount + dust at zero net cost. **Fix:** reload + drain vault residual to agent before `close_account`.
 - **Instant-refund window** — `expiry_slot > now` was the only lower bound. Agent could deposit with `expiry_slot = now + 1`, gateway delivers response, gateway's claim tx can't land before slot moves past expiry, claim fails, agent refunds. **Fix (two layers):** new `MIN_EXPIRY_BUFFER = 50` slots on-chain (`programs/escrow/src/lib.rs`); off-chain verifier in `crates/x402/src/escrow/verifier.rs` parses the previously-skipped `expiry_slot` field, fetches current slot via new `solana_rpc::get_current_slot` helper, and rejects deposits with `buffer < 50`.
 
-### Cleanup wave 1 — 1 PR ([#200](https://github.com/solvela-ai/solvela/pull/200), open)
+### Cleanup wave 1 — 1 PR ([#200](https://github.com/solvela-ai/solvela/pull/200))
 
 8 deferred MEDIUMs across CLI and escrow: `models.rs` HTTP timeout, `solana_tx.rs` USDC-MINT-parse `.expect()` removed, `recover.rs` swallowed RPC errors now `tracing::warn!`'d, `chat.rs` 402-error-chain clarification, `mcp/mod.rs` cwd-failure bail, `Transfer` → `TransferChecked` across all 5 escrow transfer sites (defense-in-depth over existing mint pinning), and a deployment checklist + `cargo build-sbf` fallback note in `programs/escrow/AGENTS.md`. None security-critical.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,7 +66,7 @@ Solvela's posture is to surface and patch latent flaws before they harm users, r
 
 ### 2026-05-09 — Whole-repo security review pass
 
-Internal review-pass across all 6 workspace crates plus the standalone Anchor escrow program. 18 must-ship PRs ([#182](https://github.com/solvela-ai/solvela/pull/182)–[#199](https://github.com/solvela-ai/solvela/pull/199)) landed on `main` and one cleanup-tier PR ([#200](https://github.com/solvela-ai/solvela/pull/200)) is open with 8 deferred MEDIUMs. Each of the 7 crate-level reviews was conducted by a fresh agent against the post-merge `main`, with findings triaged into CRITICAL/HIGH (must-ship) and MEDIUM (cleanup-tier) by severity bar. Deployment-state notes on each finding below.
+Internal review-pass across all 6 workspace crates plus the standalone Anchor escrow program. 18 must-ship PRs ([#182](https://github.com/solvela-ai/solvela/pull/182)–[#199](https://github.com/solvela-ai/solvela/pull/199)) landed on `main` and one cleanup-tier PR ([#200](https://github.com/solvela-ai/solvela/pull/200)) followed with 8 deferred MEDIUMs. Each of the 7 crate-level reviews was conducted by a fresh agent against the post-merge `main`, with findings triaged into CRITICAL/HIGH (must-ship) and MEDIUM (cleanup-tier) by severity bar. Mainnet escrow bytecode redeployed 2026-05-10 with the in-source fixes (see Redeployed section below).
 
 #### Headline CRITICAL findings (deployed gateway, fixed at HEAD)
 
@@ -76,11 +76,11 @@ Internal review-pass across all 6 workspace crates plus the standalone Anchor es
 | Gateway balance monitor | `Client::build` error was swallowed; if it failed, the gateway started without monitoring and silently never alerted on low fee-payer balance | Propagate the error through `anyhow::Context`; gateway fails to start if monitor can't be built | [#194](https://github.com/solvela-ai/solvela/pull/194) |
 | x402 verifier | Sysvar typo + missing provider check let a malformed deposit verify successfully | Correct sysvar pubkey + `has_one = provider` constraint enforced by the verifier | [#182](https://github.com/solvela-ai/solvela/pull/182) |
 
-#### Headline CRITICAL findings (escrow program, source-fixed, **mainnet redeploy pending**)
+#### Headline CRITICAL findings (escrow program, redeployed to mainnet 2026-05-10)
 
-These fixes are **in `main` source** but **not yet in the deployed mainnet bytecode** (`9neDH…HLU`). `getProgramAccounts` against the program ID returned zero accounts at the time these findings landed — the deployed bytecode has handled no real customer escrows, so neither footgun has any opportunity to fire. The findings are documented under the disclosure-transparency principle, not because of any incident.
+These fixes are now **live in the deployed mainnet bytecode** (`9neDH…HLU`, slot 418832804, bytecode SHA-256 `5fb8e7548f0653a165803523c322b8d19eab06310462d8621c7250e912bf16c9`). Between the 2026-05-09 source merge and the 2026-05-10 redeploy, `getProgramAccounts` against the program ID returned zero accounts — the deployed bytecode handled no real customer escrows during the in-source-only window, so neither footgun had any opportunity to fire. The findings are documented under the disclosure-transparency principle, not because of any incident.
 
-| Footgun | What could happen | Fix (in-source) |
+| Footgun | What could happen | Fix |
 |---|---|---|
 | **Vault dust stuffing** | `spl-token`'s `CloseAccount` aborts on any non-zero balance. Vault ATA address is publicly derivable and SPL transfers don't require recipient signature — anyone (including the agent) could transfer 1 dust unit into the vault between deposit confirmation and the gateway's claim. The claim's `close_account` CPI then fails, the entire claim tx reverts, the provider can never claim. After expiry the agent refunds full balance + dust at zero net cost. Net: agent gets the LLM response (already delivered HTTP-side before claim), provider gets nothing. | `claim` instruction now reloads the vault after the contracted transfers and drains any surplus to the agent's ATA before `close_account`. Tested via a regression test that injects 1 dust unit into the vault post-deposit and asserts `claim` succeeds. ([#198](https://github.com/solvela-ai/solvela/pull/198)) |
 | **Instant-refund window via tight `expiry_slot`** | `expiry_slot > now` was the only lower bound on deposit. Agent could deposit with `expiry_slot = now + 1`, gateway verifies + delivers the LLM response after settlement, gateway's claim transaction can't realistically land before `slot >= expiry_slot`, claim fails with `EscrowExpired`, agent calls `refund` and recovers the deposit. Same blast radius as the dust attack via different mechanism. | Two-layer fix: new `MIN_EXPIRY_BUFFER = 50` slots (~20 s) on-chain in `deposit.rs`; off-chain verifier in `crates/x402/src/escrow/verifier.rs` now parses the previously-skipped `expiry_slot` field from the deposit instruction data, fetches current slot via a new `solana_rpc::get_current_slot` helper, and rejects deposits where `expiry_slot - current_slot < 50`. ([#198](https://github.com/solvela-ai/solvela/pull/198)) |
@@ -89,7 +89,7 @@ These fixes are **in `main` source** but **not yet in the deployed mainnet bytec
 
 Twenty-plus HIGH findings across the gateway (info-leak cluster, financial correctness, budget enforcement, multi-tenant authz role-cap), x402 (atomic claim queue, fee-payer counter race, nonce-pool authority check, secret-decode-buffer zeroing), router (load-time pricing validation), protocol (`#[serde(deny_unknown_fields)]` on every payment payload type, `Role::Unknown` forward-compat, `Usage::new` saturating constructor), CLI (`fs::write`+chmod race on the wallet file, missing payment-bearing HTTP timeouts, `expiry_slot` arithmetic wrappable to a near-zero value, global `--api-url` accepting `file://`, disk-loaded wallet address re-validation, `WalletData` redacted-Debug, `Zeroizing<>` on derived secret arrays). Per-PR breakdown in `CHANGELOG.md`.
 
-#### Cleanup-tier wave 1 — 8 MEDIUMs deferred, now in PR #200
+#### Cleanup-tier wave 1 — 8 MEDIUMs shipped in PR #200
 
 Defence-in-depth and quality items: HTTP timeouts on read-only CLI listings, removal of stray `.expect()` in production paths, surfacing previously-swallowed RPC errors via `tracing::warn!`, clearer `error_msg` paths, `Transfer` → `TransferChecked` migration across all 5 escrow token-transfer sites (defense-in-depth over existing mint pinning), and a deployment checklist for `--features mainnet` plus a `cargo build-sbf` fallback in `programs/escrow/AGENTS.md`. None security-critical.
 
@@ -99,9 +99,9 @@ Defence-in-depth and quality items: HTTP timeouts on read-only CLI listings, rem
 - Per-crate test counts at HEAD: cli 189, x402 132, gateway 497, router 19, protocol 18; escrow 23 integration + 8 unit tests pass via `cargo build-sbf && cargo test --features sbf`.
 - `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` both clean.
 
-#### Outstanding
+#### Redeployed
 
-The escrow source fixes from #198 + #200 are not yet in the deployed mainnet bytecode. Redeploy follows the 2026-05-08 ceremony pattern (build with `--features mainnet`, hash-verify, `solana program deploy`); tracked in `STATUS.md` follow-ups. Until then, the deployed program (`9neDH…HLU`) remains on the 2026-05-08 bytecode (hash `2293edfce3a0e7b1b0332bc32d9f7a9e58105a2a3f825ee05d8a4f7fbf57bf26`); `getProgramAccounts` confirms zero on-chain deposits, so the new footguns have no impact surface.
+The escrow source fixes from #198 + #200 shipped to mainnet on 2026-05-10. Build was reproduced from `main` at commit `53d1c610` with `cargo build-sbf` (Anchor 0.31.1 toolchain), 23 LiteSVM integration tests + 8 unit tests passing, and bytecode SHA-256 verified post-deploy via `solana program dump` against the local artifact: `5fb8e7548f0653a165803523c322b8d19eab06310462d8621c7250e912bf16c9` (310,360 bytes). Redeploy tx: [`58ud2vrh8KsiwST8AsA9qUE7kJpN1NTDvaz8TfzqbG9RRkHM64tUMD974efAigzktVPg5DWXrbE6GWQd6wjFNkxb`](https://solscan.io/tx/58ud2vrh8KsiwST8AsA9qUE7kJpN1NTDvaz8TfzqbG9RRkHM64tUMD974efAigzktVPg5DWXrbE6GWQd6wjFNkxb), slot 418832804. Authority unchanged (`EDM9pao5miQdJYfzCtZii9cVn5ZHTBJq84Y9yyqZbsr4`); fee paid by gateway hot wallet `B7reP7…` (~0.00001 SOL). `getProgramAccounts` returned zero at redeploy time; the upgrade was zero-impact.
 
 ### 2026-05-08 — Escrow program code review
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,13 +2,13 @@
 
 > Live shipping status. See [`CHANGELOG.md`](./CHANGELOG.md) for history, [`SECURITY.md`](./SECURITY.md) for disclosure.
 
-_Last refreshed: 2026-05-09 — whole-repo security review pass complete; 18 must-ship PRs landed on `main`._
+_Last refreshed: 2026-05-10 — escrow program redeployed to mainnet with the 2026-05-09 review-pass fixes._
 
 ## Shipped
 
 - **Gateway** — Axum HTTP server with chat completions, image generation, A2A protocol, model registry, escrow endpoints, enterprise org/team/audit/budget endpoints, Prometheus metrics. 5 LLM providers (OpenAI, Anthropic, Google, xAI, DeepSeek).
 - **Protocol** — `solvela-protocol`, `solvela-x402`, `solvela-router`, `solvela-cli` published to crates.io. v0.1.1 was published with mixed/MIT metadata; v0.2.0 corrects this and aligns with the per-component split (gateway BUSL-1.1, libraries MIT, SDKs MIT). `cargo install solvela-cli` works.
-- **Escrow program** — Anchor / USDC-SPL trustless escrow. Deployed to Solana mainnet at `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`. Upgraded 2026-05-08 (slot 418438627, tx `2Rp69yKfyxeeawrFRPZbLma9NytxEXSz8PeWPdNYzWm4e3Fr2xihP3T23PiwDB9xYbnUwN8kmsnrgBKjP2dbBbuE`, bytecode SHA-256 `2293edfce3a0e7b1b0332bc32d9f7a9e58105a2a3f825ee05d8a4f7fbf57bf26`) to patch two latent settlement-path footguns surfaced in pre-launch security review — a claim-vs-refund race at the expiry boundary and a refund deadlock when the agent had closed their USDC ATA. Six secondary hardening items shipped alongside (PR #160). `getProgramAccounts` returned zero at upgrade time; both flaws were latent and unexploited.
+- **Escrow program** — Anchor / USDC-SPL trustless escrow. Deployed to Solana mainnet at `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`. Last redeployed 2026-05-10 (slot 418832804, tx `58ud2vrh8KsiwST8AsA9qUE7kJpN1NTDvaz8TfzqbG9RRkHM64tUMD974efAigzktVPg5DWXrbE6GWQd6wjFNkxb`, bytecode SHA-256 `5fb8e7548f0653a165803523c322b8d19eab06310462d8621c7250e912bf16c9`) to ship the 2026-05-09 review-pass fixes — vault dust-stuffing drain + minimum expiry buffer + `Transfer` → `TransferChecked` defense-in-depth across all 5 token transfer sites (PRs [#198](https://github.com/solvela-ai/solvela/pull/198) + [#200](https://github.com/solvela-ai/solvela/pull/200)). Prior upgrade 2026-05-08 (slot 418438627, tx `2Rp69yKfyxeeawrFRPZbLma9NytxEXSz8PeWPdNYzWm4e3Fr2xihP3T23PiwDB9xYbnUwN8kmsnrgBKjP2dbBbuE`) closed a claim-vs-refund race at the expiry boundary and a refund deadlock on closed agent ATAs (PR [#160](https://github.com/solvela-ai/solvela/pull/160)). `getProgramAccounts` returned zero at both redeploys; all flaws were latent and unexploited.
 - **SDKs** — Python, TypeScript, Go, and a wallet-client (Rust) SDK in separate repos: `solvela-python` (v0.1.0), `solvela-ts` (v0.2.0), `solvela-go` (v0.1.0), `solvela-client` (v0.2.0). Tagged + GitHub Released 2026-04-29 as the security-hardening release; Go is live via the module proxy, PyPI/npm/crates.io uploads pending operator credentials.
 - **Dashboard + Docs** — Next.js app serving `solvela.ai`, `app.solvela.ai`, `docs.solvela.ai` via subdomain middleware. `www.solvela.ai` 308-redirects to apex.
 
@@ -26,7 +26,7 @@ _Last refreshed: 2026-05-09 — whole-repo security review pass complete; 18 mus
 - Load tested to ~400 RPS sustained at p99 < 300 ms.
 - `cargo test` suite green at HEAD.
 - 4 required CI checks gate every merge to `main`: Rust (fmt, clippy, test), Smoke test, Security audit (cargo-audit), Docker build.
-- **Whole-repo security review pass complete (2026-05-09)** — 18 must-ship PRs (#182–#199) landed across all 6 workspace crates plus the Anchor escrow program. All HIGH/CRITICAL findings closed in source. See `CHANGELOG.md` and `SECURITY.md` for the per-finding breakdown. Cleanup-tier wave 1 ([PR #200](https://github.com/solvela-ai/solvela/pull/200), 8 MEDIUMs) open for review.
+- **Whole-repo security review pass complete (2026-05-09)** — 18 must-ship PRs (#182–#199) + cleanup-tier wave 1 (#200, 8 MEDIUMs) landed across all 6 workspace crates plus the Anchor escrow program. All HIGH/CRITICAL findings closed in source; escrow bytecode redeployed to mainnet 2026-05-10. See `CHANGELOG.md` and `SECURITY.md` for the per-finding breakdown.
 
 ## Repo hardening
 
@@ -38,6 +38,6 @@ _Last refreshed: 2026-05-09 — whole-repo security review pass complete; 18 mus
 
 - **Registry uploads for SDKs** (PyPI, npm, crates.io) — pending operator credentials.
 - **Vercel API token rotation** and **GitHub org 2FA enforcement** — operator-side actions still pending.
-- **Escrow program redeploy with #198 + #200 source fixes** — the 2026-05-09 review pass added a vault-dust drain in `claim`, a minimum-expiry-buffer guard in `deposit`, and a `Transfer` → `TransferChecked` migration across all 5 transfer sites. All landed in `main` source; the deployed mainnet bytecode (`9neDH…HLU`) does **not** yet include these. `getProgramAccounts` confirms zero on-chain deposits — both newly-discovered footguns are latent and unexploited (see `SECURITY.md`). Redeploy follows the 2026-05-08 ceremony pattern.
 - **Anchor 0.31 → 1.0 migration on the escrow program** (#155 / #156) — coordinated bump alongside the broader Solana 1.x → @solana/kit ecosystem migration. Not security-critical now that the deployed bytecode is hardened.
+- **Squads multisig migration for the upgrade authority** — `EDM9pao5…` is currently single-sig and the keypair file lives on the operator workstation (warm, not truly air-gapped). Squads multisig (1-of-1 → 2-of-N with HW co-signer) is the standard next step for Solana protocol upgrade authorities. See `SECURITY.md`.
 - **Dedicated escrow CI workflow** (#162) — `programs/escrow/` opts out of the workspace and isn't covered by the cross-cutting Rust job. Cargo build-sbf + LiteSVM integration tests should run on every escrow-touching PR.


### PR DESCRIPTION
## Summary

Closes the disclosure caveat from the 2026-05-09 review pass — the two CRIT-class escrow footguns from PR #198 (vault dust stuffing + instant-refund window) and the `Transfer` → `TransferChecked` defense-in-depth migration from PR #200 are now live in deployed mainnet bytecode.

### Deploy details

| Field | Value |
|---|---|
| Program ID | `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU` |
| Slot | 418832804 |
| Tx signature | `58ud2vrh8KsiwST8AsA9qUE7kJpN1NTDvaz8TfzqbG9RRkHM64tUMD974efAigzktVPg5DWXrbE6GWQd6wjFNkxb` |
| Bytecode SHA-256 | `5fb8e7548f0653a165803523c322b8d19eab06310462d8621c7250e912bf16c9` (310,360 bytes) |
| Prior bytecode SHA-256 | `2293edfce3a0e7b1b0332bc32d9f7a9e58105a2a3f825ee05d8a4f7fbf57bf26` (slot 418438627) |
| Upgrade authority | `EDM9pao5miQdJYfzCtZii9cVn5ZHTBJq84Y9yyqZbsr4` (unchanged) |
| Fee payer | `B7reP7…` (gateway hot wallet, ~0.00001 SOL) |
| `getProgramAccounts` at redeploy | `[]` (zero-impact transition) |

### Verification trail

- Built from `main` at commit `53d1c610` via `cargo build-sbf` (Anchor 0.31.1, Solana 1.x SBF toolchain)
- 23 LiteSVM integration tests + 8 unit tests passing pre-deploy
- Post-deploy `solana program dump` SHA-256 (first 310,360 bytes, ignoring on-chain slot padding) matches local artifact exactly
- Deploy tx confirmed `Status: Ok`, both signers (`B7reP7…` fee payer + `EDM9pao5…` authority) signed

### Doc changes

- **STATUS.md** — refresh date to 2026-05-10; update escrow line with new slot/tx/hash; drop the "Escrow program redeploy" follow-up (now done); add a "Squads multisig migration for the upgrade authority" follow-up to track the still-pending hardening step
- **CHANGELOG.md** — new top entry "2026-05-10 — Escrow program redeploy"; flip stale "(#200) open" references to landed
- **SECURITY.md** — rewrite the 2026-05-09 review-pass entry to reflect redeploy completion: section header changes from "**mainnet redeploy pending**" to "redeployed to mainnet 2026-05-10"; the "Outstanding" subsection becomes "Redeployed" with tx/slot/hash and verification trail

## Test plan

- [x] `solana confirm` shows tx `58ud…NkXb` `Status: Ok` in slot 418832804
- [x] `solana program show 9neDH…HLU` reports `Last Deployed In Slot: 418832804`, authority `EDM9pao5…`
- [x] `solana program dump` SHA-256 (first 310,360 bytes) matches local `cargo build-sbf` artifact: `5fb8e754…`
- [x] No code changes — docs-only PR, all CI checks should pass trivially

🤖 Generated with [Claude Code](https://claude.com/claude-code)