### PR TITLE
docs: refresh stale Repository Map entries in root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,13 @@ Each top-level directory has its own `AGENTS.md` describing its contents, testin
 | `crates/` | Rust workspace — gateway (only binary), x402, router, protocol, cli (see `crates/AGENTS.md`) |
 | `programs/` | Standalone Anchor program(s); NOT workspace members (see `programs/AGENTS.md`) |
 | `dashboard/` | Next.js 16 product + docs site (see `dashboard/AGENTS.md`) |
-| `sdks/` | Client SDKs — Go / TypeScript / Python / MCP (see `sdks/AGENTS.md`) |
+| `sdks/` | Client SDKs — Python, Go, MCP, CLI npm wrapper, signer-core, AI SDK + OpenClaw providers; canonical TypeScript SDK is external (see `sdks/AGENTS.md`) |
 | `integrations/` | Third-party-framework adapters (ElizaOS, OpenClaw) (see `integrations/AGENTS.md`) |
 | `config/` | Static TOML config consumed at startup (see `config/AGENTS.md`) |
 | `migrations/` | PostgreSQL migrations — idempotent, auto-applied on startup (see `migrations/AGENTS.md`) |
 | `scripts/` | Dev/ops helper scripts (see `scripts/AGENTS.md`) |
 | `loadtest/` | Containerized load-test harness (see `loadtest/AGENTS.md`) |
-| `docs/` | Repo-internal docs — plans, research, book, product (see `docs/AGENTS.md`) |
+| `docs/` | Repo-internal product strategy docs — use cases, FAQ, regulatory positioning, how-it-works (see `docs/AGENTS.md`) |
 
 Nested directories follow the same pattern: each non-trivial subdirectory has its own `AGENTS.md` with a `<!-- Parent: ../AGENTS.md -->` pointer for navigation.
 


### PR DESCRIPTION
## Summary

Two rows in the Repository Map table in root `AGENTS.md` no longer match what's actually on disk. Verified every row in the table with `ls`; only these two are stale.

## Stale rows

| Row | Claim | Reality |
|---|---|---|
| `docs/` | "Repo-internal docs — plans, research, book, product" | Only `book/` and `product/` exist on disk. `plans/`, `research/`, `load-tests/`, `superpowers/` were never created (or were removed long ago — confirmed in #226). After #225 retires `book/`, only `product/` remains. |
| `sdks/` | "Client SDKs — Go / TypeScript / Python / MCP" | Directory has **7** tracked subdirs: `python/`, `go/`, `mcp/`, `cli-npm/`, `signer-core/`, `ai-sdk-provider/`, `openclaw-provider/`. The canonical TypeScript SDK lives externally at `solvela-ai/solvela-ts` (per the in-tree note at `sdks/typescript` is local-only artifacts + the README §SDKs block). |

## Changes

- `sdks/` row → "Client SDKs — Python, Go, MCP, CLI npm wrapper, signer-core, AI SDK + OpenClaw providers; canonical TypeScript SDK is external"
- `docs/` row → "Repo-internal product strategy docs — use cases, FAQ, regulatory positioning, how-it-works"

Pure copy fix — no source code, no public docs, no other AGENTS.md files touched.

## Verification

```
$ for d in crates programs dashboard sdks integrations config migrations scripts loadtest docs; do
    if [ -d "$d" ]; then echo "✓ $d/"; else echo "✗ $d/"; fi
  done
```
All ten exist. Only the **descriptions** for `docs/` and `sdks/` were inaccurate.

## Relationship to #225 and #226

Independent of both. This PR only edits **lines 20 and 26** of root `AGENTS.md`; neither #225 nor #226 touches root `AGENTS.md` at all. All three can land in any order.

## Test plan

- [x] Every dir in the Repository Map table verified to exist via `ls`
- [x] Every subdir count cross-referenced against actual contents
- [x] DCO signoff present
- [ ] Reviewer confirms `sdks/` row description matches the README §SDKs block (post-#225)