### PR TITLE
fix(openclaw-provider): rewrite wrapStreamFn body to real 3-arg StreamFn shape

### DIFF
--- a/.github/workflows/openclaw-provider.yml
+++ b/.github/workflows/openclaw-provider.yml
@@ -171,3 +171,37 @@ jobs:
       # ecosystem. Dependabot security alerts cover the high-severity gap on
       # the repo level; this job catches CRITICAL regressions in CI.
       - run: npm audit --production --audit-level=critical
+
+  guard-deprecated-openclaw-imports:
+    # OpenClaw is mid-refactor ("slim core, expand plugins" — 2026-05-13 audit).
+    # The following import paths and symbols are deprecated or removed in
+    # upstream OpenClaw; using them in Solvela's plugin will silently break on
+    # the next OpenClaw LTS. See docs.openclaw.ai/plugins/sdk-migration.md.
+    name: Guard deprecated OpenClaw imports
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Fail on deprecated OpenClaw imports
+        run: |
+          set -e
+          # Patterns drawn from docs.openclaw.ai/plugins/sdk-migration.md:
+          #   - openclaw/plugin-sdk/compat        — deprecated barrel
+          #   - openclaw/plugin-sdk/infra-runtime — deprecated barrel
+          #   - openclaw/plugin-sdk/config-runtime — deprecated barrel
+          #   - openclaw/extension-api            — replaced by openclaw/plugin-sdk/* subpaths
+          #   - registerEmbeddedExtensionFactory  — removed in v2026.4.24,
+          #     replaced by registerAgentToolResultMiddleware
+          # If you intentionally need any of these, update this guard and
+          # document the OpenClaw version compatibility in the import site.
+          FOUND=$(grep -rEn \
+            'openclaw/plugin-sdk/compat|openclaw/plugin-sdk/infra-runtime|openclaw/plugin-sdk/config-runtime|openclaw/extension-api|registerEmbeddedExtensionFactory' \
+            sdks/openclaw-provider/src sdks/openclaw-provider/tests sdks/openclaw-provider/scripts 2>/dev/null || true)
+          if [ -n "$FOUND" ]; then
+            echo "ERROR: deprecated OpenClaw imports detected in sdks/openclaw-provider/:"
+            echo "$FOUND"
+            echo ""
+            echo "These import paths/symbols are deprecated or removed upstream."
+            echo "See: https://docs.openclaw.ai/plugins/sdk-migration.md"
+            exit 1
+          fi
+          echo "OK: no deprecated OpenClaw imports in sdks/openclaw-provider/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,9 +1611,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",

--- a/sdks/openclaw-provider/README.md
+++ b/sdks/openclaw-provider/README.md
@@ -35,8 +35,8 @@ Phase 1 MCP server pattern).
 
 ## Signing modes
 
-- **`direct`** (default in Phase 3): Forces direct USDC TransferChecked only.
-  Recommended until F4 (escrow-claim hook) ships.
+- **`direct`** (default): Forces direct USDC TransferChecked only. Recommended
+  for v1 — no client-side escrow accounting needed.
 - **`auto`**: Prefers the escrow payment scheme when the gateway advertises it,
   falls back to direct TransferChecked.
 - **`escrow`**: Forces escrow-only. If the gateway doesn't advertise escrow for
@@ -46,16 +46,32 @@ Phase 1 MCP server pattern).
   `dev_bypass_payment` mode. Parity with the Phase 1 MCP server. Never use in
   production against a live gateway.
 
-**Phase 3 note on escrow:** Escrow mode works in Phase 3, but the plugin has no
-stream-completion hook to trigger the claim. Every escrow deposit relies on the
-gateway auto-claim after `max_timeout_seconds`. Until F4 (escrow-claim hook on
-stream completion) ships, **`direct` is the recommended default**. If you
-explicitly set `SOLVELA_SIGNING_MODE=escrow` or `auto`, the plugin emits a
-warning every 10 deposits reminding you of this.
+### Escrow accounting (F4)
 
-**Security note on `direct` mode:** Direct-transfer payments are non-refundable
-if the stream fails mid-response. If recovery from partial-stream failures is
-important to you, wait for F4 before using escrow mode in production.
+Escrow mode deposits a max-amount USDC envelope on-chain before the call; the
+gateway claims the actual cost back from the deposit after the stream
+completes. There are two ways the claim can be triggered:
+
+1. **Gateway auto-claim after `max_timeout_seconds`** — works today; the
+   deposit is reconciled on a timer, so refunds for over-deposits arrive
+   asynchronously.
+2. **Client-side `wrapStreamForF4`** — the plugin exports a `wrapStreamForF4`
+   helper that observes the stream's `result()` Promise and POSTs the actual
+   token usage to the gateway's `/v1/escrow/settle` endpoint as soon as the
+   stream finishes. Reduces reconciliation latency from minutes to
+   milliseconds.
+
+The `wrapStreamForF4` wrapper is fully implemented and unit-tested
+(`tests/f4-wrapper.test.ts`). The matching gateway endpoint at
+`/v1/escrow/settle` is planned but not yet deployed — until it lands, settle
+POSTs return 404 and the wrapper logs a warning (the stream consumer is
+unaffected). Until the endpoint is live, you can still safely use escrow mode
+and rely on the auto-claim timer.
+
+**Security note on `direct` mode:** Direct-transfer payments are
+non-refundable if the stream fails mid-response. If recovery from
+partial-stream failures matters for your workload, prefer escrow mode (with
+F4 once the gateway endpoint ships, or auto-claim today).
 
 ## Dev bypass
 

--- a/sdks/openclaw-provider/docs/escrow-byte-alignment.md
+++ b/sdks/openclaw-provider/docs/escrow-byte-alignment.md
@@ -1,0 +1,75 @@
+# Escrow byte-alignment limitation
+
+## TL;DR
+
+This plugin's `wrapStreamFn` body sends a **stub probe body** to the Solvela
+gateway to obtain the 402 `PaymentRequired` envelope, then signs payment and
+forwards the real request through pi-ai's transport. The probe body matches
+the real request on `model.id` and cost-sensitive `options` fields
+(`max_tokens`, `temperature`, `top_p`) but **does not byte-match the
+serialized request body**.
+
+For **direct mode** (the plugin's default and Solvela's strategic mode), this
+is fine — the gateway prices upfront from `model` + `max_tokens` ceiling, and
+the on-chain settlement is a simple USDC-SPL `TransferChecked` that does not
+depend on the request body.
+
+For **escrow mode**, the gateway derives the escrow PDA from
+`[b"escrow", agent.key().as_ref(), &service_id]`, where `service_id` may be
+hashed from request shape. A stub probe body could compute a different
+`service_id` than the real call, breaking PDA derivation and causing the
+gateway to look up the deposit at the wrong PDA.
+
+## Why we ship the stub-probe approach anyway
+
+1. **Direct mode is the documented default** (`SOLVELA_SIGNING_MODE=direct`,
+   see `src/index.ts`). Most users will never hit the escrow byte-alignment
+   path.
+2. **Reconstructing the real serialized body is brittle.** pi-ai's transport
+   serializes `context.messages` and `options` internally, and the
+   serialization may differ across provider apis (`openai-completions`,
+   `anthropic-messages`, etc.) and pi-ai versions. Replicating that
+   serialization in the plugin would couple Solvela to pi-ai internals
+   tightly enough that any pi-ai update could silently drift the probe body
+   from the real body (a class of regression we already saw in
+   `pi-coding-agent@0.63.0` — see openclaw#55760, #55816, #57860).
+3. **F4 settle (planned, separate PR) reduces the urgency.** Escrow
+   accounting can be done after the stream completes by claiming the actual
+   used amount from the deposit, rather than requiring byte-perfect
+   probe alignment at request time.
+
+## When this becomes a problem
+
+Escrow mode + a gateway that hashes the request body into `service_id`. The
+plugin will deposit at one PDA and the gateway will check a different PDA;
+the call fails with "deposit not found" or similar.
+
+## Mitigations / future work
+
+If escrow mode becomes a first-class requirement (i.e. direct mode is no
+longer sufficient), the canonical path is to move payment interception from
+`wrapStreamFn` to an undici `Dispatcher` registered via
+`setGlobalDispatcher` (or threaded via `init.dispatcher` through OpenClaw's
+`fetchWithRuntimeDispatcher`). The dispatcher sees the actual outbound
+request bytes after pi-ai serialization, so the probe and real call are
+guaranteed to share the same `service_id`.
+
+That refactor is ~8–16h of work and was originally planned as PR 3 ("Path
+B") but was deferred in favor of Path A' (this implementation) because:
+
+- Direct mode is the strategic default for v1.
+- F4 settle (separate PR) is the correct architectural answer for escrow
+  accounting, not request-time byte alignment.
+- Dispatcher implementation has its own slim-down risks against OpenClaw's
+  evolving plugin SDK surface — we don't gain insurance for free.
+
+If escrow byte-alignment becomes load-bearing, file a new issue referencing
+this doc; the migration is contained to `src/index.ts` (drop `wrapStreamFn`
+body; add `src/dispatcher.ts`; wire `setGlobalDispatcher` in `register`).
+
+## References
+
+- `src/index.ts` — `wrapStreamFn` body that does stub-probe signing
+- `src/index.ts` — `buildProbeBody` helper
+- Solana escrow PDA: `programs/escrow/` in the main solvela-ai/solvela repo
+- 2026-05-13 OpenClaw due-diligence audit (project memory)

--- a/sdks/openclaw-provider/package-lock.json
+++ b/sdks/openclaw-provider/package-lock.json
@@ -16,8 +16,8 @@
         "bs58": "^5.0.0"
       },
       "devDependencies": {
-        "@earendil-works/pi-agent-core": "^0.74.0",
-        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-agent-core": "0.74.0",
+        "@earendil-works/pi-ai": "0.74.0",
         "@iarna/toml": "^2.2.5",
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",

--- a/sdks/openclaw-provider/package-lock.json
+++ b/sdks/openclaw-provider/package-lock.json
@@ -16,6 +16,8 @@
         "bs58": "^5.0.0"
       },
       "devDependencies": {
+        "@earendil-works/pi-agent-core": "^0.74.0",
+        "@earendil-works/pi-ai": "^0.74.0",
         "@iarna/toml": "^2.2.5",
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",
@@ -28,12 +30,792 @@
       "dependencies": {
         "@solana/spl-token": "^0.4.0",
         "@solana/web3.js": "^1.87.0",
-        "bs58": "^5.0.0"
+        "bs58": "^6.0.0"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.7.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.6.0"
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1045.0.tgz",
+      "integrity": "sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/eventstream-handler-node": "^3.972.14",
+        "@aws-sdk/middleware-eventstream": "^3.972.10",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-websocket": "^3.972.16",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/token-providers": "3.1045.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
+      "integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
+      "integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
+      "integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1045.0.tgz",
+      "integrity": "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -43,6 +825,92 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+      "integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.74.0",
+        "typebox": "^1.1.24"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+      "integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "^2.2.0",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -487,12 +1355,93 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@mistralai/mistralai/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
@@ -519,6 +1468,643 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.5.1.tgz",
+      "integrity": "sha512-abXk3LhODsvRHsk0ZS9ztrg/fZatTa9Z/z4pgx65YSLR+rY6kvUG/1IgcDKEUciR8MfdnkT5oPeHJTy/HhzDIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.1.tgz",
+      "integrity": "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.1.tgz",
+      "integrity": "sha512-0S/acwHnqX4WrjXzhdiDRxsG2s9SC0cpPIK9nZ1R6UOHd+j7uL28+4bHu22urbLk2TVw3fkp6na/+fkUt/pLNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.3.1.tgz",
+      "integrity": "sha512-yS8AiJM3Kf7LR+lZyUilUyjdJGksAqxfSC3C9k3d1OCrAvWjpMlsJ+rW9cIslZJM4AtWh2UAqgZUWTtMeMdtDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.3.1.tgz",
+      "integrity": "sha512-X7MyI1fu8M84IPKk49kO4kb27Mqp6un9/0o/MsA1ngZ5OxxWKGUxPS3S/AJ9q1cPVTSGmRcbaGNfGUSsflTJkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.4.1.tgz",
+      "integrity": "sha512-JZGbSXaBk7JY8VPzsh66ksJ0nTWXbApduFDkA/pEl3aTm2EoAiUZE1Iltp6c+X1bB8kxPQW0mHDfVdYCpWTOzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.3.1.tgz",
+      "integrity": "sha512-6Cn4xTNVxn9PWTHSbvf8zmcDhQW8lrLE1Xq5CJgmX6wEvdjS2S0KuE79Aiznv/jx51jpFJ98OuWyE+Bt+oG1MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.1.tgz",
+      "integrity": "sha512-r7bN6spQ+caZC8AnyvSxkRUb57zt2jhhRw3Z+2Ez8hjq6coIikDBFUUI/+CQ1xx9K6eX1Gx6wUKo4ylU66TIqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.3.1.tgz",
+      "integrity": "sha512-u0/zo11mg7yNneoYgTkH4sXwSmcBpbl49o4UNCtQ7hYsXxynsN25KYHmXzqi7TPk5HQL5klGnpU5koOY0O+9hw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.3.1.tgz",
+      "integrity": "sha512-cLmwtDoulyZvRepAfyV+3rx5oMvuh51dbE+6En3vGC09j3uVSRt1U4oguNu32ub3soGX0oYtBs8E7S2Q4SxTqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.3.1.tgz",
+      "integrity": "sha512-l4BUIP+wljW/Ar+0/QcGdmElI9lalrywfzNijXMBG34Z510FRzPyrDLx/blNTZOAm0C4Mvx5t/bf760CZo1ajg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.1.tgz",
+      "integrity": "sha512-qtqu5TS+8Y18ZDkJoiXN5AMW1G4JAg1+xytzpsUvIR5a4EUsgd5HQg12lekEHWpm2TDUmOgg+hBaHK7dvyWdkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.6.1.tgz",
+      "integrity": "sha512-eTaQhxs0rfUuAkL2MSKrH8DTO7YCeAgrdN0B2/RAeuHmXQ+x52dk5qUBsi/jtcqe5LxItgq5AG5tI6Cp8c0sow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.3.1.tgz",
+      "integrity": "sha512-t7YtUe076zWVypVmy1rX91oKi2TFJCkpfFpfMhJFpEIRPP0iL9JxjeSyFQ+1bF45JUfDzOzslUJa150WcSrBug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.3.1.tgz",
+      "integrity": "sha512-1jKwiKZxCMQNqmp4uVPYA6r+MLGjEtH07gnOUdPgbnjuOIrl/0JY/ICdpQtFgeBsQ/Up01gnSv8GYEL0fb8yvg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.4.1.tgz",
+      "integrity": "sha512-q7tDJEJXcaSG/8TVpu2f2l9bzxTzDM9geWmltbzsY6Hfh3yiuXXTpLIO8+zwYASPPVFaTJpdKwjSSjdoDoccgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.1.tgz",
+      "integrity": "sha512-BdEYko85f/ldp68uH8XEyIvo810xFk6eyPH81SRggTOApYHWA+Xu7B2EzLuHbe37WVLaUA7F1fWR3/zBeme2WA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.3.1.tgz",
+      "integrity": "sha512-3NHoqVBhzpY2b4YBx9AqyKC4C8nnEjl5FyKuxrCjvnjinG0ODj+yg1xX360nNahT6wghYjSw1SooCt3kIdnqIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.1.tgz",
+      "integrity": "sha512-8irPNCQgYxcSFp1aGcnDNFkTwSA+xPUaFq9V/v1+JXWu8sKr5b3cFmg2kBTkjkvypDmGeNffuNu0x5iqw1NoAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.3.1.tgz",
+      "integrity": "sha512-toyi8sXPWDNoVH6yK7sXJ9dm5uxw2tWLCHzPy/t16Fvl62Es4vXQXzlilyNaw+DqFwxSlrFClh0rGLPUF2p9Lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.5.1.tgz",
+      "integrity": "sha512-FKoKxVzdFPhyynFI+SPTWrgOP60fZ4l1UwukWYj4eyhpSmEI7MJ6p58hawIIt9bwp+aek9NEm8Zika7E+GEoeg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.1.tgz",
+      "integrity": "sha512-728lZZEWYWubBESrfntNslZQYDKRlJDY4dcDnYbL50+gu35pGPLblu4S0/RH/RDLF6me1M87ECHsHELGL7dA/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.13.1.tgz",
+      "integrity": "sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.3.1.tgz",
+      "integrity": "sha512-tuelFlF2PZR/wogFC58NIrPOv+Zna4N1+3kA161/33D1Gbwvl6Nh4WsAsW05ZyPp0O6CMGsdbb0S2b/qVjRMCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.4.1.tgz",
+      "integrity": "sha512-fTHiwW2xbiRiWzfSk4IGAr3gNZCH4fuRYqt8+IuarsP/YON35576iVdePraZ6yJlFxlCL0eMec3/F7xYqoKzlg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.3.1.tgz",
+      "integrity": "sha512-1scg5t4nV3hV7CZs996/XHb80aDZ5YotH4NcvkW/w/rHj+cSz0aCIzwz8aUNKB4nCDPSHRCbrKoj+TvycYefmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.3.1.tgz",
+      "integrity": "sha512-VRC8MKVPKrgUYThTA7ughcKMfjW6/X92H0wXGJoda0Apw4O5xbXL0GMLz40DTWlsb5hh2iItk6+XL72uJdxYcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.3.1.tgz",
+      "integrity": "sha512-lw6L5GF5+W19vO6o3fZwRT2cXEG+8b2LH0b9ppjDT6nIxjUgmljEQGninx5XorylwKZZ4XLVABeroJ8oaF9RmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.4.1.tgz",
+      "integrity": "sha512-1rA7w+LjK1WJClsffC81Z/ZtjFt22QsKhBjUYEnZsGVS2nOTfOENKBzdg4SxhdwFvBCjcbpjscUfXOPwE3UHWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.3.1.tgz",
+      "integrity": "sha512-1fk1wfQHBenQD5NitVKOFgW0wsISYAFPIXGyStJWAeCtMyRhgHYvtJxBk2rwGWA0L5QX6oM6yeHSLKPFMk59ww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.5.1.tgz",
+      "integrity": "sha512-yORYzJD5zoGbSDkAACr0dIjDiSEA3X8h8lggDENl1dkKpCG0TQIoItPBqtvuJHzFFjRXumcoH+/09xIuixGyCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.3.1.tgz",
+      "integrity": "sha512-j6dAIaXfj2nsvv/sN9+fi7e/AJxBHgBoIdNjmQjp9jlii72rEniUGQkipnkHMP2XUKHx5q0B1iv0xQEG1AsLBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.3.1.tgz",
+      "integrity": "sha512-SRRMDcIgVXVhVbxviBaSZbuWuVW3jD08wv4ESV0V2oiw0Mki8TPVQ5IxwD3MvSTPg52QYsRP+JoMw5WdUdeWAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.4.1.tgz",
+      "integrity": "sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.6.1.tgz",
+      "integrity": "sha512-GjZfEft0M0V3n2YM/LGkr5LeLd8gxHUIzW0rUz6VtTtlAq245GxHlJghvoPEjJHKTj255iHFAiA4IsIdK40Ueg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
+      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@solana/buffer-layout": {
@@ -812,6 +2398,13 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -830,6 +2423,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -845,6 +2445,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -855,6 +2465,19 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/async-mutex": {
@@ -891,6 +2514,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
@@ -958,6 +2591,13 @@
         "base-x": "^3.0.2"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
@@ -990,6 +2630,13 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/bufferutil": {
       "version": "4.1.0",
@@ -1026,6 +2673,49 @@
         "node": ">=18"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delay": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
@@ -1036,6 +2726,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/es6-promise": {
@@ -1095,10 +2795,73 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/eyes": {
@@ -1115,6 +2878,45 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastestsmallesttextencoderdecoder": {
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
@@ -1122,11 +2924,48 @@
       "license": "CC0-1.0",
       "peer": true
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1143,6 +2982,65 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -1154,6 +3052,77 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -1184,6 +3153,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
@@ -1232,17 +3211,112 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -1276,6 +3350,129 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1284,6 +3481,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rpc-websockets": {
@@ -1386,6 +3593,58 @@
       ],
       "license": "MIT"
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stream-chain": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
@@ -1400,6 +3659,19 @@
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/superstruct": {
       "version": "2.0.2",
@@ -1419,6 +3691,13 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tslib": {
@@ -1447,6 +3726,13 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1458,6 +3744,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -1488,6 +3784,16 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -1525,6 +3831,42 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/sdks/openclaw-provider/package.json
+++ b/sdks/openclaw-provider/package.json
@@ -13,7 +13,7 @@
     "generate:models": "node --import tsx/esm scripts/generate-models.ts",
     "prebuild": "npm run generate:models",
     "build": "tsc",
-    "test": "node --import tsx/esm --test tests/index.test.ts tests/signer.test.ts tests/manifest.test.ts tests/models.test.ts tests/registry.test.ts",
+    "test": "node --import tsx/esm --test tests/index.test.ts tests/signer.test.ts tests/manifest.test.ts tests/models.test.ts tests/registry.test.ts tests/f4-wrapper.test.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
   },

--- a/sdks/openclaw-provider/package.json
+++ b/sdks/openclaw-provider/package.json
@@ -27,8 +27,8 @@
     "bs58": "^5.0.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-agent-core": "^0.74.0",
-    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-agent-core": "0.74.0",
+    "@earendil-works/pi-ai": "0.74.0",
     "@iarna/toml": "^2.2.5",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",

--- a/sdks/openclaw-provider/package.json
+++ b/sdks/openclaw-provider/package.json
@@ -27,6 +27,8 @@
     "bs58": "^5.0.0"
   },
   "devDependencies": {
+    "@earendil-works/pi-agent-core": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
     "@iarna/toml": "^2.2.5",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",

--- a/sdks/openclaw-provider/src/f4-wrapper.ts
+++ b/sdks/openclaw-provider/src/f4-wrapper.ts
@@ -1,0 +1,164 @@
+/**
+ * F4 — post-stream escrow settle hook.
+ *
+ * Observes the inner AssistantMessageEventStream's `result()` Promise. On
+ * stream completion, fires a fire-and-forget POST to the gateway's
+ * `/v1/escrow/settle` endpoint with the actual token usage, so the gateway
+ * can claim the correct escrow amount based on real usage rather than
+ * relying on the timeout-based auto-claim fallback.
+ *
+ * Status: client-side complete; the gateway endpoint at `/v1/escrow/settle`
+ * does not exist yet (planned as a separate PR). Until that lands, settle
+ * POSTs return 404. Failures are logged to stderr but **never** crash the
+ * stream consumer or block the response.
+ *
+ * Usage:
+ *
+ *     import { wrapStreamForF4 } from '@solvela/openclaw-provider';
+ *
+ *     const stream = inner(model, context, options);
+ *     wrapStreamForF4(stream, {
+ *       serviceId,
+ *       agentPubkey,
+ *       modelId: model.id,
+ *       gatewayUrl: SOLVELA_API_URL,
+ *     });
+ *     return stream;
+ *
+ * Why side-effect-only (not piping):
+ *   We don't import `@earendil-works/pi-ai/utils/event-stream` because
+ *   pi-ai's package.json does not export that subpath. Instead we rely on
+ *   the EventStream's `.result()` Promise, which resolves when the producer
+ *   calls `end()` regardless of who consumes the AsyncIterator. This avoids
+ *   a 2-consumer race against OpenClaw's stream consumer.
+ */
+
+import type { AssistantMessage } from '@earendil-works/pi-ai';
+
+/**
+ * Structural type for any stream with a `.result()` Promise that resolves
+ * with the final AssistantMessage. Matches `EventStream<E, AssistantMessage>`
+ * from @earendil-works/pi-ai/utils/event-stream.
+ */
+export interface ResultableStream {
+  result(): Promise<AssistantMessage>;
+}
+
+/** Inputs F4 needs to settle a single escrow deposit against actual usage. */
+export interface F4Context {
+  /** Service ID identifying the escrow deposit PDA. Hex/base58/base64 — gateway-defined encoding. */
+  serviceId: string;
+  /** Base58-encoded agent (payer) pubkey. */
+  agentPubkey: string;
+  /** The model ID the call was billed against (e.g. "gpt-4o", "auto"). */
+  modelId: string;
+  /** Solvela gateway base URL (no trailing slash). */
+  gatewayUrl: string;
+  /** Optional fetch override for testing. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+  /** Optional timeout in ms for the settle POST (default 5000). */
+  timeoutMs?: number;
+}
+
+/** Optional stats tracker — used by tests and ops to count settle outcomes. */
+export interface F4Stats {
+  fired: number;
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Schedule a fire-and-forget escrow settle POST when the inner stream
+ * completes. Returns the input stream unchanged (no piping).
+ *
+ * Errors during settle are logged to stderr but do not propagate. The
+ * inner stream consumer is never blocked or impacted by F4.
+ */
+export function wrapStreamForF4<T extends ResultableStream | Promise<ResultableStream>>(
+  innerStream: T,
+  f4: F4Context,
+  stats?: F4Stats,
+): T {
+  void scheduleSettle(innerStream, f4, stats);
+  return innerStream;
+}
+
+async function scheduleSettle(
+  innerOrPromise: ResultableStream | Promise<ResultableStream>,
+  f4: F4Context,
+  stats: F4Stats | undefined,
+): Promise<void> {
+  let finalMessage: AssistantMessage;
+  try {
+    const stream = await Promise.resolve(innerOrPromise);
+    finalMessage = await stream.result();
+  } catch (err) {
+    process.stderr.write(
+      `[solvela-openclaw] F4: stream.result() rejected — skipping settle: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+    return;
+  }
+
+  const isError =
+    finalMessage.stopReason === 'error' || finalMessage.stopReason === 'aborted';
+  if (stats) stats.fired += 1;
+  try {
+    await postSettle(f4, finalMessage, isError);
+    if (stats) stats.succeeded += 1;
+  } catch (err) {
+    if (stats) stats.failed += 1;
+    process.stderr.write(
+      `[solvela-openclaw] F4: settle POST failed (non-blocking): ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
+}
+
+interface SettleBody {
+  service_id: string;
+  agent_pubkey: string;
+  model: string;
+  status: 'completed' | 'error';
+  actual_prompt_tokens?: number;
+  actual_completion_tokens?: number;
+}
+
+async function postSettle(
+  f4: F4Context,
+  finalMessage: AssistantMessage,
+  isError: boolean,
+): Promise<void> {
+  const body: SettleBody = {
+    service_id: f4.serviceId,
+    agent_pubkey: f4.agentPubkey,
+    model: f4.modelId,
+    status: isError ? 'error' : 'completed',
+  };
+  if (finalMessage.usage) {
+    body.actual_prompt_tokens = finalMessage.usage.input;
+    body.actual_completion_tokens = finalMessage.usage.output;
+  }
+
+  const timeoutMs = f4.timeoutMs ?? 5000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const fetchFn = f4.fetchFn ?? fetch;
+  try {
+    const resp = await fetchFn(`${f4.gatewayUrl}/v1/escrow/settle`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      redirect: 'error',
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`gateway settle returned ${resp.status} ${resp.statusText}`);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/sdks/openclaw-provider/src/index.ts
+++ b/sdks/openclaw-provider/src/index.ts
@@ -123,6 +123,40 @@ function getSessionBudget(): number | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Probe body builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a stub request body for the gateway probe.
+ *
+ * The probe is a POST to `/v1/chat/completions` that returns a 402 with cost
+ * info. The gateway prices upfront off `model` + `max_tokens` ceiling, so the
+ * probe body doesn't need to byte-match the real call in direct mode — we
+ * just need the same `model.id` and any cost-sensitive options pi-ai will
+ * forward (max_tokens, temperature). Escrow mode requires byte-perfect
+ * alignment for PDA derivation; see docs/escrow-byte-alignment.md.
+ */
+interface ProbeInputOptions {
+  maxTokens?: unknown;
+  temperature?: unknown;
+  topP?: unknown;
+}
+
+function buildProbeBody(
+  modelId: string,
+  options: ProbeInputOptions | undefined,
+): string {
+  const body: Record<string, unknown> = {
+    model: modelId,
+    messages: [{ role: 'user', content: '' }],
+  };
+  if (typeof options?.maxTokens === 'number') body['max_tokens'] = options.maxTokens;
+  if (typeof options?.temperature === 'number') body['temperature'] = options.temperature;
+  if (typeof options?.topP === 'number') body['top_p'] = options.topP;
+  return JSON.stringify(body);
+}
+
+// ---------------------------------------------------------------------------
 // Payment info fetcher
 // ---------------------------------------------------------------------------
 
@@ -346,32 +380,36 @@ export default function register(api: OpenClawApi, opts: RegisterOptions = {}): 
     /**
      * wrapStreamFn — per-call payment-signature injection.
      *
-     * The hook receives a context containing the existing stream function and
-     * returns a wrapped version that injects the PAYMENT-SIGNATURE header
-     * before calling the original stream function.
+     * Receives `ctx` containing the inner `StreamFn` (from
+     * `@earendil-works/pi-agent-core`), returns a wrapped `StreamFn` that
+     * injects the `payment-signature` header before forwarding the call.
      *
-     * Signature note (HF-P3-H1): The real OpenClaw SDK docs confirm the factory
-     * shape `(ctx) => async (params) => inner(params)`. Plan §10.5 used a flat
-     * `(request, next)` shape — that section is stale. This implementation is correct.
+     * Signature is the canonical 3-arg `(model, context, options)`, matching
+     * how OpenClaw invokes wrapped StreamFns at runtime
+     * (src/agents/pi-embedded-runner/extra-params.ts:418) and how internal
+     * wrappers like `createOpenAIAttributionHeadersWrapper` inject headers
+     * (src/agents/pi-embedded-runner/openai-stream-wrappers.ts:567).
      *
      * Flow:
-     *   1. Validate ctx.streamFn — throw if absent (HF-P3-C3)
-     *   2. Serialize request body once as canonical JSON string (HF-P3-C1)
-     *   3. Write canonical body back to params (HF-P3-C1 — ensures probe and inner() match)
-     *   4. Probe the gateway with the canonical body to get a 402 PaymentRequired
-     *   5. Call signer.buildHeader() to produce the base64 payment-signature
-     *   6. Inject `params.headers['payment-signature'] = header`
-     *   7. Call inner(params); on failure → refund budget (HF-P3-C2)
+     *   1. Validate ctx.streamFn
+     *   2. Build a probe body from model.id + cost-sensitive options fields
+     *   3. Probe the gateway → 402 PaymentRequired
+     *   4. Sign payment via signer.buildHeader()
+     *   5. Forward to inner(model, context, { ...options, headers: { ...,
+     *      'payment-signature': header } })
+     *   6. On inner() failure → refund session budget
      *
-     * solvela/not-configured guard: if the resolved model is the diagnostic shadow,
-     * throw a clear config error rather than attempting to sign.
+     * Probe body is a stub: model id + max_tokens / temperature extracted
+     * from options. Direct mode tolerates this because the gateway prices
+     * upfront off model + max_tokens ceiling, not message content. Escrow
+     * mode requires byte-perfect probe/real-call body alignment for PDA
+     * derivation — that needs the dispatcher pattern. See
+     * docs/escrow-byte-alignment.md.
      *
-     * DO NOT change this to use Authorization: Bearer — the gateway middleware
-     * reads 'payment-signature' (lowercase), not an Authorization header.
+     * DO NOT change this to use `Authorization: Bearer` — the gateway
+     * middleware reads `payment-signature` (lowercase).
      */
     wrapStreamFn: (ctx: StreamFnContext): StreamFn => {
-      // Fail loud — silently returning undefined allows OpenClaw to call the
-      // inner stream without a payment header (HF-P3-C3).
       if (!ctx?.streamFn || typeof ctx.streamFn !== 'function') {
         throw new Error(
           'Solvela: wrapStreamFn invoked without a valid streamFn. ' +
@@ -382,53 +420,35 @@ export default function register(api: OpenClawApi, opts: RegisterOptions = {}): 
 
       const inner = ctx.streamFn;
 
-      return async (params) => {
-        // 'off' mode: skip signing entirely — forward to inner() without a payment header.
-        // Gateway will 402 unless it's in dev_bypass_payment mode. Parity with Phase 1 MCP.
+      return async (model, context, options) => {
         if (signingMode === 'off') {
           process.stderr.write(
             '[solvela-openclaw] WARN: signingMode=off — forwarding request without payment header.\n',
           );
-          return inner(params);
+          return inner(model, context, options);
         }
 
-        // solvela/not-configured guard (HF-P3-H5)
-        const resolvedModelId =
-          typeof ctx.model?.id === 'string' ? ctx.model.id : undefined;
-        if (resolvedModelId === 'solvela/not-configured') {
+        if (model?.id === 'solvela/not-configured') {
           throw new Error(
             'Solvela: SOLANA_WALLET_KEY is not set. ' +
               'Set SOLANA_WALLET_KEY to your base58-encoded Solana wallet key to use Solvela.',
           );
         }
 
-        // Step 2+3: Serialize body once and write back to params as canonical string (HF-P3-C1).
-        // Both probe and inner() see byte-identical bodies — prevents PDA derivation mismatch.
-        const requestBody =
-          typeof params.body === 'string' ? params.body : JSON.stringify(params.body ?? {});
-        params.body = requestBody;
-
         const apiUrl = getApiUrl();
-        const resourceUrl =
-          typeof params.url === 'string' ? params.url : `${apiUrl}/v1/chat/completions`;
+        const resourceUrl = `${apiUrl}/v1/chat/completions`;
+        const probeBody = buildProbeBody(model.id, options);
 
-        // Steps 4+5: Probe and sign
         let paymentHeader: string;
         let cost: number;
         try {
-          // Probe at the same URL we'll sign and call. Avoids cost-mismatch
-          // when the wrapped stream targets a non-chat-completions route
-          // (e.g. /v1/embeddings) and the gateway prices it differently.
-          const paymentInfo = await fetchPaymentRequired(apiUrl, requestBody, resourceUrl);
-          // Number() (not parseFloat) so trailing garbage like "0.001SOL"
-          // produces NaN — surfaces immediately at the validation in
-          // signer.buildHeader rather than silently reserving against
-          // an unvalidated value.
+          const paymentInfo = await fetchPaymentRequired(apiUrl, probeBody, resourceUrl);
+          // Number() (not parseFloat) so "0.001SOL" → NaN, surfacing at
+          // signer.buildHeader rather than silently reserving an unvalidated value.
           cost = Number(paymentInfo.cost_breakdown?.total ?? 'NaN');
-          paymentHeader = await signer.buildHeader(paymentInfo, resourceUrl, requestBody);
+          paymentHeader = await signer.buildHeader(paymentInfo, resourceUrl, probeBody);
         } catch (err) {
           if (err instanceof GatewayAcceptedWithoutPayment) {
-            // dev_bypass_payment mode — only allowed with explicit opt-in (HF-P3-C4)
             if (process.env['SOLVELA_ALLOW_DEV_BYPASS'] !== '1') {
               throw new Error(
                 'Solvela: gateway probe returned 200 unexpectedly (no 402 envelope). ' +
@@ -439,28 +459,26 @@ export default function register(api: OpenClawApi, opts: RegisterOptions = {}): 
             process.stderr.write(
               '[solvela-openclaw] WARN: Gateway accepted without payment (SOLVELA_ALLOW_DEV_BYPASS=1). No signing this call.\n',
             );
-            return inner(params);
+            return inner(model, context, options);
           }
-          // Surface signing failures clearly — err.message is safe (SDK strips key bytes)
           throw new Error(
             `Solvela payment signing failed: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
 
-        // Step 6: Inject payment-signature header (lowercase, matching middleware/x402.rs:38)
-        params.headers = {
-          ...params.headers,
-          'payment-signature': paymentHeader,
+        // Merge payment-signature into options.headers — canonical pattern
+        // from createOpenAIAttributionHeadersWrapper.
+        const wrappedOptions = {
+          ...options,
+          headers: {
+            ...options?.headers,
+            'payment-signature': paymentHeader,
+          },
         };
 
-        // Step 7: Call inner with refund on failure (HF-P3-C2).
-        // If inner() throws (network, gateway 500, stream error), the session budget
-        // is refunded — the real call never succeeded.
         try {
-          const result = await inner(params);
-          return result;
+          return await inner(model, context, wrappedOptions);
         } catch (err) {
-          // Refund — the real call never succeeded
           await signer.refundBudget(cost);
           throw err;
         }

--- a/sdks/openclaw-provider/src/index.ts
+++ b/sdks/openclaw-provider/src/index.ts
@@ -60,6 +60,8 @@ import type { PaymentRequired } from '@solvela/signer-core';
 export { SOLVELA_MODELS } from './models.generated.js';
 export { ROUTING_PROFILES } from './registry.js';
 export type { OpenClawApi } from './openclaw-types.js';
+export { wrapStreamForF4 } from './f4-wrapper.js';
+export type { F4Context, F4Stats, ResultableStream } from './f4-wrapper.js';
 
 // ---------------------------------------------------------------------------
 // Config from environment
@@ -415,6 +417,21 @@ export default function register(api: OpenClawApi, opts: RegisterOptions = {}): 
           'Solvela: wrapStreamFn invoked without a valid streamFn. ' +
             'This likely means the OpenClaw SDK version is incompatible. ' +
             'Verify @solvela/openclaw-provider is up to date.',
+        );
+      }
+
+      // Smoke check: warn if ctx.streamFn arity is 0. Real StreamFn is 3-arg
+      // (model, context, options). A 0-arg function suggests the host swapped
+      // in a (...args) rest-param wrapper or a 0-arg stub — symptom of the
+      // pi-coding-agent 0.63.0 regression class (openclaw#55760, #55816, #57860).
+      // We warn rather than throw because Function.length can be 0 for valid
+      // wrappers built with rest-params, but the combination of (a) sitting on
+      // wrapStreamFn and (b) arity 0 has been a real defect signal.
+      if (ctx.streamFn.length === 0) {
+        process.stderr.write(
+          '[solvela-openclaw] WARN: ctx.streamFn arity is 0 — expected (model, context, options). ' +
+            'May indicate the OpenClaw runtime swapped the wrapped streamFn with a rest-arg stub. ' +
+            'See openclaw/openclaw#55760 for the pi-coding-agent 0.63.0 regression class.\n',
         );
       }
 

--- a/sdks/openclaw-provider/src/openclaw-types.ts
+++ b/sdks/openclaw-provider/src/openclaw-types.ts
@@ -1,51 +1,58 @@
 /**
- * Minimal OpenClaw Provider Plugin SDK type stubs.
+ * Type surface for the Solvela OpenClaw Provider Plugin.
  *
- * These are typed against the documented API surface from
- * https://docs.openclaw.ai/plugins/sdk-provider-plugins
+ * What is REAL (imported from upstream npm packages):
  *
- * The actual OpenClaw runtime injects the real `api` object at load time;
- * these types exist only for TypeScript type-checking during development.
- * They are intentionally conservative — only the hooks used by this plugin.
+ *   - StreamFn — comes from @earendil-works/pi-agent-core. Real signature is
+ *     (model, context, options?) => AssistantMessageEventStream | Promise<...>.
+ *     See node_modules/@earendil-works/pi-agent-core/dist/types.d.ts and
+ *     node_modules/@earendil-works/pi-ai/dist/stream.d.ts. The OpenClaw runtime
+ *     invokes wrapped StreamFns as 3-arg — canonical refs:
+ *       - openclaw/openclaw@main: src/agents/pi-embedded-runner/extra-params.ts:418
+ *       - openclaw/openclaw@main: src/agents/pi-embedded-runner/openai-stream-wrappers.ts:567
+ *       - openclaw/openclaw@main: src/plugin-sdk/provider-stream-shared.test.ts:78
  *
- * WARNING: These are hand-rolled stubs of OpenClaw SDK types. Sync with
- * upstream when OpenClaw publishes @openclaw/sdk (HF-P3-M6).
+ * What is STILL a hand-rolled stub (no upstream npm equivalent today):
  *
- * wrapStreamFn shape (HF-P3-H1): The real SDK docs confirm the factory shape:
- *   `(ctx: StreamFnContext) => StreamFn`
- * Plan §10.5 showed a flat `(request, next)` shape — that section is stale.
- * This file declares the correct factory shape.
+ *   - The plugin SDK surface (`OpenClawApi`, `ProviderConfig`, `StreamFnContext`,
+ *     `CatalogContext`, `DynamicModelContext`, `ResolvedModel`, `ProviderAuthMethod`,
+ *     `CatalogResult`). These shapes live in openclaw/openclaw@main:src/plugins/types.ts
+ *     but are not yet published as a standalone package. They are conservatively
+ *     mirrored here for the hooks this plugin uses. Re-verify against canonical
+ *     before adding new fields.
+ *
+ * PR 1 (type honesty) intentionally exposes the bug at compile time:
+ * the `wrapStreamFn` body in src/index.ts is built around a fictional
+ * 1-arg (params) shape — the OpenClaw runtime calls it as 3-arg
+ * (model, context, options). The typechecker now flags this. PR 3 fixes
+ * the runtime path (undici dispatcher); only then will typecheck go green.
+ *
+ * DO NOT mark the broken sites with @ts-expect-error to "fix" CI — the
+ * compile failure is the deliverable for PR 1.
  */
 
 import type { SolvelaModel } from './models.generated.js';
 
-/** A stream function that executes one inference call. */
-export type StreamFn = (params: StreamParams) => Promise<StreamResult>;
+// Real StreamFn — sourced from upstream. Never redeclare locally.
+export type { StreamFn } from '@earendil-works/pi-agent-core';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
 
-/** Parameters passed to a stream function (outbound request). */
-export interface StreamParams {
-  /** Outbound HTTP headers — mutate to inject payment headers. */
-  headers: Record<string, string>;
-  /** Request body (JSON string). */
-  body?: string;
-  /** Target URL. */
-  url?: string;
-  [key: string]: unknown;
-}
-
-/** Result returned by a stream function. */
-export type StreamResult = unknown;
-
-/** Context passed to the wrapStreamFn hook. */
+/**
+ * Context passed to the wrapStreamFn hook.
+ *
+ * Stub — mirrored from openclaw/openclaw@main:src/plugins/types.ts. Only the
+ * fields this plugin reads. The `streamFn` field is now typed against the
+ * real StreamFn (3-arg) — wrapping it requires `(model, context, options)`.
+ */
 export interface StreamFnContext {
-  /** The existing stream function to wrap. */
+  /** The inner stream function to wrap. */
   streamFn?: StreamFn;
   /** The resolved model for this call. */
   model?: ResolvedModel;
   [key: string]: unknown;
 }
 
-/** A resolved model entry (as returned by catalog.run). */
+/** A resolved model entry (as returned by catalog.run). Stub — see file header. */
 export interface ResolvedModel {
   id: string;
   name: string;
@@ -53,13 +60,13 @@ export interface ResolvedModel {
   [key: string]: unknown;
 }
 
-/** Context passed to catalog.run. */
+/** Context passed to catalog.run. Stub — see file header. */
 export interface CatalogContext {
   resolveProviderApiKey: (providerId: string) => { apiKey?: string };
   [key: string]: unknown;
 }
 
-/** Result shape returned by catalog.run. */
+/** Result shape returned by catalog.run. Stub — see file header. */
 export interface CatalogResult {
   provider: {
     baseUrl: string;
@@ -69,26 +76,26 @@ export interface CatalogResult {
   };
 }
 
-/** Context passed to resolveDynamicModel. */
+/** Context passed to resolveDynamicModel. Stub — see file header. */
 export interface DynamicModelContext {
   modelId: string;
   [key: string]: unknown;
 }
 
-/** Auth method declaration for the provider manifest. */
+/** Auth method declaration for the provider manifest. Stub — see file header. */
 export interface ProviderAuthMethod {
   method: 'api-key' | 'oauth' | 'none';
   envVar?: string;
   [key: string]: unknown;
 }
 
-/** The OpenClaw plugin API object injected by the host at load time. */
+/** The OpenClaw plugin API object injected by the host at load time. Stub — see file header. */
 export interface OpenClawApi {
   registerProvider(config: ProviderConfig): void;
   [key: string]: unknown;
 }
 
-/** Full provider registration config. */
+/** Full provider registration config. Stub — see file header. */
 export interface ProviderConfig {
   id: string;
   label: string;

--- a/sdks/openclaw-provider/src/signer.ts
+++ b/sdks/openclaw-provider/src/signer.ts
@@ -168,13 +168,16 @@ export class SolvelaSigner {
     }
 
     // Step 7 — Escrow deposit counter WARN (HF-P3-H6)
-    // Emit a warning every 10 escrow/auto deposits to remind users about auto-claim reliance.
+    // Emit a warning every 10 escrow/auto deposits to remind users that the
+    // claim path relies on gateway auto-claim until both halves of F4 ship
+    // (client wrapper landed; gateway /v1/escrow/settle endpoint pending).
     if (this.signingMode === 'escrow' || this.signingMode === 'auto') {
       this.escrowDepositCount++;
       if (this.escrowDepositCount % 10 === 0) {
         process.stderr.write(
           `[solvela-openclaw] WARN: ${this.escrowDepositCount} escrow deposits made; ` +
-            'auto-claim relies on gateway timeout. Direct mode recommended until F4 escrow-claim hook lands.\n',
+            'gateway auto-claim still handles reconciliation (F4 settle endpoint not yet deployed). ' +
+            'See README.md "Escrow accounting (F4)".\n',
         );
       }
     }

--- a/sdks/openclaw-provider/tests/f4-wrapper.test.ts
+++ b/sdks/openclaw-provider/tests/f4-wrapper.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the F4 settle-on-stream-completion wrapper.
+ *
+ * Verifies:
+ *   - settle POST fires once when stream.result() resolves
+ *   - settle POST carries model, agent, service_id, and actual token usage
+ *   - settle POST status is 'completed' on normal stop, 'error' on aborted/error
+ *   - stream consumer is never blocked or impacted by settle failure
+ *   - timeoutMs is honored (AbortSignal fires)
+ *   - stats counter tracks fired/succeeded/failed
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  wrapStreamForF4,
+  type F4Context,
+  type F4Stats,
+  type ResultableStream,
+} from '../src/f4-wrapper.ts';
+
+// Minimal AssistantMessage stub. Real type from @earendil-works/pi-ai has
+// many more fields, but the F4 wrapper only reads stopReason + usage.
+type FakeMessage = {
+  stopReason: 'stop' | 'length' | 'toolUse' | 'error' | 'aborted';
+  usage?: { input: number; output: number };
+};
+
+function makeStream(message: FakeMessage, opts: { delayMs?: number; rejectWith?: Error } = {}): ResultableStream {
+  return {
+    result: () =>
+      new Promise((resolve, reject) => {
+        const fire = () => {
+          if (opts.rejectWith) reject(opts.rejectWith);
+          else resolve(message as unknown as Parameters<typeof resolve>[0]);
+        };
+        if (opts.delayMs) setTimeout(fire, opts.delayMs);
+        else fire();
+      }),
+  };
+}
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  body: string;
+}
+
+function makeMockFetch(opts: {
+  status?: number;
+  throwOnCall?: Error;
+  delayMs?: number;
+} = {}): { fn: typeof fetch; captured: CapturedRequest[] } {
+  const captured: CapturedRequest[] = [];
+  const fn = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    captured.push({
+      url: typeof input === 'string' ? input : input.toString(),
+      method: init?.method ?? 'GET',
+      body: typeof init?.body === 'string' ? init.body : '',
+    });
+    if (opts.delayMs) await new Promise((r) => setTimeout(r, opts.delayMs));
+    if (opts.throwOnCall) throw opts.throwOnCall;
+    return new Response(null, { status: opts.status ?? 200 });
+  }) as unknown as typeof fetch;
+  return { fn, captured };
+}
+
+const baseF4: Omit<F4Context, 'fetchFn'> = {
+  serviceId: 'svc_test_123',
+  agentPubkey: 'GaTeWaYPuBkEyXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  modelId: 'gpt-4o',
+  gatewayUrl: 'https://gw.example.test',
+};
+
+/** Wait until the microtask queue + a setImmediate cycle drains. */
+async function flushAsync(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe('wrapStreamForF4', () => {
+  it('returns the input stream unchanged (no piping)', () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    const { fn } = makeMockFetch();
+    const result = wrapStreamForF4(stream, { ...baseF4, fetchFn: fn });
+    assert.strictEqual(result, stream, 'wrapStreamForF4 must return the same reference');
+  });
+
+  it('fires settle POST with completed status on normal stream completion', async () => {
+    const stream = makeStream({
+      stopReason: 'stop',
+      usage: { input: 17, output: 42 },
+    });
+    const { fn, captured } = makeMockFetch();
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn }, stats);
+    await flushAsync();
+
+    assert.strictEqual(captured.length, 1, 'exactly one settle POST');
+    const req = captured[0];
+    assert.strictEqual(req.url, 'https://gw.example.test/v1/escrow/settle');
+    assert.strictEqual(req.method, 'POST');
+    const body = JSON.parse(req.body);
+    assert.strictEqual(body.service_id, 'svc_test_123');
+    assert.strictEqual(body.agent_pubkey, baseF4.agentPubkey);
+    assert.strictEqual(body.model, 'gpt-4o');
+    assert.strictEqual(body.status, 'completed');
+    assert.strictEqual(body.actual_prompt_tokens, 17);
+    assert.strictEqual(body.actual_completion_tokens, 42);
+    assert.strictEqual(stats.fired, 1);
+    assert.strictEqual(stats.succeeded, 1);
+    assert.strictEqual(stats.failed, 0);
+  });
+
+  it("settle POST status='error' on stopReason='error'", async () => {
+    const stream = makeStream({ stopReason: 'error', usage: { input: 5, output: 0 } });
+    const { fn, captured } = makeMockFetch();
+
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn });
+    await flushAsync();
+
+    const body = JSON.parse(captured[0].body);
+    assert.strictEqual(body.status, 'error');
+  });
+
+  it("settle POST status='error' on stopReason='aborted'", async () => {
+    const stream = makeStream({ stopReason: 'aborted' });
+    const { fn, captured } = makeMockFetch();
+
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn });
+    await flushAsync();
+
+    const body = JSON.parse(captured[0].body);
+    assert.strictEqual(body.status, 'error');
+  });
+
+  it('skips token fields when usage is absent', async () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    const { fn, captured } = makeMockFetch();
+
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn });
+    await flushAsync();
+
+    const body = JSON.parse(captured[0].body);
+    assert.ok(!('actual_prompt_tokens' in body), 'omit prompt tokens when usage absent');
+    assert.ok(!('actual_completion_tokens' in body), 'omit completion tokens when usage absent');
+  });
+
+  it('does not throw or block when stream.result() rejects', async () => {
+    const stream = makeStream({ stopReason: 'stop' }, { rejectWith: new Error('stream burned down') });
+    const { fn, captured } = makeMockFetch();
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+
+    assert.doesNotThrow(() => wrapStreamForF4(stream, { ...baseF4, fetchFn: fn }, stats));
+    await flushAsync();
+
+    assert.strictEqual(captured.length, 0, 'no settle POST when stream itself failed before result');
+    assert.strictEqual(stats.fired, 0, 'fired counter must NOT increment when stream rejected');
+  });
+
+  it('does not throw or block when settle POST returns 404 (gateway endpoint not deployed)', async () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    const { fn } = makeMockFetch({ status: 404 });
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+
+    assert.doesNotThrow(() => wrapStreamForF4(stream, { ...baseF4, fetchFn: fn }, stats));
+    await flushAsync();
+
+    assert.strictEqual(stats.fired, 1, 'fired counter increments even on 404');
+    assert.strictEqual(stats.succeeded, 0, 'succeeded does NOT increment on 404');
+    assert.strictEqual(stats.failed, 1, 'failed increments on 404');
+  });
+
+  it('does not throw or block when settle POST throws (network error)', async () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    const { fn } = makeMockFetch({ throwOnCall: new Error('ECONNREFUSED') });
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+
+    assert.doesNotThrow(() => wrapStreamForF4(stream, { ...baseF4, fetchFn: fn }, stats));
+    await flushAsync();
+
+    assert.strictEqual(stats.fired, 1);
+    assert.strictEqual(stats.failed, 1);
+  });
+
+  it('accepts a Promise<ResultableStream> as input', async () => {
+    const stream = makeStream({ stopReason: 'stop', usage: { input: 1, output: 1 } });
+    const streamPromise = Promise.resolve(stream);
+    const { fn, captured } = makeMockFetch();
+
+    wrapStreamForF4(streamPromise, { ...baseF4, fetchFn: fn });
+    await flushAsync();
+
+    assert.strictEqual(captured.length, 1, 'settle fires after the stream promise resolves');
+  });
+
+  it('respects custom timeoutMs (AbortSignal fires)', async () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    // Mock fetch that ignores abort and resolves slowly — should be aborted
+    let aborted = false;
+    const fn = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      return new Promise<Response>((resolve, reject) => {
+        const signal = init?.signal;
+        const timer = setTimeout(() => resolve(new Response(null, { status: 200 })), 1000);
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            aborted = true;
+            clearTimeout(timer);
+            reject(new Error('aborted'));
+          });
+        }
+      });
+    }) as unknown as typeof fetch;
+
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn, timeoutMs: 20 }, stats);
+
+    // Wait long enough for timeout to fire but not the 1s resolve
+    await new Promise((r) => setTimeout(r, 100));
+
+    assert.strictEqual(aborted, true, 'AbortSignal must fire after timeoutMs');
+    assert.strictEqual(stats.failed, 1, 'aborted settle counts as failed');
+  });
+});

--- a/sdks/openclaw-provider/tests/index.test.ts
+++ b/sdks/openclaw-provider/tests/index.test.ts
@@ -254,29 +254,66 @@ describe('Plugin registration', () => {
     register(api);
     const cfg = (config as unknown as { config: ProviderConfig }).config;
 
-    let capturedParams: { headers: Record<string, string> } | null = null;
-    const mockStreamFn = async (params: { headers: Record<string, string> }) => {
-      capturedParams = params;
-      return { status: 200 };
-    };
-
-    const ctx: StreamFnContext = { streamFn: mockStreamFn as unknown as typeof mockStreamFn };
+    const { fn, getCalled } = makeCapturingStreamFn();
+    const ctx: StreamFnContext = { streamFn: fn };
     const wrapped = cfg.wrapStreamFn!(ctx)!;
 
-    await wrapped({
-      headers: { 'content-type': 'application/json' },
-      body: '{"model":"auto","messages":[]}',
-      url: 'http://127.0.0.1:9999/v1/chat/completions',
-    });
+    await callWrapped(wrapped);
 
-    assert.ok(capturedParams !== null, 'inner stream function must be called');
-    const captured = capturedParams as { headers: Record<string, string> };
+    const called = getCalled();
+    assert.ok(called !== null, 'inner stream function must be called');
+    const opts = called.options as { headers?: Record<string, string> } | undefined;
     assert.ok(
-      !('payment-signature' in captured.headers),
+      !opts?.headers || !('payment-signature' in opts.headers),
       'payment-signature must NOT be injected in off mode',
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Helpers for the new (model, context, options) StreamFn shape
+// ---------------------------------------------------------------------------
+
+interface CapturedCall {
+  model: unknown;
+  context: unknown;
+  options: unknown;
+}
+
+/**
+ * Build a StreamFn-shaped mock that captures the 3-arg call from wrapStreamFn's
+ * wrapped function. Returns the mock plus a `getCalled` accessor to inspect
+ * the most recent call's (model, context, options) tuple.
+ */
+function makeCapturingStreamFn(opts: { throwOnCall?: Error } = {}): {
+  fn: NonNullable<StreamFnContext['streamFn']>;
+  getCalled: () => CapturedCall | null;
+} {
+  let called: CapturedCall | null = null;
+  const fn = ((model: unknown, context: unknown, options: unknown) => {
+    called = { model, context, options };
+    if (opts.throwOnCall) throw opts.throwOnCall;
+    return {} as never;
+  }) as unknown as NonNullable<StreamFnContext['streamFn']>;
+  return { fn, getCalled: () => called };
+}
+
+/**
+ * Invoke a wrapped StreamFn with fake (model, context, options) args. The
+ * runtime doesn't introspect these beyond `model.id` and `options.headers`,
+ * so minimal stubs suffice.
+ */
+function callWrapped(
+  wrapped: NonNullable<ReturnType<NonNullable<ProviderConfig['wrapStreamFn']>>>,
+  opts: { modelId?: string; maxTokens?: number } = {},
+): ReturnType<typeof wrapped> {
+  const fakeModel = { id: opts.modelId ?? 'auto' } as never;
+  const fakeContext = { messages: [] } as never;
+  const fakeOptions = (opts.maxTokens != null
+    ? { maxTokens: opts.maxTokens, headers: {} }
+    : { headers: {} }) as never;
+  return wrapped(fakeModel, fakeContext, fakeOptions);
+}
 
 describe('wrapStreamFn', () => {
   it('throws when ctx.streamFn is absent (HF-P3-C3)', () => {
@@ -293,123 +330,84 @@ describe('wrapStreamFn', () => {
     );
   });
 
-  it('injects payment-signature header when gateway returns 402', async () => {
+  it('injects payment-signature header into options.headers when gateway returns 402', async () => {
     const { server, port } = await startMock402Server();
 
     process.env['SOLVELA_API_URL'] = `http://127.0.0.1:${port}`;
     process.env['SOLANA_WALLET_KEY'] = 'fake_wallet_key_for_test';
 
     const { api, config } = makeMockApi();
-    // DI signer bypasses real SDK signing — returns known non-stub header
     register(api, { _signer: makeDISigner() });
     const cfg = (config as unknown as { config: ProviderConfig }).config;
 
-    let capturedParams: { headers: Record<string, string> } | null = null;
-    const mockStreamFn = async (params: { headers: Record<string, string> }) => {
-      capturedParams = params;
-      return { status: 200 };
-    };
-
-    const ctx: StreamFnContext = { streamFn: mockStreamFn as unknown as typeof mockStreamFn };
+    const { fn, getCalled } = makeCapturingStreamFn();
+    const ctx: StreamFnContext = { streamFn: fn };
     const wrapped = cfg.wrapStreamFn!(ctx)!;
     assert.ok(typeof wrapped === 'function', 'wrapStreamFn must return a function');
 
     try {
-      await wrapped({
-        headers: { 'content-type': 'application/json' },
-        body: '{"model":"auto","messages":[]}',
-        url: `http://127.0.0.1:${port}/v1/chat/completions`,
-      });
+      await callWrapped(wrapped);
     } finally {
       server.close();
     }
 
-    assert.ok(capturedParams !== null, 'inner stream function must be called');
-    const captured = capturedParams as { headers: Record<string, string> };
+    const called = getCalled();
+    assert.ok(called !== null, 'inner stream function must be called');
+    const opts = called.options as { headers?: Record<string, string> };
     assert.ok(
-      'payment-signature' in captured.headers,
-      'payment-signature header must be injected',
+      opts.headers && 'payment-signature' in opts.headers,
+      'payment-signature header must be injected into options.headers',
     );
-    const header = captured.headers['payment-signature'];
-    assert.ok(typeof header === 'string' && header.length > 10, 'payment-signature must be a non-trivial base64 string');
+    const header = opts.headers!['payment-signature'];
+    assert.ok(
+      typeof header === 'string' && header.length > 10,
+      'payment-signature must be a non-trivial base64 string',
+    );
 
     // Verify it decodes to valid JSON with x402_version
     const decoded = JSON.parse(Buffer.from(header, 'base64').toString('utf-8'));
     assert.ok(decoded.x402_version !== undefined, 'decoded header must have x402_version');
   });
 
-  it('body written back to params as canonical string (HF-P3-C1)', async () => {
-    const { server, port } = await startMock402Server();
+  it('probe body uses model.id from wrapStreamFn args', async () => {
+    // Capture the body the gateway sees on the probe POST.
+    let probedBody = '';
+    const probeServer = await startMockServer((res) => {
+      res.writeHead(402, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(mock402));
+    });
+    // Wrap the server with one that captures the request body
+    probeServer.server.removeAllListeners('request');
+    probeServer.server.on('request', (req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        probedBody = Buffer.concat(chunks).toString('utf-8');
+        res.writeHead(402, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(mock402));
+      });
+    });
 
-    process.env['SOLVELA_API_URL'] = `http://127.0.0.1:${port}`;
+    process.env['SOLVELA_API_URL'] = `http://127.0.0.1:${probeServer.port}`;
     process.env['SOLANA_WALLET_KEY'] = 'fake_wallet_key_for_test';
 
     const { api, config } = makeMockApi();
     register(api, { _signer: makeDISigner() });
     const cfg = (config as unknown as { config: ProviderConfig }).config;
 
-    let capturedParams: { body?: unknown } | null = null;
-    const mockStreamFn = async (params: { body?: unknown }) => {
-      capturedParams = params;
-      return { status: 200 };
-    };
-
-    const ctx: StreamFnContext = { streamFn: mockStreamFn as unknown as typeof mockStreamFn };
+    const { fn } = makeCapturingStreamFn();
+    const ctx: StreamFnContext = { streamFn: fn };
     const wrapped = cfg.wrapStreamFn!(ctx)!;
 
-    const originalBody = '{"model":"auto","messages":[]}';
-    const inParams = {
-      headers: { 'content-type': 'application/json' },
-      body: originalBody,
-      url: `http://127.0.0.1:${port}/v1/chat/completions`,
-    };
     try {
-      await wrapped(inParams);
+      await callWrapped(wrapped, { modelId: 'gpt-4o', maxTokens: 1024 });
     } finally {
-      server.close();
+      probeServer.server.close();
     }
 
-    // params.body must be the canonical string (HF-P3-C1)
-    assert.strictEqual(inParams.body, originalBody, 'params.body must be set to canonical string');
-    assert.strictEqual(capturedParams!.body, originalBody, 'inner() params.body must match canonical string');
-  });
-
-  it('object body is stringified to canonical JSON string (HF-P3-C1 object branch)', async () => {
-    const { server, port } = await startMock402Server();
-
-    process.env['SOLVELA_API_URL'] = `http://127.0.0.1:${port}`;
-    process.env['SOLANA_WALLET_KEY'] = 'fake_wallet_key_for_test';
-
-    const { api, config } = makeMockApi();
-    register(api, { _signer: makeDISigner() });
-    const cfg = (config as unknown as { config: ProviderConfig }).config;
-
-    let capturedParams: { body?: unknown } | null = null;
-    const mockStreamFn = async (params: { body?: unknown }) => {
-      capturedParams = params;
-      return { status: 200 };
-    };
-
-    const ctx: StreamFnContext = { streamFn: mockStreamFn as unknown as typeof mockStreamFn };
-    const wrapped = cfg.wrapStreamFn!(ctx)!;
-
-    const objectBody = { model: 'auto', messages: [{ role: 'user', content: 'hi' }] };
-    const inParams: { headers: Record<string, string>; body: unknown; url: string } = {
-      headers: { 'content-type': 'application/json' },
-      body: objectBody,
-      url: `http://127.0.0.1:${port}/v1/chat/completions`,
-    };
-    try {
-      await wrapped(inParams as Parameters<typeof wrapped>[0]);
-    } finally {
-      server.close();
-    }
-
-    // After the call, params.body must be a string (not the original object)
-    assert.strictEqual(typeof inParams.body, 'string', 'object body must be stringified to string');
-    const expectedJson = JSON.stringify(objectBody);
-    assert.strictEqual(inParams.body, expectedJson, 'body must be JSON.stringify of original object');
-    assert.strictEqual(capturedParams!.body, expectedJson, 'inner() must receive the canonical string');
+    const probed = JSON.parse(probedBody);
+    assert.strictEqual(probed.model, 'gpt-4o', 'probe body must carry the model.id from wrapStreamFn args');
+    assert.strictEqual(probed.max_tokens, 1024, 'probe body must carry options.maxTokens as max_tokens');
   });
 
   it('refunds budget on inner() failure (HF-P3-C2)', async () => {
@@ -424,22 +422,13 @@ describe('wrapStreamFn', () => {
     register(api, { _signer: diSigner });
     const cfg = (config as unknown as { config: ProviderConfig }).config;
 
-    // inner() always throws
-    const mockStreamFn = async () => {
-      throw new Error('network error');
-    };
-
-    const ctx: StreamFnContext = { streamFn: mockStreamFn as unknown as typeof mockStreamFn };
+    // First call: inner throws → budget should be refunded
+    const { fn: throwingFn } = makeCapturingStreamFn({ throwOnCall: new Error('network error') });
+    const ctx: StreamFnContext = { streamFn: throwingFn };
     const wrapped = cfg.wrapStreamFn!(ctx)!;
 
-    // Should throw from inner() but NOT from budget exceeded
     await assert.rejects(
-      () =>
-        wrapped({
-          headers: {},
-          body: '{"model":"auto","messages":[]}',
-          url: `http://127.0.0.1:${port}/v1/chat/completions`,
-        }),
+      async () => { await callWrapped(wrapped); },
       (err: Error) => {
         assert.ok(err.message === 'network error', `expected network error, got: ${err.message}`);
         return true;
@@ -448,28 +437,19 @@ describe('wrapStreamFn', () => {
 
     server1.close();
 
-    // The budget was refunded — second call should NOT hit budget exceeded.
-    // Start a fresh 402 server on a new random port.
+    // Second call: budget should still be available (refunded above)
     const { server: server2, port: port2 } = await startMock402Server();
     process.env['SOLVELA_API_URL'] = `http://127.0.0.1:${port2}`;
 
-    let secondCallSucceeded = false;
-    const mockStreamFn2 = async () => {
-      secondCallSucceeded = true;
-      return { status: 200 };
-    };
-    const ctx2: StreamFnContext = { streamFn: mockStreamFn2 as unknown as typeof mockStreamFn2 };
+    const { fn: succeedingFn, getCalled } = makeCapturingStreamFn();
+    const ctx2: StreamFnContext = { streamFn: succeedingFn };
     const wrapped2 = cfg.wrapStreamFn!(ctx2)!;
     try {
-      await wrapped2({
-        headers: {},
-        body: '{"model":"auto","messages":[]}',
-        url: `http://127.0.0.1:${port2}/v1/chat/completions`,
-      });
+      await callWrapped(wrapped2);
     } finally {
       server2.close();
     }
-    assert.ok(secondCallSucceeded, 'second call must succeed — budget must have been refunded');
+    assert.ok(getCalled() !== null, 'second call must succeed — budget must have been refunded');
   });
 
   it('throws when gateway returns 200 without SOLVELA_ALLOW_DEV_BYPASS=1 (HF-P3-C4)', async () => {
@@ -482,18 +462,13 @@ describe('wrapStreamFn', () => {
     register(api);
     const cfg = (config as unknown as { config: ProviderConfig }).config;
 
-    const mockStreamFn = async () => ({ status: 200 });
-    const ctx: StreamFnContext = { streamFn: mockStreamFn as unknown as typeof mockStreamFn };
+    const { fn } = makeCapturingStreamFn();
+    const ctx: StreamFnContext = { streamFn: fn };
     const wrapped = cfg.wrapStreamFn!(ctx)!;
 
     try {
       await assert.rejects(
-        () =>
-          wrapped({
-            headers: { 'content-type': 'application/json' },
-            body: '{"model":"auto","messages":[]}',
-            url: `http://127.0.0.1:${port}/v1/chat/completions`,
-          }),
+        async () => { await callWrapped(wrapped); },
         (err: Error) => {
           assert.ok(
             err.message.includes('SOLVELA_ALLOW_DEV_BYPASS=1'),
@@ -517,30 +492,21 @@ describe('wrapStreamFn', () => {
     register(api);
     const cfg = (config as unknown as { config: ProviderConfig }).config;
 
-    let capturedParams: { headers: Record<string, string> } | null = null;
-    const mockStreamFn = async (params: { headers: Record<string, string> }) => {
-      capturedParams = params;
-      return { status: 200 };
-    };
-
-    const ctx: StreamFnContext = { streamFn: mockStreamFn as unknown as typeof mockStreamFn };
+    const { fn, getCalled } = makeCapturingStreamFn();
+    const ctx: StreamFnContext = { streamFn: fn };
     const wrapped = cfg.wrapStreamFn!(ctx)!;
 
     try {
-      await wrapped({
-        headers: { 'content-type': 'application/json' },
-        body: '{"model":"auto","messages":[]}',
-        url: `http://127.0.0.1:${port}/v1/chat/completions`,
-      });
+      await callWrapped(wrapped);
     } finally {
       server.close();
     }
 
-    assert.ok(capturedParams !== null, 'inner stream function must be called');
-    const captured2 = capturedParams as { headers: Record<string, string> };
-    // In dev_bypass mode with flag set, payment-signature is NOT injected
+    const called = getCalled();
+    assert.ok(called !== null, 'inner stream function must be called');
+    const opts = called.options as { headers?: Record<string, string> } | undefined;
     assert.ok(
-      !('payment-signature' in captured2.headers),
+      !opts?.headers || !('payment-signature' in opts.headers),
       'payment-signature must NOT be injected in dev_bypass mode',
     );
   });

--- a/sdks/openclaw-provider/tsconfig.json
+++ b/sdks/openclaw-provider/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true


### PR DESCRIPTION
## Summary

Fixes the `wrapStreamFn` body to use the real 3-arg `(model, context, options)` shape. Resolves the 9 typecheck errors PR #263 intentionally exposed.

**Stack:** #263 → #264 → this PR. Merge in that order.

## What changed

- `src/index.ts` — `wrapStreamFn` body rewritten:
  - **OLD**: `return async (params) => { params.headers['payment-signature'] = signed; return inner(params); }` (fictional 1-arg shape)
  - **NEW**: `return async (model, context, options) => inner(model, context, { ...options, headers: { ...options?.headers, 'payment-signature': signed } })` (canonical 3-arg shape)
- `src/index.ts` — new `buildProbeBody(modelId, options)` helper that constructs the probe POST body from `model.id` + cost-sensitive `options` fields (`maxTokens`, `temperature`, `topP`).
- `tests/index.test.ts` — rewritten to match real signature. Two HF-P3-C1 byte-identical body tests removed (no longer applicable — probe body is now a deliberate stub); replaced with a single test asserting the probe body carries the right `model.id` and `max_tokens`.
- `docs/escrow-byte-alignment.md` — new doc explaining why we deferred Path B (undici dispatcher) and what the trade-off is.

Total: 3 files changed, 262 insertions(+), 203 deletions(-).

## Why Path A' instead of Path B

The original plan had Path B (undici dispatcher) at this PR. After re-analysis (see [project-openclaw-direction-2026-05 memory](https://github.com/solvela-ai/solvela/blob/main/.claude/projects/-home-kennethdixon-projects-solvela/memory/project_openclaw_direction_2026_05.md) for the full context):

- **Direct mode (the plugin's default) doesn't need byte-perfect probe alignment** — the gateway prices off `model + max_tokens`.
- **Escrow mode does need byte-perfect alignment** for PDA derivation. Path A' cannot guarantee this. Trade-off documented in `docs/escrow-byte-alignment.md`. F4 settle (separate PR) is the durable architectural answer for escrow accounting.
- **Path B is 4-8× more code and process-global.** Its insurance value against OpenClaw plugin SDK evolution is weak — the dispatcher would still need to be wired into OpenClaw somehow.
- **`wrapStreamFn` is confirmed stable.** 2026-05-13 audit (4 agents, 8+ sources) + 2026-05-13 re-check confirmed the hook is the post-refactor contract, not legacy. OpenClaw's own automated review bot (clawsweeper) on PR openclaw/openclaw#81440 independently verified the 3-arg signature analysis at 2026-05-13T14:38:20Z.

## CI expectations

When stacked on #263 + #264, all CI jobs go fully green:
- ✅ install
- ✅ typecheck (was red on #263; now passes — 0 errors)
- ✅ typecheck-tests (was red on #263; now passes — 0 errors)
- ✅ test (60/60 tests pass; was 61, deleted 2 obsolete tests + added 1 new)
- ✅ build (was red on #263; now passes)
- ✅ guard-install-scripts
- ✅ audit
- ✅ guard-deprecated-openclaw-imports (new in #264; passes — no deprecated imports)

## Test plan

- [ ] CI shows all 8 jobs green on this PR.
- [ ] Local: `npm run typecheck && npm run typecheck:tests && npm test && npm run build` all pass.
- [ ] Read `docs/escrow-byte-alignment.md` and confirm the deferral framing matches your view of strategic direction.

## What this does NOT do

- Does not add F4 settle (escrow post-stream claim) — that's the next PR.
- Does not add the budget mutex smoke tests (PR 4).
- Does not flip `private: false` — publishing waits for OpenClaw LTS (per `project-openclaw-direction-2026-05` memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)