### PR TITLE
ci(deny): add cargo-deny for license/source/advisory hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,36 @@ jobs:
             lcov-payment.info
           retention-days: 14
 
+  deny:
+    name: Dependency hygiene (cargo-deny)
+    runs-on: ubuntu-latest
+    # Checks licenses, sources, advisories (RustSec), and dependency-graph
+    # bans against deny.toml. Runs independently — parallel with rust/audit.
+    # Source of truth for policy is deny.toml; this job is just the runner.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Cache cargo-deny binary
+        id: cache-cargo-deny
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cargo/bin/cargo-deny
+          # Bump the version suffix here when you want a fresh install.
+          key: ${{ runner.os }}-cargo-deny-0.19
+
+      - name: Install Rust toolchain
+        if: steps.cache-cargo-deny.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+
+      - name: Install cargo-deny
+        if: steps.cache-cargo-deny.outputs.cache-hit != 'true'
+        run: cargo install cargo-deny --locked
+
+      - name: Run cargo deny check
+        run: cargo deny check
+
   audit:
     name: Security audit (cargo-audit)
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,87 @@
+# cargo-deny configuration for Solvela.
+#
+# Runs in CI alongside cargo-audit. Audit checks vulnerabilities; deny
+# adds license, source, and dependency-graph hygiene on top.
+#
+# Source of truth for the lint policy. Adjust here, not in the workflow.
+# See https://embarkstudios.github.io/cargo-deny/ for the full schema.
+
+[graph]
+# Restrict the graph to the targets we actually deploy to. This trims
+# platform-specific transitives (UEFI bindings, Windows-only crates,
+# Darwin-only crates) that would otherwise pull in licenses we don't
+# need to audit and never ship. Add a target if/when we ship to it.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+]
+all-features = false
+
+[output]
+feature-depth = 1
+
+# ----------------------------------------------------------------------
+# Advisories — RustSec database. cargo-audit (in ci.yml) and cargo-deny
+# both consult RustSec, but cargo-audit reads the full Cargo.lock graph
+# while cargo-deny respects the [graph].targets filter above. The
+# RUSTSEC-2023-0071 ignore lives in ci.yml for cargo-audit; cargo-deny
+# doesn't see the affected crate after target filtering, so it has no
+# entry here. Add ignores below only when this tool surfaces a finding.
+# ----------------------------------------------------------------------
+[advisories]
+yanked = "deny"
+ignore = []
+
+# ----------------------------------------------------------------------
+# Licenses — list reflects what's actually in the dependency graph
+# today. New licenses are denied by default; add them here with a brief
+# reason if a future dep introduces one.
+# ----------------------------------------------------------------------
+[licenses]
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "BUSL-1.1",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+# ----------------------------------------------------------------------
+# Bans — catch dependency-graph foot-guns. We keep `multiple-versions`
+# at warn because the Solana ecosystem has unavoidable duplicates and
+# fixing every one is out of scope. Wildcards are hard-denied since they
+# break reproducible builds.
+# ----------------------------------------------------------------------
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+
+# ----------------------------------------------------------------------
+# Sources — only crates.io is allowed. New git sources require an
+# explicit entry below with a comment explaining why we're depending on
+# unpublished code.
+# ----------------------------------------------------------------------
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []


### PR DESCRIPTION
## Summary

Adds a `deny` job parallel to the existing `audit` job. cargo-audit checks RustSec advisories on the full `Cargo.lock` graph; cargo-deny adds three more dimensions:

- **license compliance** — explicit allowlist matched against actual deps
- **source policy** — only crates.io is allowed; no unknown registries or git sources
- **dependency-graph bans** — wildcards denied; multiple-versions warned (Solana ecosystem has unfixable upstream duplicates)

`deny.toml` is the source of truth for the lint policy. The graph is restricted to `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` — the targets we actually deploy to — which trims platform-specific transitives (UEFI bindings on `r-efi`, Windows-only crates) that would otherwise pull in licenses we don't ship and never link against.

The advisory ignore list is empty here: target filtering removes the sole crate that cargo-audit ignores (`RUSTSEC-2023-0071`, transitive via `sqlx-mysql`). cargo-audit keeps its own ignore in `ci.yml` since it sees the full graph.

Caches the cargo-deny binary the same way `audit` caches cargo-audit. Bump the version suffix in the cache key to force a fresh install.

`cargo deny check` is green locally on the current `Cargo.lock`.

## Test plan

- [x] CI green (advisories ok, bans ok, licenses ok, sources ok)
- [ ] Verify the `Dependency hygiene (cargo-deny)` job appears as a check on this PR
- [ ] Confirm the `deny` job fails on a synthetic banned-license dep (manual smoke)