### PR TITLE
chore(dependabot): cover all @solana/web3.js 1.x consumers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,7 +56,11 @@ updates:
       patch-and-minor:
         update-types: [patch, minor]
 
-  # ── @solana/web3.js 1.x consumers (mcp, openclaw-provider, integrations)
+  # ── @solana/web3.js 1.x consumers ───────────────────────────────────────
+  # mcp, openclaw-provider, integrations/openclaw, signer-core,
+  # ai-sdk-provider — every npm manifest in this repo that pulls
+  # @solana/web3.js 1.x or @solana/spl-token 0.4.x.
+  #
   # bigint-buffer (high) and uuid <14.0.0 (moderate) are both pinned by
   # @solana/web3.js 1.x. The npm-suggested "fix" downgrades to 0.9.2 which
   # is a regression. Resolution path: migrate to @solana/kit. See SECURITY.md.
@@ -96,13 +100,31 @@ updates:
       - dependency-name: "@solana/web3.js"
         versions: ["<2"]
 
-  # ── Other npm packages ──────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /sdks/signer-core
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: bigint-buffer
+      - dependency-name: uuid
+        versions: ["<14.0.0"]
+      - dependency-name: "@solana/web3.js"
+        versions: ["<2"]
+
   - package-ecosystem: npm
     directory: /sdks/ai-sdk-provider
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: bigint-buffer
+      - dependency-name: uuid
+        versions: ["<14.0.0"]
+      - dependency-name: "@solana/web3.js"
+        versions: ["<2"]
 
+  # ── Other npm packages ──────────────────────────────────────────────────
   - package-ecosystem: npm
     directory: /sdks/cli-npm
     schedule:


### PR DESCRIPTION
## Summary

Aligns `.github/dependabot.yml` with reality: every npm manifest in this repo that pulls `@solana/web3.js` 1.x now carries the same accepted-risk ignore rules.

### Gaps closed

- **`sdks/signer-core`** was missing from `dependabot.yml` entirely. Its 1 high `bigint-buffer` alert (`#76`) had no place to land — Dependabot wasn't tracking the manifest, so no auto-PR, no ignore rule, no risk-acceptance trail.
- **`sdks/ai-sdk-provider`** was tracked in the "Other npm" group without ignore rules. Its 1 high `bigint-buffer` alert (`#77`) was the same Solana-1.x transitive pattern but couldn't be suppressed.

### After this PR — five aligned blocks

| Block | Was | Now |
|---|---|---|
| `/sdks/mcp` | Tracked + ignores | Tracked + ignores |
| `/sdks/openclaw-provider` | Tracked + ignores | Tracked + ignores |
| `/integrations/openclaw` | Tracked + ignores | Tracked + ignores |
| `/sdks/signer-core` | **Not tracked** | Tracked + ignores |
| `/sdks/ai-sdk-provider` | Tracked, no ignores | Tracked + ignores |

All five share the same ignore list: `bigint-buffer`, `uuid <14.0.0`, `@solana/web3.js <2` — already documented in `SECURITY.md` lines 47–55 as accepted-risk gated on the `@solana/kit` migration.

## Verification

- [x] `yaml.safe_load` parses cleanly — 10 `updates:` entries (was 9; +1 for `signer-core`).
- [x] All 5 Solana consumers carry identical ignore rules (verified via summary listing).
- [x] Both manifests confirmed to pull `@solana/web3.js` 1.x via their `package.json`:
  - `sdks/ai-sdk-provider`: `@solana/web3.js`, `@solana/spl-token`
  - `sdks/signer-core`: `@solana/web3.js ^1.87.0`, `@solana/spl-token ^0.4.0`
- [x] Both lockfiles confirmed to pull `bigint-buffer 1.1.5` via the same `@solana/buffer-layout` chain.

## Expected effect

- 2 high `bigint-buffer` alerts (`#76` signer-core, `#77` ai-sdk-provider) → suppressed via documented-risk ignore.
- Open Dependabot alerts: **8 → 6** (after this PR + #228 which closed the 12-alert Next.js cluster).
- Remaining 6 alerts (no change from this PR): 3× `uuid` already-accepted; 2× `fast-uri` + 1× `ip-address` in `sdks/mcp` — separate investigation (not Solana transitives).

## Out of scope

- `fast-uri` + `ip-address` in `sdks/mcp` (3 alerts) — these are not `@solana/web3.js` transitives; need parent-package bump or upstream fix, not ignore rules.
- `@solana/kit` migration — the actual resolution of every alert this PR ignores. Tracked separately; this PR just makes the config accurate until that lands.