### PR TITLE
docs(sdks/python): rewrite against actual solvela-sdk 0.2.0 surface

### DIFF
--- a/docs/book/src/sdks/python.md
+++ b/docs/book/src/sdks/python.md
@@ -1,165 +1,302 @@
 # Python SDK
 
-The Python SDK provides a synchronous and asynchronous client for Solvela with transparent x402 payment handling.
+`solvela-sdk` is the official Python SDK for the Solvela gateway. It's async-first, dataclass-typed, and handles the x402 payment handshake transparently when a `Signer` is configured.
+
+- **Package:** [`solvela-sdk` on PyPI](https://pypi.org/project/solvela-sdk/)
+- **Source:** [solvela-ai/solvela-python](https://github.com/solvela-ai/solvela-python)
+- **Python:** 3.10+
 
 ## Installation
 
 ```bash
-pip install solvela
+pip install solvela-sdk
 ```
 
-With Solana wallet support (transaction signing):
-
-```bash
-pip install solvela[solana]
-```
+Solana wallet, keypair signing, and RPC integration are all built in — no extras required.
 
 ## Quick Start
 
-```python
-from solvela import LLMClient
-
-client = LLMClient(api_url="http://localhost:8402")
-
-# Simple one-shot chat
-reply = client.chat("openai/gpt-4o", "What is the x402 protocol?")
-print(reply)
-```
-
-The SDK handles the full x402 flow automatically:
-1. Sends the request
-2. Receives the 402 with the price quote
-3. Signs a USDC-SPL transaction using the configured wallet
-4. Retries with the `PAYMENT-SIGNATURE` header
-5. Returns the response
-
-## Configuration
-
-The client reads from environment variables by default:
-
-| Variable | Description |
-|----------|-------------|
-| `SOLANA_WALLET_KEY` | Base58 wallet private key for signing payments |
-| `SOLVELA_API_URL` | Gateway URL (default: `http://localhost:8402`) |
-| `SOLANA_RPC_URL` | Solana RPC endpoint for transaction submission |
-
-Or configure explicitly:
-
-```python
-client = LLMClient(
-    api_url="https://solvela-gateway.fly.dev",
-    wallet_key="your-base58-private-key",
-    rpc_url="https://api.mainnet-beta.solana.com",
-)
-```
-
-## Async Usage
+The SDK is async-only. Every example here is meant to be awaited from inside an async function (or wrapped with `asyncio.run`).
 
 ```python
 import asyncio
-from solvela import AsyncLLMClient
+from solvela import SolvelaClient, ClientConfig
 
 async def main():
-    async with AsyncLLMClient(api_url="http://localhost:8402") as client:
-        reply = await client.chat("openai/gpt-4o", "Hello!")
-        print(reply)
+    client = SolvelaClient(config=ClientConfig(gateway_url="http://localhost:8402"))
+
+    # List available models from the gateway's registry.
+    models = await client.models()
+    for m in models[:3]:
+        print(f"{m.id}  —  {m.display_name}  (${m.input_usdc_per_million}/M in)")
 
 asyncio.run(main())
 ```
 
+Without a `Signer` configured, paid endpoints will raise `PaymentRequiredError` on the first call so the agent can react.
+
+## Configuration
+
+`ClientConfig` is a dataclass; `ClientBuilder` is a fluent equivalent. Both are exported from `solvela`.
+
+```python
+from solvela import ClientConfig
+
+config = ClientConfig(
+    gateway_url="http://localhost:8402",    # default: https://api.solvela.ai
+    rpc_url="https://api.mainnet-beta.solana.com",
+    prefer_escrow=False,                    # "exact" first, "escrow" fallback
+    timeout=180.0,
+    max_payment_amount=10_000_000,          # cap per call (10 USDC = 10_000_000 atomic)
+    expected_recipient=None,                # if set, gateway must pay-to this address
+    enable_cache=False,                     # opt-in response caching
+    enable_sessions=False,                  # opt-in three-strike session escalation
+    session_ttl=1800.0,
+    enable_quality_check=False,             # opt-in degraded-response retry
+    max_quality_retries=1,
+    free_fallback_model=None,               # swap to free model when balance hits zero
+)
+```
+
+Or with the builder:
+
+```python
+from solvela import ClientBuilder
+
+config = (
+    ClientBuilder()
+    .gateway_url("http://localhost:8402")
+    .enable_cache(True)
+    .enable_sessions(True)
+    .free_fallback_model("openai/gpt-4o-mini")
+    .max_payment_amount(100_000)            # 0.10 USDC cap
+    .build()
+)
+```
+
+### Security defaults
+
+- Non-loopback `gateway_url` or `rpc_url` must use `https://`. Plain `http://` to a remote host raises `ClientError` at construction.
+- Unknown payment schemes from the gateway raise `ClientError` rather than silently mis-branching.
+- Malformed amount strings in the 402 body raise `ClientError`, not bare `ValueError`.
+
+## The chat flow
+
+`SolvelaClient.chat()` runs a seven-step smart flow when enabled: balance guard → session lookup → cache check → request → quality check → cache store → session record. For a minimal call only the request step fires.
+
+```python
+from solvela import SolvelaClient, ClientConfig
+from solvela.types import ChatRequest, ChatMessage, Role
+
+async def ask(prompt: str) -> str:
+    client = SolvelaClient(config=ClientConfig(gateway_url="http://localhost:8402"))
+    request = ChatRequest(
+        model="openai/gpt-4o-mini",
+        messages=[ChatMessage(role=Role.USER, content=prompt)],
+        max_tokens=200,
+    )
+    response = await client.chat(request)
+    return response.choices[0].message.content or ""
+```
+
+`ChatResponse` is OpenAI-compatible — `response.id`, `response.choices[i].message`, `response.usage`.
+
+### With a wallet and signer (paid endpoints)
+
+```python
+from solvela import SolvelaClient, ClientConfig, Wallet, KeypairSigner
+
+wallet, mnemonic = Wallet.create()
+print(f"Save this mnemonic: {mnemonic}")
+print(f"Fund this address with USDC: {wallet.address()}")
+
+signer = KeypairSigner(wallet=wallet, rpc_url="https://api.devnet.solana.com")
+client = SolvelaClient(
+    config=ClientConfig(gateway_url="http://localhost:8402"),
+    wallet=wallet,
+    signer=signer,
+)
+
+response = await client.chat(request)
+```
+
+The SDK automatically:
+
+1. Sends the request.
+2. Receives 402 with the price quote.
+3. Picks a compatible scheme (`exact` or `escrow`, respecting `prefer_escrow`).
+4. Calls `signer.sign_payment(...)` to build and sign the SPL transfer.
+5. Retries the request with the `Payment-Signature` header.
+
+If the gateway returns 402 a *second* time after the signed retry, the SDK raises `PaymentRejectedError` carrying the second `PaymentRequired` body so the caller can inspect *why* it was rejected.
+
 ## Streaming
 
 ```python
-for chunk in client.chat_stream("openai/gpt-4o", "Write a poem about Solana"):
-    print(chunk, end="", flush=True)
+async for chunk in client.chat_stream(request):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
 print()
 ```
 
-Async streaming:
+`chat_stream` runs the same preflight payment handshake as `chat()`. A post-signing 402 on the streaming POST is converted to `PaymentRejectedError` so streaming callers can distinguish "needs signing" from "signed and rejected."
+
+## Models and pricing
 
 ```python
-async for chunk in client.chat_stream("openai/gpt-4o", "Write a poem"):
-    print(chunk, end="", flush=True)
+models = await client.models()  # list[ModelInfo]
+
+for m in models:
+    print(
+        f"{m.id:<35} "
+        f"in={m.input_usdc_per_million:>5.2f}  "
+        f"out={m.output_usdc_per_million:>5.2f}  "
+        f"ctx={m.context_window:>7}  "
+        f"tools={m.supports_tools}  vision={m.supports_vision}  reasoning={m.reasoning}"
+    )
 ```
 
-## Session Budgets
+`ModelInfo` mirrors the gateway's `/v1/models` shape — capabilities and pricing are flattened off the nested objects the gateway emits, so the dataclass surface stays terse:
 
-Set a maximum USDC spend per session to prevent runaway costs:
+| Field | Type | Description |
+|---|---|---|
+| `id` | `str` | Canonical model identifier (e.g. `"openai/gpt-4o"`) |
+| `provider` | `str` | Upstream provider (`"openai"`, `"anthropic"`, etc.) |
+| `display_name` | `str` | Human-readable label |
+| `context_window` | `int` | Maximum input tokens |
+| `supports_streaming` / `supports_tools` / `supports_vision` / `reasoning` | `bool` | Capability flags |
+| `input_usdc_per_million` / `output_usdc_per_million` | `float` | Provider rate in USDC per million tokens (human units, not atomic) |
+| `currency` / `fee_percent` | `str` / `int` | Platform fee terms |
+
+### Cost estimation
 
 ```python
-from solvela import LLMClient, BudgetExceededError
-
-client = LLMClient(session_budget=0.50)  # Max $0.50 USDC
-
-try:
-    reply = client.chat("openai/gpt-4o", "Expensive analysis...")
-except BudgetExceededError:
-    print(f"Budget exceeded! Spent: ${client.session_spent:.4f}")
+quote = await client.estimate_cost("openai/gpt-4o")
+print(f"Estimated total: {quote.cost_breakdown.total} {quote.cost_breakdown.currency}")
+print(f"Provider: {quote.cost_breakdown.provider_cost}, fee: {quote.cost_breakdown.platform_fee}")
 ```
 
-## Smart Routing
+`estimate_cost` triggers a 402 against the model, returns the parsed `PaymentRequired` without signing.
 
-Let the gateway pick the optimal model based on request complexity:
+## Error hierarchy
 
-```python
-# Use a routing profile
-response = client.smart_chat("Explain quantum computing", profile="eco")
-
-# Aliases work too
-response = client.smart_chat("Write a sorting algorithm", profile="auto")
-```
-
-Profile options: `eco`, `auto`, `premium`, `free`
-
-## Full Chat Completion
-
-For full control over the request:
-
-```python
-from solvela import LLMClient
-
-client = LLMClient(api_url="http://localhost:8402")
-
-response = client.chat_completion(
-    model="anthropic/claude-sonnet-4.6",
-    messages=[
-        {"role": "system", "content": "You are a Rust expert."},
-        {"role": "user", "content": "Explain ownership and borrowing."},
-    ],
-    max_tokens=1000,
-    temperature=0.3,
-)
-
-print(response["choices"][0]["message"]["content"])
-print(f"Tokens used: {response['usage']['total_tokens']}")
-```
-
-## Error Handling
+All SDK errors inherit from `ClientError`. Catch the base for "anything the SDK threw," catch a subclass for specific recovery.
 
 ```python
 from solvela import (
-    LLMClient,
-    BudgetExceededError,
-    PaymentError,
-    ProviderError,
+    ClientError,
+    PaymentRequiredError,
+    PaymentRejectedError,
+    AmountExceedsMaxError,
+    RecipientMismatchError,
+    InsufficientBalanceError,
+    GatewayError,
+    SignerError,
+    WalletError,
+    TimeoutError as SolvelaTimeoutError,
 )
 
-client = LLMClient(api_url="http://localhost:8402")
-
 try:
-    reply = client.chat("openai/gpt-4o", "Hello")
-except BudgetExceededError:
-    print("Session budget exceeded")
-except PaymentError as e:
-    print(f"Payment failed: {e}")
-except ProviderError as e:
-    print(f"Provider error: {e.status_code} - {e.message}")
+    response = await client.chat(request)
+except PaymentRequiredError as exc:
+    # No signer configured — adopt one or surface to the user.
+    pr = exc.payment_required
+    print(f"Payment needed: {pr.cost_breakdown.total} {pr.cost_breakdown.currency}")
+except PaymentRejectedError as exc:
+    # Signed but the gateway still rejected. `payment_required` carries the
+    # second 402 body (cost, schemes, gateway error message).
+    print(f"Rejected: {exc.reason}; body: {exc.payment_required}")
+except AmountExceedsMaxError as exc:
+    print(f"Quote {exc.amount} exceeds local cap {exc.max_amount}")
+except GatewayError as exc:
+    print(f"Gateway HTTP {exc.status}: {exc.message}")
+except SolvelaTimeoutError as exc:
+    print(f"Timed out after {exc.timeout_secs}s")
 ```
 
-## List Models
+| Error | Raised when |
+|---|---|
+| `PaymentRequiredError` | Gateway returns 402 and no `Signer` is configured. Carries `payment_required` (the parsed body). |
+| `PaymentRejectedError` | Gateway returns 402 *again* after a signed retry. Carries `reason` and (optional) `payment_required`. |
+| `AmountExceedsMaxError` | Gateway's quoted amount exceeds the local `max_payment_amount` cap. Carries `amount` and `max_amount` as `AtomicUsdc`. |
+| `RecipientMismatchError` | Gateway's `pay_to` doesn't match the configured `expected_recipient`. |
+| `InsufficientBalanceError` | Wallet balance is too low for the quoted amount. Carries `have` / `need` as `AtomicUsdc`. |
+| `GatewayError` | Non-200/402 HTTP response. Carries `status` and `message`. |
+| `SignerError` | The configured `Signer` failed to build or sign the payment transaction. |
+| `WalletError` | Wallet operation failed (e.g. mnemonic parse, keypair derivation). |
+| `TimeoutError` | HTTP timeout exceeded. |
+| `ClientError` | Base — also raised directly for wire-format violations (unknown scheme, malformed amount). |
+
+## Balance monitoring
+
+For long-running agents, `BalanceMonitor` polls USDC balance in the background and wires transitions back into the client's balance guard.
 
 ```python
-models = client.list_models()
-for model in models:
-    print(f"{model['id']}: ${model['pricing']['input_cost_per_million']}/M input")
+from solvela import BalanceMonitor
+
+monitor = BalanceMonitor(
+    fetch_balance=client.usdc_balance,
+    poll_interval=30.0,
+    low_balance_threshold=0.50,             # USDC
+    on_low_balance=lambda b: print(f"Low: ${b:.4f}"),
+    on_balance_change=client.balance_state_setter(),
+)
+monitor.start()
+# ... agent loop ...
+monitor.stop()
 ```
+
+When the polled balance hits `0.0` and `ClientConfig.free_fallback_model` is set, the client's chat balance guard swaps the requested model for the free fallback automatically. On RPC failure, `on_balance_change(None)` clears the cached balance to "unknown" so a stale `0.0` doesn't lock callers into the fallback during an outage.
+
+## OpenAI-compatible interface
+
+For code that already targets the OpenAI Python SDK, `OpenAICompat` provides a drop-in shim.
+
+```python
+from solvela import SolvelaClient
+from solvela.openai_compat import OpenAICompat
+
+client = SolvelaClient()
+openai = OpenAICompat(client)
+
+response = await openai.chat.completions.create(
+    model="openai/gpt-4o",
+    messages=[{"role": "user", "content": "Hello!"}],
+    max_tokens=100,
+)
+print(response.choices[0].message.content)
+```
+
+`openai.chat.completions.create(stream=True, ...)` returns the same `AsyncIterator[ChatChunk]` as `SolvelaClient.chat_stream()`.
+
+## Custom signers
+
+The default `KeypairSigner` builds and signs Solana SPL transfers. You can implement the `Signer` ABC to plug in HSM-backed signing, multi-sig flows, or a custodial backend:
+
+```python
+from solvela import Signer
+from solvela.types import AtomicUsdc, PaymentAccept, PaymentPayload, Resource
+
+class MyCustomSigner(Signer):
+    async def sign_payment(
+        self,
+        amount_atomic: AtomicUsdc,
+        recipient: str,
+        resource: Resource,
+        accepted: PaymentAccept,
+    ) -> PaymentPayload:
+        # Build, sign, and return a PaymentPayload your way.
+        ...
+```
+
+`AtomicUsdc` is a type-only `NewType` over `int`; pass `AtomicUsdc(123)` at the boundary to make mypy track the unit. Wire amounts (`accept.amount`) are decimal strings in atomic USDC (1 USDC = 1,000,000).
+
+## Cancellation and timeouts
+
+`ClientConfig.timeout` (default 180s) caps every HTTP call. Cancel an in-flight `chat()` by cancelling the surrounding asyncio task — `httpx` propagates cancellation through cleanly.
+
+## Where to look next
+
+- **Source:** [src/solvela/client.py](https://github.com/solvela-ai/solvela-python/blob/main/src/solvela/client.py) is the canonical entry point for the chat flow.
+- **Examples:** [scripts/smoke.py](https://github.com/solvela-ai/solvela-python/blob/main/scripts/smoke.py) is a 60-line end-to-end script that hits `/v1/models` and an unsigned `/v1/chat/completions` and verifies the wire contract.
+- **Release process:** [docs/RELEASE_CHECKLIST.md](https://github.com/solvela-ai/solvela-python/blob/main/docs/RELEASE_CHECKLIST.md) in the SDK repo.
+- **x402 protocol:** [Solvela's x402 implementation](../concepts/x402-protocol.html), [x402.org](https://www.x402.org/).


### PR DESCRIPTION
## Summary

The previous \`sdks/python.md\` page documented a fictional Python SDK that doesn't exist. Every code example on it would have failed at \`ImportError\` or the first method call. Full rewrite against the published \`solvela-sdk\` 0.2.0 surface.

Sister tracking issue: #218 catalogues drift on the other docs pages (\`api/models.md\`, \`api/chat-completions.md\`, \`x402-protocol.md\`, \`quickstart.md\`, \`troubleshooting.md\`). Those need product-owner decisions on canonical wire format before they can be rewritten and are intentionally out of scope here.

## What was wrong

| Old docs claimed | Reality |
|---|---|
| \`pip install solvela\` | \`pip install solvela-sdk\` |
| \`pip install solvela[solana]\` (extras) | No \`[solana]\` extra — solana built in |
| \`from solvela import LLMClient\` | \`from solvela import SolvelaClient\` |
| \`LLMClient(api_url=...)\` | \`SolvelaClient(config=ClientConfig(gateway_url=...))\` |
| \`client.chat(\"model\", \"prompt\")\` (sync, positional strings) | \`await client.chat(ChatRequest(model=..., messages=[ChatMessage(...)]))\` |
| \`AsyncLLMClient\` | Doesn't exist — \`SolvelaClient\` IS async |
| \`client.smart_chat(\"prompt\", profile=\"eco\")\` | Doesn't exist |
| \`client.chat_completion(model=, messages=, max_tokens=)\` returning dict | Doesn't exist — \`chat()\` returns a \`ChatResponse\` dataclass |
| \`BudgetExceededError\`, \`PaymentError\`, \`ProviderError\` | Don't exist — real types: \`PaymentRequiredError\`, \`PaymentRejectedError\`, \`AmountExceedsMaxError\`, \`GatewayError\` |
| \`client.list_models()\` returning dicts | \`await client.models()\` returning \`list[ModelInfo]\` |
| \`SOLANA_WALLET_KEY\` / \`SOLVELA_API_URL\` env vars auto-read | SDK doesn't read env automatically |

## What the new page covers

- Installation (correct package name)
- Quick start with \`SolvelaClient\` + \`await\`
- \`ClientConfig\` (dataclass) and \`ClientBuilder\` (fluent), all fields documented
- Security defaults (HTTPS-enforcement, typed wire-format errors)
- The chat flow — minimal call and signer-attached paid flow with the real \`PaymentRejectedError\` body capture from 0.2.0
- Streaming with \`chat_stream\`
- \`ModelInfo\` shape and field reference matching the 0.2.0 \`input_usdc_per_million\` rename and capabilities flattening
- \`estimate_cost\` for price quotes without payment
- Full error hierarchy with a reference table
- \`BalanceMonitor\` wiring with the new \`on_balance_change\` callback (0.2.0)
- \`OpenAICompat\` shim
- Custom signer authoring via the \`Signer\` ABC
- Cancellation and timeout semantics

## Test plan

- [x] Every code example matches an actual symbol in [solvela-ai/solvela-python at v0.2.0](https://github.com/solvela-ai/solvela-python/tree/v0.2.0) (verified by reading \`src/solvela/__init__.py\` exports and \`src/solvela/client.py\`).
- [x] Field names and types in the \`ModelInfo\` table match the dataclass in \`src/solvela/types.py\`.
- [x] Error hierarchy table matches the exports in \`src/solvela/errors.py\`.
- [ ] mdBook render check — I can't run \`mdbook build\` locally (binary not installed in this environment). The page uses only standard Markdown + tables; no mdbook-mermaid or mdbook-admonish directives are introduced.

## Out of scope

- Other docs pages catalogued in #218.
- \`/v1/models\` and 402 response shape rewrites on the API reference — those require a product-owner decision on which wire format wins (docs, current gateway, or x402 spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)