### PR TITLE
ci(dashboard): add dashboard CI workflow + sync stale test fixtures

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,87 @@
+name: dashboard
+
+on:
+  push:
+    paths:
+      - 'dashboard/**'
+      - '.github/workflows/dashboard.yml'
+  pull_request:
+    paths:
+      - 'dashboard/**'
+      - '.github/workflows/dashboard.yml'
+
+defaults:
+  run:
+    working-directory: dashboard
+
+jobs:
+  install:
+    name: Install (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Node 18 is dropped: vitest 4.x and other dev tooling import
+        # `node:util.styleText`, which was added in Node 20.12. Keep in
+        # lockstep with the SDK workflows (ai-sdk-provider.yml).
+        node: ['20']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+      - run: npm ci
+
+  test:
+    name: Tests (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    needs: install
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+      - run: npm ci
+      - run: npm test
+
+  build:
+    name: Next.js build
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+      - run: npm ci
+      # `next build` runs the TypeScript compiler over the entire app
+      # tree, so this also covers typecheck. A dedicated `tsc --noEmit`
+      # step would duplicate the work.
+      - run: npm run build
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+      - run: npm ci
+      # Dashboard has no Solana dependencies, so the bigint-buffer CVE
+      # exception that the SDK workflows carry doesn't apply here.
+      # `--audit-level=high` is the right floor for a frontend with no
+      # crypto-adjacent transitives.
+      - run: npm audit --production --audit-level=high

--- a/dashboard/src/__tests__/mock-data.test.ts
+++ b/dashboard/src/__tests__/mock-data.test.ts
@@ -40,12 +40,12 @@ describe("SPEND_HISTORY", () => {
     expect(SPEND_HISTORY[0].requests).toBe(SPEND_HISTORY[0].requests);
   });
 
-  it("first entry is Feb 1", () => {
-    expect(SPEND_HISTORY[0].date).toBe("Feb 1");
+  it("first entry is Mar 16", () => {
+    expect(SPEND_HISTORY[0].date).toBe("Mar 16");
   });
 
-  it("last entry is Mar 2", () => {
-    expect(SPEND_HISTORY[29].date).toBe("Mar 2");
+  it("last entry is Apr 14", () => {
+    expect(SPEND_HISTORY[29].date).toBe("Apr 14");
   });
 });
 
@@ -78,8 +78,8 @@ describe("MODEL_USAGE", () => {
     }
   });
 
-  it("has 5 model entries", () => {
-    expect(MODEL_USAGE).toHaveLength(5);
+  it("has 8 model entries", () => {
+    expect(MODEL_USAGE).toHaveLength(8);
   });
 });
 

--- a/dashboard/src/__tests__/utils.test.ts
+++ b/dashboard/src/__tests__/utils.test.ts
@@ -104,31 +104,31 @@ describe("providerColor", () => {
 
 describe("providerBadgeClass", () => {
   it("returns emerald classes for openai", () => {
-    expect(providerBadgeClass("openai")).toBe("bg-emerald-100 text-emerald-800");
+    expect(providerBadgeClass("openai")).toBe("bg-emerald-500/15 text-emerald-400");
   });
 
   it("returns orange classes for anthropic", () => {
-    expect(providerBadgeClass("anthropic")).toBe("bg-orange-100 text-orange-800");
+    expect(providerBadgeClass("anthropic")).toBe("bg-orange-500/15 text-orange-400");
   });
 
   it("returns blue classes for google", () => {
-    expect(providerBadgeClass("google")).toBe("bg-blue-100 text-blue-800");
+    expect(providerBadgeClass("google")).toBe("bg-blue-500/15 text-blue-400");
   });
 
   it("returns gray classes for xai", () => {
-    expect(providerBadgeClass("xai")).toBe("bg-gray-100 text-gray-800");
+    expect(providerBadgeClass("xai")).toBe("bg-gray-500/15 text-gray-400");
   });
 
   it("returns indigo classes for deepseek", () => {
-    expect(providerBadgeClass("deepseek")).toBe("bg-indigo-100 text-indigo-800");
+    expect(providerBadgeClass("deepseek")).toBe("bg-indigo-500/15 text-indigo-400");
   });
 
   it("is case-insensitive", () => {
-    expect(providerBadgeClass("OpenAI")).toBe("bg-emerald-100 text-emerald-800");
+    expect(providerBadgeClass("OpenAI")).toBe("bg-emerald-500/15 text-emerald-400");
   });
 
   it("returns fallback classes for unknown provider", () => {
-    expect(providerBadgeClass("mistral")).toBe("bg-gray-100 text-gray-700");
+    expect(providerBadgeClass("mistral")).toBe("bg-gray-500/15 text-gray-400");
   });
 });
 


### PR DESCRIPTION
## Summary

The dashboard had a working `vitest` suite (100 tests) and a `next build` script, but **no workflow ran them**. As a result, two test files had drifted out of sync with the actual code without anyone noticing:

- `utils.test.ts`: `providerBadgeClass()` expectations were against the pre-redesign Tailwind classes (`"bg-emerald-100 text-emerald-800"`), but the implementation was updated to the semi-transparent variant (`"bg-emerald-500/15 text-emerald-400"`) in the design refresh.
- `mock-data.test.ts`: the `SPEND_HISTORY` fixture window was rotated forward (Mar 16 → Apr 14, was Feb 1 → Mar 2) and `MODEL_USAGE` grew from 5 to 8 entries, but the date- and length-asserting tests were not updated.

Both are stale tests, not behaviour changes — fixing the expectations makes the suite green against the current code. After the fix, all 100 tests pass locally.

The new workflow runs install / test / build / audit on Node 20 with path filters scoped to `dashboard/**`. `next build` covers typecheck implicitly via the Next.js compiler. `npm audit` runs at `--audit-level=high` because the dashboard has no Solana dependencies.

**Lint is intentionally NOT in this workflow yet**: the dashboard has preexisting eslint findings (6 `react-hooks/set-state-in-effect`, 12 warnings, plus generated `.source/` files lacking eslint-ignore coverage). Adding the lint job alongside known-red findings would land a red workflow. A follow-up PR will clean up lint and add the job.

## Test plan

- [x] CI green (4 jobs: install, test, build, audit)
- [x] Confirmed 100/100 tests pass locally
- [x] Confirmed `next build` succeeds locally
- [ ] Watch first non-trivial `dashboard/` PR after merge to confirm trigger fires