### PR TITLE
ci(sdks): re-run on crates/protocol/ changes

### DIFF
--- a/.github/workflows/ai-sdk-provider.yml
+++ b/.github/workflows/ai-sdk-provider.yml
@@ -5,11 +5,18 @@ on:
     paths:
       - 'sdks/ai-sdk-provider/**'
       - 'sdks/signer-core/**'
+      # Wire-format types in `crates/protocol/` are hand-mirrored by the
+      # TS SDK. A change here doesn't directly run the SDK, but re-running
+      # SDK CI is the cheapest way to flag "did anyone update the SDK
+      # side?". Proper end-to-end wire-compat verification needs SDK
+      # tests against a live gateway — tracked separately.
+      - 'crates/protocol/**'
       - '.github/workflows/ai-sdk-provider.yml'
   pull_request:
     paths:
       - 'sdks/ai-sdk-provider/**'
       - 'sdks/signer-core/**'
+      - 'crates/protocol/**'
       - '.github/workflows/ai-sdk-provider.yml'
 
 defaults:

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -5,11 +5,18 @@ on:
     paths:
       - 'sdks/mcp/**'
       - 'sdks/signer-core/**'
+      # Wire-format types in `crates/protocol/` are hand-mirrored by the
+      # TS SDK. A change here doesn't directly run the SDK, but re-running
+      # SDK CI is the cheapest way to flag "did anyone update the SDK
+      # side?". Proper end-to-end wire-compat verification needs SDK
+      # tests against a live gateway — tracked separately.
+      - 'crates/protocol/**'
       - '.github/workflows/mcp.yml'
   pull_request:
     paths:
       - 'sdks/mcp/**'
       - 'sdks/signer-core/**'
+      - 'crates/protocol/**'
       - '.github/workflows/mcp.yml'
 
 defaults:

--- a/.github/workflows/openclaw-provider.yml
+++ b/.github/workflows/openclaw-provider.yml
@@ -5,11 +5,18 @@ on:
     paths:
       - 'sdks/openclaw-provider/**'
       - 'sdks/signer-core/**'
+      # Wire-format types in `crates/protocol/` are hand-mirrored by the
+      # TS SDK. A change here doesn't directly run the SDK, but re-running
+      # SDK CI is the cheapest way to flag "did anyone update the SDK
+      # side?". Proper end-to-end wire-compat verification needs SDK
+      # tests against a live gateway — tracked separately.
+      - 'crates/protocol/**'
       - '.github/workflows/openclaw-provider.yml'
   pull_request:
     paths:
       - 'sdks/openclaw-provider/**'
       - 'sdks/signer-core/**'
+      - 'crates/protocol/**'
       - '.github/workflows/openclaw-provider.yml'
 
 defaults:


### PR DESCRIPTION
## Summary

Each TypeScript SDK hand-mirrors the wire-format types defined in `crates/protocol/`. Today the SDK workflows fire only on changes inside `sdks/<name>/**` and `sdks/signer-core/**`, so a Rust-side change to a wire type can land without anyone re-checking that the SDK side still matches.

Adds `crates/protocol/**` to the `push` and `pull_request` path filters on the three SDK workflows that ship public clients:

- `ai-sdk-provider.yml`
- `openclaw-provider.yml`
- `mcp.yml`

This is a **re-check signal, not a wire-compat guarantee**. The SDK tests themselves run against mocks, not a live gateway, so a Rust type change that breaks the wire format will still pass these jobs. Until SDK tests can run against a booted gateway, having SDK CI re-run when the protocol crate changes at least surfaces "do these still build with the latest dependency lock?" and prompts a reviewer to manually check that the SDK's hand-written types still align.

The proper fix (end-to-end SDK tests against a live gateway) is tracked separately.

## Test plan

- [x] All four workflows green on the branch (each fires when its own file changes; that's why they ran here)
- [ ] After merge, push a no-op change to `crates/protocol/` on a future branch and confirm all three SDK workflows fire