### PR TITLE
docs(public): retire rcr rebrand drift in dashboard public docs

### DIFF
--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -222,13 +222,13 @@ data: [DONE]
         "fmt"
         "log"
         "os"
-        rcr "github.com/solvela-ai/solvela-go"
+        solvela "github.com/solvela-ai/solvela-go"
     )
 
     func main() {
-        client, err := rcr.NewClient(
-            rcr.WithAPIURL("https://api.solvela.ai"),
-            rcr.WithPrivateKey(os.Getenv("SOLANA_PRIVATE_KEY")),
+        client, err := solvela.NewClient(
+            solvela.WithAPIURL("https://api.solvela.ai"),
+            solvela.WithPrivateKey(os.Getenv("SOLANA_PRIVATE_KEY")),
         )
         if err != nil {
             log.Fatal(err)
@@ -244,11 +244,11 @@ data: [DONE]
         fmt.Println(text)
 
         // Full request
-        resp, err := client.ChatCompletion(ctx, rcr.ChatRequest{
+        resp, err := client.ChatCompletion(ctx, solvela.ChatRequest{
             Model: "openai/gpt-4o",
-            Messages: []rcr.ChatMessage{
-                {Role: rcr.RoleSystem, Content: "You are a blockchain expert."},
-                {Role: rcr.RoleUser, Content: "Explain proof of history."},
+            Messages: []solvela.ChatMessage{
+                {Role: solvela.RoleSystem, Content: "You are a blockchain expert."},
+                {Role: solvela.RoleUser, Content: "Explain proof of history."},
             },
             MaxTokens:   intPtr(500),
             Temperature: float64Ptr(0.7),

--- a/dashboard/content/docs/concepts/architecture.mdx
+++ b/dashboard/content/docs/concepts/architecture.mdx
@@ -22,7 +22,7 @@ Solvela is a Rust workspace composed of five focused crates, an on-chain Anchor 
   </Card>
 </CardGroup>
 
-There is also a fifth crate — **cli** (`rcr-cli`) — providing `wallet`, `chat`, `models`, `health`, `stats`, and `doctor` commands for operators and developers.
+There is also a fifth crate — **cli** (`solvela-cli`) — providing `wallet`, `chat`, `models`, `health`, `stats`, and `doctor` commands for operators and developers.
 
 ## Crate Dependency Graph
 

--- a/dashboard/content/docs/operations/deployment.mdx
+++ b/dashboard/content/docs/operations/deployment.mdx
@@ -56,10 +56,10 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y \
     ca-certificates libssl3 libpq5 \
     && rm -rf /var/lib/apt/lists/*
-RUN useradd --uid 1001 --no-create-home --shell /bin/false rcr
+RUN useradd --uid 1001 --no-create-home --shell /bin/false solvela
 COPY --from=builder /app/target/release/solvela /usr/local/bin/solvela
 EXPOSE 8402
-USER rcr
+USER solvela
 CMD ["/usr/local/bin/solvela"]
 ```
 
@@ -67,7 +67,7 @@ Key points:
 
 - Dependencies are cached in the `cargo chef cook` step -- only rebuilds when `Cargo.toml`/`Cargo.lock` change
 - Runtime image is `debian:bookworm-slim` (minimal, no build tools)
-- Runs as non-root user `rcr` (UID 1001)
+- Runs as non-root user `solvela` (UID 1001)
 - Exposes port 8402
 
 Build the image:
@@ -142,7 +142,7 @@ fly secrets set SOLVELA_SOLANA_FEE_PAYER_KEY=your-fee-payer-key
 fly secrets set SOLVELA_ADMIN_TOKEN=your-admin-token
 fly secrets set DATABASE_URL=postgres://...
 fly secrets set REDIS_URL=redis://...
-fly secrets set RCR_SESSION_SECRET=your-session-secret
+fly secrets set SOLVELA_SESSION_SECRET=your-session-secret
 ```
 
 ### Health Checks
@@ -155,7 +155,7 @@ Before deploying to production:
 
 - [ ] Set `SOLVELA_ENV=production` (disables localhost CORS origins)
 - [ ] Set `SOLVELA_ADMIN_TOKEN` (protects `/metrics` and `/v1/escrow/health`)
-- [ ] Set `RCR_SESSION_SECRET` to a stable value (auto-generated secret changes on restart)
+- [ ] Set `SOLVELA_SESSION_SECRET` to a stable value (auto-generated secret changes on restart)
 - [ ] Set `SOLVELA_SOLANA_RPC_URL` to a mainnet-beta endpoint
 - [ ] Configure `DATABASE_URL` with production PostgreSQL credentials
 - [ ] Configure `REDIS_URL` with production Redis

--- a/dashboard/content/docs/operations/troubleshooting.mdx
+++ b/dashboard/content/docs/operations/troubleshooting.mdx
@@ -82,10 +82,10 @@ Key fields to check:
 
 ## CLI Diagnostics
 
-The `rcr doctor` command runs a comprehensive check:
+The `solvela doctor` command runs a comprehensive check:
 
 ```bash
-cargo run -p cli -- doctor
+cargo run -p solvela-cli -- doctor
 ```
 
 Checks performed:

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -86,12 +86,12 @@ First, send a request without any payment header. The gateway will respond with 
     import (
         "context"
         "fmt"
-        rcr "github.com/solvela-ai/solvela-go"
+        solvela "github.com/solvela-ai/solvela-go"
     )
 
     func main() {
-        client, _ := rcr.NewClient(
-            rcr.WithAPIURL("https://api.solvela.ai"),
+        client, _ := solvela.NewClient(
+            solvela.WithAPIURL("https://api.solvela.ai"),
         )
         reply, err := client.Chat(context.Background(), "auto", "What is x402?")
         if err != nil {
@@ -200,9 +200,9 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
   </Tab>
   <Tab value="Go">
     ```go
-    client, _ := rcr.NewClient(
-        rcr.WithAPIURL("https://api.solvela.ai"),
-        rcr.WithPrivateKey(os.Getenv("SOLANA_PRIVATE_KEY")),
+    client, _ := solvela.NewClient(
+        solvela.WithAPIURL("https://api.solvela.ai"),
+        solvela.WithPrivateKey(os.Getenv("SOLANA_PRIVATE_KEY")),
     )
 
     reply, err := client.Chat(ctx, "gpt-4o", "Explain Solana in one sentence.")

--- a/dashboard/content/docs/sdks/go.mdx
+++ b/dashboard/content/docs/sdks/go.mdx
@@ -21,13 +21,13 @@ import (
     "log"
     "os"
 
-    rcr "github.com/solvela-ai/solvela-go"
+    solvela "github.com/solvela-ai/solvela-go"
 )
 
 func main() {
-    client, err := rcr.NewClient(
-        rcr.WithAPIURL("https://api.solvela.ai"),
-        rcr.WithPrivateKey(os.Getenv("SOLANA_PRIVATE_KEY")),
+    client, err := solvela.NewClient(
+        solvela.WithAPIURL("https://api.solvela.ai"),
+        solvela.WithPrivateKey(os.Getenv("SOLANA_PRIVATE_KEY")),
     )
     if err != nil {
         log.Fatal(err)
@@ -45,12 +45,12 @@ func main() {
 ## Client options
 
 ```go
-client, err := rcr.NewClient(
-    rcr.WithAPIURL("https://api.solvela.ai"),
-    rcr.WithPrivateKey(os.Getenv("SOLANA_PRIVATE_KEY")),
-    rcr.WithSessionBudget(0.10),              // USDC cap
-    rcr.WithTimeout(30 * time.Second),        // default: 60s
-    rcr.WithHTTPClient(customHTTPClient),     // replace the http.Client entirely
+client, err := solvela.NewClient(
+    solvela.WithAPIURL("https://api.solvela.ai"),
+    solvela.WithPrivateKey(os.Getenv("SOLANA_PRIVATE_KEY")),
+    solvela.WithSessionBudget(0.10),              // USDC cap
+    solvela.WithTimeout(30 * time.Second),        // default: 60s
+    solvela.WithHTTPClient(customHTTPClient),     // replace the http.Client entirely
 )
 ```
 
@@ -77,11 +77,11 @@ text, err := client.Chat(ctx, "openai/gpt-4o", "Explain proof of history.")
 Full OpenAI-compatible request. Returns a `*ChatResponse`.
 
 ```go
-resp, err := client.ChatCompletion(ctx, rcr.ChatRequest{
+resp, err := client.ChatCompletion(ctx, solvela.ChatRequest{
     Model: "auto",
-    Messages: []rcr.ChatMessage{
-        {Role: rcr.RoleSystem, Content: "You are a blockchain expert."},
-        {Role: rcr.RoleUser, Content: "What is a validator?"},
+    Messages: []solvela.ChatMessage{
+        {Role: solvela.RoleSystem, Content: "You are a blockchain expert."},
+        {Role: solvela.RoleUser, Content: "What is a validator?"},
     },
     MaxTokens:   intPtr(500),
     Temperature: float64Ptr(0.7),
@@ -161,9 +161,9 @@ import "errors"
 
 resp, err := client.ChatCompletion(ctx, req)
 if err != nil {
-    var payErr *rcr.PaymentError
-    var budgetErr *rcr.BudgetExceededError
-    var apiErr *rcr.APIError
+    var payErr *solvela.PaymentError
+    var budgetErr *solvela.BudgetExceededError
+    var apiErr *solvela.APIError
 
     switch {
     case errors.As(err, &budgetErr):


### PR DESCRIPTION
## Summary

Tier A of the rebrand-rot scan that came out of the PR #205 review pass — focused on the **public docs at solvela.vercel.app** (`dashboard/content/docs/`). One actively misleading instruction + five pages of stale labels.

**Actively misleading (real fix):**
- `operations/deployment.mdx:145,158` told users to `fly secrets set RCR_SESSION_SECRET=…`. Runtime now emits a deprecation warning for that env var (`crates/gateway/src/main.rs:479` falls back from `SOLVELA_SESSION_SECRET`). Updated to the current name.

**Stale labels (cosmetic but obviously rot):**
- `concepts/architecture.mdx` — \`rcr-cli\` → \`solvela-cli\` (matches `crates/cli/Cargo.toml`)
- `operations/troubleshooting.mdx` — \`rcr doctor\` → \`solvela doctor\`; `cargo run -p cli` → `cargo run -p solvela-cli`
- `operations/deployment.mdx` Dockerfile snippet — non-root user name `rcr` → `solvela`
- `quickstart.mdx`, `api/chat-completions.mdx`, `sdks/go.mdx` — Go SDK import alias \`rcr\` → \`solvela\`

**Skipped (intentional, not rot):**
- `rcr` / `rcr_dev_password` postgres credentials in troubleshooting.mdx + deployment.mdx — match the local-dev docker-compose user.
- Redis `rcr:*` keyspace prefix — documented backward-compat per `crates/gateway/src/cache.rs:32`.
- `RCR_*` env vars where the doc already says \"or `RCR_…` for backward compat\" — accurate.

**Out of scope (separate follow-up):**
The Dockerfile snippet in `deployment.mdx` still uses `cargo build --release -p gateway` and binary path `target/release/solvela`, while the real Dockerfile uses `--bin solvela-gateway` and binary `solvela-gateway`. Worth a separate PR to either sync the snippet to current truth or relabel it as aspirational.

Tier B (`docs/book/` mdBook handbook — ~10–15 of the same drift) remains queued.

## Test plan

- [x] No code changes; pure docs
- [x] All remaining `rcr` matches in `dashboard/content/docs/` are intentional dev-creds / backward-compat
- [ ] Verify Vercel preview renders all six MDX pages cleanly
- [ ] Spot-check the Go example syntax-highlights correctly with `solvela` alias