### PR TITLE
docs(status): drop warm-key Squads-multisig follow-up

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -39,5 +39,4 @@ _Last refreshed: 2026-05-10 — escrow program redeployed to mainnet with the 20
 - **Registry uploads for SDKs** (PyPI, npm, crates.io) — pending operator credentials.
 - **Vercel API token rotation** and **GitHub org 2FA enforcement** — operator-side actions still pending.
 - **Anchor 0.31 → 1.0 migration on the escrow program** (#155 / #156) — coordinated bump alongside the broader Solana 1.x → @solana/kit ecosystem migration. Not security-critical now that the deployed bytecode is hardened.
-- **Squads multisig migration for the upgrade authority** — `EDM9pao5…` is currently single-sig and the keypair file lives on the operator workstation (warm, not truly air-gapped). Squads multisig (1-of-1 → 2-of-N with HW co-signer) is the standard next step for Solana protocol upgrade authorities. See `SECURITY.md`.
 - **Dedicated escrow CI workflow** (#162) — `programs/escrow/` opts out of the workspace and isn't covered by the cross-cutting Rust job. Cargo build-sbf + LiteSVM integration tests should run on every escrow-touching PR.


### PR DESCRIPTION
## Summary

Drop the "Squads multisig migration for the upgrade authority" bullet from STATUS.md § Known follow-ups. The bullet was added on 2026-05-10 alongside the redeploy ceremony (#202) to surface the warm-key situation.

## Why

- **SECURITY.md already covers it** — the 2026-05-08 entry's "What's still imperfect (tracked)" subsection carries the full Squads-multisig trajectory (1-of-1 → 2-of-N with HW co-signer), with rationale and links.
- **STATUS.md line 13 is now accurate** (PR #203) — readers no longer get a misleading "stored offline" claim, so the STATUS-level reminder is less load-bearing.
- **Two doc surfaces tracking the same item produces drift risk** without adding clarity for external readers. SECURITY.md is the natural home for threat-model commentary; STATUS.md should be reserved for operational follow-ups with concrete next-step shape (Anchor 1.0 migration, escrow CI workflow, registry uploads, etc.).

If the multisig migration moves from "planned" to "scheduled" (with a target PR or date), surface it via a fresh, dated follow-up entry rather than re-adding the generic placeholder.

## Test plan

- [x] No code changes — docs-only.
- [x] SECURITY.md remains the authoritative tracker for the Squads migration.
- [x] CI runs the standard fmt/clippy/test/audit lanes which should pass trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)