### PR TITLE
docs(status): drop stale claim about deploy-staleness workflow

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -32,7 +32,6 @@ _Last refreshed: 2026-05-12 — review-batch closeout: 6 M-tier security fixes f
 
 - **Branch protection on `solvela-ai/solvela:main`** — 1 PR approval required, 4 required CI checks, branches must be up-to-date, conversation resolution required, force-push and delete blocked.
 - **Auto-merge enabled** for dependabot patch/minor batches with required-checks gating.
-- **Hourly deploy-staleness check** (`.github/workflows/deploy-staleness-check.yml`) opens an issue if production lags `main` HEAD by more than an hour.
 - **Container hardening** — gateway runtime stage runs as non-root `solvela` user (UID 1001, no home, no login shell) since [#215](https://github.com/solvela-ai/solvela/pull/215) (2026-05-11). Files copied from the build stage use `--chown=solvela:solvela`; verified via CI smoke test that the container responds on `/health` as the non-root user.
 
 ## Known follow-ups


### PR DESCRIPTION
## Summary

\`STATUS.md\` "Repo hardening" section was listing the hourly deploy-staleness check as if it shipped, citing \`.github/workflows/deploy-staleness-check.yml\` as the path. **The file has never existed in main.** Verified locally — no workflow with that filename and no cron-scheduled workflow at all in \`.github/workflows/\`.

The PR that would have added it ([#63](https://github.com/solvela-ai/solvela/pull/63)) was opened 2026-04-29 and never merged; a fresh-from-main reapplication ([#247](https://github.com/solvela-ai/solvela/pull/247)) was opened earlier today (2026-05-12) and closed without merging per maintainer decision.

Removing the bullet so \`STATUS.md\` only describes what's actually live.

## Heads-up

\`CHANGELOG.md:214\` makes the same false claim, embedded in the v0.1.1 release notes:

> - **Hourly deploy-staleness check** (\`.github/workflows/deploy-staleness-check.yml\`) — opens a tracking issue if production sha lags main by more than 1 hour. Closes the gap that caused a 10-day silent stall.

Not corrected here — editing a dated release-notes entry is a different judgment call (strikethrough? footnote? leave for historical accuracy of "what we *thought* shipped"?). Flagging for your separate decision.

## Test plan

- [x] One-line deletion, doc-only diff.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)