### PR TITLE
docs: drop Go SDK ref from CLAUDE.md, fix CLI name in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,6 @@ cargo fmt --all -- --check        # CI mode (check only)
 # Dashboard tests
 npm --prefix dashboard test
 
-# Go SDK tests
-go test ./... -v
-
 # Local dev stack
 docker compose up -d              # PostgreSQL + Redis
 cp .env.example .env              # fill in at least one provider API key

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ response, _ := client.Chat(ctx, "openai/gpt-4o", "Hello!")
 
 ## CLI
 
-The `rcr` CLI provides wallet management, model discovery, chat, and diagnostics.
+The `solvela` CLI provides wallet management, model discovery, chat, and diagnostics.
 
 ```bash
 cargo install --path crates/cli


### PR DESCRIPTION
## Summary

Two pre-rebrand / pre-SDK-move stragglers:

- **CLAUDE.md** "Build & Test Commands" listed `go test ./... -v`, but the Go SDK lives in the standalone `solvela-go` repo now. Running it here exits with "no Go files in <repo>" — actively misleading guidance.
- **README.md** said _"The `rcr` CLI provides..."_ but the binary has been called `solvela` since the rebrand. The example commands immediately below were already correct (`solvela wallet init` etc.) — only the descriptive sentence had drifted.

Other `rcr` references in `docs/book/` are tracked as a separate follow-up. CHANGELOG.md's historical line about the rename is intentionally left as-is — that's documenting the change, not participating in it.

## Test plan

- [x] CI green (no code changes)
- [ ] Visual diff confirms `solvela` reads correctly in the CLI section
- [ ] Confirm CLAUDE.md "Build & Test Commands" no longer references `go test`