### PR TITLE
docs(changelog): drop false deploy-staleness claim from v0.1.1 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,6 @@ Per-SDK highlights:
 ### Repository hardening
 
 - **Branch protection on `main`** — 1 PR approval, 4 required CI checks (Rust fmt/clippy/test, Smoke test, Security audit, Docker build), branches must be up-to-date, force-push/delete blocked.
-- **Hourly deploy-staleness check** (`.github/workflows/deploy-staleness-check.yml`) — opens a tracking issue if production sha lags `main` by more than 1 hour. Closes the gap that caused a 10-day silent stall.
 - **`www.solvela.ai`** added as a 308 redirect to the apex on Vercel.
 - **GitHub Releases** — first releases tagged on the main repo (`v0.1.1`, `solvela-x402-v0.1.2`) and on all four SDK repos.
 


### PR DESCRIPTION
## Summary

\`CHANGELOG.md:214\` had been listing an "Hourly deploy-staleness check" under the **v0.1.1 Repository hardening** section, citing \`.github/workflows/deploy-staleness-check.yml\` as the path. **The workflow file never shipped in main** — the PR that would have added it ([#63](https://github.com/solvela-ai/solvela/pull/63), 2026-04-29) sat unmerged, and the fresh-from-main reapplication ([#247](https://github.com/solvela-ai/solvela/pull/247), 2026-05-12) was closed without merging by maintainer decision.

The v0.1.1 release notes shouldn't claim something that didn't ship. Removing the bullet so the section accurately reflects what was in v0.1.1.

Paired with [#249](https://github.com/solvela-ai/solvela/pull/249), which dropped the same stale claim from \`STATUS.md\`.

## Test plan

- [x] One-line deletion, doc-only diff.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)