### PR TITLE
chore(protocol): bump solvela-protocol to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solvela-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Shared wire-format types for the Solvela ecosystem (x402 payment protocol + OpenAI-compatible chat types)"
 license = "MIT"


### PR DESCRIPTION
## Summary

Releases the ModelInfo nested-wire fix from [#229](https://github.com/solvela-ai/solvela/pull/229) as a patch so downstream consumers pinned to `^0.2` pick it up via `cargo update` automatically — no per-consumer `Cargo.toml` edit, no coordinated bump across the SDK family.

Two-line diff: `crates/protocol/Cargo.toml` version field, plus the corresponding `Cargo.lock` refresh.

## Why patch (0.2.1) and not minor (0.3.0)

1. **Cargo SemVer is defined on the public Rust API** — field set, signatures, exported types. `ModelInfo`'s Rust surface is byte-identical before and after #229. Only the serde wire shape changed; that's downstream behavior, not API.
2. **Caret-range uptake.** `^0.2` matches `0.2.1` automatically; `^0.3.0` does not. Patch means the next `cargo update` carries the fix to every downstream consumer for free.
3. **It's a fix, not a feature.** The gateway has emitted the nested wire shape since the initial commit. The flat-derives were always wrong about what the gateway actually emitted — this just stops being wrong.
4. **Reserves the next minor for actual API breaks.** Type splits, struct-field additions, removed pub items — those are the changes that earn a minor bump.
5. **Nothing shipped at 0.2.0.** crates.io still serves `0.1.0`; the repo-tagged `0.2.0` (license-metadata cleanup) never published. Reusing the 0.2 series keeps the registry timeline continuous (`0.1.0 → 0.2.1`).

The "Pre-0.3.0" framing in #229's commit message is aspirational — written before caret-range uptake was weighed.

## Verification

- [x] `cargo check --workspace` clean — all 5 crates (protocol, router, x402, gateway, cli) resolve against `solvela-protocol v0.2.1`.
- [x] `Cargo.lock` regenerated; no other crate versions drift.
- [x] No source code touched.

## Follow-ups after merge

1. `cargo publish -p solvela-protocol` from the merge commit.
2. Bump `solvela-client/Cargo.toml` workspace pin (`solvela-protocol = "0.1"` → `"0.2"`); workspace members inherit via `workspace = true`.
3. Mirror the smoke-harness Critical 6 + ModelInfo block into `solvela-client/scripts/smoke` once it's consuming the fixed crate (pattern already in `solvela-python` and `solvela-go`).