### PR TITLE
chore(openclaw-provider): pin pi-* devDeps + guard deprecated OpenClaw imports

### DIFF
--- a/.github/workflows/openclaw-provider.yml
+++ b/.github/workflows/openclaw-provider.yml
@@ -171,3 +171,37 @@ jobs:
       # ecosystem. Dependabot security alerts cover the high-severity gap on
       # the repo level; this job catches CRITICAL regressions in CI.
       - run: npm audit --production --audit-level=critical
+
+  guard-deprecated-openclaw-imports:
+    # OpenClaw is mid-refactor ("slim core, expand plugins" — 2026-05-13 audit).
+    # The following import paths and symbols are deprecated or removed in
+    # upstream OpenClaw; using them in Solvela's plugin will silently break on
+    # the next OpenClaw LTS. See docs.openclaw.ai/plugins/sdk-migration.md.
+    name: Guard deprecated OpenClaw imports
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Fail on deprecated OpenClaw imports
+        run: |
+          set -e
+          # Patterns drawn from docs.openclaw.ai/plugins/sdk-migration.md:
+          #   - openclaw/plugin-sdk/compat        — deprecated barrel
+          #   - openclaw/plugin-sdk/infra-runtime — deprecated barrel
+          #   - openclaw/plugin-sdk/config-runtime — deprecated barrel
+          #   - openclaw/extension-api            — replaced by openclaw/plugin-sdk/* subpaths
+          #   - registerEmbeddedExtensionFactory  — removed in v2026.4.24,
+          #     replaced by registerAgentToolResultMiddleware
+          # If you intentionally need any of these, update this guard and
+          # document the OpenClaw version compatibility in the import site.
+          FOUND=$(grep -rEn \
+            'openclaw/plugin-sdk/compat|openclaw/plugin-sdk/infra-runtime|openclaw/plugin-sdk/config-runtime|openclaw/extension-api|registerEmbeddedExtensionFactory' \
+            sdks/openclaw-provider/src sdks/openclaw-provider/tests sdks/openclaw-provider/scripts 2>/dev/null || true)
+          if [ -n "$FOUND" ]; then
+            echo "ERROR: deprecated OpenClaw imports detected in sdks/openclaw-provider/:"
+            echo "$FOUND"
+            echo ""
+            echo "These import paths/symbols are deprecated or removed upstream."
+            echo "See: https://docs.openclaw.ai/plugins/sdk-migration.md"
+            exit 1
+          fi
+          echo "OK: no deprecated OpenClaw imports in sdks/openclaw-provider/"

--- a/sdks/openclaw-provider/package-lock.json
+++ b/sdks/openclaw-provider/package-lock.json
@@ -16,8 +16,8 @@
         "bs58": "^5.0.0"
       },
       "devDependencies": {
-        "@earendil-works/pi-agent-core": "^0.74.0",
-        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-agent-core": "0.74.0",
+        "@earendil-works/pi-ai": "0.74.0",
         "@iarna/toml": "^2.2.5",
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",

--- a/sdks/openclaw-provider/package.json
+++ b/sdks/openclaw-provider/package.json
@@ -27,8 +27,8 @@
     "bs58": "^5.0.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-agent-core": "^0.74.0",
-    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-agent-core": "0.74.0",
+    "@earendil-works/pi-ai": "0.74.0",
     "@iarna/toml": "^2.2.5",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",


### PR DESCRIPTION
## Summary

Two preventive actions for the Solvela OpenClaw provider, drawn from the 2026-05-13 due-diligence audit (see [project memory note](https://github.com/solvela-ai/solvela/blob/main/.claude/projects/-home-kennethdixon-projects-solvela/memory/project_openclaw_direction_2026_05.md) for the full rationale).

### 1. Pin `@earendil-works/pi-*` devDep versions exactly

`^0.74.0` → `0.74.0` on both `@earendil-works/pi-agent-core` and `@earendil-works/pi-ai`.

The pi-* org has a track record of breaking `streamFn` overrides on patch bumps — `pi-coding-agent@0.63.0` silently replaced session streamFns with bare `streamSimple`, defeating provider wrappers in production (openclaw#55760, #55816, #57860). Caret ranges on this seam would let `0.74.x` redefine `StreamFn` underneath us silently, and `npm ci` would not flag it. Pinning makes any future drift a deliberate upgrade decision.

### 2. New CI job — guard deprecated OpenClaw imports

Adds `guard-deprecated-openclaw-imports` to the `openclaw-provider.yml` workflow. Greps `sdks/openclaw-provider/{src,tests,scripts}/` for five patterns from `docs.openclaw.ai/plugins/sdk-migration.md`:

- `openclaw/plugin-sdk/compat` (deprecated barrel)
- `openclaw/plugin-sdk/infra-runtime` (deprecated barrel)
- `openclaw/plugin-sdk/config-runtime` (deprecated barrel)
- `openclaw/extension-api` (replaced by `openclaw/plugin-sdk/*` subpaths)
- `registerEmbeddedExtensionFactory` (removed v2026.4.24)

OpenClaw's compatibility registry enforces a **3-month removal SLA**. Anything deprecated today is gone by August 2026. Catching deprecated imports at PR time costs nothing; catching them after upstream removes the path costs an emergency Solvela release.

## Why now

2026-05-13 audit found:
- Solvela's plugin surface (`wrapStreamFn`, `catalog`, `resolveDynamicModel`) is the **post-refactor stable contract** — direction-aligned with OpenClaw's "slim core, expand plugins" trajectory.
- But the seam has shifted once in 30 days (the pi-coding-agent 0.63.0 regression) — version-pinning is justified.
- LTS targeted "later May 2026" — locking down the perimeter now is cheap insurance before the next OpenClaw release.

## Stack note

This PR stacks on **#263** (type honesty PR) only because both touch `sdks/openclaw-provider/`. The CI guard itself does not depend on #263; if you want to merge it independently, cherry-pick the `0d7d3494` commit onto main.

Base for merge: **rebase onto main after #263 merges**, or rebase onto main directly if #263 is closed/held.

## Test plan

- [ ] CI shows `guard-deprecated-openclaw-imports` job passes (verified locally: `OK: no deprecated imports`).
- [ ] All inherited CI jobs from #263 remain consistent (3 jobs intentionally red per #263; others green).
- [ ] Lockfile diff is minimal (only the two version-range strings change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)