### PR TITLE
docs(security): correct upgrade authority storage wording

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ A `.well-known/security.txt` is served from `api.solvela.ai`.
 
 The gateway (`api.solvela.ai`) and dashboard (`solvela.ai`, `app.solvela.ai`, `docs.solvela.ai`) run on a clean dependency tree (`cargo audit` and `npm audit` both pass at HEAD).
 
-The escrow program is deployed to Solana mainnet at `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`. Upgrade authority is held at `EDM9pao5miQdJYfzCtZii9cVn5ZHTBJq84Y9yyqZbsr4` (single-sig, stored offline). Authority was migrated on 2026-05-08 from the gateway's hot-wallet keypair (`B7reP7rzzYsKwteQqCgwfx76xQmNTL4bQ7yk4tQTxL1A`) so a runtime compromise of the gateway can no longer escalate to upgrade rights over the deployed program. Migration to a Squads multisig (or hardware-wallet-backed authority) is the next planned step.
+The escrow program is deployed to Solana mainnet at `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`. Upgrade authority is held at `EDM9pao5miQdJYfzCtZii9cVn5ZHTBJq84Y9yyqZbsr4` (single-sig, stored on the operator workstation, not air-gapped). Authority was migrated on 2026-05-08 from the gateway's hot-wallet keypair (`B7reP7rzzYsKwteQqCgwfx76xQmNTL4bQ7yk4tQTxL1A`) so a runtime compromise of the gateway can no longer escalate to upgrade rights over the deployed program. Migration to a Squads multisig (or hardware-wallet-backed authority) is the next planned step.
 
 ## Known transitive advisories — accepted with reason
 


### PR DESCRIPTION
## Summary

`SECURITY.md` § Current security posture described the escrow upgrade authority key (`EDM9pao5…`) as "stored offline". That wording implies **air-gapped** to security-professional readers. The actual file lives at `~/.config/solana/solvela-upgrade-authority.json` on the operator workstation — single-sig, on a live network-attached filesystem, retrieved during ceremonies (incl. yesterday's redeploy that produced PR #202).

The 2026-05-08 entry further down (line 125) was already accurate: *"the new authority key is single-sig and stored on disk"*. This PR brings the top-line summary into alignment.

## Diff

| Before | After |
|---|---|
| `(single-sig, stored offline)` | `(single-sig, stored on the operator workstation, not air-gapped)` |

The next sentence already says *"Migration to a Squads multisig (or hardware-wallet-backed authority) is the next planned step."* — so the trajectory is preserved without additional edits.

## Why now

- Identified during the 2026-05-10 redeploy ceremony when I located the keypair file on the operator's WSL2 filesystem.
- Public-facing security doc; honesty about the actual threat model is the bar.
- Single-line wording change — minimal blast radius, no logic touched.

## Test plan

- [x] No code changes; CI runs the standard fmt/clippy/test/audit lanes which should pass trivially.
- [x] The existing 2026-05-08 entry's "stored on disk" framing remains consistent with the new top-line wording.
- [x] STATUS.md § Known follow-ups already carries the "Squads multisig migration" item — readers get the full picture by combining the two docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)