### PR TITLE
harden(docker): run gateway runtime stage as non-root solvela user (UID 1001)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,15 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
+# Create non-root runtime user (no home, no login shell)
+RUN useradd --uid 1001 --no-create-home --shell /usr/sbin/nologin solvela
+
 WORKDIR /app
 
-COPY --from=builder /app/target/release/solvela-gateway .
-COPY --from=builder /app/config/ config/
+COPY --from=builder --chown=solvela:solvela /app/target/release/solvela-gateway .
+COPY --from=builder --chown=solvela:solvela /app/config/ config/
+
+USER solvela
 
 EXPOSE 8402
 

--- a/dashboard/content/docs/operations/deployment.mdx
+++ b/dashboard/content/docs/operations/deployment.mdx
@@ -69,9 +69,14 @@ RUN cargo build --release --bin solvela-gateway
 # Stage 2: Runtime
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Create non-root runtime user (no home, no login shell)
+RUN useradd --uid 1001 --no-create-home --shell /usr/sbin/nologin solvela
+
 WORKDIR /app
-COPY --from=builder /app/target/release/solvela-gateway .
-COPY --from=builder /app/config/ config/
+COPY --from=builder --chown=solvela:solvela /app/target/release/solvela-gateway .
+COPY --from=builder --chown=solvela:solvela /app/config/ config/
+USER solvela
 EXPOSE 8402
 CMD ["./solvela-gateway"]
 ```
@@ -82,7 +87,7 @@ Key points:
 - Migration SQL files in `migrations/` are read at compile time by `sqlx::migrate!`, so they must be present in the build context.
 - Runtime image is `debian:bookworm-slim` with only `ca-certificates` installed.
 - Exposes port 8402.
-- The runtime stage currently runs as root. Adding a non-root user is a recommended hardening step (separate from this snippet).
+- Runs as non-root user `solvela` (UID 1001). Files copied from the build stage use `--chown=solvela:solvela` so the binary and config are owned by the runtime user.
 
 Build the image:
 

--- a/docs/book/src/operations/deployment.md
+++ b/docs/book/src/operations/deployment.md
@@ -66,9 +66,14 @@ RUN cargo build --release --bin solvela-gateway
 # Stage 2: Runtime
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Create non-root runtime user (no home, no login shell)
+RUN useradd --uid 1001 --no-create-home --shell /usr/sbin/nologin solvela
+
 WORKDIR /app
-COPY --from=builder /app/target/release/solvela-gateway .
-COPY --from=builder /app/config/ config/
+COPY --from=builder --chown=solvela:solvela /app/target/release/solvela-gateway .
+COPY --from=builder --chown=solvela:solvela /app/config/ config/
+USER solvela
 EXPOSE 8402
 CMD ["./solvela-gateway"]
 ```
@@ -79,7 +84,7 @@ Key points:
 - Migration SQL files in `migrations/` are read at compile time by `sqlx::migrate!`, so they must be present in the build context.
 - Runtime image is `debian:bookworm-slim` with only `ca-certificates` installed.
 - Exposes port 8402.
-- The runtime stage currently runs as root. Adding a non-root user is a recommended hardening step (separate from this snippet).
+- Runs as non-root user `solvela` (UID 1001). Files copied from the build stage use `--chown=solvela:solvela` so the binary and config are owned by the runtime user.
 
 Build the image:
 


### PR DESCRIPTION
## Summary

Closes the hardening gap surfaced at the end of #214: the runtime stage of the production `Dockerfile` was running as root. Now creates a non-root `solvela` user (UID 1001, no home, no login shell) and runs the gateway binary under that identity.

### Dockerfile changes

\`\`\`diff
+ # Create non-root runtime user (no home, no login shell)
+ RUN useradd --uid 1001 --no-create-home --shell /usr/sbin/nologin solvela
+
  WORKDIR /app
- COPY --from=builder /app/target/release/solvela-gateway .
- COPY --from=builder /app/config/ config/
+ COPY --from=builder --chown=solvela:solvela /app/target/release/solvela-gateway .
+ COPY --from=builder --chown=solvela:solvela /app/config/ config/
+ USER solvela
  EXPOSE 8402
  CMD ["./solvela-gateway"]
\`\`\`

### Safety analysis

- **Port 8402 is unprivileged** — non-root bind works.
- **Gateway writes nothing to disk in production**: logs go to stdout, Postgres + Redis are external, `/tmp` (if ever used) is world-writable.
- **Config dir is read-only at runtime**; `--chown` ensures `solvela` can read its TOML files.

### Local smoke test (before pushing)

```
$ docker build -t solvela-gateway:nonroot-test .
... [release] Finished in 1m 15s ...

$ docker run -d -p 18402:8402 solvela-gateway:nonroot-test
$ curl http://localhost:18402/health
{"status":"error"}    # responds — gateway booted (error is "no provider keys", expected for minimal boot)

$ docker exec ... id
uid=1001(solvela) gid=1001(solvela) groups=1001(solvela)

$ docker exec ... ls -la /app
drwxr-xr-x 2 solvela solvela     4096 ...  config
-rwxr-xr-x 1 solvela solvela 18446104 ...  solvela-gateway
```

### Bundled doc updates

Both deployment pages updated so the docs reflect reality at merge time (would otherwise go stale the moment this lands):
- `dashboard/content/docs/operations/deployment.mdx`
- `docs/book/src/operations/deployment.md`

Snippet block now matches the actual Dockerfile; Key Points bullet replaced *"currently runs as root..."* with *"Runs as non-root user solvela (UID 1001)..."*.

### Production rollout note

This will trigger a new image build on next `fly deploy` to `solvela-gateway`. The container will run as `solvela` instead of `root` going forward. No env-var or fly-secrets changes needed.

## Test plan

- [x] Local `docker build` succeeds
- [x] Local container responds on `/health` as the non-root user
- [x] `id` and `ls -la /app` confirm UID 1001 ownership
- [ ] CI smoke test (`Smoke test (boot gateway + curl endpoints)`) passes
- [ ] Vercel preview renders the updated deployment snippet cleanly