### PR TITLE
chore(sdks): drop redirect tombstones, fix README SDK lineup

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ All prices are provider cost in USDC. A 5% platform fee is applied on top. See `
 
 ### Python
 
+Lives in the standalone [`solvela-python`](https://github.com/solvela-ai/solvela-python) repo.
+
 ```bash
 pip install solvela
 ```
@@ -231,20 +233,9 @@ client = LLMClient()
 response = client.chat("openai/gpt-4o", "Hello!")
 ```
 
-### TypeScript
-
-```bash
-npm install @solvela/sdk
-```
-
-```typescript
-import { LLMClient } from '@solvela/sdk';
-
-const client = new LLMClient();
-const response = await client.chat('openai/gpt-4o', 'Hello!');
-```
-
 ### Go
+
+Lives in the standalone [`solvela-go`](https://github.com/solvela-ai/solvela-go) repo.
 
 ```bash
 go get github.com/solvela-ai/solvela-go
@@ -255,7 +246,18 @@ client, _ := solvela.NewClient()
 response, _ := client.Chat(ctx, "openai/gpt-4o", "Hello!")
 ```
 
-### MCP (Claude Code)
+### TypeScript / JavaScript
+
+In-repo under `sdks/`:
+
+| Package | Use case |
+|---|---|
+| [`@solvela/ai-sdk-provider`](sdks/ai-sdk-provider) | Vercel AI SDK provider — the recommended path for most TS apps |
+| [`@solvela/openclaw-provider`](sdks/openclaw-provider) | OpenClaw plugin that registers Solvela as a first-class LLM provider |
+| [`@solvela/signer-core`](sdks/signer-core) | Shared low-level signing / x402 protocol library used by the providers above |
+| [`@solvela/mcp-server`](sdks/mcp) | MCP server (see "MCP" below) |
+
+### MCP (Claude Code, Cursor, Claude Desktop, OpenClaw)
 
 ```bash
 # Add to your Claude Code MCP config:

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,7 +1,0 @@
-# (Removed — canonical SDK lives in standalone repo)
-
-The Solvela Go SDK now lives at https://github.com/solvela-ai/solvela-go.
-
-```
-go get github.com/solvela-ai/solvela-go
-```

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,7 +1,0 @@
-# (Removed — canonical SDK lives in standalone repo)
-
-The Solvela Python SDK now lives at https://github.com/solvela-ai/solvela-python.
-
-```
-pip install solvela
-```


### PR DESCRIPTION
## Summary

`sdks/go/README.md` and `sdks/python/README.md` were single-line redirects pointing to the standalone `solvela-go` and `solvela-python` repos, sitting in their own otherwise-empty directories. The main README is the canonical "where do I find the X SDK?" answer, and the redirects added two extra directories to the listing without providing meaningful in-repo content.

Folded into the same change because they are tightly coupled:

- Updated README's "SDKs" section to reflect the actual in-repo TypeScript lineup (`@solvela/ai-sdk-provider`, `@solvela/openclaw-provider`, `@solvela/signer-core`, `@solvela/mcp-server`) instead of the published-but-wire-incompatible `@solvela/sdk` package. Each in-repo package now links to its source directory.
- Added explicit "Lives in the standalone &lt;repo&gt;" lines to the Python and Go sections to preserve the cross-repo pointer that the deleted READMEs were carrying.

`sdks/typescript/` is not addressed here: it has zero git-tracked content, so it is already invisible from GitHub. Dev-machine cleanup is out of scope.

The four in-repo TypeScript packages were verified against their own `package.json` files at HEAD before being added to the README table.

## Test plan

- [x] CI green
- [ ] Render README on GitHub, confirm SDK section reads cleanly
- [ ] Click each of the four `sdks/<pkg>` links in the new TS table — confirm they resolve
- [ ] Confirm `sdks/go/` and `sdks/python/` no longer show in the repo file tree