### PR TITLE
docs(sdks): retire stale Go SDK pointer in AGENTS.md

### DIFF
--- a/sdks/AGENTS.md
+++ b/sdks/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-04-16 | Updated: 2026-04-16 -->
+<!-- Generated: 2026-04-16 | Updated: 2026-05-10 -->
 
 # sdks
 
@@ -12,7 +12,7 @@ _(no loose files — see subdirectories)_
 ## Subdirectories
 | Directory | Purpose |
 |-----------|---------|
-| `go/` | Go SDK — signing support in progress (see `go/AGENTS.md`) |
+| `go/` | Redirect stub — canonical Go SDK lives at [solvela-ai/solvela-go](https://github.com/solvela-ai/solvela-go) |
 | `typescript/` | TypeScript/Node SDK (see `typescript/AGENTS.md`) |
 | `python/` | Python SDK (see `python/AGENTS.md`) |
 | `mcp/` | MCP server exposing Solvela as tools to MCP clients (see `mcp/AGENTS.md`) |


### PR DESCRIPTION
## Summary

Follow-up advisory caught in the PR #205 review pass — same class of rot the previous PR fixed.

`sdks/AGENTS.md:15` was pointing readers at `go/AGENTS.md` (no longer exists) and describing the Go SDK as "signing support in progress". The Go SDK was moved to the standalone `solvela-ai/solvela-go` repo months ago; `sdks/go/` now contains only a redirect `README.md`. This row now mirrors that redirect pattern so agents land in the right place.

Bumped the `Updated:` header timestamp to today as well.

## Test plan

- [x] No code changes — pure docs
- [x] Diff confirms only the `go/` row + the `Updated:` timestamp change
- [ ] Verify the link to `solvela-ai/solvela-go` resolves in the PR preview