### PR TITLE
docs(sdks/python): tier-B sync to solvela-sdk 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,23 @@ All prices are provider cost in USDC. A 5% platform fee is applied on top. See `
 ### Python
 
 ```bash
-pip install solvela
+pip install solvela-sdk
 ```
 
 ```python
-from solvela import LLMClient
+import asyncio
+from solvela import SolvelaClient
+from solvela.types import ChatRequest, ChatMessage, Role
 
-client = LLMClient()
-response = client.chat("openai/gpt-4o", "Hello!")
+async def main():
+    client = SolvelaClient()  # defaults to https://api.solvela.ai
+    response = await client.chat(ChatRequest(
+        model="openai/gpt-4o",
+        messages=[ChatMessage(role=Role.USER, content="Hello!")],
+    ))
+    print(response.choices[0].message.content)
+
+asyncio.run(main())
 ```
 
 ### TypeScript
@@ -379,7 +388,7 @@ crates/
 programs/
   escrow/           Anchor escrow program (deposit/claim/refund, PDA vault)
 sdks/
-  python/           pip install solvela
+  python/           pip install solvela-sdk (canonical source: github.com/solvela-ai/solvela-python)
   go/               go get github.com/solvela-ai/solvela-go
   mcp/              Claude Code MCP server
   signer-core/      Shared x402 parser + payment-signer primitives

--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -184,33 +184,42 @@ data: [DONE]
   </Tab>
   <Tab value="Python">
     ```python
-    import os
-    from solvela import LLMClient
+    import asyncio
+    from solvela import SolvelaClient, ClientConfig, Wallet, KeypairSigner
+    from solvela.types import ChatRequest, ChatMessage, Role
 
-    client = LLMClient(
-        private_key=os.environ['SOLANA_PRIVATE_KEY'],
-        api_url='https://api.solvela.ai',
-        session_budget=0.10,  # stop if we spend more than $0.10
-    )
+    async def main():
+        wallet = Wallet.from_env('SOLANA_PRIVATE_KEY')
+        signer = KeypairSigner(wallet=wallet)
+        client = SolvelaClient(
+            config=ClientConfig(
+                gateway_url='https://api.solvela.ai',
+                max_payment_amount=100_000,  # per-call cap: 0.10 USDC (atomic units)
+            ),
+            wallet=wallet,
+            signer=signer,
+        )
 
-    # Simple one-shot
-    text = client.chat('auto', 'What is Solana?')
-    print(text)
+        # Quick request — model 'auto' invokes the smart router.
+        quick = await client.chat(ChatRequest(
+            model='auto',
+            messages=[ChatMessage(role=Role.USER, content='What is Solana?')],
+        ))
+        print(quick.choices[0].message.content)
 
-    # Full request
-    from solvela import ChatMessage, Role
+        # Full request with system prompt + sampling controls.
+        response = await client.chat(ChatRequest(
+            model='openai/gpt-4o',
+            messages=[
+                ChatMessage(role=Role.SYSTEM, content='You are a blockchain expert.'),
+                ChatMessage(role=Role.USER, content='Explain proof of history.'),
+            ],
+            max_tokens=500,
+            temperature=0.7,
+        ))
+        print(response.choices[0].message.content)
 
-    response = client.chat_completion(
-        model='openai/gpt-4o',
-        messages=[
-            ChatMessage(role=Role.SYSTEM, content='You are a blockchain expert.'),
-            ChatMessage(role=Role.USER, content='Explain proof of history.'),
-        ],
-        max_tokens=500,
-        temperature=0.7,
-    )
-    print(response.choices[0].message.content)
-    print(f'Spent: {client.session_spent:.6f} USDC')
+    asyncio.run(main())
     ```
   </Tab>
   <Tab value="Go">

--- a/dashboard/content/docs/concepts/payment-flow.mdx
+++ b/dashboard/content/docs/concepts/payment-flow.mdx
@@ -176,10 +176,18 @@ All official SDKs support a `sessionBudget` option that caps total spending for 
   </Tab>
   <Tab value="Python">
     ```python
+    from solvela import SolvelaClient, ClientConfig, Wallet, KeypairSigner
+
+    # solvela-sdk 0.2.0 caps spend per call, not per session.
+    # Track lifetime spend yourself if you need a session-wide budget.
+    wallet = Wallet.from_env("SOLANA_PRIVATE_KEY")
     client = SolvelaClient(
-        endpoint="https://api.solvela.ai",
-        wallet_key=os.environ["SOLANA_PRIVATE_KEY"],
-        session_budget="0.10",  # max $0.10 USDC this session
+        config=ClientConfig(
+            gateway_url="https://api.solvela.ai",
+            max_payment_amount=100_000,  # per-call cap: 0.10 USDC (atomic units)
+        ),
+        wallet=wallet,
+        signer=KeypairSigner(wallet=wallet),
     )
     ```
   </Tab>

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -70,13 +70,20 @@ First, send a request without any payment header. The gateway will respond with 
   </Tab>
   <Tab value="Python">
     ```python
-    from solvela import LLMClient
+    import asyncio
+    from solvela import SolvelaClient
+    from solvela.types import ChatRequest, ChatMessage, Role
 
-    client = LLMClient(api_url='https://api.solvela.ai')
+    async def main():
+        client = SolvelaClient()  # defaults to https://api.solvela.ai
+        # The SDK handles the 402 flow when a Signer is configured.
+        response = await client.chat(ChatRequest(
+            model='auto',
+            messages=[ChatMessage(role=Role.USER, content='What is x402?')],
+        ))
+        print(response.choices[0].message.content)
 
-    # The SDK automatically handles the 402 flow.
-    reply = client.chat('auto', 'What is x402?')
-    print(reply)
+    asyncio.run(main())
     ```
   </Tab>
   <Tab value="Go">
@@ -185,17 +192,24 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
   </Tab>
   <Tab value="Python">
     ```python
-    import os
-    from solvela import LLMClient
+    import asyncio
+    from solvela import SolvelaClient, Wallet, KeypairSigner
+    from solvela.types import ChatRequest, ChatMessage, Role
 
-    client = LLMClient(
-        private_key=os.environ['SOLANA_PRIVATE_KEY'],  # base58 private key
-        api_url='https://api.solvela.ai',
-    )
+    async def main():
+        wallet = Wallet.from_env('SOLANA_PRIVATE_KEY')  # base58 keypair
+        signer = KeypairSigner(wallet=wallet)
+        client = SolvelaClient(wallet=wallet, signer=signer)
 
-    reply = client.chat('gpt-4o', 'Explain Solana in one sentence.')
-    print(reply)
-    print(f'Spent: {client.session_spent:.6f} USDC')
+        response = await client.chat(ChatRequest(
+            model='gpt-4o',
+            messages=[ChatMessage(role=Role.USER, content='Explain Solana in one sentence.')],
+        ))
+        print(response.choices[0].message.content)
+        balance = await client.usdc_balance()
+        print(f'Wallet USDC balance: {balance:.6f}')
+
+    asyncio.run(main())
     ```
   </Tab>
   <Tab value="Go">

--- a/docs/book/src/concepts/smart-routing.md
+++ b/docs/book/src/concepts/smart-routing.md
@@ -112,11 +112,22 @@ curl -X POST http://localhost:8402/v1/chat/completions \
 
 ### Via Python SDK
 
-```python
-from solvela import LLMClient
+Smart routing in `solvela-sdk` 0.2.0 is invoked by passing a profile name (`"auto"` / `"eco"` / `"premium"` / `"free"`) as the model — there is no separate `smart_chat` method.
 
-client = LLMClient(api_url="http://localhost:8402")
-response = client.smart_chat("Explain quantum entanglement", profile="eco")
+```python
+import asyncio
+from solvela import SolvelaClient, ClientConfig
+from solvela.types import ChatRequest, ChatMessage, Role
+
+async def main():
+    client = SolvelaClient(config=ClientConfig(gateway_url="http://localhost:8402"))
+    response = await client.chat(ChatRequest(
+        model="eco",  # routing profile — gateway picks the cheapest capable model
+        messages=[ChatMessage(role=Role.USER, content="Explain quantum entanglement")],
+    ))
+    print(response.choices[0].message.content)
+
+asyncio.run(main())
 ```
 
 ### Via CLI

--- a/docs/book/src/getting-started/quickstart.md
+++ b/docs/book/src/getting-started/quickstart.md
@@ -100,11 +100,19 @@ This is the x402 protocol in action. The agent must:
 With an SDK (recommended), payment is transparent:
 
 ```python
-from solvela import LLMClient
+import asyncio
+from solvela import SolvelaClient, ClientConfig
+from solvela.types import ChatRequest, ChatMessage, Role
 
-client = LLMClient(api_url="http://localhost:8402")
-reply = client.chat("openai/gpt-4o-mini", "Hello!")
-print(reply)
+async def main():
+    client = SolvelaClient(config=ClientConfig(gateway_url="http://localhost:8402"))
+    response = await client.chat(ChatRequest(
+        model="openai/gpt-4o-mini",
+        messages=[ChatMessage(role=Role.USER, content="Hello!")],
+    ))
+    print(response.choices[0].message.content)
+
+asyncio.run(main())
 ```
 
 Or using the CLI:

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -3,5 +3,5 @@
 The Solvela Python SDK now lives at https://github.com/solvela-ai/solvela-python.
 
 ```
-pip install solvela
+pip install solvela-sdk
 ```


### PR DESCRIPTION
## Summary

Follow-up sweep to PRs #219 + #220. The canonical Python SDK pages (`docs/book/src/sdks/python.md` + `dashboard/content/docs/sdks/python.mdx`) are aligned with `solvela-sdk` 0.2.0; this PR brings every remaining Python snippet in the doc corpus onto the same surface so a reader who clicks through from the quickstart or README no longer hits non-working code.

## What changed

Replaces removed API symbols (`LLMClient`, `AsyncLLMClient`, `chat()` positional shape, `chat_completion`, `smart_chat`, `session_budget`, `wallet_key`, `session_spent`, `pip install solvela`) with the actual 0.2.0 entry points (`SolvelaClient`, `ClientConfig`, `ChatRequest` + `ChatMessage` + `Role` from `solvela.types`, `Wallet.from_env`, `KeypairSigner`, `max_payment_amount`, `usdc_balance`, `pip install solvela-sdk`).

| File | Change |
|---|---|
| `README.md` | Top-level Python snippet (lines 223–235) + `sdks/python/` directory line (382) |
| `dashboard/content/docs/quickstart.mdx` | Both Python tabs (with and without signing) |
| `dashboard/content/docs/api/chat-completions.mdx` | Python tab |
| `dashboard/content/docs/concepts/payment-flow.mdx` | Python tab in Session Budgets — uses `max_payment_amount` with an inline note that 0.2.0 caps per call, not per session |
| `docs/book/src/getting-started/quickstart.md` | Python snippet (lines 102–108) |
| `docs/book/src/concepts/smart-routing.md` | Python snippet + prose noting that `smart_chat` is replaced by passing the profile name (`"auto"`/`"eco"`/`"premium"`/`"free"`) as `model` in `ChatRequest` |
| `sdks/python/README.md` | `pip install solvela` → `solvela-sdk` |

## Out of scope (intentional)

- **TypeScript `LLMClient` references** in `README.md:252`, `dashboard/content/docs/quickstart.mdx`, and `dashboard/content/docs/api/chat-completions.mdx`. The npm `@solvela/sdk@0.2.1` package is wire-incompatible with the production gateway today, so "fixing" those snippets to use the current TS SDK API would document a broken client. Tracked as **tier-C**; needs a separate decision (remove TS tabs / replace with `curl` / point at `@solvela/signer-core` in-repo path).
- **Go and Rust tabs** left unchanged — different SDKs, different release cadences.
- The **"Session Budgets" section header/intro** and TS/Go/Rust tabs in `payment-flow.mdx`. The section's thesis ("all official SDKs cap lifetime spend") is no longer uniformly true; reconciling across all four SDKs is a separate doc rewrite outside tier-B Python scope. This PR only updates the Python tab to be accurate and adds an inline note about the semantic shift.

## Test plan

- [x] `grep -rnE '(pip install solvela[^-]|from solvela import LLMClient|LLMClient\(|smart_chat|chat_completion|session_budget=|wallet_key=|\.session_spent)' --include='*.md' --include='*.mdx'` returns only intentional matches (Go SDK / TS AI-SDK provider / MCP server's own tool names / the explanatory sentence I added in `smart-routing.md`)
- [ ] `mdbook build docs/book` succeeds with no broken links
- [ ] `npm --prefix dashboard run build` renders the four touched dashboard pages
- [ ] Spot-check that every new snippet imports symbols that actually exist in `solvela-sdk` 0.2.0 (verified against `solvela-ai/solvela-python` @ 55faa6f: `SolvelaClient`, `ClientConfig`, `Wallet.from_env`, `KeypairSigner`, `ChatRequest`, `ChatMessage`, `Role`, `client.usdc_balance`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)