### PR TITLE
chore(sdks): drop sdks/{go,python}/README.md tombstones

### DIFF
--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,7 +1,0 @@
-# (Removed — canonical SDK lives in standalone repo)
-
-The Solvela Go SDK now lives at https://github.com/solvela-ai/solvela-go.
-
-```
-go get github.com/solvela-ai/solvela-go
-```

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,7 +1,0 @@
-# (Removed — canonical SDK lives in standalone repo)
-
-The Solvela Python SDK now lives at https://github.com/solvela-ai/solvela-python.
-
-```
-pip install solvela-sdk
-```


### PR DESCRIPTION
## Summary

Both files were 4-6 line redirect stubs in otherwise-empty directories, pointing to the standalone `solvela-go` and `solvela-python` repos. The main README's SDK section is the canonical "where do I find the X SDK?" answer, and these in-repo tombstones added two extra directories to the `sdks/` listing without providing meaningful content. The dashboard docs at `/docs/sdks/{go,python}` are URL routes, not file paths, so they are unaffected.

## Why fresh, not a rebase of #206

[#206](https://github.com/solvela-ai/solvela/pull/206) was opened 2026-05-10 and tried to rewrite the root `README.md` as well. Main has since been updated by [#225](https://github.com/solvela-ai/solvela/pull/225) (`cd Solvela` → `cd solvela` typo, hardcoded test counts removed, etc.) and [#221](https://github.com/solvela-ai/solvela/pull/221) (Python SDK section rewritten against the published `solvela-sdk` 0.2.0 surface). A literal rebase of #206 would have regressed those wins. This PR extracts only the tombstone-deletion intent; root README untouched.

## Verification

- [x] `git ls-files sdks/go/` → only `sdks/go/README.md`; deletion removes the dir entirely.
- [x] `git ls-files sdks/python/` → only `sdks/python/README.md`; deletion removes the dir entirely.
- [x] No tracked file references `sdks/python/README.md` or `sdks/go/README.md` (only CHANGELOG.md history mentions the path).
- [x] Dashboard docs link to `/docs/sdks/{python,go}` URL routes, not these file paths — verified at `dashboard/content/docs/sdks/index.mdx:31-32`.

## Test plan

- [x] Local `git rm` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)