### PR TITLE
feat(sdks/go): pull Go SDK into the monorepo

### DIFF
--- a/.github/workflows/sdks-go.yml
+++ b/.github/workflows/sdks-go.yml
@@ -1,0 +1,34 @@
+name: sdks-go
+
+on:
+  push:
+    paths:
+      - 'sdks/go/**'
+      - '.github/workflows/sdks-go.yml'
+  pull_request:
+    paths:
+      - 'sdks/go/**'
+      - '.github/workflows/sdks-go.yml'
+
+defaults:
+  run:
+    working-directory: sdks/go
+
+jobs:
+  test:
+    name: Test (Go ${{ matrix.go }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Match the CI matrix the SDK had as a standalone repo.
+        go: ['1.23']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          cache-dependency-path: sdks/go/go.sum
+      - run: go vet ./...
+      - run: go build ./...
+      - run: go test ./... -count=1

--- a/sdks/go/CLAUDE.md
+++ b/sdks/go/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with this repository.
+
+## Build & Test Commands
+
+```bash
+go test ./... -v -count=1          # Run all tests
+go test ./... -cover               # Run tests with coverage summary
+go test ./... -tags=live           # Run live tests (requires running gateway)
+go vet ./...                       # Static analysis
+go fmt ./...                       # Format all files
+
+# Manual smoke test against a live gateway (catches wire-format drift the
+# unit/integration tests can't). Mirrors solvela-python scripts/smoke.py and
+# solvela-ts scripts/smoke.ts. Defaults to http://localhost:8402.
+SOLVELA_GATEWAY_URL=https://staging.solvela.ai go run ./scripts/smoke
+```
+
+Single-file test example:
+
+```bash
+go test -v -run TestCacheKey       # Run tests matching pattern
+```
+
+## Architecture
+
+Single-package Go SDK (`package solvela`) — no sub-packages. Module: `github.com/solvela-ai/solvela/sdks/go`.
+
+| File | Purpose |
+|------|---------|
+| `client.go` | `SolvelaClient` — main entry point. `Chat()`, `ChatStream()`, `Models()`. Orchestrates payment, caching, sessions, quality checking. |
+| `transport.go` | `Transport` — HTTP layer. `SendChat()`, `SendChatStream()` (SSE), `FetchModels()`. Handles 200/402/error responses. |
+| `wallet.go` | `Wallet` — ed25519 keypair. `CreateWallet()`, `WalletFromKeypairB58()`, `WalletFromEnv()`. Uses `mr-tron/base58`. |
+| `signer.go` | `Signer` interface + `KeypairSigner` stub. Pluggable payment transaction signing. |
+| `cache.go` | `ResponseCache` — thread-safe LRU with TTL and dedup window. Default: 100 entries, 5m TTL, 2s dedup. |
+| `session.go` | `SessionStore` — conversation tracking with three-strike model escalation. |
+| `quality.go` | `CheckDegraded()` — detects empty, error-phrase, repetitive, or truncated responses. |
+| `balance.go` | `BalanceMonitor` — periodic balance polling with low-balance callbacks. |
+| `config.go` | `ClientConfig` + functional `Option` pattern (e.g., `WithGatewayURL()`, `WithCache()`). |
+| `types.go` | OpenAI-compatible request/response types, x402 payment types. |
+| `errors.go` | Typed errors: `PaymentRequiredError`, `GatewayError`, `AmountExceedsMaxError`, etc. |
+| `constants.go` | `X402Version`, `USDCMint`, `SolanaNetwork`, `PlatformFeePercent`. |
+
+### Request flow
+
+1. Balance guard — fall back to free model if wallet is empty
+2. Session lookup — check for model escalation (three-strike rule)
+3. Cache check — return cached response if available
+4. `sendWithPayment()` — send request, handle 402 (sign + retry)
+5. Quality check — retry if response is degraded
+6. Cache store + session update
+
+## Code Conventions
+
+- **Single dependency**: only `github.com/mr-tron/base58` (Go 1.23.7)
+- **Functional options**: `NewClient(wallet, signer, WithCache(true), ...)`
+- **Thread safety**: `sync.Mutex` on all shared state (`ResponseCache`, `SessionStore`, `BalanceMonitor`)
+- **Error types**: concrete structs implementing `error`, not sentinel values
+- **No `.unwrap()` equivalent**: all errors returned, never panicked
+- **OpenAI-compatible**: types mirror the OpenAI chat completions API
+- **x402 protocol**: payment negotiation via HTTP 402 with `Payment-Signature` header
+- **Secrets**: `Wallet.String()` and `SolvelaClient.String()` always redact private keys
+
+## CI
+
+GitHub Actions runs `go test` and `go vet` on Go 1.23 (see `.github/workflows/ci.yml`).

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,7 +1,135 @@
-# (Removed — canonical SDK lives in standalone repo)
+# solvela-go
 
-The Solvela Go SDK now lives at https://github.com/solvela-ai/solvela-go.
+Go SDK for [Solvela](https://solvela.ai) — a Solana-native AI agent payment gateway.
 
+AI agents pay for LLM API calls with USDC-SPL on Solana via the x402 protocol. No API keys, no accounts, just wallets.
+
+## Install
+
+```bash
+go get github.com/solvela-ai/solvela/sdks/go
 ```
-go get github.com/solvela-ai/solvela-go
+
+## Quick Start
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	solvela "github.com/solvela-ai/solvela/sdks/go"
+)
+
+func main() {
+	wallet, _, err := solvela.CreateWallet()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Wallet:", wallet.Address())
+
+	client, err := solvela.NewClient(wallet, nil,
+		solvela.WithGatewayURL("https://api.solvela.ai"),
+		solvela.WithCache(true),
+		solvela.WithSessions(true),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp, err := client.Chat(context.Background(), &solvela.ChatRequest{
+		Model: "gpt-4o-mini",
+		Messages: []solvela.ChatMessage{
+			{Role: solvela.RoleUser, Content: "Hello!"},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(resp.Choices[0].Message.Content)
+}
 ```
+
+## Status
+
+The core SDK (transport, caching, sessions, quality checking, streaming, balance monitoring) is fully implemented and tested.
+
+**`KeypairSigner` is not yet implemented.** The bundled `KeypairSigner` type returns an error when `SignPayment` is called — it is a placeholder, not a working signer. To make payments you have two options:
+
+1. **Use a different SDK** — the [Python SDK](https://github.com/solvela-ai/solvela-python) and TypeScript SDK include working `KeypairSigner` implementations backed by their respective Solana libraries.
+2. **Implement a custom `Signer`** — the `Signer` interface is pluggable. Provide your own implementation using `crypto/ed25519` (already in the Go standard library) and a Solana JSON-RPC client of your choice.
+
+```go
+type MySigner struct{ wallet *solvela.Wallet }
+
+func (s *MySigner) SignPayment(ctx context.Context, amount uint64, recipient string, resource solvela.Resource, accepted solvela.PaymentAccept) (*solvela.PaymentPayload, error) {
+    // build and sign a USDC-SPL transfer transaction, return PaymentPayload
+}
+
+client, err := solvela.NewClient(wallet, &MySigner{wallet: wallet}, ...)
+```
+
+## Features
+
+- Automatic x402 payment flow (402 detection, signing, retry)
+- Response caching with LRU eviction and dedup window
+- Session tracking with three-strike model escalation
+- Quality checking with automatic retry on degraded responses
+- SSE streaming support
+- Balance monitoring with low-balance callbacks
+- Pluggable `Signer` interface for custom payment signing
+
+## Configuration
+
+The default per-request payment cap is **10 USDC** (`10_000_000` atomic units). `WithMaxPaymentAmount` is only needed when a caller explicitly requires a higher cap.
+
+```go
+client, err := solvela.NewClient(wallet, signer,
+	solvela.WithGatewayURL("https://api.solvela.ai"),
+	solvela.WithTimeout(60 * time.Second),
+	solvela.WithCache(true),
+	solvela.WithSessions(true),
+	solvela.WithQualityCheck(true),
+	solvela.WithMaxQualityRetries(2),
+	solvela.WithExpectedRecipient("expected-wallet-address"),
+	solvela.WithMaxPaymentAmount(10_000_000), // atomic USDC units (10 USDC; the default cap)
+	solvela.WithFreeFallbackModel("gpt-4o-mini"),
+)
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+## Breaking Changes (security hardening)
+
+- `NewClient` now returns `(*SolvelaClient, error)`. Callers must check the
+  error; it is non-nil when the configured gateway URL is invalid (for
+  example, a plaintext `http://` URL pointing at a non-loopback host).
+- The default `GatewayURL` is now `https://api.solvela.ai`. Plaintext
+  `http://` URLs are only accepted for `localhost`, `127.0.0.1`, and `::1`.
+- `MaxPaymentAmount` now defaults to **10 USDC atomic units**
+  (`10_000_000`). Callers that legitimately need higher per-request payments
+  must override this via `WithMaxPaymentAmount(...)`. A `nil`
+  `MaxPaymentAmount` is rejected at request time as a misconfiguration.
+- `Wallet.PrivateKey()` has been removed. Use `Wallet.Sign(msg)` for
+  signing operations, or `Wallet.ToKeypairBytes()` /
+  `Wallet.ToKeypairB58()` for persistence (clearly marked secret).
+- `ChatStream` now performs the x402 402-handshake before opening the
+  stream, matching `Chat`'s behavior. A `Signer` is therefore required for
+  paid streaming; when none is configured the call returns
+  `*PaymentRequiredError`.
+
+## Testing
+
+```bash
+go test ./... -v -count=1
+
+# Live tests (requires running gateway)
+go test ./... -v -tags=live
+```
+
+## License
+
+MIT

--- a/sdks/go/balance.go
+++ b/sdks/go/balance.go
@@ -1,0 +1,116 @@
+package solvela
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+// BalanceMonitor periodically checks wallet balance and fires callbacks on low balance.
+type BalanceMonitor struct {
+	fetchBalance        func() (float64, error)
+	pollInterval        time.Duration
+	lowBalanceThreshold *float64
+	onLowBalance        func(float64)
+	onPoll              func(float64)
+
+	mu      sync.Mutex
+	balance *float64
+	wasLow  bool
+	stopCh  chan struct{}
+	stopped bool
+}
+
+// NewBalanceMonitor creates a new balance monitor.
+func NewBalanceMonitor(
+	fetchBalance func() (float64, error),
+	pollInterval time.Duration,
+	lowBalanceThreshold *float64,
+	onLowBalance func(float64),
+) *BalanceMonitor {
+	return &BalanceMonitor{
+		fetchBalance:        fetchBalance,
+		pollInterval:        pollInterval,
+		lowBalanceThreshold: lowBalanceThreshold,
+		onLowBalance:        onLowBalance,
+		stopCh:              make(chan struct{}),
+	}
+}
+
+// SetOnPoll registers a callback that fires after each successful balance
+// poll. The callback runs on the monitor's polling goroutine, so it must
+// not block. Call SetOnPoll before [BalanceMonitor.Start]; after Start the
+// callback is read without locking.
+func (m *BalanceMonitor) SetOnPoll(cb func(float64)) {
+	m.onPoll = cb
+}
+
+// Start begins polling in a background goroutine.
+func (m *BalanceMonitor) Start() {
+	go m.run()
+}
+
+// Stop halts the polling loop. Safe to call multiple times.
+func (m *BalanceMonitor) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.stopped {
+		m.stopped = true
+		close(m.stopCh)
+	}
+}
+
+// LastKnownBalance returns the most recently fetched balance, or nil if none.
+func (m *BalanceMonitor) LastKnownBalance() *float64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.balance
+}
+
+func (m *BalanceMonitor) run() {
+	ticker := time.NewTicker(m.pollInterval)
+	defer ticker.Stop()
+
+	m.poll() // initial poll
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.poll()
+		}
+	}
+}
+
+func (m *BalanceMonitor) poll() {
+	balance, err := m.fetchBalance()
+	if err != nil {
+		// Surface poll errors. A silent failure would leave LastKnownBalance
+		// stuck at nil and silently disable the freeFallbackModel guard in
+		// SolvelaClient. Mirrors the warn-on-poll-error fix in the TS SDK.
+		log.Printf("[BalanceMonitor] balance poll failed: %v", err)
+		return
+	}
+
+	m.mu.Lock()
+	m.balance = &balance
+	onPoll := m.onPoll
+	onLow := m.onLowBalance
+	threshold := m.lowBalanceThreshold
+	wasLow := m.wasLow
+	if threshold != nil && onLow != nil {
+		m.wasLow = balance < *threshold
+	}
+	m.mu.Unlock()
+
+	if onPoll != nil {
+		onPoll(balance)
+	}
+	if threshold != nil && onLow != nil {
+		isLow := balance < *threshold
+		if isLow && !wasLow {
+			onLow(balance)
+		}
+	}
+}

--- a/sdks/go/balance_test.go
+++ b/sdks/go/balance_test.go
@@ -1,0 +1,202 @@
+package solvela
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBalanceMonitorPollsAndUpdates(t *testing.T) {
+	callCount := 0
+	var mu sync.Mutex
+
+	monitor := NewBalanceMonitor(
+		func() (float64, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			callCount++
+			return 100.0, nil
+		},
+		50*time.Millisecond,
+		nil,
+		nil,
+	)
+
+	monitor.Start()
+	time.Sleep(80 * time.Millisecond)
+	monitor.Stop()
+
+	balance := monitor.LastKnownBalance()
+	if balance == nil {
+		t.Fatal("expected balance to be set")
+	}
+	if *balance != 100.0 {
+		t.Errorf("balance: got %f, want 100.0", *balance)
+	}
+
+	mu.Lock()
+	count := callCount
+	mu.Unlock()
+	if count < 1 {
+		t.Errorf("expected at least 1 poll, got %d", count)
+	}
+}
+
+func TestBalanceMonitorLowBalanceCallback(t *testing.T) {
+	balance := 50.0
+	threshold := 10.0
+	var callbackBalance float64
+	callbackCalled := false
+	var mu sync.Mutex
+
+	callIdx := 0
+
+	monitor := NewBalanceMonitor(
+		func() (float64, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			callIdx++
+			if callIdx >= 3 {
+				return 5.0, nil // Drop below threshold
+			}
+			return balance, nil
+		},
+		30*time.Millisecond,
+		&threshold,
+		func(b float64) {
+			mu.Lock()
+			defer mu.Unlock()
+			callbackCalled = true
+			callbackBalance = b
+		},
+	)
+
+	monitor.Start()
+	time.Sleep(150 * time.Millisecond)
+	monitor.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !callbackCalled {
+		t.Error("expected low balance callback to be called")
+	}
+	if callbackBalance != 5.0 {
+		t.Errorf("callback balance: got %f, want 5.0", callbackBalance)
+	}
+}
+
+func TestBalanceMonitorTransitionDebounce(t *testing.T) {
+	threshold := 10.0
+	callbackCount := 0
+	var mu sync.Mutex
+	callIdx := 0
+
+	monitor := NewBalanceMonitor(
+		func() (float64, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			callIdx++
+			// Stay below threshold for multiple polls
+			return 5.0, nil
+		},
+		30*time.Millisecond,
+		&threshold,
+		func(b float64) {
+			mu.Lock()
+			defer mu.Unlock()
+			callbackCount++
+		},
+	)
+
+	monitor.Start()
+	time.Sleep(150 * time.Millisecond)
+	monitor.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Should only fire once on transition, not every poll
+	if callbackCount != 1 {
+		t.Errorf("callback count: got %d, want 1 (should only fire on transition)", callbackCount)
+	}
+}
+
+func TestBalanceMonitorStopIdempotent(t *testing.T) {
+	monitor := NewBalanceMonitor(
+		func() (float64, error) { return 100.0, nil },
+		50*time.Millisecond,
+		nil,
+		nil,
+	)
+
+	monitor.Start()
+	// Calling Stop multiple times should not panic
+	monitor.Stop()
+	monitor.Stop()
+	monitor.Stop()
+}
+
+func TestBalanceMonitorNilBeforeStart(t *testing.T) {
+	monitor := NewBalanceMonitor(
+		func() (float64, error) { return 100.0, nil },
+		50*time.Millisecond,
+		nil,
+		nil,
+	)
+
+	balance := monitor.LastKnownBalance()
+	if balance != nil {
+		t.Error("expected nil balance before start")
+	}
+}
+
+func TestBalanceMonitorLogsAndRecoversAfterError(t *testing.T) {
+	// Capture log output so we can assert the warning is emitted on the
+	// failed first poll. Mirrors the warn-on-poll-error contract in the TS
+	// SDK: a silent failure would leave LastKnownBalance() stuck at nil.
+	var buf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(originalOutput)
+
+	callIdx := 0
+	var mu sync.Mutex
+
+	monitor := NewBalanceMonitor(
+		func() (float64, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			callIdx++
+			if callIdx == 1 {
+				return 0, errors.New("network error")
+			}
+			return 42.0, nil
+		},
+		30*time.Millisecond,
+		nil,
+		nil,
+	)
+
+	monitor.Start()
+	time.Sleep(100 * time.Millisecond)
+	monitor.Stop()
+
+	balance := monitor.LastKnownBalance()
+	if balance == nil {
+		t.Fatal("expected balance after recovery")
+	}
+	if *balance != 42.0 {
+		t.Errorf("balance: got %f, want 42.0", *balance)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "[BalanceMonitor]") {
+		t.Errorf("expected log to contain '[BalanceMonitor]' tag; got: %q", logged)
+	}
+	if !strings.Contains(logged, "network error") {
+		t.Errorf("expected log to contain underlying error message; got: %q", logged)
+	}
+}

--- a/sdks/go/cache.go
+++ b/sdks/go/cache.go
@@ -1,0 +1,107 @@
+package solvela
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	response ChatResponse
+	inserted time.Time
+}
+
+// ResponseCache is a thread-safe LRU cache for chat responses.
+type ResponseCache struct {
+	mu          sync.Mutex
+	entries     map[uint64]*cacheEntry
+	order       []uint64
+	maxEntries  int
+	ttl         time.Duration
+	dedupWindow time.Duration
+}
+
+// NewResponseCache creates a cache with default settings (100 entries, 5m TTL, 2s dedup).
+func NewResponseCache() *ResponseCache {
+	return NewResponseCacheWithConfig(100, 5*time.Minute, 2*time.Second)
+}
+
+// NewResponseCacheWithConfig creates a cache with custom settings.
+func NewResponseCacheWithConfig(maxEntries int, ttl, dedupWindow time.Duration) *ResponseCache {
+	return &ResponseCache{
+		entries:     make(map[uint64]*cacheEntry),
+		order:       make([]uint64, 0),
+		maxEntries:  maxEntries,
+		ttl:         ttl,
+		dedupWindow: dedupWindow,
+	}
+}
+
+// CacheKey computes a deterministic key from model and messages.
+func CacheKey(model string, messages []ChatMessage) uint64 {
+	h := sha256.New()
+	h.Write([]byte(model))
+	for _, msg := range messages {
+		h.Write([]byte(msg.Role))
+		h.Write([]byte(msg.Content))
+	}
+	return binary.BigEndian.Uint64(h.Sum(nil)[:8])
+}
+
+// Get retrieves a cached response. Returns the response and true if found and not expired.
+func (c *ResponseCache) Get(key uint64) (ChatResponse, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return ChatResponse{}, false
+	}
+	if time.Since(entry.inserted) > c.ttl {
+		delete(c.entries, key)
+		c.removeFromOrder(key)
+		return ChatResponse{}, false
+	}
+	// Move to end of order (most recently used)
+	c.removeFromOrder(key)
+	c.order = append(c.order, key)
+	return entry.response, true
+}
+
+// Put adds a response to the cache. If the cache is full, the least recently used entry is evicted.
+// If the key was inserted within the dedup window, the put is ignored.
+func (c *ResponseCache) Put(key uint64, response ChatResponse) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check dedup window
+	if existing, ok := c.entries[key]; ok {
+		if time.Since(existing.inserted) < c.dedupWindow {
+			return
+		}
+	}
+
+	// Evict LRU if at capacity
+	for len(c.entries) >= c.maxEntries && len(c.order) > 0 {
+		oldest := c.order[0]
+		c.order = c.order[1:]
+		delete(c.entries, oldest)
+	}
+
+	c.entries[key] = &cacheEntry{
+		response: response,
+		inserted: time.Now(),
+	}
+	c.removeFromOrder(key)
+	c.order = append(c.order, key)
+}
+
+func (c *ResponseCache) removeFromOrder(key uint64) {
+	for i, k := range c.order {
+		if k == key {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			return
+		}
+	}
+}

--- a/sdks/go/cache_test.go
+++ b/sdks/go/cache_test.go
@@ -1,0 +1,181 @@
+package solvela
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheMiss(t *testing.T) {
+	c := NewResponseCache()
+	_, ok := c.Get(12345)
+	if ok {
+		t.Error("expected cache miss")
+	}
+}
+
+func TestCacheHit(t *testing.T) {
+	c := NewResponseCache()
+	resp := ChatResponse{ID: "test-1", Model: "gpt-4"}
+	key := uint64(42)
+
+	c.Put(key, resp)
+	got, ok := c.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got.ID != "test-1" {
+		t.Errorf("id: got %q, want %q", got.ID, "test-1")
+	}
+}
+
+func TestCacheTTLExpiry(t *testing.T) {
+	c := NewResponseCacheWithConfig(100, 50*time.Millisecond, 0)
+	resp := ChatResponse{ID: "test-ttl"}
+	key := uint64(99)
+
+	c.Put(key, resp)
+	_, ok := c.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit before TTL")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	_, ok = c.Get(key)
+	if ok {
+		t.Error("expected cache miss after TTL expiry")
+	}
+}
+
+func TestCacheLRUEviction(t *testing.T) {
+	c := NewResponseCacheWithConfig(3, 5*time.Minute, 0)
+
+	// Fill cache
+	c.Put(1, ChatResponse{ID: "first"})
+	c.Put(2, ChatResponse{ID: "second"})
+	c.Put(3, ChatResponse{ID: "third"})
+
+	// Access first to make it recently used
+	c.Get(1)
+
+	// Add fourth — should evict key 2 (LRU)
+	c.Put(4, ChatResponse{ID: "fourth"})
+
+	if _, ok := c.Get(1); !ok {
+		t.Error("key 1 should still be in cache (was accessed)")
+	}
+	if _, ok := c.Get(2); ok {
+		t.Error("key 2 should have been evicted (LRU)")
+	}
+	if _, ok := c.Get(3); !ok {
+		t.Error("key 3 should still be in cache")
+	}
+	if _, ok := c.Get(4); !ok {
+		t.Error("key 4 should be in cache")
+	}
+}
+
+func TestCacheDedupWindow(t *testing.T) {
+	c := NewResponseCacheWithConfig(100, 5*time.Minute, 100*time.Millisecond)
+	key := uint64(77)
+
+	c.Put(key, ChatResponse{ID: "original"})
+
+	// Try to overwrite within dedup window
+	c.Put(key, ChatResponse{ID: "duplicate"})
+
+	got, ok := c.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got.ID != "original" {
+		t.Errorf("id: got %q, want %q (dedup should have prevented overwrite)", got.ID, "original")
+	}
+
+	// Wait for dedup window to pass
+	time.Sleep(110 * time.Millisecond)
+
+	c.Put(key, ChatResponse{ID: "updated"})
+	got, ok = c.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit after dedup window")
+	}
+	if got.ID != "updated" {
+		t.Errorf("id: got %q, want %q (should have updated after dedup window)", got.ID, "updated")
+	}
+}
+
+func TestCacheKeyDeterminism(t *testing.T) {
+	msgs := []ChatMessage{
+		{Role: RoleUser, Content: "Hello"},
+		{Role: RoleAssistant, Content: "Hi there"},
+	}
+
+	k1 := CacheKey("gpt-4", msgs)
+	k2 := CacheKey("gpt-4", msgs)
+	if k1 != k2 {
+		t.Errorf("same inputs should produce same key: %d != %d", k1, k2)
+	}
+
+	k3 := CacheKey("gpt-3.5-turbo", msgs)
+	if k1 == k3 {
+		t.Error("different models should produce different keys")
+	}
+
+	msgs2 := []ChatMessage{
+		{Role: RoleUser, Content: "Different message"},
+	}
+	k4 := CacheKey("gpt-4", msgs2)
+	if k1 == k4 {
+		t.Error("different messages should produce different keys")
+	}
+}
+
+// TestNewResponseCacheDefaultsBehavioral verifies the documented defaults
+// (100 entries, 5m TTL, 2s dedup) by exercising observable behavior rather
+// than reading unexported fields. Reading struct internals couples the test
+// to the layout; behavioral coverage survives field renames.
+func TestNewResponseCacheDefaultsBehavioral(t *testing.T) {
+	t.Run("ttl_admits_recent_inserts", func(t *testing.T) {
+		// Default TTL is 5m, so a fresh insert must be readable.
+		c := NewResponseCache()
+		c.Put(1, ChatResponse{ID: "fresh"})
+		if got, ok := c.Get(1); !ok || got.ID != "fresh" {
+			t.Fatalf("default TTL should admit fresh inserts: got=%+v ok=%v", got, ok)
+		}
+	})
+
+	t.Run("dedup_window_blocks_immediate_overwrite", func(t *testing.T) {
+		// The default 2s dedup window must reject a same-key overwrite that
+		// happens immediately after the first Put.
+		c := NewResponseCache()
+		c.Put(2, ChatResponse{ID: "first"})
+		c.Put(2, ChatResponse{ID: "second"}) // within dedup window
+		got, ok := c.Get(2)
+		if !ok {
+			t.Fatal("expected hit on key 2")
+		}
+		if got.ID != "first" {
+			t.Errorf("default dedup window should have blocked overwrite: got %q, want %q", got.ID, "first")
+		}
+	})
+
+	t.Run("eviction_at_documented_capacity", func(t *testing.T) {
+		// The default cap is 100 entries: inserting 101 must evict the
+		// least-recently-used key (key 0). Keys 1..100 must remain.
+		c := NewResponseCache()
+		for i := 0; i < 101; i++ {
+			c.Put(uint64(i), ChatResponse{ID: "v"})
+		}
+		if _, ok := c.Get(0); ok {
+			t.Error("key 0 should have been evicted at capacity 100")
+		}
+		// Spot-check that a non-evicted key is still present.
+		if _, ok := c.Get(50); !ok {
+			t.Error("key 50 should still be in cache")
+		}
+		if _, ok := c.Get(100); !ok {
+			t.Error("key 100 (most recent) should still be in cache")
+		}
+	})
+}

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -1,0 +1,584 @@
+package solvela
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// validateGatewayURL rejects plaintext http:// gateway URLs unless the host is
+// a recognized loopback address. Sending payments over plaintext to a remote
+// host would leak the Payment-Signature header and expose the request body to
+// any on-path observer.
+func validateGatewayURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid gateway URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("gateway URL must use http or https, got %q", u.Scheme)
+	}
+	if u.Scheme == "http" {
+		host := u.Hostname()
+		if host != "localhost" && host != "127.0.0.1" && host != "::1" {
+			return fmt.Errorf("gateway URL must use https:// for non-local endpoints, got %s://%s", u.Scheme, host)
+		}
+	}
+	return nil
+}
+
+// SolvelaClient is the main client for interacting with the Solvela gateway.
+type SolvelaClient struct {
+	config       ClientConfig
+	wallet       *Wallet
+	signer       Signer
+	transport    *Transport
+	cache        *ResponseCache
+	sessionStore *SessionStore
+	sessionSalt  []byte
+
+	balanceMu      sync.RWMutex
+	lastBalance    float64
+	lastBalanceSet bool
+
+	balanceMonitor *BalanceMonitor
+}
+
+// NewClient creates a new SolvelaClient with functional options.
+//
+// The gateway URL is validated: plaintext http:// is only allowed for the
+// loopback hosts localhost, 127.0.0.1, and ::1. All other endpoints must use
+// https://. Misconfigured URLs return a [ClientError]; the client itself is
+// returned only on success.
+func NewClient(wallet *Wallet, signer Signer, opts ...Option) (*SolvelaClient, error) {
+	cfg := DefaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if err := validateGatewayURL(cfg.GatewayURL); err != nil {
+		return nil, &ClientError{Message: err.Error()}
+	}
+
+	salt, err := newSessionSalt()
+	if err != nil {
+		return nil, &ClientError{Message: fmt.Sprintf("failed to seed session salt: %v", err)}
+	}
+
+	c := &SolvelaClient{
+		config:      cfg,
+		wallet:      wallet,
+		signer:      signer,
+		transport:   NewTransport(cfg.GatewayURL, cfg.Timeout),
+		sessionSalt: salt,
+	}
+	if cfg.EnableCache {
+		c.cache = NewResponseCache()
+	}
+	if cfg.EnableSessions {
+		c.sessionStore = NewSessionStore(cfg.SessionTTL)
+	}
+	// Opt-in: only spin up a background poller when the caller has asked for
+	// one via [WithBalanceMonitor]. Auto-starting would be a surprising RPC
+	// tax for the common case where the free-fallback guard is unused.
+	if cfg.BalancePollInterval > 0 && cfg.BalanceFetcher != nil {
+		monitor := NewBalanceMonitor(cfg.BalanceFetcher, cfg.BalancePollInterval, nil, nil)
+		monitor.SetOnPoll(func(b float64) { c.setLastBalance(b) })
+		c.balanceMonitor = monitor
+		monitor.Start()
+	}
+	return c, nil
+}
+
+// Close releases resources held by the client. It stops the background
+// balance monitor (if one was started via [WithBalanceMonitor]). Safe to
+// call multiple times. After Close the client should not be reused.
+func (c *SolvelaClient) Close() {
+	if c.balanceMonitor != nil {
+		c.balanceMonitor.Stop()
+	}
+}
+
+// setLastBalance stores the latest balance under the balance lock.
+func (c *SolvelaClient) setLastBalance(b float64) {
+	c.balanceMu.Lock()
+	c.lastBalance = b
+	c.lastBalanceSet = true
+	c.balanceMu.Unlock()
+}
+
+// getLastBalance returns the most recent balance and whether one has been
+// recorded. Reads under a shared lock so concurrent Chat / ChatStream calls
+// do not race the BalanceMonitor goroutine.
+func (c *SolvelaClient) getLastBalance() (float64, bool) {
+	c.balanceMu.RLock()
+	defer c.balanceMu.RUnlock()
+	return c.lastBalance, c.lastBalanceSet
+}
+
+// Chat sends a non-streaming chat request with automatic payment, caching,
+// session tracking, and quality checking.
+func (c *SolvelaClient) Chat(ctx context.Context, request *ChatRequest) (*ChatResponse, error) {
+	model := request.Model
+
+	// Step 1: Balance guard
+	if balance, ok := c.getLastBalance(); ok && balance == 0 && c.config.FreeFallbackModel != "" {
+		model = c.config.FreeFallbackModel
+	}
+
+	// Step 2: Session lookup
+	var sessionID string
+	if c.sessionStore != nil {
+		sessionID = DeriveSessionIDWithSalt(c.sessionSalt, request.Messages)
+		info := c.sessionStore.GetOrCreate(sessionID, model)
+		if model == request.Model { // not overridden by balance guard
+			model = info.Model
+		}
+	}
+
+	// Step 3: Cache check (after model finalization)
+	var cacheKey uint64
+	if c.cache != nil {
+		cacheKey = CacheKey(model, request.Messages)
+		if cached, ok := c.cache.Get(cacheKey); ok {
+			return &cached, nil
+		}
+	}
+
+	// Build effective request
+	effectiveReq := &ChatRequest{
+		Model:       model,
+		Messages:    request.Messages,
+		MaxTokens:   request.MaxTokens,
+		Temperature: request.Temperature,
+		TopP:        request.TopP,
+		Stream:      false,
+		Tools:       request.Tools,
+		ToolChoice:  request.ToolChoice,
+	}
+
+	// Step 4: Send request
+	response, err := c.sendWithPayment(ctx, effectiveReq, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 5: Quality check + retry. After the retry loop exits we re-evaluate
+	// the final response: a still-degraded result must surface as
+	// [QualityDegradedError] rather than be silently returned. Caching a
+	// degraded response would replay it forever; skip the cache write on the
+	// error path.
+	if c.config.EnableQualityCheck {
+		var lastReason DegradedReason
+		for i := 0; i <= c.config.MaxQualityRetries; i++ {
+			if len(response.Choices) == 0 {
+				lastReason = DegradedEmptyContent
+			} else {
+				lastReason = CheckDegraded(response.Choices[0].Message.Content)
+			}
+			if lastReason == "" {
+				break
+			}
+			if i == c.config.MaxQualityRetries {
+				// Exhausted retries; the response is still degraded. Do not
+				// cache and do not record the session — return the typed
+				// error so callers can branch on it.
+				return nil, &QualityDegradedError{Reason: lastReason, Response: response}
+			}
+			response, err = c.sendWithPayment(ctx, effectiveReq, map[string]string{
+				"X-Solvela-Retry-Reason": "degraded",
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Step 6: Cache store
+	if c.cache != nil {
+		c.cache.Put(cacheKey, *response)
+	}
+
+	// Step 7: Session update
+	if c.sessionStore != nil && sessionID != "" {
+		hash := CacheKey(model, request.Messages)
+		c.sessionStore.RecordRequest(sessionID, hash)
+	}
+
+	return response, nil
+}
+
+// ChatStream sends a streaming chat request.
+//
+// Payment handshake: the streaming endpoint still returns a 402 on the initial
+// POST when payment is required, so this method runs the same handshake as
+// [SolvelaClient.Chat] before opening the stream — a non-streaming request is
+// issued first to discover the price, the configured [Signer] (if any) signs
+// the payment, and the streaming request is then re-sent with the
+// Payment-Signature header attached. If no [Signer] is configured and a 402 is
+// returned, this method surfaces a [PaymentRequiredError] rather than silently
+// streaming an unauthenticated request.
+func (c *SolvelaClient) ChatStream(ctx context.Context, request *ChatRequest) (<-chan ChatChunkOrError, error) {
+	model := request.Model
+
+	// Step 1: Balance guard
+	if balance, ok := c.getLastBalance(); ok && balance == 0 && c.config.FreeFallbackModel != "" {
+		model = c.config.FreeFallbackModel
+	}
+
+	// Step 2: Session lookup
+	var sessionID string
+	if c.sessionStore != nil {
+		sessionID = DeriveSessionIDWithSalt(c.sessionSalt, request.Messages)
+		info := c.sessionStore.GetOrCreate(sessionID, model)
+		if model == request.Model {
+			model = info.Model
+		}
+	}
+
+	effectiveReq := &ChatRequest{
+		Model:    model,
+		Messages: request.Messages,
+		Stream:   true,
+	}
+
+	// Step 3: Resolve payment (if any) before opening the stream.
+	//
+	// resolvePaymentSignature first issues a non-streaming probe so the gateway
+	// can return 402 (price discovery) or 200 (no payment required, full
+	// response). When the probe returns 200 the body IS already a complete
+	// completion: opening a second streaming connection would cost the caller
+	// a second paid request and discard the first. Reuse the probe response
+	// by synthesizing a single-chunk SSE-like stream instead.
+	sig, probeResp, err := c.resolvePaymentSignature(ctx, effectiveReq)
+	if err != nil {
+		return nil, err
+	}
+	if probeResp != nil {
+		// Probe returned 200 — turn the ChatResponse into a one-shot channel
+		// and avoid the second paid round trip. Session recording happens
+		// synchronously here because there is no upstream goroutine to defer
+		// it to.
+		if c.sessionStore != nil && sessionID != "" {
+			hash := CacheKey(model, request.Messages)
+			c.sessionStore.RecordRequest(sessionID, hash)
+		}
+		return synthesizeStreamFromResponse(probeResp), nil
+	}
+
+	// Drive the upstream goroutine with a child context so cancellation here
+	// (consumer abandons the stream early) propagates immediately. Without
+	// this the transport goroutine would block forever on `ch <- chunk` once
+	// the consumer stopped reading, leaking a goroutine plus the underlying
+	// HTTP body.
+	streamCtx, cancel := context.WithCancel(ctx)
+	ch, err := c.transport.SendChatStream(streamCtx, effectiveReq, sig, nil)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	wrappedCh := make(chan ChatChunkOrError)
+	go func() {
+		defer close(wrappedCh)
+		// Cancelling here unblocks the transport goroutine if the consumer
+		// abandons wrappedCh before the stream completes.
+		defer cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				// Consumer's parent context cancelled. Cancel the child to
+				// unblock the upstream goroutine; the deferred cancel above
+				// would also do this, but doing it eagerly avoids holding
+				// onto the body any longer than needed.
+				cancel()
+				// Drain remaining items so the upstream goroutine can return.
+				go func() {
+					for range ch {
+					}
+				}()
+				return
+			case item, ok := <-ch:
+				if !ok {
+					if c.sessionStore != nil && sessionID != "" {
+						hash := CacheKey(model, request.Messages)
+						c.sessionStore.RecordRequest(sessionID, hash)
+					}
+					return
+				}
+				select {
+				case wrappedCh <- item:
+				case <-ctx.Done():
+					cancel()
+					go func() {
+						for range ch {
+						}
+					}()
+					return
+				}
+			}
+		}
+	}()
+	return wrappedCh, nil
+}
+
+// Models retrieves available models from the gateway.
+func (c *SolvelaClient) Models(ctx context.Context) ([]ModelInfo, error) {
+	return c.transport.FetchModels(ctx)
+}
+
+// LastKnownBalance returns the most recently known wallet balance and a
+// boolean reporting whether one has been recorded yet. The boolean
+// distinguishes "balance is zero" from "we have not polled yet" — the
+// former triggers the free-fallback-model guard, the latter does not. The
+// background poller configured via [WithBalanceMonitor] is responsible for
+// populating this value; without that option the second return is always
+// false.
+func (c *SolvelaClient) LastKnownBalance() (float64, bool) {
+	return c.getLastBalance()
+}
+
+// String returns a debug-safe representation with redacted secrets.
+func (c *SolvelaClient) String() string {
+	return fmt.Sprintf("SolvelaClient(gateway=%s, wallet=REDACTED)", c.config.GatewayURL)
+}
+
+func (c *SolvelaClient) sendWithPayment(ctx context.Context, request *ChatRequest, extraHeaders map[string]string) (*ChatResponse, error) {
+	// Force non-streaming for the price-discovery probe; we will stream at the
+	// caller layer if needed. This is also the live request when the caller
+	// invokes Chat (non-streaming).
+	probeReq := *request
+	probeReq.Stream = false
+
+	result, err := c.transport.SendChat(ctx, &probeReq, "", extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.PaymentRequired == nil {
+		return result.Response, nil
+	}
+
+	sig, err := c.signPaymentRequired(ctx, result.PaymentRequired)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err = c.transport.SendChat(ctx, &probeReq, sig, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+	if result.PaymentRequired != nil {
+		return nil, &PaymentRejectedError{Reason: "payment rejected after signing"}
+	}
+	return result.Response, nil
+}
+
+// resolvePaymentSignature issues a non-streaming probe to discover whether the
+// gateway requires payment for the given request, and signs the payment if so.
+// Returns:
+//   - sig:        the encoded Payment-Signature header value, or "" if no
+//                 payment is needed (or the probe already returned a fully
+//                 resolved 200 response).
+//   - probeResp:  non-nil when the probe returned 200 with a complete
+//                 ChatResponse. Callers (ChatStream) MUST reuse this body
+//                 instead of issuing a second request — opening a streaming
+//                 follow-up would charge the caller twice and discard the
+//                 already-paid completion.
+//   - err:        any error encountered.
+//
+// The probe shares the same handshake logic as non-streaming Chat — the
+// gateway returns 402 on the initial POST whether or not the response is
+// streamed, so the same flow is safe to reuse.
+func (c *SolvelaClient) resolvePaymentSignature(ctx context.Context, request *ChatRequest) (string, *ChatResponse, error) {
+	probeReq := *request
+	probeReq.Stream = false
+
+	result, err := c.transport.SendChat(ctx, &probeReq, "", nil)
+	if err != nil {
+		return "", nil, err
+	}
+	if result.PaymentRequired == nil {
+		// No payment required; surface the already-resolved response so the
+		// streaming caller can replay it without a second paid request.
+		return "", result.Response, nil
+	}
+	sig, err := c.signPaymentRequired(ctx, result.PaymentRequired)
+	if err != nil {
+		return "", nil, err
+	}
+	return sig, nil, nil
+}
+
+// synthesizeStreamFromResponse converts a fully-resolved [ChatResponse] into a
+// closed [ChatChunkOrError] channel that emits one chunk per choice and then
+// closes. This lets [SolvelaClient.ChatStream] reuse a 200 response from the
+// price-discovery probe instead of issuing a second paid request just to get
+// the bytes in streaming form.
+func synthesizeStreamFromResponse(resp *ChatResponse) <-chan ChatChunkOrError {
+	ch := make(chan ChatChunkOrError, len(resp.Choices)+1)
+	for _, choice := range resp.Choices {
+		// Snapshot per-iteration so each chunk owns its own role/content
+		// pointers; addressing the loop variable directly would alias every
+		// emitted chunk to the same backing storage.
+		role := choice.Message.Role
+		content := choice.Message.Content
+		chunk := &ChatChunk{
+			ID:      resp.ID,
+			Object:  resp.Object,
+			Created: resp.Created,
+			Model:   resp.Model,
+			Choices: []ChatChunkChoice{
+				{
+					Index: choice.Index,
+					Delta: ChatDelta{
+						Role:    &role,
+						Content: &content,
+					},
+					FinishReason: choice.FinishReason,
+				},
+			},
+		}
+		ch <- ChatChunkOrError{Chunk: chunk}
+	}
+	close(ch)
+	return ch
+}
+
+// signPaymentRequired runs the validation + signer pipeline for a 402 response
+// and returns the base64-encoded Payment-Signature header value.
+func (c *SolvelaClient) signPaymentRequired(ctx context.Context, pr *PaymentRequired) (string, error) {
+	if c.signer == nil {
+		return "", &PaymentRequiredError{PaymentRequired: *pr}
+	}
+	accepted := c.findCompatibleScheme(pr)
+	if accepted == nil {
+		return "", &PaymentRequiredError{PaymentRequired: *pr}
+	}
+	if err := c.validatePayment(accepted); err != nil {
+		return "", err
+	}
+	if err := c.validateResourceOrigin(pr.Resource.URL); err != nil {
+		return "", err
+	}
+
+	amountAtomic, err := parseAmount(accepted.Amount)
+	if err != nil {
+		return "", err
+	}
+	payload, err := c.signer.SignPayment(ctx, amountAtomic, accepted.PayTo, pr.Resource, *accepted)
+	if err != nil {
+		return "", err
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encode payment payload: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(payloadJSON), nil
+}
+
+// isCompatibleAccept reports whether an accepted scheme entry is one we can
+// safely sign and pay. We require:
+//   - scheme is "exact" or "escrow"
+//   - network is the Solana mainnet identifier we support
+//   - asset is the canonical USDC mint (no surprise SPL tokens)
+//
+// Asset and network must be validated here to prevent a malicious gateway from
+// tricking the SDK into signing a transfer of a different token, or paying on
+// a different chain.
+func isCompatibleAccept(a PaymentAccept, scheme Scheme) bool {
+	return a.Scheme == scheme && a.Network == SolanaNetwork && a.Asset == USDCMint
+}
+
+func (c *SolvelaClient) findCompatibleScheme(pr *PaymentRequired) *PaymentAccept {
+	for i := range pr.Accepts {
+		if isCompatibleAccept(pr.Accepts[i], SchemeExact) {
+			return &pr.Accepts[i]
+		}
+	}
+	for i := range pr.Accepts {
+		if isCompatibleAccept(pr.Accepts[i], SchemeEscrow) {
+			return &pr.Accepts[i]
+		}
+	}
+	return nil
+}
+
+// validateResourceOrigin rejects a 402 Resource.URL whose origin (scheme+host)
+// does not match the configured gateway. The Resource.URL is server-supplied
+// and may be embedded into the signed payment payload (e.g., as a memo field),
+// so we cannot let a rogue gateway substitute a foreign URL and trick the
+// signer into binding payment metadata to an unintended endpoint.
+//
+// An empty Resource.URL is permitted: not every gateway populates it, and
+// rejecting on absence would break legitimate flows. Only mismatches are
+// fatal.
+func (c *SolvelaClient) validateResourceOrigin(resourceURL string) error {
+	if resourceURL == "" {
+		return nil
+	}
+	ru, err := url.Parse(resourceURL)
+	if err != nil {
+		return &ClientError{Message: fmt.Sprintf("invalid resource URL %q: %v", resourceURL, err)}
+	}
+	gu, err := url.Parse(c.config.GatewayURL)
+	if err != nil {
+		return &ClientError{Message: fmt.Sprintf("invalid gateway URL %q: %v", c.config.GatewayURL, err)}
+	}
+	if ru.Scheme != gu.Scheme || ru.Host != gu.Host {
+		return &ClientError{Message: fmt.Sprintf("resource URL origin does not match configured gateway: resource=%s://%s gateway=%s://%s", ru.Scheme, ru.Host, gu.Scheme, gu.Host)}
+	}
+	return nil
+}
+
+func (c *SolvelaClient) validatePayment(accepted *PaymentAccept) error {
+	if c.config.ExpectedRecipient != "" && accepted.PayTo != c.config.ExpectedRecipient {
+		return &RecipientMismatchError{Expected: c.config.ExpectedRecipient, Actual: accepted.PayTo}
+	}
+	// Defense-in-depth: re-verify network and asset here in case a caller bypassed
+	// findCompatibleScheme.
+	if accepted.Network != SolanaNetwork {
+		return &ClientError{Message: fmt.Sprintf("unsupported network: %q (expected %q)", accepted.Network, SolanaNetwork)}
+	}
+	if accepted.Asset != USDCMint {
+		return &ClientError{Message: fmt.Sprintf("unsupported asset: %q (expected USDC mint %q)", accepted.Asset, USDCMint)}
+	}
+	// Fail closed when no max is configured. A nil cap means "unbounded", which
+	// turns the SDK into a footgun if a misconfigured gateway returns an
+	// inflated amount; better to refuse than to drain the wallet.
+	if c.config.MaxPaymentAmount == nil {
+		return &ClientError{Message: "client misconfigured: MaxPaymentAmount must be set (use WithMaxPaymentAmount or DefaultConfig)"}
+	}
+	amount, err := parseAmount(accepted.Amount)
+	if err != nil {
+		return err
+	}
+	if amount > *c.config.MaxPaymentAmount {
+		return &AmountExceedsMaxError{Amount: amount, MaxAmount: *c.config.MaxPaymentAmount}
+	}
+	return nil
+}
+
+// parseAmount parses a 402-supplied atomic-units amount string. It rejects
+// empty, non-numeric, overflowing, and zero values. Zero is rejected because
+// no legitimate 402 says "pay zero", and silently treating bad input as zero
+// would let a malicious gateway slip past the MaxPaymentAmount cap.
+func parseAmount(s string) (uint64, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return 0, &ClientError{Message: fmt.Sprintf("invalid payment amount %q: empty", s)}
+	}
+	n, err := strconv.ParseUint(trimmed, 10, 64)
+	if err != nil {
+		return 0, &ClientError{Message: fmt.Sprintf("invalid payment amount %q: %v", s, err)}
+	}
+	if n == 0 {
+		return 0, &ClientError{Message: fmt.Sprintf("invalid payment amount %q: must be greater than zero", s)}
+	}
+	return n, nil
+}

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -1,0 +1,1231 @@
+package solvela
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewClientCreation(t *testing.T) {
+	wallet, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+
+	client, err := NewClient(wallet, nil,
+		WithGatewayURL("https://example.com"),
+		WithTimeout(30*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	if client.config.GatewayURL != "https://example.com" {
+		t.Errorf("gateway: got %q, want %q", client.config.GatewayURL, "https://example.com")
+	}
+	if client.config.Timeout != 30*time.Second {
+		t.Errorf("timeout: got %v, want 30s", client.config.Timeout)
+	}
+	if client.cache != nil {
+		t.Error("cache should be nil by default")
+	}
+	if client.sessionStore != nil {
+		t.Error("session store should be nil by default")
+	}
+}
+
+func TestNewClientWithCache(t *testing.T) {
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil, WithCache(true))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if client.cache == nil {
+		t.Error("cache should be enabled")
+	}
+}
+
+func TestNewClientWithSessions(t *testing.T) {
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil, WithSessions(true))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if client.sessionStore == nil {
+		t.Error("session store should be enabled")
+	}
+}
+
+func TestNewClientRejectsPlaintextRemote(t *testing.T) {
+	wallet, _, _ := CreateWallet()
+	if _, err := NewClient(wallet, nil, WithGatewayURL("http://api.solvela.ai")); err == nil {
+		t.Fatal("expected error rejecting plaintext remote URL")
+	}
+}
+
+func TestNewClientAllowsPlaintextLocalhost(t *testing.T) {
+	wallet, _, _ := CreateWallet()
+	for _, host := range []string{"http://localhost:8402", "http://127.0.0.1:8402", "http://[::1]:8402"} {
+		if _, err := NewClient(wallet, nil, WithGatewayURL(host)); err != nil {
+			t.Errorf("loopback URL %q should be allowed: %v", host, err)
+		}
+	}
+}
+
+func TestClientChatSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ChatResponse{
+			ID:    "chatcmpl-test",
+			Model: "gpt-4",
+			Choices: []ChatChoice{
+				{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: "Hello!"}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil, WithGatewayURL(server.URL))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	resp, err := client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ID != "chatcmpl-test" {
+		t.Errorf("id: got %q, want %q", resp.ID, "chatcmpl-test")
+	}
+	if resp.Choices[0].Message.Content != "Hello!" {
+		t.Errorf("content: got %q, want %q", resp.Choices[0].Message.Content, "Hello!")
+	}
+}
+
+func TestClientChatWithCache(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		resp := ChatResponse{
+			ID:    "chatcmpl-cached",
+			Model: "gpt-4",
+			Choices: []ChatChoice{
+				{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: "Cached response."}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil,
+		WithGatewayURL(server.URL),
+		WithCache(true),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	req := &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hello"}},
+	}
+
+	// First call
+	resp1, err := client.Chat(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+
+	// Second call (should be cached)
+	resp2, err := client.Chat(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 HTTP call, got %d (cache should have prevented second call)", callCount)
+	}
+	if resp1.ID != resp2.ID {
+		t.Errorf("cached response should match: %q != %q", resp1.ID, resp2.ID)
+	}
+}
+
+func TestClientChat402WithoutSigner(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version: 2,
+			Error:       "payment required",
+			CostBreakdown: CostBreakdown{
+				Total:    "1000",
+				Currency: "USDC",
+			},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "recipient123"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil, WithGatewayURL(server.URL)) // no signer
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	_, ok := err.(*PaymentRequiredError)
+	if !ok {
+		t.Fatalf("expected PaymentRequiredError, got %T: %v", err, err)
+	}
+}
+
+func TestClientLastKnownBalance(t *testing.T) {
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	if _, ok := client.LastKnownBalance(); ok {
+		t.Error("expected unset balance initially")
+	}
+
+	// Drive through the same code path used by the BalanceMonitor callback
+	// so the test exercises the real getter/setter pair, not a direct field
+	// assignment that would tautologically pass.
+	client.setLastBalance(42.5)
+
+	got, ok := client.LastKnownBalance()
+	if !ok {
+		t.Fatal("expected balance to be set")
+	}
+	if got != 42.5 {
+		t.Errorf("balance: got %v, want 42.5", got)
+	}
+}
+
+// TestChatCallsRecordRequestExactlyOnce asserts that one call to Chat
+// produces exactly one RecordRequest invocation. With the previous bug,
+// GetOrCreate also counted, so three Chat calls escalated immediately;
+// after the fix three Chat calls plus the matching three RecordRequest
+// increments are needed.
+func TestChatCallsRecordRequestExactlyOnce(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ChatResponse{
+			ID:    "chat-1",
+			Model: "gpt-4",
+			Choices: []ChatChoice{
+				{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: "ok"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil,
+		WithGatewayURL(server.URL),
+		WithSessions(true),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	req := &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := client.Chat(context.Background(), req); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+
+	// After 3 Chat calls with identical messages, three RecordRequests
+	// should have fired (one per call). The session is escalated only when
+	// the threshold is crossed by RecordRequest, never by GetOrCreate.
+	sessionID := DeriveSessionIDWithSalt(client.sessionSalt, req.Messages)
+	client.sessionStore.mu.Lock()
+	entry, ok := client.sessionStore.sessions[sessionID]
+	client.sessionStore.mu.Unlock()
+	if !ok {
+		t.Fatal("session not stored")
+	}
+	if got := len(entry.recentHashes); got != 3 {
+		t.Errorf("recentHashes len: got %d, want 3", got)
+	}
+	if !entry.escalated {
+		t.Error("expected escalation after 3 identical RecordRequests")
+	}
+}
+
+// TestChatBalanceGuardSubstitutesFreeModel exercises the wired-up
+// BalanceMonitor path: when the monitor reports a zero balance the next
+// Chat call must substitute the configured free fallback model.
+func TestChatBalanceGuardSubstitutesFreeModel(t *testing.T) {
+	var seenModels []string
+	var modelMu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		modelMu.Lock()
+		seenModels = append(seenModels, req.Model)
+		modelMu.Unlock()
+		json.NewEncoder(w).Encode(ChatResponse{
+			ID:    "chat-free",
+			Model: req.Model,
+			Choices: []ChatChoice{
+				{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: "ok"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+
+	// Fetcher returns 0.0 — drives the guard.
+	fetcher := func() (float64, error) { return 0.0, nil }
+
+	client, err := NewClient(wallet, nil,
+		WithGatewayURL(server.URL),
+		WithFreeFallbackModel("free-model"),
+		WithBalanceMonitor(20*time.Millisecond, fetcher),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	defer client.Close()
+
+	// Wait for the first poll to land. The monitor polls immediately on
+	// Start, but it runs on a separate goroutine so we need to give it a
+	// moment.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if bal, ok := client.LastKnownBalance(); ok && bal == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if bal, ok := client.LastKnownBalance(); !ok || bal != 0 {
+		t.Fatalf("monitor never reported balance=0 (got=%v ok=%v)", bal, ok)
+	}
+
+	if _, err := client.Chat(context.Background(), &ChatRequest{
+		Model:    "premium-model",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	}); err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+
+	modelMu.Lock()
+	defer modelMu.Unlock()
+	if len(seenModels) != 1 {
+		t.Fatalf("server saw %d requests, want 1: %v", len(seenModels), seenModels)
+	}
+	if seenModels[0] != "free-model" {
+		t.Errorf("balance guard did not substitute free model: server saw %q, want %q", seenModels[0], "free-model")
+	}
+}
+
+// TestChatBalanceGuardDormantWithoutMonitor confirms that without
+// WithBalanceMonitor the guard is dormant and the requested model passes
+// through verbatim, even with a free fallback configured.
+func TestChatBalanceGuardDormantWithoutMonitor(t *testing.T) {
+	var seenModel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		seenModel = req.Model
+		json.NewEncoder(w).Encode(ChatResponse{
+			ID:      "x",
+			Model:   req.Model,
+			Choices: []ChatChoice{{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: "ok"}}},
+		})
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil,
+		WithGatewayURL(server.URL),
+		WithFreeFallbackModel("free-model"),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	defer client.Close()
+
+	if _, err := client.Chat(context.Background(), &ChatRequest{
+		Model:    "premium-model",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	}); err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	if seenModel != "premium-model" {
+		t.Errorf("expected guard dormant; server saw %q, want %q", seenModel, "premium-model")
+	}
+}
+
+// fakeStreamSigner returns a minimal valid PaymentPayload so ChatStream
+// tests can exercise the streaming path without needing real Solana RPC
+// connectivity. Used to drive the 402 → sign → re-issue handshake.
+type fakeStreamSigner struct{}
+
+func (fakeStreamSigner) SignPayment(_ context.Context, _ uint64, payTo string, resource Resource, accepted PaymentAccept) (*PaymentPayload, error) {
+	return &PaymentPayload{
+		X402Version: X402Version,
+		Resource:    resource,
+		Accepted:    accepted,
+		Payload:     SolanaPayload{Transaction: "fake-tx"},
+	}, nil
+}
+
+// TestChatStreamCancelDoesNotLeakGoroutines exercises the SSE goroutine
+// fix: the consumer cancels the parent context after reading a single
+// chunk and the upstream goroutine plus body must close, not block on a
+// channel send forever.
+//
+// Uses a 402 probe response followed by a successful streaming response so
+// the actual transport.SendChatStream goroutine is the one being tested
+// for cleanup.
+func TestChatStreamCancelDoesNotLeakGoroutines(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		// Non-stream probe: return 402 to force the SDK to sign and re-issue
+		// as a streaming request, so the SSE goroutine fix is actually
+		// exercised.
+		if !req.Stream {
+			pr := PaymentRequired{
+				X402Version:   X402Version,
+				CostBreakdown: CostBreakdown{Total: "100"},
+				Resource:      Resource{URL: serverURL + "/v1/chat/completions", Method: "POST"},
+				Accepts: []PaymentAccept{
+					{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
+				},
+			}
+			w.WriteHeader(402)
+			json.NewEncoder(w).Encode(pr)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("ResponseWriter does not support flushing")
+			return
+		}
+		ctx := r.Context()
+		for i := 0; i < 1000; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			content := "x"
+			role := RoleAssistant
+			chunk := ChatChunk{
+				ID:      "chunk",
+				Model:   "gpt-4",
+				Choices: []ChatChunkChoice{{Index: 0, Delta: ChatDelta{Role: &role, Content: &content}}},
+			}
+			data, _ := json.Marshal(chunk)
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+			time.Sleep(5 * time.Millisecond)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, fakeStreamSigner{},
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	// Baseline goroutine count.
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	for i := 0; i < 5; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		ch, err := client.ChatStream(ctx, &ChatRequest{
+			Model:    "gpt-4",
+			Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+		})
+		if err != nil {
+			cancel()
+			t.Fatalf("ChatStream: %v", err)
+		}
+		// Read exactly one chunk, then cancel and stop reading.
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			cancel()
+			t.Fatal("never received first chunk")
+		}
+		cancel()
+	}
+
+	// Allow goroutines to unwind. If the fix is missing, the upstream
+	// goroutines stay parked on `ch <- chunk` forever and the count keeps
+	// climbing.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		if runtime.NumGoroutine() <= baseline+2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	final := runtime.NumGoroutine()
+	if final > baseline+2 {
+		t.Errorf("goroutine leak suspected: baseline=%d, final=%d (5 abandoned streams)", baseline, final)
+	}
+}
+
+func TestClientStringRedacts(t *testing.T) {
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil, WithGatewayURL("https://gateway.example.com"))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	s := client.String()
+	if !strings.Contains(s, "REDACTED") {
+		t.Error("String() should contain REDACTED")
+	}
+	if !strings.Contains(s, "gateway.example.com") {
+		t.Error("String() should contain gateway URL")
+	}
+	if strings.Contains(s, wallet.Address()) {
+		t.Error("String() should not contain wallet address")
+	}
+}
+
+func TestClientModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := struct {
+			Data []ModelInfo `json:"data"`
+		}{
+			Data: []ModelInfo{
+				{ID: "gpt-4", Provider: "openai"},
+			},
+		}
+		json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil, WithGatewayURL(server.URL))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	models, err := client.Models(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("got %d models, want 1", len(models))
+	}
+	if models[0].ID != "gpt-4" {
+		t.Errorf("model id: got %q, want %q", models[0].ID, "gpt-4")
+	}
+}
+
+func TestClientRecipientMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "1000"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "wrong-recipient"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithExpectedRecipient("expected-recipient"),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	_, ok := err.(*RecipientMismatchError)
+	if !ok {
+		t.Fatalf("expected RecipientMismatchError, got %T: %v", err, err)
+	}
+}
+
+func TestClientAmountExceedsMax(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "999999"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "999999", PayTo: "recipient"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	_, ok := err.(*AmountExceedsMaxError)
+	if !ok {
+		t.Fatalf("expected AmountExceedsMaxError, got %T: %v", err, err)
+	}
+}
+
+func TestParseAmount(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint64
+		wantErr bool
+	}{
+		{name: "valid", input: "1000", want: 1000, wantErr: false},
+		{name: "valid_large", input: "999999", want: 999999, wantErr: false},
+		{name: "valid_with_whitespace", input: " 42 ", want: 42, wantErr: false},
+		{name: "zero_rejected", input: "0", wantErr: true},
+		{name: "empty_rejected", input: "", wantErr: true},
+		{name: "whitespace_only_rejected", input: "   ", wantErr: true},
+		{name: "non_numeric_rejected", input: "abc", wantErr: true},
+		{name: "negative_rejected", input: "-1", wantErr: true},
+		{name: "decimal_rejected", input: "1.5", wantErr: true},
+		{name: "overflow_rejected", input: "99999999999999999999999999", wantErr: true},
+		{name: "trailing_garbage_rejected", input: "100abc", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAmount(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseAmount(%q): expected error, got %d", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseAmount(%q): unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseAmount(%q): got %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClientRejectsZeroAmountAttack verifies that a malicious gateway
+// returning amount="0" is rejected during validation rather than passing
+// through to the signer with a zero amount.
+func TestClientRejectsZeroAmountAttack(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "0"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "0", PayTo: "recipient"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for zero-amount payment")
+	}
+	ce, ok := err.(*ClientError)
+	if !ok {
+		t.Fatalf("expected ClientError, got %T: %v", err, err)
+	}
+	if !strings.Contains(ce.Message, "invalid payment amount") {
+		t.Errorf("unexpected ClientError message: %q", ce.Message)
+	}
+}
+
+// TestClientRejectsNonNumericAmount verifies that non-numeric amounts are
+// rejected — previously fmt.Sscanf would treat them as zero and silently
+// pass the cap check.
+func TestClientRejectsNonNumericAmount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "junk"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "notanumber", PayTo: "recipient"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-numeric amount")
+	}
+	if _, ok := err.(*ClientError); !ok {
+		t.Fatalf("expected ClientError, got %T: %v", err, err)
+	}
+}
+
+// TestClientRejectsForeignResourceURL verifies the SDK refuses to sign a
+// payment when the 402 Resource.URL points at an origin different from the
+// configured gateway. A rogue gateway must not be able to bind a foreign URL
+// into the signed payment metadata.
+func TestClientRejectsForeignResourceURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "100"},
+			Resource:      Resource{URL: "https://attacker.example.com/v1/chat/completions", Method: "POST"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for foreign resource URL")
+	}
+	ce, ok := err.(*ClientError)
+	if !ok {
+		t.Fatalf("expected ClientError, got %T: %v", err, err)
+	}
+	if !strings.Contains(ce.Message, "resource URL origin does not match") {
+		t.Errorf("unexpected ClientError message: %q", ce.Message)
+	}
+}
+
+// TestClientAllowsMatchingResourceURL verifies the origin check passes when
+// the Resource.URL matches the configured gateway origin.
+func TestClientAllowsMatchingResourceURL(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "100"},
+			Resource:      Resource{URL: serverURL + "/v1/chat/completions", Method: "POST"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	// We expect this path to pass the origin check and reach SignPayment
+	// (which the stub signer may fail). Either way, we must NOT see a
+	// "resource URL origin does not match" ClientError — that would mean
+	// the origin check rejected a legitimate matching URL.
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		if ce, ok := err.(*ClientError); ok {
+			if strings.Contains(ce.Message, "resource URL origin does not match") {
+				t.Fatalf("origin check incorrectly rejected matching URL: %v", err)
+			}
+		}
+	}
+}
+
+// TestChatReturnsQualityDegradedErrorAfterRetryExhaustion drives a gateway
+// that returns empty content on every call, exhausts the quality retry
+// budget (1 + MaxQualityRetries calls), and asserts that Chat surfaces a
+// *QualityDegradedError instead of silently returning the empty response.
+// Also asserts that a degraded response is NOT cached — replaying it
+// forever from the cache would be worse than the degraded result.
+func TestChatReturnsQualityDegradedErrorAfterRetryExhaustion(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		json.NewEncoder(w).Encode(ChatResponse{
+			ID:    "chat-empty",
+			Model: "gpt-4",
+			Choices: []ChatChoice{
+				{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: ""}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil,
+		WithGatewayURL(server.URL),
+		WithCache(true),
+		WithQualityCheck(true),
+		WithMaxQualityRetries(2),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	req := &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	}
+	_, err = client.Chat(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected QualityDegradedError, got nil")
+	}
+	var qde *QualityDegradedError
+	if !errors.As(err, &qde) {
+		t.Fatalf("expected *QualityDegradedError, got %T: %v", err, err)
+	}
+	if qde.Reason != DegradedEmptyContent {
+		t.Errorf("reason: got %q, want %q", qde.Reason, DegradedEmptyContent)
+	}
+	if qde.Response == nil {
+		t.Fatal("Response field must surface the last (degraded) response")
+	}
+	if qde.Response.ID != "chat-empty" {
+		t.Errorf("Response.ID: got %q, want %q", qde.Response.ID, "chat-empty")
+	}
+
+	// Initial + 2 retries = 3 total HTTP calls.
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("HTTP calls: got %d, want 3 (initial + MaxQualityRetries)", got)
+	}
+
+	// The degraded response must NOT be cached. A second call should hit the
+	// gateway again rather than replay an empty response.
+	_, err = client.Chat(context.Background(), req)
+	if err == nil {
+		t.Fatal("second call: expected error, got nil")
+	}
+	if got := atomic.LoadInt32(&calls); got != 6 {
+		t.Errorf("HTTP calls after second Chat: got %d, want 6 (degraded responses must not be cached)", got)
+	}
+}
+
+// TestChatStreamReusesProbeResponseWhenNoPaymentRequired covers the
+// price-discovery probe reuse fix: when the gateway returns 200 to the
+// non-streaming probe, ChatStream must NOT issue a second streaming
+// request. Instead it should synthesize a chunk channel from the probe
+// body, saving the caller a duplicate paid round trip.
+func TestChatStreamReusesProbeResponseWhenNoPaymentRequired(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		var req ChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		// Always answer with a regular ChatResponse — the probe path returns
+		// Stream=false; if the SDK incorrectly issues a second streaming
+		// request the handler would see Stream=true here too, but our
+		// assertion is on the call count rather than the body shape.
+		json.NewEncoder(w).Encode(ChatResponse{
+			ID:    "probe-reused",
+			Model: req.Model,
+			Choices: []ChatChoice{
+				{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: "hello world"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil, WithGatewayURL(server.URL))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	ch, err := client.ChatStream(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+
+	var got []string
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case item, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			if item.Err != nil {
+				t.Fatalf("unexpected stream error: %v", item.Err)
+			}
+			if item.Chunk == nil || len(item.Chunk.Choices) == 0 || item.Chunk.Choices[0].Delta.Content == nil {
+				t.Fatal("synthesized chunk missing content")
+			}
+			got = append(got, *item.Chunk.Choices[0].Delta.Content)
+		case <-timeout:
+			t.Fatal("stream never closed")
+		}
+	}
+done:
+
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Errorf("HTTP calls: got %d, want 1 (probe response must be reused, not re-fetched)", n)
+	}
+	if len(got) != 1 || got[0] != "hello world" {
+		t.Errorf("synthesized stream content: got %v, want [\"hello world\"]", got)
+	}
+}
+
+// TestChatStreamPaid402Path drives the end-to-end paid streaming path: the
+// non-streaming probe returns 402 (price discovery), the client signs with
+// the stub signer, and the follow-up streaming POST returns multi-chunk SSE.
+// Asserts the chunks arrive in order and the Payment-Signature header is set
+// on the streaming request. Before recent agent work this happy-path was
+// uncovered.
+func TestChatStreamPaid402Path(t *testing.T) {
+	var serverURL string
+	chunkContents := []string{"alpha", "beta", "gamma"}
+
+	var streamSigSeen string
+	var streamSigMu sync.Mutex
+	var probeCount, streamCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if !req.Stream {
+			// Probe: demand payment.
+			atomic.AddInt32(&probeCount, 1)
+			pr := PaymentRequired{
+				X402Version:   X402Version,
+				CostBreakdown: CostBreakdown{Total: "100"},
+				Resource:      Resource{URL: serverURL + "/v1/chat/completions", Method: "POST"},
+				Accepts: []PaymentAccept{
+					{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
+				},
+			}
+			w.WriteHeader(402)
+			json.NewEncoder(w).Encode(pr)
+			return
+		}
+		// Streaming follow-up after sign.
+		atomic.AddInt32(&streamCount, 1)
+		streamSigMu.Lock()
+		streamSigSeen = r.Header.Get("Payment-Signature")
+		streamSigMu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("ResponseWriter does not support flushing")
+			return
+		}
+		for _, c := range chunkContents {
+			content := c
+			role := RoleAssistant
+			chunk := ChatChunk{
+				ID:      "chunk-" + c,
+				Model:   "gpt-4",
+				Choices: []ChatChunkChoice{{Index: 0, Delta: ChatDelta{Role: &role, Content: &content}}},
+			}
+			data, _ := json.Marshal(chunk)
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, fakeStreamSigner{},
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	defer client.Close()
+
+	ch, err := client.ChatStream(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+
+	var got []string
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case item, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			if item.Err != nil {
+				t.Fatalf("unexpected stream error: %v", item.Err)
+			}
+			if item.Chunk == nil || len(item.Chunk.Choices) == 0 || item.Chunk.Choices[0].Delta.Content == nil {
+				t.Fatal("chunk missing content")
+			}
+			got = append(got, *item.Chunk.Choices[0].Delta.Content)
+		case <-timeout:
+			t.Fatal("stream never closed")
+		}
+	}
+done:
+
+	if len(got) != len(chunkContents) {
+		t.Fatalf("chunks: got %d, want %d (got=%v)", len(got), len(chunkContents), got)
+	}
+	for i, want := range chunkContents {
+		if got[i] != want {
+			t.Errorf("chunk[%d]: got %q, want %q (full=%v)", i, got[i], want, got)
+		}
+	}
+	if pc := atomic.LoadInt32(&probeCount); pc != 1 {
+		t.Errorf("probe count: got %d, want 1", pc)
+	}
+	if sc := atomic.LoadInt32(&streamCount); sc != 1 {
+		t.Errorf("stream count: got %d, want 1", sc)
+	}
+	streamSigMu.Lock()
+	defer streamSigMu.Unlock()
+	if streamSigSeen == "" {
+		t.Error("Payment-Signature header missing on streaming follow-up")
+	}
+}
+
+// TestChatThreeStrikeEscalationViaChat asserts that the wired escalation
+// path actually swaps the outgoing model on the wire after three identical
+// session-keyed Chat() calls. The unit-level SessionStore test covers the
+// counter logic in isolation; this exercises the integration through Chat.
+func TestChatThreeStrikeEscalationViaChat(t *testing.T) {
+	var seenModels []string
+	var modelMu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		modelMu.Lock()
+		seenModels = append(seenModels, req.Model)
+		modelMu.Unlock()
+		json.NewEncoder(w).Encode(ChatResponse{
+			ID:    "ok",
+			Model: req.Model,
+			Choices: []ChatChoice{
+				{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: "ok"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil,
+		WithGatewayURL(server.URL),
+		WithSessions(true),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	req := &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Same question"}},
+	}
+	// First three Chat calls record requests and trip the three-strike
+	// counter; the fourth must see the escalated model on the wire.
+	for i := 0; i < 4; i++ {
+		if _, err := client.Chat(context.Background(), req); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+
+	modelMu.Lock()
+	defer modelMu.Unlock()
+	if len(seenModels) != 4 {
+		t.Fatalf("server saw %d requests, want 4: %v", len(seenModels), seenModels)
+	}
+	// Read the session's escalated model directly to learn what name the
+	// store substituted, then assert the outgoing model on call #4 matches it
+	// (and that calls #1..#3 used the original requested model).
+	sessionID := DeriveSessionIDWithSalt(client.sessionSalt, req.Messages)
+	client.sessionStore.mu.Lock()
+	entry, ok := client.sessionStore.sessions[sessionID]
+	if !ok {
+		client.sessionStore.mu.Unlock()
+		t.Fatal("session not stored")
+	}
+	if !entry.escalated {
+		client.sessionStore.mu.Unlock()
+		t.Fatal("session should be escalated after three identical RecordRequests")
+	}
+	escalatedModel := entry.model
+	client.sessionStore.mu.Unlock()
+
+	for i := 0; i < 3; i++ {
+		if seenModels[i] != "gpt-4" {
+			t.Errorf("call %d: wire model = %q, want %q (pre-escalation)", i, seenModels[i], "gpt-4")
+		}
+	}
+	if seenModels[3] != escalatedModel {
+		t.Errorf("call 4: wire model = %q, want escalated %q", seenModels[3], escalatedModel)
+	}
+}
+
+// TestChatPaymentRejectedAfterSign drives a gateway that returns 402 on
+// both the probe AND the post-sign re-issue. After the SDK signs and sends
+// the Payment-Signature header, a second 402 must surface as
+// *PaymentRejectedError, not loop forever.
+func TestChatPaymentRejectedAfterSign(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always return 402 — the gateway "rejects" both the probe and the
+		// signed retry. The double-402 guard in sendWithPayment must catch
+		// the second 402 and return PaymentRejectedError.
+		pr := PaymentRequired{
+			X402Version:   X402Version,
+			CostBreakdown: CostBreakdown{Total: "100"},
+			Resource:      Resource{URL: serverURL + "/v1/chat/completions", Method: "POST"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, fakeStreamSigner{},
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected PaymentRejectedError, got nil")
+	}
+	var pre *PaymentRejectedError
+	if !errors.As(err, &pre) {
+		t.Fatalf("expected *PaymentRejectedError, got %T: %v", err, err)
+	}
+	if pre.Reason == "" {
+		t.Error("PaymentRejectedError.Reason should be non-empty")
+	}
+}

--- a/sdks/go/config.go
+++ b/sdks/go/config.go
@@ -1,0 +1,125 @@
+package solvela
+
+import "time"
+
+// DefaultMaxPaymentAmount is the default cap on a single payment, in atomic
+// USDC units (10 USDC = 10_000_000). This is high enough to cover any
+// reasonable single LLM call, but low enough to block obvious wallet drains
+// when a misbehaving or malicious gateway returns a wildly inflated amount.
+//
+// Callers that need a higher per-request cap must override this explicitly via
+// [WithMaxPaymentAmount]. Callers that want no cap at all should pass the
+// largest uint64 value.
+const DefaultMaxPaymentAmount uint64 = 10_000_000
+
+// ClientConfig holds all configuration for a Solvela client.
+type ClientConfig struct {
+	GatewayURL         string
+	RPCURL             string
+	PreferEscrow       bool
+	Timeout            time.Duration
+	ExpectedRecipient  string
+	MaxPaymentAmount   *uint64
+	EnableCache        bool
+	EnableSessions     bool
+	SessionTTL         time.Duration
+	EnableQualityCheck bool
+	MaxQualityRetries  int
+	FreeFallbackModel  string
+	// BalancePollInterval, when non-zero, instructs [NewClient] to start a
+	// background [BalanceMonitor] that periodically refreshes the client's
+	// last-known wallet balance. The free-fallback-model guard in
+	// [SolvelaClient.Chat] / [SolvelaClient.ChatStream] reads that value to
+	// detect a depleted wallet and substitute [ClientConfig.FreeFallbackModel].
+	// Without a non-zero interval and a [BalanceFetcher], lastBalance is
+	// never populated and the guard is dormant. Set via [WithBalanceMonitor].
+	BalancePollInterval time.Duration
+	// BalanceFetcher returns the wallet's current balance for the background
+	// [BalanceMonitor]. Required when [BalancePollInterval] is non-zero. Set
+	// via [WithBalanceMonitor].
+	BalanceFetcher func() (float64, error)
+}
+
+// DefaultConfig returns a ClientConfig with sensible defaults.
+//
+// Security defaults:
+//   - GatewayURL points to the production HTTPS endpoint.
+//   - MaxPaymentAmount is set to [DefaultMaxPaymentAmount] (10 USDC atomic) to
+//     prevent wallet drains from a misconfigured or malicious gateway.
+func DefaultConfig() ClientConfig {
+	defaultMax := DefaultMaxPaymentAmount
+	return ClientConfig{
+		GatewayURL:        "https://api.solvela.ai",
+		RPCURL:            "https://api.mainnet-beta.solana.com",
+		Timeout:           180 * time.Second,
+		SessionTTL:        1800 * time.Second,
+		MaxQualityRetries: 1,
+		MaxPaymentAmount:  &defaultMax,
+	}
+}
+
+// Option is a functional option for configuring ClientConfig.
+type Option func(*ClientConfig)
+
+// WithGatewayURL sets the gateway URL.
+func WithGatewayURL(url string) Option { return func(c *ClientConfig) { c.GatewayURL = url } }
+
+// WithRPCURL sets the Solana RPC URL.
+func WithRPCURL(url string) Option { return func(c *ClientConfig) { c.RPCURL = url } }
+
+// WithTimeout sets the request timeout.
+func WithTimeout(d time.Duration) Option { return func(c *ClientConfig) { c.Timeout = d } }
+
+// WithExpectedRecipient sets the expected payment recipient for verification.
+func WithExpectedRecipient(r string) Option {
+	return func(c *ClientConfig) { c.ExpectedRecipient = r }
+}
+
+// WithMaxPaymentAmount sets the maximum payment amount in atomic units.
+func WithMaxPaymentAmount(max uint64) Option {
+	return func(c *ClientConfig) { m := max; c.MaxPaymentAmount = &m }
+}
+
+// WithCache enables or disables response caching.
+func WithCache(enable bool) Option { return func(c *ClientConfig) { c.EnableCache = enable } }
+
+// WithSessions enables or disables session tracking.
+func WithSessions(enable bool) Option { return func(c *ClientConfig) { c.EnableSessions = enable } }
+
+// WithSessionTTL sets the session time-to-live.
+func WithSessionTTL(d time.Duration) Option { return func(c *ClientConfig) { c.SessionTTL = d } }
+
+// WithQualityCheck enables or disables quality checking.
+func WithQualityCheck(enable bool) Option {
+	return func(c *ClientConfig) { c.EnableQualityCheck = enable }
+}
+
+// WithMaxQualityRetries sets the maximum number of quality retries.
+func WithMaxQualityRetries(n int) Option {
+	return func(c *ClientConfig) { c.MaxQualityRetries = n }
+}
+
+// WithFreeFallbackModel sets the free model to fall back to.
+func WithFreeFallbackModel(model string) Option {
+	return func(c *ClientConfig) { c.FreeFallbackModel = model }
+}
+
+// WithBalanceMonitor enables a background goroutine that polls the wallet
+// balance every interval using fetcher and feeds the result into the
+// client's last-known balance cache. This is required for the free-fallback
+// model guard configured by [WithFreeFallbackModel] to fire — without a
+// monitor the cache stays empty and the guard is dormant.
+//
+// The monitor is opt-in by design: NewClient does not auto-start network
+// pollers, so callers that do not care about balance-aware fallback pay no
+// background-RPC tax. Call [SolvelaClient.Close] to stop the monitor when
+// the client is no longer needed.
+//
+// interval and fetcher must both be non-zero/non-nil; passing zero or nil
+// is a no-op for safety.
+func WithBalanceMonitor(interval time.Duration, fetcher func() (float64, error)) Option {
+	return func(c *ClientConfig) {
+		c.BalancePollInterval = interval
+		c.BalanceFetcher = fetcher
+	}
+}

--- a/sdks/go/config_test.go
+++ b/sdks/go/config_test.go
@@ -1,0 +1,167 @@
+package solvela
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.GatewayURL != "https://api.solvela.ai" {
+		t.Errorf("GatewayURL: got %q", cfg.GatewayURL)
+	}
+	if cfg.RPCURL != "https://api.mainnet-beta.solana.com" {
+		t.Errorf("RPCURL: got %q", cfg.RPCURL)
+	}
+	if cfg.Timeout != 180*time.Second {
+		t.Errorf("Timeout: got %v", cfg.Timeout)
+	}
+	if cfg.SessionTTL != 1800*time.Second {
+		t.Errorf("SessionTTL: got %v", cfg.SessionTTL)
+	}
+	if cfg.MaxQualityRetries != 1 {
+		t.Errorf("MaxQualityRetries: got %d", cfg.MaxQualityRetries)
+	}
+	if cfg.PreferEscrow {
+		t.Error("PreferEscrow should default to false")
+	}
+	if cfg.EnableCache {
+		t.Error("EnableCache should default to false")
+	}
+	if cfg.EnableSessions {
+		t.Error("EnableSessions should default to false")
+	}
+	if cfg.EnableQualityCheck {
+		t.Error("EnableQualityCheck should default to false")
+	}
+	if cfg.MaxPaymentAmount == nil {
+		t.Error("MaxPaymentAmount should default to a non-nil cap (security)")
+	} else if *cfg.MaxPaymentAmount != DefaultMaxPaymentAmount {
+		t.Errorf("MaxPaymentAmount default: got %d, want %d", *cfg.MaxPaymentAmount, DefaultMaxPaymentAmount)
+	}
+	if cfg.ExpectedRecipient != "" {
+		t.Error("ExpectedRecipient should default to empty")
+	}
+	if cfg.FreeFallbackModel != "" {
+		t.Error("FreeFallbackModel should default to empty")
+	}
+}
+
+func TestWithGatewayURL(t *testing.T) {
+	cfg := DefaultConfig()
+	WithGatewayURL("https://gateway.example.com")(&cfg)
+	if cfg.GatewayURL != "https://gateway.example.com" {
+		t.Errorf("got %q", cfg.GatewayURL)
+	}
+}
+
+func TestWithRPCURL(t *testing.T) {
+	cfg := DefaultConfig()
+	WithRPCURL("https://rpc.example.com")(&cfg)
+	if cfg.RPCURL != "https://rpc.example.com" {
+		t.Errorf("got %q", cfg.RPCURL)
+	}
+}
+
+func TestWithTimeout(t *testing.T) {
+	cfg := DefaultConfig()
+	WithTimeout(60 * time.Second)(&cfg)
+	if cfg.Timeout != 60*time.Second {
+		t.Errorf("got %v", cfg.Timeout)
+	}
+}
+
+func TestWithExpectedRecipient(t *testing.T) {
+	cfg := DefaultConfig()
+	WithExpectedRecipient("recipient123")(&cfg)
+	if cfg.ExpectedRecipient != "recipient123" {
+		t.Errorf("got %q", cfg.ExpectedRecipient)
+	}
+}
+
+func TestWithMaxPaymentAmount(t *testing.T) {
+	cfg := DefaultConfig()
+	WithMaxPaymentAmount(5000)(&cfg)
+	if cfg.MaxPaymentAmount == nil || *cfg.MaxPaymentAmount != 5000 {
+		t.Errorf("got %v", cfg.MaxPaymentAmount)
+	}
+}
+
+func TestWithCache(t *testing.T) {
+	cfg := DefaultConfig()
+	WithCache(true)(&cfg)
+	if !cfg.EnableCache {
+		t.Error("expected EnableCache to be true")
+	}
+}
+
+func TestWithSessions(t *testing.T) {
+	cfg := DefaultConfig()
+	WithSessions(true)(&cfg)
+	if !cfg.EnableSessions {
+		t.Error("expected EnableSessions to be true")
+	}
+}
+
+func TestWithSessionTTL(t *testing.T) {
+	cfg := DefaultConfig()
+	WithSessionTTL(600 * time.Second)(&cfg)
+	if cfg.SessionTTL != 600*time.Second {
+		t.Errorf("got %v", cfg.SessionTTL)
+	}
+}
+
+func TestWithQualityCheck(t *testing.T) {
+	cfg := DefaultConfig()
+	WithQualityCheck(true)(&cfg)
+	if !cfg.EnableQualityCheck {
+		t.Error("expected EnableQualityCheck to be true")
+	}
+}
+
+func TestWithMaxQualityRetries(t *testing.T) {
+	cfg := DefaultConfig()
+	WithMaxQualityRetries(3)(&cfg)
+	if cfg.MaxQualityRetries != 3 {
+		t.Errorf("got %d", cfg.MaxQualityRetries)
+	}
+}
+
+func TestWithFreeFallbackModel(t *testing.T) {
+	cfg := DefaultConfig()
+	WithFreeFallbackModel("free/gemini-2.0-flash")(&cfg)
+	if cfg.FreeFallbackModel != "free/gemini-2.0-flash" {
+		t.Errorf("got %q", cfg.FreeFallbackModel)
+	}
+}
+
+func TestMultipleOptions(t *testing.T) {
+	cfg := DefaultConfig()
+	opts := []Option{
+		WithGatewayURL("https://gw.test"),
+		WithTimeout(30 * time.Second),
+		WithCache(true),
+		WithSessions(true),
+		WithMaxPaymentAmount(10000),
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.GatewayURL != "https://gw.test" {
+		t.Errorf("GatewayURL: got %q", cfg.GatewayURL)
+	}
+	if cfg.Timeout != 30*time.Second {
+		t.Errorf("Timeout: got %v", cfg.Timeout)
+	}
+	if !cfg.EnableCache {
+		t.Error("EnableCache should be true")
+	}
+	if !cfg.EnableSessions {
+		t.Error("EnableSessions should be true")
+	}
+	if cfg.MaxPaymentAmount == nil || *cfg.MaxPaymentAmount != 10000 {
+		t.Errorf("MaxPaymentAmount: got %v", cfg.MaxPaymentAmount)
+	}
+}

--- a/sdks/go/constants.go
+++ b/sdks/go/constants.go
@@ -1,0 +1,22 @@
+package solvela
+
+const (
+	// X402Version is the protocol version of the x402 payment scheme this SDK speaks.
+	X402Version = 2
+
+	// USDCMint is the SPL-token mint address of USDC on Solana mainnet-beta.
+	USDCMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+	// SolanaNetwork is the x402 network identifier this SDK targets by default
+	// (Solana mainnet-beta, encoded as "solana:<genesis-hash-prefix>").
+	SolanaNetwork = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+
+	// MaxTimeoutSeconds is the upper bound (in seconds) enforced on
+	// [ClientConfig].Timeout when constructing a client.
+	MaxTimeoutSeconds = 300
+
+	// PlatformFeePercent is the percentage of each payment that Solvela
+	// retains as a platform fee; applied gateway-side, surfaced here for
+	// callers that want to display fee-inclusive pricing.
+	PlatformFeePercent = 5
+)

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -1,0 +1,102 @@
+package solvela
+
+import "fmt"
+
+// ClientError represents a general client error.
+type ClientError struct {
+	Message string
+}
+
+func (e *ClientError) Error() string { return e.Message }
+
+// WalletError represents a wallet-related error.
+type WalletError struct {
+	Message string
+}
+
+func (e *WalletError) Error() string { return fmt.Sprintf("wallet error: %s", e.Message) }
+
+// SignerError represents a signing-related error.
+type SignerError struct {
+	Message string
+}
+
+func (e *SignerError) Error() string { return fmt.Sprintf("signer error: %s", e.Message) }
+
+// InsufficientBalanceError indicates the wallet does not have enough funds.
+type InsufficientBalanceError struct {
+	Have, Need uint64
+}
+
+func (e *InsufficientBalanceError) Error() string {
+	return fmt.Sprintf("insufficient balance: have %d, need %d", e.Have, e.Need)
+}
+
+// GatewayError represents an HTTP error from the gateway.
+type GatewayError struct {
+	Status  int
+	Message string
+}
+
+func (e *GatewayError) Error() string {
+	return fmt.Sprintf("gateway error %d: %s", e.Status, e.Message)
+}
+
+// PaymentRequiredError wraps a 402 response.
+type PaymentRequiredError struct {
+	PaymentRequired PaymentRequired
+}
+
+func (e *PaymentRequiredError) Error() string {
+	return fmt.Sprintf("payment required: %s USDC", e.PaymentRequired.CostBreakdown.Total)
+}
+
+// PaymentRejectedError indicates the payment was not accepted.
+type PaymentRejectedError struct {
+	Reason string
+}
+
+func (e *PaymentRejectedError) Error() string {
+	return fmt.Sprintf("payment rejected: %s", e.Reason)
+}
+
+// RecipientMismatchError indicates the payment recipient does not match expectations.
+type RecipientMismatchError struct {
+	Expected, Actual string
+}
+
+func (e *RecipientMismatchError) Error() string {
+	return fmt.Sprintf("recipient mismatch: expected %s, got %s", e.Expected, e.Actual)
+}
+
+// AmountExceedsMaxError indicates the payment amount exceeds the configured maximum.
+type AmountExceedsMaxError struct {
+	Amount, MaxAmount uint64
+}
+
+func (e *AmountExceedsMaxError) Error() string {
+	return fmt.Sprintf("amount %d exceeds max %d", e.Amount, e.MaxAmount)
+}
+
+// TimeoutError indicates a request timed out.
+type TimeoutError struct {
+	TimeoutSecs float64
+}
+
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("request timed out after %.1fs", e.TimeoutSecs)
+}
+
+// QualityDegradedError is returned by [SolvelaClient.Chat] when a response
+// repeatedly fails the quality check (after MaxQualityRetries) and the
+// caller cannot get a clean response. The Response field is the last
+// (still-degraded) response, available for callers that prefer to use it
+// anyway. Degraded responses are never cached.
+type QualityDegradedError struct {
+	Reason   DegradedReason
+	Response *ChatResponse
+}
+
+func (e *QualityDegradedError) Error() string {
+	return fmt.Sprintf("response quality degraded after retries: %s", e.Reason)
+}

--- a/sdks/go/errors_test.go
+++ b/sdks/go/errors_test.go
@@ -1,0 +1,138 @@
+package solvela
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClientError(t *testing.T) {
+	err := &ClientError{Message: "something went wrong"}
+	if err.Error() != "something went wrong" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestWalletError(t *testing.T) {
+	err := &WalletError{Message: "invalid key"}
+	if err.Error() != "wallet error: invalid key" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestSignerError(t *testing.T) {
+	err := &SignerError{Message: "sign failed"}
+	if err.Error() != "signer error: sign failed" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestInsufficientBalanceError(t *testing.T) {
+	err := &InsufficientBalanceError{Have: 100, Need: 500}
+	if err.Error() != "insufficient balance: have 100, need 500" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestGatewayError(t *testing.T) {
+	err := &GatewayError{Status: 500, Message: "internal error"}
+	if err.Error() != "gateway error 500: internal error" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestPaymentRequiredError(t *testing.T) {
+	err := &PaymentRequiredError{
+		PaymentRequired: PaymentRequired{
+			CostBreakdown: CostBreakdown{Total: "1000"},
+		},
+	}
+	if err.Error() != "payment required: 1000 USDC" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestPaymentRejectedError(t *testing.T) {
+	err := &PaymentRejectedError{Reason: "invalid signature"}
+	if err.Error() != "payment rejected: invalid signature" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestRecipientMismatchError(t *testing.T) {
+	err := &RecipientMismatchError{Expected: "abc", Actual: "xyz"}
+	if err.Error() != "recipient mismatch: expected abc, got xyz" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestAmountExceedsMaxError(t *testing.T) {
+	err := &AmountExceedsMaxError{Amount: 1000, MaxAmount: 500}
+	if err.Error() != "amount 1000 exceeds max 500" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestTimeoutError(t *testing.T) {
+	err := &TimeoutError{TimeoutSecs: 30.0}
+	if err.Error() != "request timed out after 30.0s" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestQualityDegradedError(t *testing.T) {
+	resp := &ChatResponse{
+		ID: "chat-degraded",
+		Choices: []ChatChoice{
+			{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: ""}},
+		},
+	}
+	err := &QualityDegradedError{Reason: DegradedEmptyContent, Response: resp}
+
+	want := "response quality degraded after retries: empty_content"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+
+	// Round-trip Response: the same pointer should be retrievable so callers
+	// can opt into the degraded response if they want it.
+	if err.Response != resp {
+		t.Error("Response field should round-trip the supplied pointer")
+	}
+	if err.Response.ID != "chat-degraded" {
+		t.Errorf("Response.ID: got %q, want %q", err.Response.ID, "chat-degraded")
+	}
+
+	// Type assertion via errors.As.
+	var qde *QualityDegradedError
+	if !errors.As(error(err), &qde) {
+		t.Error("expected QualityDegradedError type assertion to succeed")
+	}
+	if qde.Reason != DegradedEmptyContent {
+		t.Errorf("Reason after As: got %q, want %q", qde.Reason, DegradedEmptyContent)
+	}
+}
+
+func TestErrorTypeAssertions(t *testing.T) {
+	var err error
+
+	err = &ClientError{Message: "test"}
+	var clientErr *ClientError
+	if !errors.As(err, &clientErr) {
+		t.Error("expected ClientError type assertion to succeed")
+	}
+
+	err = &GatewayError{Status: 402, Message: "payment required"}
+	var gwErr *GatewayError
+	if !errors.As(err, &gwErr) {
+		t.Error("expected GatewayError type assertion to succeed")
+	}
+	if gwErr.Status != 402 {
+		t.Errorf("status: got %d, want 402", gwErr.Status)
+	}
+
+	err = &InsufficientBalanceError{Have: 0, Need: 100}
+	var balErr *InsufficientBalanceError
+	if !errors.As(err, &balErr) {
+		t.Error("expected InsufficientBalanceError type assertion to succeed")
+	}
+}

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/solvela-ai/solvela/sdks/go
+
+go 1.23.7
+
+require github.com/mr-tron/base58 v1.2.0

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,0 +1,2 @@
+github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
+github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=

--- a/sdks/go/live_test.go
+++ b/sdks/go/live_test.go
@@ -1,0 +1,65 @@
+//go:build live
+
+package solvela_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	solvela "github.com/solvela-ai/solvela/sdks/go"
+)
+
+func TestLiveHealth(t *testing.T) {
+	gatewayURL := os.Getenv("SOLVELA_GATEWAY_URL")
+	if gatewayURL == "" {
+		gatewayURL = "http://localhost:8402"
+	}
+
+	transport := solvela.NewTransport(gatewayURL, 10*time.Second)
+	models, err := transport.FetchModels(context.Background())
+	if err != nil {
+		t.Fatalf("fetch models: %v", err)
+	}
+	if len(models) == 0 {
+		t.Error("expected at least one model")
+	}
+	t.Logf("found %d models", len(models))
+}
+
+func TestLiveChat402(t *testing.T) {
+	gatewayURL := os.Getenv("SOLVELA_GATEWAY_URL")
+	if gatewayURL == "" {
+		gatewayURL = "http://localhost:8402"
+	}
+
+	wallet, _, err := solvela.CreateWallet()
+	if err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+
+	client, err := solvela.NewClient(wallet, nil,
+		solvela.WithGatewayURL(gatewayURL),
+		solvela.WithTimeout(30*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &solvela.ChatRequest{
+		Model: "gpt-4o-mini",
+		Messages: []solvela.ChatMessage{
+			{Role: solvela.RoleUser, Content: "Say hello in one word."},
+		},
+	})
+
+	// Expect 402 since we have no payment signer
+	if err == nil {
+		t.Fatal("expected error (402 payment required)")
+	}
+	_, ok := err.(*solvela.PaymentRequiredError)
+	if !ok {
+		t.Logf("got error type %T: %v", err, err)
+	}
+}

--- a/sdks/go/quality.go
+++ b/sdks/go/quality.go
@@ -1,0 +1,82 @@
+package solvela
+
+import "strings"
+
+// DegradedReason describes why a response was considered degraded.
+type DegradedReason string
+
+const (
+	DegradedEmptyContent     DegradedReason = "empty_content"
+	DegradedKnownErrorPhrase DegradedReason = "known_error_phrase"
+	DegradedRepetitiveLoop   DegradedReason = "repetitive_loop"
+	DegradedTruncatedMidWord DegradedReason = "truncated_mid_word"
+)
+
+var knownErrorPhrases = []string{
+	"i cannot",
+	"as an ai",
+	"i'm sorry, but i",
+}
+
+// CheckDegraded checks if response content is degraded.
+// Returns empty [DegradedReason] if OK, or a specific DegradedReason value.
+func CheckDegraded(content string) DegradedReason {
+	// 1. Empty/whitespace
+	if strings.TrimSpace(content) == "" {
+		return DegradedEmptyContent
+	}
+
+	// 2. Known error phrases (case-insensitive)
+	lower := strings.ToLower(content)
+	for _, phrase := range knownErrorPhrases {
+		if strings.Contains(lower, phrase) {
+			return DegradedKnownErrorPhrase
+		}
+	}
+
+	// 3. Repetitive 3-word phrases (any trigram appears 5+ times)
+	words := strings.Fields(content)
+	if len(words) >= 15 {
+		counts := make(map[string]int)
+		for i := 0; i <= len(words)-3; i++ {
+			trigram := words[i] + " " + words[i+1] + " " + words[i+2]
+			counts[trigram]++
+			if counts[trigram] >= 5 {
+				return DegradedRepetitiveLoop
+			}
+		}
+	}
+
+	// 4. Truncated mid-word.
+	//
+	// A response is treated as truncated mid-word only when all three of these
+	// hold:
+	//   - the (right-trimmed) content is longer than 100 chars,
+	//   - the final non-space character is not a closing-style character
+	//     (sentence punctuation, closing quote, closing bracket, backtick,
+	//     or newline) that would naturally end well-formed prose, AND
+	//   - the final whitespace-delimited token is at least 4 chars long.
+	//
+	// Trailing whitespace alone is not a truncation signal — well-formed
+	// streamed completions often end with a newline. Short final tokens
+	// like "OK", "Hi", or "1" are not truncation signals either; they are
+	// common legitimate endings and would false-positive almost every
+	// short reply otherwise. The previous heuristic (>100 chars && last
+	// char is alphanumeric) flagged virtually any prose ending in a
+	// letter, including correctly punctuated sentences whose closing
+	// quote was followed by no punctuation.
+	trimmed := strings.TrimRight(content, " \t\r\n")
+	if len(trimmed) > 100 {
+		last := rune(trimmed[len(trimmed)-1])
+		const closers = ".!?\"'`)]}"
+		if !strings.ContainsRune(closers, last) {
+			lastSpace := strings.LastIndexAny(trimmed, " \t\n")
+			lastToken := trimmed[lastSpace+1:]
+			if len(lastToken) >= 4 {
+				return DegradedTruncatedMidWord
+			}
+		}
+	}
+
+	return ""
+}

--- a/sdks/go/quality_test.go
+++ b/sdks/go/quality_test.go
@@ -1,0 +1,163 @@
+package solvela
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckDegradedEmptyContent(t *testing.T) {
+	reason := CheckDegraded("")
+	if reason != DegradedEmptyContent {
+		t.Errorf("got %q, want %q", reason, DegradedEmptyContent)
+	}
+}
+
+func TestCheckDegradedWhitespaceOnly(t *testing.T) {
+	reason := CheckDegraded("   \t\n  ")
+	if reason != DegradedEmptyContent {
+		t.Errorf("got %q, want %q", reason, DegradedEmptyContent)
+	}
+}
+
+func TestCheckDegradedKnownErrorPhrase(t *testing.T) {
+	reason := CheckDegraded("I cannot help with that request.")
+	if reason != DegradedKnownErrorPhrase {
+		t.Errorf("got %q, want %q", reason, DegradedKnownErrorPhrase)
+	}
+}
+
+func TestCheckDegradedKnownErrorPhraseCaseInsensitive(t *testing.T) {
+	reason := CheckDegraded("AS AN AI language model, I can help.")
+	if reason != DegradedKnownErrorPhrase {
+		t.Errorf("got %q, want %q", reason, DegradedKnownErrorPhrase)
+	}
+}
+
+func TestCheckDegradedRepetitiveLoop(t *testing.T) {
+	// Build content with a trigram repeated 5+ times
+	repeated := strings.Repeat("the quick brown fox jumps ", 6)
+	reason := CheckDegraded(repeated)
+	if reason != DegradedRepetitiveLoop {
+		t.Errorf("got %q, want %q", reason, DegradedRepetitiveLoop)
+	}
+}
+
+func TestCheckDegradedTruncatedMidWord(t *testing.T) {
+	// >100 chars ending with a long unfinished token: "comput" (6 chars,
+	// no trailing punctuation, not a closer).
+	content := "The system processes input data and continues to handle each request through the long pipeline as it comput"
+	if len(content) <= 100 {
+		t.Fatalf("test content too short: %d chars", len(content))
+	}
+	reason := CheckDegraded(content)
+	if reason != DegradedTruncatedMidWord {
+		t.Errorf("got %q, want %q", reason, DegradedTruncatedMidWord)
+	}
+}
+
+// TestCheckDegradedClosingChars walks the closer set: prose ending in a
+// closer should never flag as truncated, even when it would have under the
+// old "ends-with-alphanumeric" heuristic.
+func TestCheckDegradedClosingChars(t *testing.T) {
+	base := "The quick brown fox jumps over the lazy dog and then runs through the forest while the birds sing softly all evening long"
+	if len(base) <= 100 {
+		t.Fatalf("test base too short: %d chars", len(base))
+	}
+	cases := []struct {
+		name string
+		end  string
+	}{
+		{"period", "."},
+		{"exclamation", "!"},
+		{"question", "?"},
+		{"double_quote", `."`},
+		{"close_paren", ")"},
+		{"close_bracket", "]"},
+		{"close_brace", "}"},
+		{"backtick", "`"},
+		{"single_quote", "'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := base + tc.end
+			if len(content) <= 100 {
+				t.Fatalf("test content too short: %d chars", len(content))
+			}
+			reason := CheckDegraded(content)
+			if reason != "" {
+				t.Errorf("ending %q: got %q, want not degraded", tc.end, reason)
+			}
+		})
+	}
+}
+
+// TestCheckDegradedShortFinalToken — a short final token like "OK" is a
+// common legitimate ending and must NOT flag as truncated, even when the
+// total content exceeds 100 chars.
+func TestCheckDegradedShortFinalToken(t *testing.T) {
+	// Total >100 chars but the last whitespace-delimited token is "OK"
+	// (2 chars) — under the 4-char threshold for mid-word truncation.
+	content := "The system processes the input and produces a result, and the current status of every queued job is OK"
+	if len(content) <= 100 {
+		t.Fatalf("test content too short: %d chars", len(content))
+	}
+	reason := CheckDegraded(content)
+	if reason != "" {
+		t.Errorf("got %q, want empty (short final token is not truncation)", reason)
+	}
+}
+
+// TestCheckDegradedTrailingWhitespace — well-formed completions that end in
+// trailing whitespace (often a newline from the model) must not be
+// flagged as truncated. The trailing-whitespace trim happens before the
+// closer check.
+func TestCheckDegradedTrailingWhitespace(t *testing.T) {
+	content := "The quick brown fox jumps over the lazy dog and then runs through the forest while the birds sing softly.\n"
+	if len(content) <= 100 {
+		t.Fatalf("test content too short: %d chars", len(content))
+	}
+	reason := CheckDegraded(content)
+	if reason != "" {
+		t.Errorf("got %q, want empty (trailing whitespace is not truncation)", reason)
+	}
+}
+
+// TestCheckDegradedTrailingWhitespaceLongTokenStillTruncated — trailing
+// whitespace alone is benign, but a stream ending mid-long-token followed
+// by whitespace is still truncated. The right-trim must reveal the
+// underlying mid-word boundary.
+func TestCheckDegradedTrailingWhitespaceLongTokenStillTruncated(t *testing.T) {
+	content := "The system processes input data and continues to handle each request through the pipeline as it comput   "
+	reason := CheckDegraded(content)
+	if reason != DegradedTruncatedMidWord {
+		t.Errorf("got %q, want %q (trim should expose mid-word boundary)", reason, DegradedTruncatedMidWord)
+	}
+}
+
+func TestCheckDegradedNormalContent(t *testing.T) {
+	reason := CheckDegraded("This is a perfectly normal response.")
+	if reason != "" {
+		t.Errorf("got %q, want empty (not degraded)", reason)
+	}
+}
+
+func TestCheckDegradedContentEndingWithPeriod(t *testing.T) {
+	// >100 chars ending with period should NOT be truncated
+	// Use diverse words to avoid triggering repetitive loop detection
+	content := "The quick brown fox jumps over the lazy dog and then runs through the forest while the birds sing their beautiful songs in the morning light."
+	if len(content) <= 100 {
+		t.Fatalf("test content too short: %d chars", len(content))
+	}
+	reason := CheckDegraded(content)
+	if reason != "" {
+		t.Errorf("got %q, want empty (period ending is not truncated)", reason)
+	}
+}
+
+func TestCheckDegradedShortContentEndingAlphanumeric(t *testing.T) {
+	// <=100 chars ending with alphanumeric should NOT be truncated
+	reason := CheckDegraded("Short text ending with word")
+	if reason != "" {
+		t.Errorf("got %q, want empty (short content not checked for truncation)", reason)
+	}
+}

--- a/sdks/go/scripts/smoke/main.go
+++ b/sdks/go/scripts/smoke/main.go
@@ -1,0 +1,186 @@
+// Manual smoke test — exercises the real wire contract before release.
+//
+// Run before tagging a release to verify the SDK still agrees with a live
+// Solvela gateway. Catches wire-format drift that unit/integration tests
+// cannot (header names, JSON field renames, accepts-array ordering, new
+// required fields).
+//
+// Usage:
+//
+//	SOLVELA_GATEWAY_URL=https://staging.solvela.ai \
+//	go run ./scripts/smoke
+//
+// Defaults to http://localhost:8402 if SOLVELA_GATEWAY_URL is unset.
+//
+// Exit codes:
+//
+//	0 — all assertions passed
+//	1 — an assertion failed or the gateway is unreachable
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+
+	solvela "github.com/solvela-ai/solvela/sdks/go"
+)
+
+// solanaPubkeyRE matches Solana base58 pubkeys (32–44 chars over the Bitcoin
+// base58 alphabet; no 0/O/I/l). An empty or malformed PayTo would route
+// signed funds to address-zero — the most expensive class of silent drift.
+var solanaPubkeyRE = regexp.MustCompile(`^[1-9A-HJ-NP-Za-km-z]{32,44}$`)
+
+// amountRE matches positive decimal-integer strings (no leading sign, no
+// decimals, no scientific notation).
+var amountRE = regexp.MustCompile(`^\d+$`)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	gatewayURL := os.Getenv("SOLVELA_GATEWAY_URL")
+	if gatewayURL == "" {
+		gatewayURL = "http://localhost:8402"
+	}
+	fmt.Printf("Smoke test against: %s\n\n", gatewayURL)
+
+	// No wallet, no signer: smoke probes the gateway's unsigned-request paths
+	// (models registry + 402 negotiation), not payment settlement.
+	client, err := solvela.NewClient(nil, nil, solvela.WithGatewayURL(gatewayURL))
+	if err != nil {
+		fmt.Printf("FAIL: client construction rejected gateway URL: %v\n", err)
+		return 1
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// 1. Models() reaches the gateway and parses the response.
+	models, err := client.Models(ctx)
+	if err != nil {
+		fmt.Printf("FAIL: Models() returned error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("  Models()           -> %d model(s) returned\n", len(models))
+	if len(models) == 0 {
+		fmt.Println("FAIL: expected at least one model from the gateway")
+		return 1
+	}
+	sample := models[0]
+	fmt.Printf("  sample model       -> id=%q ctx=%d in=%g/M out=%g/M\n",
+		sample.ID, sample.ContextWindow, sample.InputUsdcPerMillion, sample.OutputUsdcPerMillion)
+
+	// Guard against silent ModelInfo wire drift: every prior shape change
+	// surfaced as all-zero pricing / all-false capabilities. Assert at least
+	// one model in the registry exposes streaming and paid input pricing.
+	anyStreaming := false
+	anyPriced := false
+	for _, m := range models {
+		if m.SupportsStreaming {
+			anyStreaming = true
+		}
+		if m.InputUsdcPerMillion > 0 {
+			anyPriced = true
+		}
+	}
+	if !anyStreaming {
+		fmt.Println("FAIL: no model reports SupportsStreaming=true — capabilities parsing may be drifted")
+		return 1
+	}
+	if !anyPriced {
+		fmt.Println("FAIL: no model reports InputUsdcPerMillion > 0 — pricing parsing may be drifted")
+		return 1
+	}
+	if sample.DisplayName == "" || sample.Provider == "" {
+		fmt.Println("FAIL: sample model missing DisplayName or Provider")
+		return 1
+	}
+
+	// 2. Unsigned chat returns 402 with a parseable PaymentRequired body.
+	req := &solvela.ChatRequest{
+		Model: sample.ID,
+		Messages: []solvela.ChatMessage{
+			{Role: solvela.RoleUser, Content: "ping"},
+		},
+	}
+	_, err = client.Chat(ctx, req)
+	if err == nil {
+		fmt.Println("FAIL: Chat() returned a response with no signer configured (expected 402)")
+		return 1
+	}
+	var prErr *solvela.PaymentRequiredError
+	if !errors.As(err, &prErr) {
+		fmt.Printf("FAIL: Chat() raised %T (expected *PaymentRequiredError): %v\n", err, err)
+		return 1
+	}
+	pr := prErr.PaymentRequired
+	schemes := make([]string, 0, len(pr.Accepts))
+	for _, a := range pr.Accepts {
+		schemes = append(schemes, string(a.Scheme))
+	}
+	fmt.Printf("  Chat() unsigned    -> 402 OK (total=%s %s, schemes=%v)\n",
+		pr.CostBreakdown.Total, pr.CostBreakdown.Currency, schemes)
+	if len(pr.Accepts) == 0 {
+		fmt.Println("FAIL: 402 response had empty accepts array")
+		return 1
+	}
+
+	// Critical drift checks — a silent regression in any of these would
+	// route real funds wrong. All six are derivable from the unsigned 402
+	// we just received, so no extra gateway round-trip is required.
+	accept := pr.Accepts[0]
+	if accept.PayTo == "" || !solanaPubkeyRE.MatchString(accept.PayTo) {
+		fmt.Printf("FAIL: accepts[0].PayTo invalid: %q\n", truncate(accept.PayTo, 64))
+		return 1
+	}
+	if !amountRE.MatchString(accept.Amount) {
+		fmt.Printf("FAIL: accepts[0].Amount must be a positive decimal-integer string: %q\n",
+			truncate(accept.Amount, 32))
+		return 1
+	}
+	amt, err := strconv.ParseUint(accept.Amount, 10, 64)
+	if err != nil || amt == 0 {
+		fmt.Printf("FAIL: accepts[0].Amount must parse as a positive uint: %q\n",
+			truncate(accept.Amount, 32))
+		return 1
+	}
+	if accept.Network != solvela.SolanaNetwork {
+		fmt.Printf("FAIL: accepts[0].Network=%q (expected %q)\n",
+			accept.Network, solvela.SolanaNetwork)
+		return 1
+	}
+	if accept.Asset != solvela.USDCMint {
+		fmt.Printf("FAIL: accepts[0].Asset=%q (expected %q)\n",
+			accept.Asset, solvela.USDCMint)
+		return 1
+	}
+	if pr.CostBreakdown.Currency != "USDC" {
+		fmt.Printf("FAIL: cost_breakdown.currency=%q (expected %q)\n",
+			pr.CostBreakdown.Currency, "USDC")
+		return 1
+	}
+	if pr.X402Version != solvela.X402Version {
+		fmt.Printf("FAIL: x402_version=%d (SDK expects %d)\n",
+			pr.X402Version, solvela.X402Version)
+		return 1
+	}
+	fmt.Printf("  critical checks    -> PayTo OK Amount OK Network OK Asset OK Currency OK x402_version=%d OK\n",
+		solvela.X402Version)
+
+	fmt.Println("\nSmoke test PASSED")
+	return 0
+}
+
+// truncate returns s clipped to at most n runes, used only for printing
+// invalid wire fields without flooding stderr on garbage input.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/sdks/go/session.go
+++ b/sdks/go/session.go
@@ -1,0 +1,143 @@
+package solvela
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// SessionInfo holds the current state of a session.
+type SessionInfo struct {
+	Model     string
+	Escalated bool
+}
+
+type sessionEntry struct {
+	model        string
+	created      time.Time
+	recentHashes []uint64
+	escalated    bool
+}
+
+// SessionStore manages conversation sessions with model escalation.
+type SessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]*sessionEntry
+	ttl      time.Duration
+}
+
+// NewSessionStore creates a session store with the given TTL.
+func NewSessionStore(ttl time.Duration) *SessionStore {
+	return &SessionStore{
+		sessions: make(map[string]*sessionEntry),
+		ttl:      ttl,
+	}
+}
+
+// GetOrCreate returns session info for the given ID, creating a new session if needed.
+// Expired sessions are replaced with fresh ones.
+//
+// GetOrCreate is read-only with respect to escalation: it never advances the
+// three-strike counter. That is the exclusive job of
+// [SessionStore.RecordRequest], invoked once per successful request from the
+// client.
+func (s *SessionStore) GetOrCreate(sessionID, defaultModel string) SessionInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.sessions[sessionID]
+	if !ok || time.Since(entry.created) > s.ttl {
+		s.sessions[sessionID] = &sessionEntry{
+			model:        defaultModel,
+			created:      time.Now(),
+			recentHashes: make([]uint64, 0),
+			escalated:    false,
+		}
+		return SessionInfo{Model: defaultModel, Escalated: false}
+	}
+
+	return SessionInfo{Model: entry.model, Escalated: entry.escalated}
+}
+
+// RecordRequest records a request hash. If 3 or more identical hashes appear,
+// the session is escalated (three-strike rule).
+func (s *SessionStore) RecordRequest(sessionID string, requestHash uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.sessions[sessionID]
+	if !ok {
+		return
+	}
+
+	entry.recentHashes = append(entry.recentHashes, requestHash)
+
+	// Count occurrences of this hash
+	count := 0
+	for _, h := range entry.recentHashes {
+		if h == requestHash {
+			count++
+		}
+	}
+	if count >= 3 {
+		entry.escalated = true
+	}
+}
+
+// CleanupExpired removes all sessions that have exceeded their TTL.
+func (s *SessionStore) CleanupExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, entry := range s.sessions {
+		if time.Since(entry.created) > s.ttl {
+			delete(s.sessions, id)
+		}
+	}
+}
+
+// DeriveSessionID generates a deterministic session ID from the first message.
+//
+// Deprecated: this function keys only on the first message, which means
+// distinct conversations that happen to share the same opening message
+// collide on the same session. Prefer [DeriveSessionIDWithSalt], which mixes
+// in a per-client random salt and the message count to avoid that collision.
+func DeriveSessionID(messages []ChatMessage) string {
+	h := sha256.New()
+	if len(messages) > 0 {
+		h.Write([]byte(messages[0].Role))
+		h.Write([]byte(messages[0].Content))
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)[:16])
+}
+
+// DeriveSessionIDWithSalt generates a session ID that mixes a per-client salt,
+// the message count, and the first message. The salt prevents cross-client
+// session aliasing, and the message count separates conversations that begin
+// with the same prompt but evolve differently.
+func DeriveSessionIDWithSalt(salt []byte, messages []ChatMessage) string {
+	h := sha256.New()
+	h.Write(salt)
+	var countBuf [8]byte
+	binary.BigEndian.PutUint64(countBuf[:], uint64(len(messages)))
+	h.Write(countBuf[:])
+	if len(messages) > 0 {
+		h.Write([]byte(messages[0].Role))
+		h.Write([]byte(messages[0].Content))
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)[:16])
+}
+
+// newSessionSalt returns 8 bytes of cryptographically random salt for use as
+// a per-client session-ID salt. Returns an error only if the system entropy
+// source is unavailable.
+func newSessionSalt() ([]byte, error) {
+	salt := make([]byte, 8)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, err
+	}
+	return salt, nil
+}

--- a/sdks/go/session_test.go
+++ b/sdks/go/session_test.go
@@ -1,0 +1,194 @@
+package solvela
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewSession(t *testing.T) {
+	store := NewSessionStore(30 * time.Minute)
+	info := store.GetOrCreate("sess-1", "gpt-4")
+
+	if info.Model != "gpt-4" {
+		t.Errorf("model: got %q, want %q", info.Model, "gpt-4")
+	}
+	if info.Escalated {
+		t.Error("new session should not be escalated")
+	}
+}
+
+func TestExistingSession(t *testing.T) {
+	store := NewSessionStore(30 * time.Minute)
+
+	// Create session
+	store.GetOrCreate("sess-1", "gpt-4")
+
+	// Access again — should return same model
+	info := store.GetOrCreate("sess-1", "gpt-3.5-turbo")
+	if info.Model != "gpt-4" {
+		t.Errorf("model: got %q, want %q (should keep original model)", info.Model, "gpt-4")
+	}
+}
+
+func TestExpiredSession(t *testing.T) {
+	store := NewSessionStore(50 * time.Millisecond)
+
+	store.GetOrCreate("sess-1", "gpt-4")
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Expired session should be replaced
+	info := store.GetOrCreate("sess-1", "gpt-3.5-turbo")
+	if info.Model != "gpt-3.5-turbo" {
+		t.Errorf("model: got %q, want %q (expired session should use new default)", info.Model, "gpt-3.5-turbo")
+	}
+}
+
+func TestThreeStrikeEscalation(t *testing.T) {
+	store := NewSessionStore(30 * time.Minute)
+	store.GetOrCreate("sess-1", "gpt-4")
+
+	hash := uint64(12345)
+
+	// Record same hash 3 times
+	store.RecordRequest("sess-1", hash)
+	info := store.GetOrCreate("sess-1", "gpt-4")
+	if info.Escalated {
+		t.Error("should not escalate after 1 strike")
+	}
+
+	store.RecordRequest("sess-1", hash)
+	info = store.GetOrCreate("sess-1", "gpt-4")
+	if info.Escalated {
+		t.Error("should not escalate after 2 strikes")
+	}
+
+	store.RecordRequest("sess-1", hash)
+	info = store.GetOrCreate("sess-1", "gpt-4")
+	if !info.Escalated {
+		t.Error("should escalate after 3 strikes")
+	}
+}
+
+func TestThreeStrikeDifferentHashes(t *testing.T) {
+	store := NewSessionStore(30 * time.Minute)
+	store.GetOrCreate("sess-1", "gpt-4")
+
+	// Different hashes should not trigger escalation
+	store.RecordRequest("sess-1", 1)
+	store.RecordRequest("sess-1", 2)
+	store.RecordRequest("sess-1", 3)
+
+	info := store.GetOrCreate("sess-1", "gpt-4")
+	if info.Escalated {
+		t.Error("different hashes should not trigger escalation")
+	}
+}
+
+func TestCleanupExpired(t *testing.T) {
+	store := NewSessionStore(50 * time.Millisecond)
+
+	store.GetOrCreate("sess-1", "gpt-4")
+	store.GetOrCreate("sess-2", "gpt-4")
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Create a fresh session that should survive cleanup
+	store.GetOrCreate("sess-3", "gpt-4")
+
+	store.CleanupExpired()
+
+	// sess-1 and sess-2 should be gone
+	info1 := store.GetOrCreate("sess-1", "new-model")
+	if info1.Model != "new-model" {
+		t.Error("sess-1 should have been cleaned up and recreated")
+	}
+
+	info2 := store.GetOrCreate("sess-2", "new-model")
+	if info2.Model != "new-model" {
+		t.Error("sess-2 should have been cleaned up and recreated")
+	}
+
+	// sess-3 should still exist
+	info3 := store.GetOrCreate("sess-3", "different-model")
+	if info3.Model != "gpt-4" {
+		t.Error("sess-3 should still exist with original model")
+	}
+}
+
+func TestDeriveSessionID(t *testing.T) {
+	msgs := []ChatMessage{
+		{Role: RoleSystem, Content: "You are a helpful assistant."},
+		{Role: RoleUser, Content: "Hello"},
+	}
+
+	id1 := DeriveSessionID(msgs)
+	id2 := DeriveSessionID(msgs)
+	if id1 != id2 {
+		t.Errorf("same messages should produce same session ID: %q != %q", id1, id2)
+	}
+
+	if len(id1) != 32 {
+		t.Errorf("session ID should be 32 hex chars: got %d", len(id1))
+	}
+
+	// Different first message should produce different ID
+	msgs2 := []ChatMessage{
+		{Role: RoleSystem, Content: "You are a different assistant."},
+		{Role: RoleUser, Content: "Hello"},
+	}
+	id3 := DeriveSessionID(msgs2)
+	if id1 == id3 {
+		t.Error("different first messages should produce different session IDs")
+	}
+}
+
+func TestDeriveSessionIDEmpty(t *testing.T) {
+	id := DeriveSessionID([]ChatMessage{})
+	if len(id) != 32 {
+		t.Errorf("empty messages should still produce valid session ID: got len %d", len(id))
+	}
+}
+
+func TestRecordRequestNonexistentSession(t *testing.T) {
+	store := NewSessionStore(30 * time.Minute)
+	// Should not panic
+	store.RecordRequest("nonexistent", 12345)
+}
+
+// TestGetOrCreateDoesNotIncrementRequestCount asserts that calling
+// GetOrCreate multiple times does not, by itself, advance the three-strike
+// escalation counter. Counting is RecordRequest's job; previously
+// GetOrCreate double-counted and could trigger escalation prematurely.
+func TestGetOrCreateDoesNotIncrementRequestCount(t *testing.T) {
+	store := NewSessionStore(30 * time.Minute)
+	store.GetOrCreate("sess-1", "gpt-4")
+
+	// Five GetOrCreate calls with the same id should not escalate, because
+	// nothing has been RecordRequest'd yet.
+	for i := 0; i < 5; i++ {
+		info := store.GetOrCreate("sess-1", "gpt-4")
+		if info.Escalated {
+			t.Fatalf("GetOrCreate alone must not escalate (iteration %d)", i)
+		}
+	}
+
+	// Two RecordRequests with the same hash plus more GetOrCreates still
+	// must not escalate — only three RecordRequests do.
+	store.RecordRequest("sess-1", 7)
+	store.RecordRequest("sess-1", 7)
+	for i := 0; i < 3; i++ {
+		info := store.GetOrCreate("sess-1", "gpt-4")
+		if info.Escalated {
+			t.Fatalf("escalation triggered by GetOrCreate after only 2 RecordRequests (iter %d)", i)
+		}
+	}
+
+	// Third RecordRequest crosses the threshold.
+	store.RecordRequest("sess-1", 7)
+	info := store.GetOrCreate("sess-1", "gpt-4")
+	if !info.Escalated {
+		t.Fatal("expected escalation after 3 RecordRequests with same hash")
+	}
+}
+

--- a/sdks/go/signer.go
+++ b/sdks/go/signer.go
@@ -1,0 +1,57 @@
+package solvela
+
+import "context"
+
+// Signer is a pluggable interface for signing payment transactions.
+type Signer interface {
+	SignPayment(ctx context.Context, amountAtomic uint64, recipient string, resource Resource, accepted PaymentAccept) (*PaymentPayload, error)
+}
+
+// Compile-time assertion that UnimplementedSigner satisfies Signer. If the
+// interface drifts (e.g., a method is renamed), the build fails here rather
+// than at first runtime call.
+var _ Signer = (*UnimplementedSigner)(nil)
+
+// UnimplementedSigner is a placeholder Signer for callers who do not yet
+// have a real Solana USDC-SPL signing implementation. Its SignPayment
+// method always returns an error. Construct your own Signer implementation
+// (or use a future built-in signer) before sending paid requests.
+type UnimplementedSigner struct {
+	wallet *Wallet
+	rpcURL string
+}
+
+// NewUnimplementedSigner creates a stub [Signer] from a wallet and optional
+// Solana RPC URL. If rpcURL is empty, defaults to mainnet-beta. The returned
+// signer's SignPayment always returns an error; see [UnimplementedSigner].
+func NewUnimplementedSigner(wallet *Wallet, rpcURL string) *UnimplementedSigner {
+	if rpcURL == "" {
+		rpcURL = "https://api.mainnet-beta.solana.com"
+	}
+	return &UnimplementedSigner{wallet: wallet, rpcURL: rpcURL}
+}
+
+// SignPayment is not yet implemented in solvela-go.
+//
+// Use the Python SDK (solvela-python) or TypeScript SDK (solvela-ts) for
+// production payment signing, or implement a custom [Signer] using the
+// standard library's crypto/ed25519 package and a Solana JSON-RPC client
+// of your choice.
+func (s *UnimplementedSigner) SignPayment(_ context.Context, _ uint64, _ string, _ Resource, _ PaymentAccept) (*PaymentPayload, error) {
+	return nil, &SignerError{Message: "UnimplementedSigner.SignPayment is not yet implemented in solvela-go; use the Python or TS SDK, or implement a custom Signer"}
+}
+
+// KeypairSigner is a deprecated alias for [UnimplementedSigner].
+//
+// Deprecated: renamed to UnimplementedSigner because the original name
+// implied a working keypair-based signer; the type is in fact a stub. Use
+// [UnimplementedSigner] directly. This alias will be removed in a future
+// release.
+type KeypairSigner = UnimplementedSigner
+
+// NewKeypairSigner is a deprecated alias for [NewUnimplementedSigner].
+//
+// Deprecated: see [KeypairSigner].
+func NewKeypairSigner(wallet *Wallet, rpcURL string) *UnimplementedSigner {
+	return NewUnimplementedSigner(wallet, rpcURL)
+}

--- a/sdks/go/signer_test.go
+++ b/sdks/go/signer_test.go
@@ -1,0 +1,54 @@
+package solvela
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewKeypairSignerDefaultRPCURL(t *testing.T) {
+	wallet, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+	signer := NewKeypairSigner(wallet, "")
+	if signer.rpcURL != "https://api.mainnet-beta.solana.com" {
+		t.Errorf("rpcURL: got %q, want default mainnet", signer.rpcURL)
+	}
+}
+
+func TestNewKeypairSignerCustomRPCURL(t *testing.T) {
+	wallet, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+	signer := NewKeypairSigner(wallet, "https://api.devnet.solana.com")
+	if signer.rpcURL != "https://api.devnet.solana.com" {
+		t.Errorf("rpcURL: got %q, want devnet", signer.rpcURL)
+	}
+}
+
+func TestKeypairSignerReturnsStubError(t *testing.T) {
+	wallet, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+	signer := NewKeypairSigner(wallet, "")
+
+	_, err = signer.SignPayment(
+		context.Background(),
+		1000,
+		"recipient",
+		Resource{URL: "/v1/chat/completions", Method: "POST"},
+		PaymentAccept{Scheme: "exact", Network: SolanaNetwork, Amount: "1000"},
+	)
+	if err == nil {
+		t.Fatal("expected error from stub signer")
+	}
+	signerErr, ok := err.(*SignerError)
+	if !ok {
+		t.Fatalf("expected SignerError, got %T", err)
+	}
+	if signerErr.Message == "" {
+		t.Error("expected non-empty error message")
+	}
+}

--- a/sdks/go/transport.go
+++ b/sdks/go/transport.go
@@ -1,0 +1,256 @@
+package solvela
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// maxResponseBytes caps the response body size to 10 MB to prevent memory
+// exhaustion from a malicious or misbehaving gateway. Used on success paths
+// (chat completions, model lists) where a legitimate body can be large.
+const maxResponseBytes = 10 << 20 // 10 MB
+
+// maxErrorBodyBytes caps the response body size for pure error paths where
+// the body is destined for a GatewayError.Message string. 4 KB is plenty for
+// any human-readable diagnostic (rate-limit text, auth failure, HTML title)
+// and prevents a misbehaving gateway from forcing a multi-MB error string
+// into memory and logs. Applied where we know the body cannot be a
+// legitimate large success payload.
+const maxErrorBodyBytes = 4 << 10 // 4 KB
+
+// Transport handles HTTP communication with the Solvela gateway.
+type Transport struct {
+	baseURL string
+	timeout time.Duration
+	client  *http.Client
+}
+
+// NewTransport creates a new Transport with the given base URL and timeout.
+func NewTransport(baseURL string, timeout time.Duration) *Transport {
+	return &Transport{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		timeout: timeout,
+		client: &http.Client{
+			Timeout: timeout,
+			// Refuse redirects entirely: following a redirect would forward the
+			// Payment-Signature header to an unintended destination.
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+// SendChatResult is either a ChatResponse or PaymentRequired.
+type SendChatResult struct {
+	Response        *ChatResponse
+	PaymentRequired *PaymentRequired
+}
+
+// SendChat sends a non-streaming chat request.
+func (t *Transport) SendChat(ctx context.Context, request *ChatRequest, paymentSignature string, extraHeaders map[string]string) (*SendChatResult, error) {
+	request.Stream = false
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := t.baseURL + "/v1/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if paymentSignature != "" {
+		req.Header.Set("Payment-Signature", paymentSignature)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &TimeoutError{TimeoutSecs: t.timeout.Seconds()}
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		var chatResp ChatResponse
+		if err := json.Unmarshal(data, &chatResp); err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		return &SendChatResult{Response: &chatResp}, nil
+	case 402:
+		var pr PaymentRequired
+		if err := json.Unmarshal(data, &pr); err != nil {
+			return nil, fmt.Errorf("parse 402 error: %w", err)
+		}
+		return &SendChatResult{PaymentRequired: &pr}, nil
+	default:
+		// Best-effort JSON parse: prefer .error from a structured body, fall
+		// back to the raw response text. A non-JSON body is expected here
+		// (e.g., HTML error pages from a misconfigured proxy), so the
+		// unmarshal error is intentionally discarded.
+		var errData map[string]interface{}
+		_ = json.Unmarshal(data, &errData)
+		msg := string(data)
+		if e, ok := errData["error"]; ok {
+			msg = fmt.Sprintf("%v", e)
+		}
+		return nil, &GatewayError{Status: resp.StatusCode, Message: msg}
+	}
+}
+
+// ChatChunkOrError holds either a streaming chunk or an error.
+type ChatChunkOrError struct {
+	Chunk *ChatChunk
+	Err   error
+}
+
+// SendChatStream sends a streaming chat request and returns a channel of chunks.
+func (t *Transport) SendChatStream(ctx context.Context, request *ChatRequest, paymentSignature string, extraHeaders map[string]string) (<-chan ChatChunkOrError, error) {
+	request.Stream = true
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := t.baseURL + "/v1/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if paymentSignature != "" {
+		req.Header.Set("Payment-Signature", paymentSignature)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == 402 {
+		defer resp.Body.Close()
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+		if readErr != nil {
+			return nil, &GatewayError{Status: 402, Message: fmt.Sprintf("read 402 body: %v", readErr)}
+		}
+		var pr PaymentRequired
+		if err := json.Unmarshal(data, &pr); err != nil {
+			return nil, &GatewayError{Status: 402, Message: fmt.Sprintf("parse 402 body: %v", err)}
+		}
+		return nil, &PaymentRequiredError{PaymentRequired: pr}
+	}
+	if resp.StatusCode != 200 {
+		defer resp.Body.Close()
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		if readErr != nil {
+			return nil, &GatewayError{Status: resp.StatusCode, Message: fmt.Sprintf("read error body: %v", readErr)}
+		}
+		return nil, &GatewayError{Status: resp.StatusCode, Message: string(data)}
+	}
+
+	ch := make(chan ChatChunkOrError)
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+		scanner := bufio.NewScanner(resp.Body)
+		// Default scanner token buffer is 64 KB, which can truncate large SSE
+		// chunks containing long completions. Allow up to 1 MB per line.
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		// send returns false if the context was cancelled while we waited to
+		// hand off; the caller must then return so the deferred body close
+		// runs and the goroutine exits.
+		send := func(item ChatChunkOrError) bool {
+			select {
+			case ch <- item:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+		for scanner.Scan() {
+			if ctx.Err() != nil {
+				return
+			}
+			line := scanner.Text()
+			if strings.HasPrefix(line, "data: ") {
+				dataStr := strings.TrimPrefix(line, "data: ")
+				dataStr = strings.TrimSpace(dataStr)
+				if dataStr == "[DONE]" {
+					return
+				}
+				var chunk ChatChunk
+				if err := json.Unmarshal([]byte(dataStr), &chunk); err != nil {
+					send(ChatChunkOrError{Err: err})
+					return
+				}
+				if !send(ChatChunkOrError{Chunk: &chunk}) {
+					return
+				}
+			}
+		}
+		// Surface scanner errors (e.g., connection reset, oversize line) so
+		// truncated streams are not mistaken for clean closes. Skip the
+		// error-send if the context is already cancelled (consumer left).
+		if err := scanner.Err(); err != nil && ctx.Err() == nil {
+			send(ChatChunkOrError{Err: fmt.Errorf("stream read error: %w", err)})
+		}
+	}()
+	return ch, nil
+}
+
+// FetchModels retrieves available models from the gateway.
+func (t *Transport) FetchModels(ctx context.Context) ([]ModelInfo, error) {
+	url := t.baseURL + "/v1/models"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		// Surface the response body so callers can diagnose an upstream
+		// failure (rate-limit message, auth error, etc.) instead of seeing
+		// a bare status code. Mirror SendChatStream's non-200 branch: if the
+		// body read itself fails (connection reset, timeout mid-drain), report
+		// that explicitly rather than producing an empty Message.
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		if readErr != nil {
+			return nil, &GatewayError{Status: resp.StatusCode, Message: fmt.Sprintf("read error body: %v", readErr)}
+		}
+		return nil, &GatewayError{Status: resp.StatusCode, Message: string(data)}
+	}
+	var result struct {
+		Data []ModelInfo `json:"data"`
+	}
+	// Cap the response body to maxResponseBytes to prevent a malicious or
+	// misbehaving gateway from forcing the client to allocate unbounded memory.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&result); err != nil {
+		return nil, fmt.Errorf("parse models: %w", err)
+	}
+	return result.Data, nil
+}

--- a/sdks/go/transport_test.go
+++ b/sdks/go/transport_test.go
@@ -1,0 +1,434 @@
+package solvela
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTransportSendChat200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Error("missing Content-Type header")
+		}
+
+		resp := ChatResponse{
+			ID:    "chatcmpl-test",
+			Model: "gpt-4",
+			Choices: []ChatChoice{
+				{Index: 0, Message: ChatMessage{Role: RoleAssistant, Content: "Hello!"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+
+	result, err := transport.SendChat(context.Background(), req, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Response == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if result.Response.ID != "chatcmpl-test" {
+		t.Errorf("id: got %q, want %q", result.Response.ID, "chatcmpl-test")
+	}
+	if result.PaymentRequired != nil {
+		t.Error("expected no payment required")
+	}
+}
+
+func TestTransportSendChat402(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version: 2,
+			Error:       "payment required",
+			CostBreakdown: CostBreakdown{
+				Total:    "1000",
+				Currency: "USDC",
+			},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Amount: "1000", PayTo: "recipient123"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+
+	result, err := transport.SendChat(context.Background(), req, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PaymentRequired == nil {
+		t.Fatal("expected payment required")
+	}
+	if result.PaymentRequired.CostBreakdown.Total != "1000" {
+		t.Errorf("total: got %q, want %q", result.PaymentRequired.CostBreakdown.Total, "1000")
+	}
+}
+
+func TestTransportSendChat500(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+
+	_, err := transport.SendChat(context.Background(), req, "", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	gatewayErr, ok := err.(*GatewayError)
+	if !ok {
+		t.Fatalf("expected GatewayError, got %T", err)
+	}
+	if gatewayErr.Status != 500 {
+		t.Errorf("status: got %d, want 500", gatewayErr.Status)
+	}
+}
+
+func TestTransportSendChatPaymentHeader(t *testing.T) {
+	var receivedSig string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedSig = r.Header.Get("Payment-Signature")
+		resp := ChatResponse{ID: "paid"}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+
+	_, err := transport.SendChat(context.Background(), req, "test-sig-123", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedSig != "test-sig-123" {
+		t.Errorf("sig: got %q, want %q", receivedSig, "test-sig-123")
+	}
+}
+
+func TestTransportSendChatExtraHeaders(t *testing.T) {
+	var receivedCustom string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCustom = r.Header.Get("X-Custom")
+		json.NewEncoder(w).Encode(ChatResponse{ID: "test"})
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+	headers := map[string]string{"X-Custom": "custom-value"}
+
+	_, err := transport.SendChat(context.Background(), req, "", headers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedCustom != "custom-value" {
+		t.Errorf("custom header: got %q, want %q", receivedCustom, "custom-value")
+	}
+}
+
+func TestTransportSendChatStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+
+		content := "Hello"
+		chunk := ChatChunk{
+			ID:    "chunk-1",
+			Model: "gpt-4",
+			Choices: []ChatChunkChoice{
+				{Index: 0, Delta: ChatDelta{Content: &content}},
+			},
+		}
+		data, _ := json.Marshal(chunk)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+
+	ch, err := transport.SendChatStream(context.Background(), req, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var chunks []ChatChunk
+	for item := range ch {
+		if item.Err != nil {
+			t.Fatalf("chunk error: %v", item.Err)
+		}
+		chunks = append(chunks, *item.Chunk)
+	}
+
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(chunks))
+	}
+	if chunks[0].ID != "chunk-1" {
+		t.Errorf("chunk id: got %q, want %q", chunks[0].ID, "chunk-1")
+	}
+}
+
+func TestTransportSendChatStream402(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(PaymentRequired{X402Version: 2})
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+
+	_, err := transport.SendChatStream(context.Background(), req, "", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	_, ok := err.(*PaymentRequiredError)
+	if !ok {
+		t.Fatalf("expected PaymentRequiredError, got %T: %v", err, err)
+	}
+}
+
+func TestTransportFetchModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		result := struct {
+			Data []ModelInfo `json:"data"`
+		}{
+			Data: []ModelInfo{
+				{ID: "gpt-4", Provider: "openai", DisplayName: "GPT-4"},
+				{ID: "claude-3", Provider: "anthropic", DisplayName: "Claude 3"},
+			},
+		}
+		json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	models, err := transport.FetchModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("got %d models, want 2", len(models))
+	}
+	if models[0].ID != "gpt-4" {
+		t.Errorf("model[0].ID: got %q, want %q", models[0].ID, "gpt-4")
+	}
+}
+
+func TestTransportFetchModels500(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	_, err := transport.FetchModels(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	gatewayErr, ok := err.(*GatewayError)
+	if !ok {
+		t.Fatalf("expected GatewayError, got %T", err)
+	}
+	if gatewayErr.Status != 500 {
+		t.Errorf("status: got %d, want 500", gatewayErr.Status)
+	}
+	if !strings.Contains(gatewayErr.Message, "internal server error") {
+		t.Errorf("message: got %q, want substring %q", gatewayErr.Message, "internal server error")
+	}
+}
+
+// TestTransportFetchModels500BodyCapped sends an error body larger than
+// maxErrorBodyBytes and verifies the LimitReader ceiling holds, so a
+// misbehaving gateway cannot force an unbounded GatewayError.Message
+// allocation. Locks the cap as a regression-prevention invariant.
+func TestTransportFetchModels500BodyCapped(t *testing.T) {
+	oversized := bytes.Repeat([]byte("A"), maxErrorBodyBytes+1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write(oversized)
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 30*time.Second)
+	_, err := transport.FetchModels(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	gatewayErr, ok := err.(*GatewayError)
+	if !ok {
+		t.Fatalf("expected GatewayError, got %T", err)
+	}
+	if len(gatewayErr.Message) > maxErrorBodyBytes {
+		t.Errorf("message length: got %d, want <= %d (LimitReader cap)", len(gatewayErr.Message), maxErrorBodyBytes)
+	}
+}
+
+// TestSendChatStreamSurfacesScannerErr drives a server that hijacks the
+// connection, writes a partial SSE line (no terminating newline) along with
+// a chunked-transfer header, and then closes the underlying TCP connection.
+// The bufio scanner inside SendChatStream must surface the resulting read
+// error via the channel as a ChatChunkOrError{Err: ...} rather than letting
+// the stream look like a clean close.
+func TestSendChatStreamSurfacesScannerErr(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hijack the connection so we can write malformed/truncated bytes
+		// directly. After writing a partial chunk the underlying TCP
+		// connection is closed, which triggers an unexpected EOF inside the
+		// scanner once it has consumed the partial chunk.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatalf("ResponseWriter does not support hijack")
+		}
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		// Send the response head with chunked encoding; we will then write a
+		// chunk that *claims* more bytes than we actually deliver before
+		// closing. This guarantees the client-side bufio.Scanner observes an
+		// unexpected EOF rather than a clean close.
+		fmt.Fprint(bufrw, "HTTP/1.1 200 OK\r\n")
+		fmt.Fprint(bufrw, "Content-Type: text/event-stream\r\n")
+		fmt.Fprint(bufrw, "Transfer-Encoding: chunked\r\n")
+		fmt.Fprint(bufrw, "\r\n")
+		// First chunk: a complete, valid JSON SSE event terminated with
+		// "\n\n". The scanner consumes one line, the JSON parses, the
+		// chunk lands on the channel, and the loop continues. The second
+		// chunk header promises 100 bytes but we only write 13 before
+		// slamming the connection shut. The Go HTTP client surfaces this
+		// truncation as io.ErrUnexpectedEOF, which bufio.Scanner reports
+		// via scanner.Err() (since it is non-EOF). This is the exact
+		// surface the security-fix agent added handling for.
+		role := "assistant"
+		content := "first"
+		first := fmt.Sprintf(`{"id":"c1","model":"gpt-4","choices":[{"index":0,"delta":{"role":%q,"content":%q}}]}`, role, content)
+		ssePayload := fmt.Sprintf("data: %s\n\n", first)
+		fmt.Fprintf(bufrw, "%x\r\n", len(ssePayload))
+		fmt.Fprint(bufrw, ssePayload)
+		fmt.Fprint(bufrw, "\r\n")
+		// Promise a second 100-byte chunk but only deliver 7 bytes, then
+		// close. The Go chunked-transfer reader surfaces this truncation
+		// as io.ErrUnexpectedEOF on the next read after the buffered bytes
+		// are consumed. The bytes themselves do NOT begin with "data: " so
+		// the scanner skips them; the next Scan call observes the
+		// truncation as a non-EOF error and surfaces it via scanner.Err().
+		fmt.Fprint(bufrw, "64\r\n")  // 0x64 = 100 in hex (promise 100 bytes)
+		fmt.Fprint(bufrw, "garbage") // 7 bytes, no "data: " prefix, no terminator
+		bufrw.Flush()
+		conn.Close()
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+
+	ch, err := transport.SendChatStream(context.Background(), req, "", nil)
+	if err != nil {
+		t.Fatalf("SendChatStream: %v", err)
+	}
+
+	var sawErr bool
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case item, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			if item.Err != nil {
+				sawErr = true
+				if !strings.Contains(item.Err.Error(), "stream read error") {
+					t.Errorf("expected wrapped scanner error, got %v", item.Err)
+				}
+			}
+		case <-timeout:
+			t.Fatal("stream never closed")
+		}
+	}
+done:
+	if !sawErr {
+		t.Error("expected ChatChunkOrError with non-nil Err for truncated stream; got clean close")
+	}
+}
+
+// TestSendChatStreamRejectsMalformed402Body verifies that a 402 with a
+// non-JSON body returns *GatewayError mentioning "parse 402 body" rather
+// than silently producing a zero-value PaymentRequiredError that the SDK
+// could not act on. This exercises the body-parse wrapper added by the
+// security fix agent.
+func TestSendChatStreamRejectsMalformed402Body(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(402)
+		_, _ = w.Write([]byte("not-json-at-all<<<"))
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL, 10*time.Second)
+	req := &ChatRequest{Model: "gpt-4", Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}}}
+
+	_, err := transport.SendChatStream(context.Background(), req, "", nil)
+	if err == nil {
+		t.Fatal("expected error for malformed 402 body, got nil")
+	}
+	// Must surface as GatewayError with the parse-error wrapper, not as a
+	// PaymentRequiredError carrying a zero-value PaymentRequired struct.
+	var gwErr *GatewayError
+	if !errors.As(err, &gwErr) {
+		t.Fatalf("expected *GatewayError, got %T: %v", err, err)
+	}
+	if gwErr.Status != 402 {
+		t.Errorf("status: got %d, want 402", gwErr.Status)
+	}
+	if !strings.Contains(gwErr.Message, "parse 402 body") {
+		t.Errorf("expected message to contain 'parse 402 body', got %q", gwErr.Message)
+	}
+	if _, isPRE := err.(*PaymentRequiredError); isPRE {
+		t.Error("malformed 402 body must NOT be returned as PaymentRequiredError")
+	}
+}
+
+func TestTransportBaseURLTrailingSlash(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ChatResponse{ID: "test"})
+	}))
+	defer server.Close()
+
+	transport := NewTransport(server.URL+"/", 10*time.Second)
+	if transport.baseURL != server.URL {
+		t.Errorf("trailing slash not trimmed: got %q", transport.baseURL)
+	}
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -1,0 +1,324 @@
+package solvela
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Role represents a chat message role.
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+	RoleDeveloper Role = "developer"
+)
+
+// ChatMessage represents a single message in a chat conversation.
+type ChatMessage struct {
+	Role       Role       `json:"role"`
+	Content    string     `json:"content"`
+	Name       *string    `json:"name,omitempty"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID *string    `json:"tool_call_id,omitempty"`
+}
+
+// ChatRequest represents a chat completion request.
+type ChatRequest struct {
+	Model       string           `json:"model"`
+	Messages    []ChatMessage    `json:"messages"`
+	MaxTokens   *int             `json:"max_tokens,omitempty"`
+	Temperature *float64         `json:"temperature,omitempty"`
+	TopP        *float64         `json:"top_p,omitempty"`
+	Stream      bool             `json:"stream"`
+	Tools       []ToolDefinition `json:"tools,omitempty"`
+	ToolChoice  interface{}      `json:"tool_choice,omitempty"`
+}
+
+// ChatResponse represents a chat completion response.
+type ChatResponse struct {
+	ID      string       `json:"id"`
+	Object  string       `json:"object"`
+	Created int64        `json:"created"`
+	Model   string       `json:"model"`
+	Choices []ChatChoice `json:"choices"`
+	Usage   *Usage       `json:"usage,omitempty"`
+}
+
+// ChatChoice represents a single completion choice.
+type ChatChoice struct {
+	Index        int         `json:"index"`
+	Message      ChatMessage `json:"message"`
+	FinishReason *string     `json:"finish_reason,omitempty"`
+}
+
+// Usage represents token usage statistics.
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// ChatChunk represents a streaming chat completion chunk.
+type ChatChunk struct {
+	ID      string            `json:"id"`
+	Object  string            `json:"object"`
+	Created int64             `json:"created"`
+	Model   string            `json:"model"`
+	Choices []ChatChunkChoice `json:"choices"`
+}
+
+// ChatChunkChoice represents a single streaming choice.
+type ChatChunkChoice struct {
+	Index        int       `json:"index"`
+	Delta        ChatDelta `json:"delta"`
+	FinishReason *string   `json:"finish_reason,omitempty"`
+}
+
+// ChatDelta represents incremental content in a streaming chunk.
+type ChatDelta struct {
+	Role      *Role           `json:"role,omitempty"`
+	Content   *string         `json:"content,omitempty"`
+	ToolCalls []ToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+// ToolCall represents a tool call in a message.
+type ToolCall struct {
+	ID       string       `json:"id"`
+	Type     string       `json:"type"`
+	Function FunctionCall `json:"function"`
+}
+
+// FunctionCall represents the function details in a tool call.
+type FunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// ToolCallDelta represents an incremental tool call in streaming.
+type ToolCallDelta struct {
+	Index    int                `json:"index"`
+	ID       *string            `json:"id,omitempty"`
+	Type     *string            `json:"type,omitempty"`
+	Function *FunctionCallDelta `json:"function,omitempty"`
+}
+
+// FunctionCallDelta represents incremental function call data.
+type FunctionCallDelta struct {
+	Name      *string `json:"name,omitempty"`
+	Arguments *string `json:"arguments,omitempty"`
+}
+
+// ToolDefinition represents a tool that can be used by the model.
+type ToolDefinition struct {
+	Type     string                  `json:"type"`
+	Function FunctionDefinitionInner `json:"function"`
+}
+
+// FunctionDefinitionInner represents the function details in a tool definition.
+type FunctionDefinitionInner struct {
+	Name        string      `json:"name"`
+	Description *string     `json:"description,omitempty"`
+	Parameters  interface{} `json:"parameters,omitempty"`
+}
+
+// Resource represents the API resource being accessed.
+type Resource struct {
+	URL    string `json:"url"`
+	Method string `json:"method"`
+}
+
+// Scheme is the x402 payment scheme. Mirrors Python's
+// `Scheme = Literal["exact", "escrow"]` + `_KNOWN_SCHEMES` guard: a gateway
+// response carrying an unknown scheme is rejected at parse time rather than
+// silently mis-branching at scheme-matching time.
+type Scheme string
+
+const (
+	SchemeExact  Scheme = "exact"
+	SchemeEscrow Scheme = "escrow"
+)
+
+// parseScheme validates a wire scheme string and returns the typed value.
+// An unknown scheme is a wire-format failure, surfaced as a typed ClientError
+// so callers can distinguish "gateway refused" from "gateway speaks a dialect
+// we don't understand."
+func parseScheme(raw string) (Scheme, error) {
+	switch Scheme(raw) {
+	case SchemeExact, SchemeEscrow:
+		return Scheme(raw), nil
+	}
+	return "", &ClientError{Message: fmt.Sprintf("unknown payment scheme: %q", raw)}
+}
+
+// PaymentAccept describes an accepted payment scheme.
+type PaymentAccept struct {
+	Scheme            Scheme  `json:"scheme"`
+	Network           string  `json:"network"`
+	Amount            string  `json:"amount"`
+	Asset             string  `json:"asset"`
+	PayTo             string  `json:"pay_to"`
+	MaxTimeoutSeconds int     `json:"max_timeout_seconds"`
+	EscrowProgramID   *string `json:"escrow_program_id,omitempty"`
+}
+
+// UnmarshalJSON decodes a PaymentAccept and rejects unknown schemes at the
+// wire boundary. See parseScheme for rationale.
+func (p *PaymentAccept) UnmarshalJSON(data []byte) error {
+	type alias PaymentAccept
+	aux := &struct {
+		Scheme string `json:"scheme"`
+		*alias
+	}{alias: (*alias)(p)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	s, err := parseScheme(aux.Scheme)
+	if err != nil {
+		return err
+	}
+	p.Scheme = s
+	return nil
+}
+
+// PaymentRequired represents a 402 Payment Required response.
+type PaymentRequired struct {
+	X402Version   int             `json:"x402_version"`
+	Resource      Resource        `json:"resource"`
+	Accepts       []PaymentAccept `json:"accepts"`
+	CostBreakdown CostBreakdown   `json:"cost_breakdown"`
+	Error         string          `json:"error"`
+}
+
+// CostBreakdown provides the cost details for a request.
+type CostBreakdown struct {
+	ProviderCost string `json:"provider_cost"`
+	PlatformFee  string `json:"platform_fee"`
+	Total        string `json:"total"`
+	Currency     string `json:"currency"`
+	FeePercent   int    `json:"fee_percent"`
+}
+
+// SolanaPayload is the payload for exact Solana payments.
+type SolanaPayload struct {
+	Transaction string `json:"transaction"`
+}
+
+// EscrowPayload is the payload for escrow-based payments.
+type EscrowPayload struct {
+	DepositTx   string `json:"deposit_tx"`
+	ServiceID   string `json:"service_id"`
+	AgentPubkey string `json:"agent_pubkey"`
+}
+
+// PaymentPayload represents a payment attached to a request.
+type PaymentPayload struct {
+	X402Version int           `json:"x402_version"`
+	Resource    Resource      `json:"resource"`
+	Accepted    PaymentAccept `json:"accepted"`
+	Payload     interface{}   `json:"payload"`
+}
+
+// ModelInfo describes a model available on the gateway's GET /v1/models
+// registry.
+//
+// The wire format nests capabilities under `capabilities: {...}` and pricing
+// under `pricing: {...}`; the struct flattens those so internal code stays
+// terse. Pricing values are USDC per million tokens as floats (e.g. 0.28 for
+// DeepSeek's input rate), NOT atomic units — convert at the boundary if you
+// need atomic units.
+//
+// Mirrors Python's ModelInfo dataclass (the cross-SDK canonical) and TS's
+// post-rewrite layout. Pre-fix flat fields silently parsed every value as
+// zero/false; see commit history for the regression.
+type ModelInfo struct {
+	ID                   string
+	Provider             string
+	DisplayName          string
+	ContextWindow        int
+	SupportsStreaming    bool
+	SupportsTools        bool
+	SupportsVision       bool
+	Reasoning            bool
+	InputUsdcPerMillion  float64
+	OutputUsdcPerMillion float64
+	Currency             string
+	FeePercent           int
+}
+
+type modelInfoWire struct {
+	ID            string `json:"id"`
+	Object        string `json:"object,omitempty"`
+	Provider      string `json:"provider"`
+	DisplayName   string `json:"display_name"`
+	ContextWindow int    `json:"context_window"`
+	Capabilities  struct {
+		Streaming bool `json:"streaming"`
+		Tools     bool `json:"tools"`
+		Vision    bool `json:"vision"`
+		Reasoning bool `json:"reasoning"`
+	} `json:"capabilities"`
+	Pricing struct {
+		InputPerMillion  float64 `json:"input_per_million"`
+		OutputPerMillion float64 `json:"output_per_million"`
+		Currency         *string `json:"currency,omitempty"`
+		FeePercent       *int    `json:"fee_percent,omitempty"`
+	} `json:"pricing"`
+}
+
+// MarshalJSON emits the nested gateway wire shape.
+func (m ModelInfo) MarshalJSON() ([]byte, error) {
+	w := modelInfoWire{
+		ID:            m.ID,
+		Object:        "model",
+		Provider:      m.Provider,
+		DisplayName:   m.DisplayName,
+		ContextWindow: m.ContextWindow,
+	}
+	w.Capabilities.Streaming = m.SupportsStreaming
+	w.Capabilities.Tools = m.SupportsTools
+	w.Capabilities.Vision = m.SupportsVision
+	w.Capabilities.Reasoning = m.Reasoning
+	w.Pricing.InputPerMillion = m.InputUsdcPerMillion
+	w.Pricing.OutputPerMillion = m.OutputUsdcPerMillion
+	currency := m.Currency
+	if currency == "" {
+		currency = "USDC"
+	}
+	w.Pricing.Currency = &currency
+	feePercent := m.FeePercent
+	w.Pricing.FeePercent = &feePercent
+	return json.Marshal(w)
+}
+
+// UnmarshalJSON decodes the nested gateway wire shape, defaulting currency to
+// "USDC" and fee_percent to 5 when the gateway omits them (matches Python).
+func (m *ModelInfo) UnmarshalJSON(data []byte) error {
+	var w modelInfoWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	m.ID = w.ID
+	m.Provider = w.Provider
+	m.DisplayName = w.DisplayName
+	m.ContextWindow = w.ContextWindow
+	m.SupportsStreaming = w.Capabilities.Streaming
+	m.SupportsTools = w.Capabilities.Tools
+	m.SupportsVision = w.Capabilities.Vision
+	m.Reasoning = w.Capabilities.Reasoning
+	m.InputUsdcPerMillion = w.Pricing.InputPerMillion
+	m.OutputUsdcPerMillion = w.Pricing.OutputPerMillion
+	if w.Pricing.Currency != nil {
+		m.Currency = *w.Pricing.Currency
+	} else {
+		m.Currency = "USDC"
+	}
+	if w.Pricing.FeePercent != nil {
+		m.FeePercent = *w.Pricing.FeePercent
+	} else {
+		m.FeePercent = 5
+	}
+	return nil
+}

--- a/sdks/go/types_test.go
+++ b/sdks/go/types_test.go
@@ -1,0 +1,401 @@
+package solvela
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChatMessageRoundtrip(t *testing.T) {
+	name := "test-user"
+	msg := ChatMessage{
+		Role:    RoleUser,
+		Content: "Hello, world!",
+		Name:    &name,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded ChatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Role != msg.Role {
+		t.Errorf("role: got %q, want %q", decoded.Role, msg.Role)
+	}
+	if decoded.Content != msg.Content {
+		t.Errorf("content: got %q, want %q", decoded.Content, msg.Content)
+	}
+	if decoded.Name == nil || *decoded.Name != name {
+		t.Errorf("name: got %v, want %q", decoded.Name, name)
+	}
+}
+
+func TestChatMessageOmitempty(t *testing.T) {
+	msg := ChatMessage{
+		Role:    RoleAssistant,
+		Content: "Hi",
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	raw := string(data)
+	// Optional fields should be omitted
+	for _, field := range []string{"name", "tool_calls", "tool_call_id"} {
+		if contains(raw, `"`+field+`"`) {
+			t.Errorf("expected field %q to be omitted, got: %s", field, raw)
+		}
+	}
+}
+
+func TestChatResponseRoundtrip(t *testing.T) {
+	finishReason := "stop"
+	resp := ChatResponse{
+		ID:      "chatcmpl-123",
+		Object:  "chat.completion",
+		Created: 1700000000,
+		Model:   "gpt-4",
+		Choices: []ChatChoice{
+			{
+				Index: 0,
+				Message: ChatMessage{
+					Role:    RoleAssistant,
+					Content: "Hello!",
+				},
+				FinishReason: &finishReason,
+			},
+		},
+		Usage: &Usage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded ChatResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.ID != resp.ID {
+		t.Errorf("id: got %q, want %q", decoded.ID, resp.ID)
+	}
+	if decoded.Model != resp.Model {
+		t.Errorf("model: got %q, want %q", decoded.Model, resp.Model)
+	}
+	if len(decoded.Choices) != 1 {
+		t.Fatalf("choices len: got %d, want 1", len(decoded.Choices))
+	}
+	if decoded.Choices[0].Message.Content != "Hello!" {
+		t.Errorf("content: got %q, want %q", decoded.Choices[0].Message.Content, "Hello!")
+	}
+	if decoded.Usage == nil || decoded.Usage.TotalTokens != 15 {
+		t.Errorf("usage: got %v", decoded.Usage)
+	}
+}
+
+func TestChatResponseOmitUsage(t *testing.T) {
+	resp := ChatResponse{
+		ID:      "chatcmpl-123",
+		Object:  "chat.completion",
+		Created: 1700000000,
+		Model:   "gpt-4",
+		Choices: []ChatChoice{},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if contains(string(data), `"usage"`) {
+		t.Error("expected usage to be omitted when nil")
+	}
+}
+
+func TestPaymentRequiredRoundtrip(t *testing.T) {
+	pr := PaymentRequired{
+		X402Version: 2,
+		Resource:    Resource{URL: "/v1/chat/completions", Method: "POST"},
+		Accepts: []PaymentAccept{
+			{
+				Scheme:            "exact",
+				Network:           SolanaNetwork,
+				Amount:            "1000",
+				Asset:             USDCMint,
+				PayTo:             "11111111111111111111111111111112",
+				MaxTimeoutSeconds: 300,
+			},
+		},
+		CostBreakdown: CostBreakdown{
+			ProviderCost: "950",
+			PlatformFee:  "50",
+			Total:        "1000",
+			Currency:     "USDC",
+			FeePercent:   5,
+		},
+		Error: "Payment required",
+	}
+
+	data, err := json.Marshal(pr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded PaymentRequired
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.X402Version != 2 {
+		t.Errorf("version: got %d, want 2", decoded.X402Version)
+	}
+	if decoded.CostBreakdown.Total != "1000" {
+		t.Errorf("total: got %q, want %q", decoded.CostBreakdown.Total, "1000")
+	}
+	if decoded.Accepts[0].Scheme != "exact" {
+		t.Errorf("scheme: got %q, want %q", decoded.Accepts[0].Scheme, "exact")
+	}
+}
+
+func TestPaymentAcceptOmitEscrowProgramID(t *testing.T) {
+	pa := PaymentAccept{
+		Scheme:            "exact",
+		Network:           SolanaNetwork,
+		Amount:            "1000",
+		Asset:             USDCMint,
+		PayTo:             "test",
+		MaxTimeoutSeconds: 300,
+	}
+
+	data, err := json.Marshal(pa)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if contains(string(data), `"escrow_program_id"`) {
+		t.Error("expected escrow_program_id to be omitted when nil")
+	}
+}
+
+func TestModelInfoRoundtrip(t *testing.T) {
+	mi := ModelInfo{
+		ID:                   "openai/gpt-4",
+		Provider:             "openai",
+		DisplayName:          "GPT-4",
+		ContextWindow:        128000,
+		SupportsStreaming:    true,
+		SupportsTools:        true,
+		SupportsVision:       true,
+		Reasoning:            false,
+		InputUsdcPerMillion:  30.0,
+		OutputUsdcPerMillion: 60.0,
+		Currency:             "USDC",
+		FeePercent:           5,
+	}
+
+	data, err := json.Marshal(mi)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// MarshalJSON must emit the nested gateway wire shape — flat top-level
+	// pricing/capability fields would silently regress to the pre-fix layout.
+	wire := string(data)
+	for _, want := range []string{
+		`"capabilities":`,
+		`"streaming":true`,
+		`"pricing":`,
+		`"input_per_million":30`,
+		`"fee_percent":5`,
+	} {
+		if !contains(wire, want) {
+			t.Errorf("wire missing %q: %s", want, wire)
+		}
+	}
+
+	var decoded ModelInfo
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded != mi {
+		t.Errorf("roundtrip mismatch:\n got  %+v\n want %+v", decoded, mi)
+	}
+}
+
+// TestModelInfoFromNestedWire locks the canonical gateway shape: a raw JSON
+// payload with `capabilities` + `pricing` nested objects must decode into the
+// flat struct. Regression guard for the pre-fix drift where every model
+// parsed to all-zero pricing / all-false capabilities.
+func TestModelInfoFromNestedWire(t *testing.T) {
+	raw := []byte(`{
+		"id": "deepseek/deepseek-chat",
+		"object": "model",
+		"provider": "deepseek",
+		"display_name": "DeepSeek Chat",
+		"context_window": 64000,
+		"capabilities": {"streaming": true, "tools": true, "vision": false, "reasoning": false},
+		"pricing": {"input_per_million": 0.28, "output_per_million": 1.10, "currency": "USDC", "fee_percent": 5}
+	}`)
+	var mi ModelInfo
+	if err := json.Unmarshal(raw, &mi); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !mi.SupportsStreaming {
+		t.Error("expected supports_streaming=true from nested capabilities")
+	}
+	if mi.InputUsdcPerMillion != 0.28 {
+		t.Errorf("input usdc/M: got %v, want 0.28", mi.InputUsdcPerMillion)
+	}
+	if mi.OutputUsdcPerMillion != 1.10 {
+		t.Errorf("output usdc/M: got %v, want 1.10", mi.OutputUsdcPerMillion)
+	}
+	if mi.ContextWindow != 64000 {
+		t.Errorf("context window: got %d, want 64000", mi.ContextWindow)
+	}
+}
+
+// TestModelInfoDefaults verifies that omitted pricing.currency/fee_percent
+// fall back to USDC/5, matching Python's `pricing.get("currency", "USDC")`
+// and `pricing.get("fee_percent", 5)` defaults.
+func TestModelInfoDefaults(t *testing.T) {
+	raw := []byte(`{
+		"id": "free-model",
+		"provider": "p",
+		"display_name": "Free",
+		"context_window": 8000,
+		"capabilities": {},
+		"pricing": {"input_per_million": 0, "output_per_million": 0}
+	}`)
+	var mi ModelInfo
+	if err := json.Unmarshal(raw, &mi); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if mi.Currency != "USDC" {
+		t.Errorf("currency default: got %q, want %q", mi.Currency, "USDC")
+	}
+	if mi.FeePercent != 5 {
+		t.Errorf("fee_percent default: got %d, want 5", mi.FeePercent)
+	}
+}
+
+// TestPaymentAcceptUnknownScheme guards the Scheme-literal validation: a
+// gateway response with an unknown scheme must surface as a typed ClientError
+// at decode time, not silently fall through to "no compatible scheme" later.
+// Mirrors solvela-python tests/unit/security_validation.test and TS
+// tests/unit/security_validation.test.
+func TestPaymentAcceptUnknownScheme(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"unknown scheme", `{"scheme":"future-scheme","network":"x","amount":"1","asset":"x","pay_to":"x","max_timeout_seconds":1}`},
+		{"empty scheme", `{"scheme":"","network":"x","amount":"1","asset":"x","pay_to":"x","max_timeout_seconds":1}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var pa PaymentAccept
+			err := json.Unmarshal([]byte(tc.raw), &pa)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if _, ok := err.(*ClientError); !ok {
+				t.Fatalf("expected *ClientError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestPaymentAcceptKnownSchemes(t *testing.T) {
+	for _, scheme := range []string{"exact", "escrow"} {
+		raw := []byte(`{"scheme":"` + scheme + `","network":"x","amount":"1","asset":"x","pay_to":"x","max_timeout_seconds":1}`)
+		var pa PaymentAccept
+		if err := json.Unmarshal(raw, &pa); err != nil {
+			t.Fatalf("scheme %q: unexpected error: %v", scheme, err)
+		}
+		if string(pa.Scheme) != scheme {
+			t.Errorf("scheme: got %q, want %q", pa.Scheme, scheme)
+		}
+	}
+}
+
+func TestConstants(t *testing.T) {
+	if X402Version != 2 {
+		t.Errorf("X402Version: got %d, want 2", X402Version)
+	}
+	if USDCMint != "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" {
+		t.Errorf("USDCMint: got %q", USDCMint)
+	}
+	if SolanaNetwork != "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" {
+		t.Errorf("SolanaNetwork: got %q", SolanaNetwork)
+	}
+	if MaxTimeoutSeconds != 300 {
+		t.Errorf("MaxTimeoutSeconds: got %d, want 300", MaxTimeoutSeconds)
+	}
+	if PlatformFeePercent != 5 {
+		t.Errorf("PlatformFeePercent: got %d, want 5", PlatformFeePercent)
+	}
+}
+
+func TestJSONSnakeCaseFields(t *testing.T) {
+	resp := ChatResponse{
+		ID:      "test",
+		Object:  "chat.completion",
+		Created: 123,
+		Model:   "gpt-4",
+		Choices: []ChatChoice{
+			{
+				Index: 0,
+				Message: ChatMessage{
+					Role:    RoleAssistant,
+					Content: "hi",
+				},
+			},
+		},
+		Usage: &Usage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	raw := string(data)
+	for _, field := range []string{"prompt_tokens", "completion_tokens", "total_tokens", "finish_reason"} {
+		// finish_reason is omitempty nil, so skip that check
+		if field == "finish_reason" {
+			continue
+		}
+		if !contains(raw, `"`+field+`"`) {
+			t.Errorf("expected snake_case field %q in JSON: %s", field, raw)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/sdks/go/wallet.go
+++ b/sdks/go/wallet.go
@@ -1,0 +1,105 @@
+package solvela
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"os"
+
+	"github.com/mr-tron/base58"
+)
+
+// Wallet holds an ed25519 keypair for Solana operations.
+type Wallet struct {
+	privateKey ed25519.PrivateKey
+}
+
+// CreateWallet generates a new random wallet.
+// Returns the wallet and a placeholder mnemonic string.
+func CreateWallet() (*Wallet, string, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, "", &WalletError{Message: fmt.Sprintf("failed to generate keypair: %v", err)}
+	}
+	return &Wallet{privateKey: priv}, "(mnemonic not supported — store keypair bytes)", nil
+}
+
+// WalletFromKeypairBytes creates a wallet from raw 64-byte ed25519 keypair bytes.
+func WalletFromKeypairBytes(raw []byte) (*Wallet, error) {
+	if len(raw) != ed25519.PrivateKeySize {
+		return nil, &WalletError{
+			Message: fmt.Sprintf("invalid keypair length: expected %d, got %d", ed25519.PrivateKeySize, len(raw)),
+		}
+	}
+	return &Wallet{privateKey: ed25519.PrivateKey(raw)}, nil
+}
+
+// WalletFromKeypairB58 creates a wallet from a base58-encoded keypair.
+func WalletFromKeypairB58(b58 string) (*Wallet, error) {
+	raw, err := base58.Decode(b58)
+	if err != nil {
+		return nil, &WalletError{Message: fmt.Sprintf("invalid base58: %v", err)}
+	}
+	return WalletFromKeypairBytes(raw)
+}
+
+// WalletFromEnv creates a wallet from a base58-encoded keypair stored in an environment variable.
+func WalletFromEnv(varName string) (*Wallet, error) {
+	val := os.Getenv(varName)
+	if val == "" {
+		return nil, &WalletError{Message: fmt.Sprintf("environment variable %s not set", varName)}
+	}
+	return WalletFromKeypairB58(val)
+}
+
+// Address returns the base58-encoded public key (Solana address).
+func (w *Wallet) Address() string {
+	return base58.Encode(w.PublicKey())
+}
+
+// PublicKey returns the ed25519 public key.
+func (w *Wallet) PublicKey() ed25519.PublicKey {
+	return w.privateKey.Public().(ed25519.PublicKey)
+}
+
+// privateKeyBytes returns the raw ed25519 private key. It is unexported so the
+// secret material does not leak across the package boundary; callers that need
+// to sign should use [Wallet.Sign]. Persistence helpers within this package
+// (e.g. [Wallet.ToKeypairBytes]) use this internally.
+//
+// SECURITY: callers within the package MUST NOT log, print, or otherwise
+// expose the returned bytes.
+func (w *Wallet) privateKeyBytes() ed25519.PrivateKey {
+	return w.privateKey
+}
+
+// Sign signs the given message with the wallet's ed25519 private key and
+// returns the signature. Callers should prefer this over reaching for raw
+// key bytes — it keeps the secret inside the package.
+func (w *Wallet) Sign(msg []byte) ([]byte, error) {
+	if w == nil || len(w.privateKey) != ed25519.PrivateKeySize {
+		return nil, &WalletError{Message: "wallet is not initialized"}
+	}
+	return ed25519.Sign(w.privateKey, msg), nil
+}
+
+// ToKeypairBytes returns the raw 64-byte keypair.
+//
+// SECURITY: returns the secret key bytes. Use only for persistence (writing
+// to a keystore or env var). Never log or print the result.
+func (w *Wallet) ToKeypairBytes() []byte {
+	return []byte(w.privateKey)
+}
+
+// ToKeypairB58 returns the base58-encoded keypair.
+//
+// SECURITY: returns the secret key in serialized form. Use only for
+// persistence; never log or print the result.
+func (w *Wallet) ToKeypairB58() string {
+	return base58.Encode(w.privateKey)
+}
+
+// String returns a debug-safe representation that redacts the secret key.
+func (w *Wallet) String() string {
+	return fmt.Sprintf("Wallet(address=%s, secret=REDACTED)", w.Address())
+}

--- a/sdks/go/wallet_test.go
+++ b/sdks/go/wallet_test.go
@@ -1,0 +1,143 @@
+package solvela
+
+import (
+	"crypto/ed25519"
+	"strings"
+	"testing"
+)
+
+func TestCreateWallet(t *testing.T) {
+	w, mnemonic, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("CreateWallet: %v", err)
+	}
+	if w == nil {
+		t.Fatal("wallet should not be nil")
+	}
+	if mnemonic == "" {
+		t.Error("mnemonic placeholder should not be empty")
+	}
+	if len(w.Address()) == 0 {
+		t.Error("address should not be empty")
+	}
+	if len(w.PublicKey()) != ed25519.PublicKeySize {
+		t.Errorf("public key length: got %d, want %d", len(w.PublicKey()), ed25519.PublicKeySize)
+	}
+	// Private key is no longer exported; verify length via the persistence helper.
+	if len(w.ToKeypairBytes()) != ed25519.PrivateKeySize {
+		t.Errorf("private key length: got %d, want %d", len(w.ToKeypairBytes()), ed25519.PrivateKeySize)
+	}
+	// Sign should succeed on a freshly created wallet.
+	sig, err := w.Sign([]byte("hello"))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		t.Errorf("sig length: got %d, want %d", len(sig), ed25519.SignatureSize)
+	}
+}
+
+func TestWalletRoundtripBytes(t *testing.T) {
+	w1, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("CreateWallet: %v", err)
+	}
+
+	raw := w1.ToKeypairBytes()
+	w2, err := WalletFromKeypairBytes(raw)
+	if err != nil {
+		t.Fatalf("WalletFromKeypairBytes: %v", err)
+	}
+
+	if w1.Address() != w2.Address() {
+		t.Errorf("address mismatch: %q != %q", w1.Address(), w2.Address())
+	}
+}
+
+func TestWalletRoundtripB58(t *testing.T) {
+	w1, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("CreateWallet: %v", err)
+	}
+
+	b58 := w1.ToKeypairB58()
+	w2, err := WalletFromKeypairB58(b58)
+	if err != nil {
+		t.Fatalf("WalletFromKeypairB58: %v", err)
+	}
+
+	if w1.Address() != w2.Address() {
+		t.Errorf("address mismatch: %q != %q", w1.Address(), w2.Address())
+	}
+}
+
+func TestWalletFromKeypairBytesInvalidLength(t *testing.T) {
+	_, err := WalletFromKeypairBytes([]byte("too short"))
+	if err == nil {
+		t.Fatal("expected error for invalid length")
+	}
+	var walletErr *WalletError
+	if !isWalletError(err, &walletErr) {
+		t.Errorf("expected WalletError, got %T", err)
+	}
+}
+
+func TestWalletFromKeypairB58Invalid(t *testing.T) {
+	_, err := WalletFromKeypairB58("not-valid-base58!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid base58")
+	}
+}
+
+func TestWalletFromEnv(t *testing.T) {
+	w1, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("CreateWallet: %v", err)
+	}
+
+	t.Setenv("TEST_WALLET_KEY", w1.ToKeypairB58())
+
+	w2, err := WalletFromEnv("TEST_WALLET_KEY")
+	if err != nil {
+		t.Fatalf("WalletFromEnv: %v", err)
+	}
+
+	if w1.Address() != w2.Address() {
+		t.Errorf("address mismatch: %q != %q", w1.Address(), w2.Address())
+	}
+}
+
+func TestWalletFromEnvMissing(t *testing.T) {
+	_, err := WalletFromEnv("NONEXISTENT_VAR_12345")
+	if err == nil {
+		t.Fatal("expected error for missing env var")
+	}
+}
+
+func TestWalletStringRedacts(t *testing.T) {
+	w, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("CreateWallet: %v", err)
+	}
+
+	s := w.String()
+	if !strings.Contains(s, "REDACTED") {
+		t.Errorf("String() should contain REDACTED: got %q", s)
+	}
+	if !strings.Contains(s, w.Address()) {
+		t.Errorf("String() should contain address: got %q", s)
+	}
+	// Ensure the private key is not in the string
+	b58 := w.ToKeypairB58()
+	if strings.Contains(s, b58) {
+		t.Error("String() should not contain the full private key")
+	}
+}
+
+func isWalletError(err error, target **WalletError) bool {
+	we, ok := err.(*WalletError)
+	if ok && target != nil {
+		*target = we
+	}
+	return ok
+}


### PR DESCRIPTION
## Summary
- Move the Go SDK source from `solvela-ai/solvela-go` into `sdks/go/`.
- Rewrite the module path to `github.com/solvela-ai/solvela/sdks/go` (only 2 `.go` files referenced the old path: `live_test.go` and `scripts/smoke/main.go`).
- Add `.github/workflows/sdks-go.yml` — path-scoped CI matching the `mcp.yml` style.
- Drop `LICENSE` / `SECURITY.md` duplicates; monorepo-root files apply.

## Why
Wire-format drift between the gateway and an SDK in a separate repo can only be detected after the fact (see 2026-05-11 ModelInfo nested-shape incident). With the Go SDK in the same workspace, any `crates/protocol` change that breaks the Go SDK fails CI in the same PR.

## Test plan
- [x] `go vet ./...` / `go build ./...` / `go test ./... -count=1` green under `sdks/go/`
- [x] No remaining references to `solvela-ai/solvela-go` under `sdks/go/`
- [ ] CI `sdks-go` job green on the PR

## Not in this PR (separate steps)
- Archive `solvela-ai/solvela-go` with a README pointer — wait until this merges + a release tag exists.
- Other SDKs (TS, Python, Rust) follow the same pattern in their own PRs, independently.