### PR TITLE
docs(agents): trim docs/AGENTS.md to reflect actual directory state

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,7 +4,7 @@
 # docs
 
 ## Purpose
-Repository-internal documentation: operational handbooks, implementation plans, research notes, product specs, and load-test results. This is distinct from the **public** docs site, which lives under `../dashboard/content/docs/` and is what end-users read on solvela.vercel.app.
+Repository-internal product docs (strategy, use cases, FAQ, regulatory positioning). This is distinct from the **public** docs site, which lives under `../dashboard/content/docs/` and is what end-users read on docs.solvela.ai.
 
 ## Key Files
 _(no loose files — see subdirectories)_
@@ -12,24 +12,18 @@ _(no loose files — see subdirectories)_
 ## Subdirectories
 | Directory | Purpose |
 |-----------|---------|
-| `plans/` | Implementation plans — one markdown file per initiative (see `plans/AGENTS.md`) |
 | `product/` | Product strategy, use cases, FAQ, regulatory position (see `product/AGENTS.md`) |
-| `research/` | Research notes and external investigations (see `research/AGENTS.md`) |
-| `load-tests/` | Load-test plans + results (see `load-tests/AGENTS.md`) |
-| `superpowers/` | Plans + specs authored via the `superpowers` skill (see `superpowers/AGENTS.md`) |
 
 ## For AI Agents
 
 ### Working In This Directory
 - Public docs live in `../dashboard/content/docs/`. Do **not** duplicate material here — link instead.
-- Plans: prefer updating an existing plan's status section over spawning a new file for each iteration; when a plan lands, note outcome in HANDOFF.md / CHANGELOG.md and leave the plan as-is for history.
-- Filenames use the `YYYY-MM-DD-slug.md` convention in `plans/`, `load-tests/`, `research/`, and `superpowers/plans/`.
 
 ### Testing Requirements
 No automated tests — reviews are the quality gate.
 
 ### Common Patterns
-- Dated filenames for plans/research; undated for evergreen reference material (product FAQ, how-it-works).
+- Undated filenames — evergreen reference material (product FAQ, how-it-works, regulatory positioning, use cases).
 - GitHub-flavoured Markdown throughout.
 
 ## Dependencies


### PR DESCRIPTION
## Summary

Cleanup pass on `docs/AGENTS.md` — the file claimed `docs/` contains six subdirectories, but only two actually exist on disk (`book/` and `product/`), and `book/` is itself being retired in #225.

## What's wrong today

| Claim in current `docs/AGENTS.md` | Reality |
|---|---|
| `plans/` subdirectory | ❌ does not exist |
| `research/` subdirectory | ❌ does not exist |
| `load-tests/` subdirectory | ❌ does not exist |
| `superpowers/` subdirectory | ❌ does not exist |
| Purpose mentions "operational handbooks, implementation plans, research notes, product specs, and load-test results" | only product specs survive (after #225) |
| Public docs URL is `solvela.vercel.app` | actually `docs.solvela.ai` for weeks |
| Bullet about updating plans + noting outcome in `HANDOFF.md / CHANGELOG.md` | `plans/` doesn't exist; `HANDOFF.md` was retired pre-launch |
| Bullet about `YYYY-MM-DD-slug.md` convention in `plans/`, `load-tests/`, `research/`, `superpowers/plans/` | all four target dirs don't exist |
| Common Patterns says "Dated filenames for plans/research" | dead clause |

## Changes

- **Subdirectories table:** drop the four phantom rows (`plans/`, `research/`, `load-tests/`, `superpowers/`).
- **Purpose line:** trim to what survives + fix the stale URL (`solvela.vercel.app` → `docs.solvela.ai`).
- **Working In This Directory:** drop the plan-lifecycle bullet (with the dead `HANDOFF.md` ref) and the YYYY-MM-DD filename-convention bullet.
- **Common Patterns:** drop the dead "dated filenames for plans/research" clause; keep the undated-files convention.

Pure docs cleanup — no source code, no product docs (`docs/product/`), no public docs (`dashboard/content/docs/`) touched.

## Relationship to #225

Independent. #225 edits **lines 15, 30, 42** of `docs/AGENTS.md` (the `book/` row, mdBook prose in Testing Requirements, and mdBook entry in External Dependencies). This PR edits **lines 7, 16, 18, 19, 20, 26, 27, 33** — zero overlap. Both PRs are independently mergeable in any order.

After both merge, `docs/AGENTS.md` cleanly describes its only surviving content: `docs/product/`.

## Test plan

- [x] `git --no-pager diff origin/main..HEAD` reviewed; only `docs/AGENTS.md` changed
- [x] Diff lines do not overlap with PR #225's diff lines
- [x] DCO signoff present
- [ ] Reviewer confirms no agent context referencing the trimmed bullets relies on them (none should — the dirs they describe are absent)

## Related follow-up (not in this PR)

Root `AGENTS.md` line 26 has the same class of stale text: `\`docs/\` | Repo-internal docs — plans, research, book, product (see \`docs/AGENTS.md\`)`. After this PR and #225 land, only `product` is accurate there. Worth a separate one-line fix; out of scope here.