### PR TITLE
feat(openclaw-provider): F4 settle wrapper + 3-arg streamFn smoke check

### DIFF
--- a/sdks/openclaw-provider/README.md
+++ b/sdks/openclaw-provider/README.md
@@ -35,8 +35,8 @@ Phase 1 MCP server pattern).
 
 ## Signing modes
 
-- **`direct`** (default in Phase 3): Forces direct USDC TransferChecked only.
-  Recommended until F4 (escrow-claim hook) ships.
+- **`direct`** (default): Forces direct USDC TransferChecked only. Recommended
+  for v1 — no client-side escrow accounting needed.
 - **`auto`**: Prefers the escrow payment scheme when the gateway advertises it,
   falls back to direct TransferChecked.
 - **`escrow`**: Forces escrow-only. If the gateway doesn't advertise escrow for
@@ -46,16 +46,32 @@ Phase 1 MCP server pattern).
   `dev_bypass_payment` mode. Parity with the Phase 1 MCP server. Never use in
   production against a live gateway.
 
-**Phase 3 note on escrow:** Escrow mode works in Phase 3, but the plugin has no
-stream-completion hook to trigger the claim. Every escrow deposit relies on the
-gateway auto-claim after `max_timeout_seconds`. Until F4 (escrow-claim hook on
-stream completion) ships, **`direct` is the recommended default**. If you
-explicitly set `SOLVELA_SIGNING_MODE=escrow` or `auto`, the plugin emits a
-warning every 10 deposits reminding you of this.
+### Escrow accounting (F4)
 
-**Security note on `direct` mode:** Direct-transfer payments are non-refundable
-if the stream fails mid-response. If recovery from partial-stream failures is
-important to you, wait for F4 before using escrow mode in production.
+Escrow mode deposits a max-amount USDC envelope on-chain before the call; the
+gateway claims the actual cost back from the deposit after the stream
+completes. There are two ways the claim can be triggered:
+
+1. **Gateway auto-claim after `max_timeout_seconds`** — works today; the
+   deposit is reconciled on a timer, so refunds for over-deposits arrive
+   asynchronously.
+2. **Client-side `wrapStreamForF4`** — the plugin exports a `wrapStreamForF4`
+   helper that observes the stream's `result()` Promise and POSTs the actual
+   token usage to the gateway's `/v1/escrow/settle` endpoint as soon as the
+   stream finishes. Reduces reconciliation latency from minutes to
+   milliseconds.
+
+The `wrapStreamForF4` wrapper is fully implemented and unit-tested
+(`tests/f4-wrapper.test.ts`). The matching gateway endpoint at
+`/v1/escrow/settle` is planned but not yet deployed — until it lands, settle
+POSTs return 404 and the wrapper logs a warning (the stream consumer is
+unaffected). Until the endpoint is live, you can still safely use escrow mode
+and rely on the auto-claim timer.
+
+**Security note on `direct` mode:** Direct-transfer payments are
+non-refundable if the stream fails mid-response. If recovery from
+partial-stream failures matters for your workload, prefer escrow mode (with
+F4 once the gateway endpoint ships, or auto-claim today).
 
 ## Dev bypass
 

--- a/sdks/openclaw-provider/package.json
+++ b/sdks/openclaw-provider/package.json
@@ -13,7 +13,7 @@
     "generate:models": "node --import tsx/esm scripts/generate-models.ts",
     "prebuild": "npm run generate:models",
     "build": "tsc",
-    "test": "node --import tsx/esm --test tests/index.test.ts tests/signer.test.ts tests/manifest.test.ts tests/models.test.ts tests/registry.test.ts",
+    "test": "node --import tsx/esm --test tests/index.test.ts tests/signer.test.ts tests/manifest.test.ts tests/models.test.ts tests/registry.test.ts tests/f4-wrapper.test.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
   },

--- a/sdks/openclaw-provider/src/f4-wrapper.ts
+++ b/sdks/openclaw-provider/src/f4-wrapper.ts
@@ -1,0 +1,164 @@
+/**
+ * F4 — post-stream escrow settle hook.
+ *
+ * Observes the inner AssistantMessageEventStream's `result()` Promise. On
+ * stream completion, fires a fire-and-forget POST to the gateway's
+ * `/v1/escrow/settle` endpoint with the actual token usage, so the gateway
+ * can claim the correct escrow amount based on real usage rather than
+ * relying on the timeout-based auto-claim fallback.
+ *
+ * Status: client-side complete; the gateway endpoint at `/v1/escrow/settle`
+ * does not exist yet (planned as a separate PR). Until that lands, settle
+ * POSTs return 404. Failures are logged to stderr but **never** crash the
+ * stream consumer or block the response.
+ *
+ * Usage:
+ *
+ *     import { wrapStreamForF4 } from '@solvela/openclaw-provider';
+ *
+ *     const stream = inner(model, context, options);
+ *     wrapStreamForF4(stream, {
+ *       serviceId,
+ *       agentPubkey,
+ *       modelId: model.id,
+ *       gatewayUrl: SOLVELA_API_URL,
+ *     });
+ *     return stream;
+ *
+ * Why side-effect-only (not piping):
+ *   We don't import `@earendil-works/pi-ai/utils/event-stream` because
+ *   pi-ai's package.json does not export that subpath. Instead we rely on
+ *   the EventStream's `.result()` Promise, which resolves when the producer
+ *   calls `end()` regardless of who consumes the AsyncIterator. This avoids
+ *   a 2-consumer race against OpenClaw's stream consumer.
+ */
+
+import type { AssistantMessage } from '@earendil-works/pi-ai';
+
+/**
+ * Structural type for any stream with a `.result()` Promise that resolves
+ * with the final AssistantMessage. Matches `EventStream<E, AssistantMessage>`
+ * from @earendil-works/pi-ai/utils/event-stream.
+ */
+export interface ResultableStream {
+  result(): Promise<AssistantMessage>;
+}
+
+/** Inputs F4 needs to settle a single escrow deposit against actual usage. */
+export interface F4Context {
+  /** Service ID identifying the escrow deposit PDA. Hex/base58/base64 — gateway-defined encoding. */
+  serviceId: string;
+  /** Base58-encoded agent (payer) pubkey. */
+  agentPubkey: string;
+  /** The model ID the call was billed against (e.g. "gpt-4o", "auto"). */
+  modelId: string;
+  /** Solvela gateway base URL (no trailing slash). */
+  gatewayUrl: string;
+  /** Optional fetch override for testing. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+  /** Optional timeout in ms for the settle POST (default 5000). */
+  timeoutMs?: number;
+}
+
+/** Optional stats tracker — used by tests and ops to count settle outcomes. */
+export interface F4Stats {
+  fired: number;
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Schedule a fire-and-forget escrow settle POST when the inner stream
+ * completes. Returns the input stream unchanged (no piping).
+ *
+ * Errors during settle are logged to stderr but do not propagate. The
+ * inner stream consumer is never blocked or impacted by F4.
+ */
+export function wrapStreamForF4<T extends ResultableStream | Promise<ResultableStream>>(
+  innerStream: T,
+  f4: F4Context,
+  stats?: F4Stats,
+): T {
+  void scheduleSettle(innerStream, f4, stats);
+  return innerStream;
+}
+
+async function scheduleSettle(
+  innerOrPromise: ResultableStream | Promise<ResultableStream>,
+  f4: F4Context,
+  stats: F4Stats | undefined,
+): Promise<void> {
+  let finalMessage: AssistantMessage;
+  try {
+    const stream = await Promise.resolve(innerOrPromise);
+    finalMessage = await stream.result();
+  } catch (err) {
+    process.stderr.write(
+      `[solvela-openclaw] F4: stream.result() rejected — skipping settle: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+    return;
+  }
+
+  const isError =
+    finalMessage.stopReason === 'error' || finalMessage.stopReason === 'aborted';
+  if (stats) stats.fired += 1;
+  try {
+    await postSettle(f4, finalMessage, isError);
+    if (stats) stats.succeeded += 1;
+  } catch (err) {
+    if (stats) stats.failed += 1;
+    process.stderr.write(
+      `[solvela-openclaw] F4: settle POST failed (non-blocking): ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
+}
+
+interface SettleBody {
+  service_id: string;
+  agent_pubkey: string;
+  model: string;
+  status: 'completed' | 'error';
+  actual_prompt_tokens?: number;
+  actual_completion_tokens?: number;
+}
+
+async function postSettle(
+  f4: F4Context,
+  finalMessage: AssistantMessage,
+  isError: boolean,
+): Promise<void> {
+  const body: SettleBody = {
+    service_id: f4.serviceId,
+    agent_pubkey: f4.agentPubkey,
+    model: f4.modelId,
+    status: isError ? 'error' : 'completed',
+  };
+  if (finalMessage.usage) {
+    body.actual_prompt_tokens = finalMessage.usage.input;
+    body.actual_completion_tokens = finalMessage.usage.output;
+  }
+
+  const timeoutMs = f4.timeoutMs ?? 5000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const fetchFn = f4.fetchFn ?? fetch;
+  try {
+    const resp = await fetchFn(`${f4.gatewayUrl}/v1/escrow/settle`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      redirect: 'error',
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`gateway settle returned ${resp.status} ${resp.statusText}`);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/sdks/openclaw-provider/src/index.ts
+++ b/sdks/openclaw-provider/src/index.ts
@@ -60,6 +60,8 @@ import type { PaymentRequired } from '@solvela/signer-core';
 export { SOLVELA_MODELS } from './models.generated.js';
 export { ROUTING_PROFILES } from './registry.js';
 export type { OpenClawApi } from './openclaw-types.js';
+export { wrapStreamForF4 } from './f4-wrapper.js';
+export type { F4Context, F4Stats, ResultableStream } from './f4-wrapper.js';
 
 // ---------------------------------------------------------------------------
 // Config from environment
@@ -415,6 +417,21 @@ export default function register(api: OpenClawApi, opts: RegisterOptions = {}): 
           'Solvela: wrapStreamFn invoked without a valid streamFn. ' +
             'This likely means the OpenClaw SDK version is incompatible. ' +
             'Verify @solvela/openclaw-provider is up to date.',
+        );
+      }
+
+      // Smoke check: warn if ctx.streamFn arity is 0. Real StreamFn is 3-arg
+      // (model, context, options). A 0-arg function suggests the host swapped
+      // in a (...args) rest-param wrapper or a 0-arg stub — symptom of the
+      // pi-coding-agent 0.63.0 regression class (openclaw#55760, #55816, #57860).
+      // We warn rather than throw because Function.length can be 0 for valid
+      // wrappers built with rest-params, but the combination of (a) sitting on
+      // wrapStreamFn and (b) arity 0 has been a real defect signal.
+      if (ctx.streamFn.length === 0) {
+        process.stderr.write(
+          '[solvela-openclaw] WARN: ctx.streamFn arity is 0 — expected (model, context, options). ' +
+            'May indicate the OpenClaw runtime swapped the wrapped streamFn with a rest-arg stub. ' +
+            'See openclaw/openclaw#55760 for the pi-coding-agent 0.63.0 regression class.\n',
         );
       }
 

--- a/sdks/openclaw-provider/src/signer.ts
+++ b/sdks/openclaw-provider/src/signer.ts
@@ -168,13 +168,16 @@ export class SolvelaSigner {
     }
 
     // Step 7 — Escrow deposit counter WARN (HF-P3-H6)
-    // Emit a warning every 10 escrow/auto deposits to remind users about auto-claim reliance.
+    // Emit a warning every 10 escrow/auto deposits to remind users that the
+    // claim path relies on gateway auto-claim until both halves of F4 ship
+    // (client wrapper landed; gateway /v1/escrow/settle endpoint pending).
     if (this.signingMode === 'escrow' || this.signingMode === 'auto') {
       this.escrowDepositCount++;
       if (this.escrowDepositCount % 10 === 0) {
         process.stderr.write(
           `[solvela-openclaw] WARN: ${this.escrowDepositCount} escrow deposits made; ` +
-            'auto-claim relies on gateway timeout. Direct mode recommended until F4 escrow-claim hook lands.\n',
+            'gateway auto-claim still handles reconciliation (F4 settle endpoint not yet deployed). ' +
+            'See README.md "Escrow accounting (F4)".\n',
         );
       }
     }

--- a/sdks/openclaw-provider/tests/f4-wrapper.test.ts
+++ b/sdks/openclaw-provider/tests/f4-wrapper.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the F4 settle-on-stream-completion wrapper.
+ *
+ * Verifies:
+ *   - settle POST fires once when stream.result() resolves
+ *   - settle POST carries model, agent, service_id, and actual token usage
+ *   - settle POST status is 'completed' on normal stop, 'error' on aborted/error
+ *   - stream consumer is never blocked or impacted by settle failure
+ *   - timeoutMs is honored (AbortSignal fires)
+ *   - stats counter tracks fired/succeeded/failed
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  wrapStreamForF4,
+  type F4Context,
+  type F4Stats,
+  type ResultableStream,
+} from '../src/f4-wrapper.ts';
+
+// Minimal AssistantMessage stub. Real type from @earendil-works/pi-ai has
+// many more fields, but the F4 wrapper only reads stopReason + usage.
+type FakeMessage = {
+  stopReason: 'stop' | 'length' | 'toolUse' | 'error' | 'aborted';
+  usage?: { input: number; output: number };
+};
+
+function makeStream(message: FakeMessage, opts: { delayMs?: number; rejectWith?: Error } = {}): ResultableStream {
+  return {
+    result: () =>
+      new Promise((resolve, reject) => {
+        const fire = () => {
+          if (opts.rejectWith) reject(opts.rejectWith);
+          else resolve(message as unknown as Parameters<typeof resolve>[0]);
+        };
+        if (opts.delayMs) setTimeout(fire, opts.delayMs);
+        else fire();
+      }),
+  };
+}
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  body: string;
+}
+
+function makeMockFetch(opts: {
+  status?: number;
+  throwOnCall?: Error;
+  delayMs?: number;
+} = {}): { fn: typeof fetch; captured: CapturedRequest[] } {
+  const captured: CapturedRequest[] = [];
+  const fn = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    captured.push({
+      url: typeof input === 'string' ? input : input.toString(),
+      method: init?.method ?? 'GET',
+      body: typeof init?.body === 'string' ? init.body : '',
+    });
+    if (opts.delayMs) await new Promise((r) => setTimeout(r, opts.delayMs));
+    if (opts.throwOnCall) throw opts.throwOnCall;
+    return new Response(null, { status: opts.status ?? 200 });
+  }) as unknown as typeof fetch;
+  return { fn, captured };
+}
+
+const baseF4: Omit<F4Context, 'fetchFn'> = {
+  serviceId: 'svc_test_123',
+  agentPubkey: 'GaTeWaYPuBkEyXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  modelId: 'gpt-4o',
+  gatewayUrl: 'https://gw.example.test',
+};
+
+/** Wait until the microtask queue + a setImmediate cycle drains. */
+async function flushAsync(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe('wrapStreamForF4', () => {
+  it('returns the input stream unchanged (no piping)', () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    const { fn } = makeMockFetch();
+    const result = wrapStreamForF4(stream, { ...baseF4, fetchFn: fn });
+    assert.strictEqual(result, stream, 'wrapStreamForF4 must return the same reference');
+  });
+
+  it('fires settle POST with completed status on normal stream completion', async () => {
+    const stream = makeStream({
+      stopReason: 'stop',
+      usage: { input: 17, output: 42 },
+    });
+    const { fn, captured } = makeMockFetch();
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn }, stats);
+    await flushAsync();
+
+    assert.strictEqual(captured.length, 1, 'exactly one settle POST');
+    const req = captured[0];
+    assert.strictEqual(req.url, 'https://gw.example.test/v1/escrow/settle');
+    assert.strictEqual(req.method, 'POST');
+    const body = JSON.parse(req.body);
+    assert.strictEqual(body.service_id, 'svc_test_123');
+    assert.strictEqual(body.agent_pubkey, baseF4.agentPubkey);
+    assert.strictEqual(body.model, 'gpt-4o');
+    assert.strictEqual(body.status, 'completed');
+    assert.strictEqual(body.actual_prompt_tokens, 17);
+    assert.strictEqual(body.actual_completion_tokens, 42);
+    assert.strictEqual(stats.fired, 1);
+    assert.strictEqual(stats.succeeded, 1);
+    assert.strictEqual(stats.failed, 0);
+  });
+
+  it("settle POST status='error' on stopReason='error'", async () => {
+    const stream = makeStream({ stopReason: 'error', usage: { input: 5, output: 0 } });
+    const { fn, captured } = makeMockFetch();
+
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn });
+    await flushAsync();
+
+    const body = JSON.parse(captured[0].body);
+    assert.strictEqual(body.status, 'error');
+  });
+
+  it("settle POST status='error' on stopReason='aborted'", async () => {
+    const stream = makeStream({ stopReason: 'aborted' });
+    const { fn, captured } = makeMockFetch();
+
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn });
+    await flushAsync();
+
+    const body = JSON.parse(captured[0].body);
+    assert.strictEqual(body.status, 'error');
+  });
+
+  it('skips token fields when usage is absent', async () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    const { fn, captured } = makeMockFetch();
+
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn });
+    await flushAsync();
+
+    const body = JSON.parse(captured[0].body);
+    assert.ok(!('actual_prompt_tokens' in body), 'omit prompt tokens when usage absent');
+    assert.ok(!('actual_completion_tokens' in body), 'omit completion tokens when usage absent');
+  });
+
+  it('does not throw or block when stream.result() rejects', async () => {
+    const stream = makeStream({ stopReason: 'stop' }, { rejectWith: new Error('stream burned down') });
+    const { fn, captured } = makeMockFetch();
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+
+    assert.doesNotThrow(() => wrapStreamForF4(stream, { ...baseF4, fetchFn: fn }, stats));
+    await flushAsync();
+
+    assert.strictEqual(captured.length, 0, 'no settle POST when stream itself failed before result');
+    assert.strictEqual(stats.fired, 0, 'fired counter must NOT increment when stream rejected');
+  });
+
+  it('does not throw or block when settle POST returns 404 (gateway endpoint not deployed)', async () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    const { fn } = makeMockFetch({ status: 404 });
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+
+    assert.doesNotThrow(() => wrapStreamForF4(stream, { ...baseF4, fetchFn: fn }, stats));
+    await flushAsync();
+
+    assert.strictEqual(stats.fired, 1, 'fired counter increments even on 404');
+    assert.strictEqual(stats.succeeded, 0, 'succeeded does NOT increment on 404');
+    assert.strictEqual(stats.failed, 1, 'failed increments on 404');
+  });
+
+  it('does not throw or block when settle POST throws (network error)', async () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    const { fn } = makeMockFetch({ throwOnCall: new Error('ECONNREFUSED') });
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+
+    assert.doesNotThrow(() => wrapStreamForF4(stream, { ...baseF4, fetchFn: fn }, stats));
+    await flushAsync();
+
+    assert.strictEqual(stats.fired, 1);
+    assert.strictEqual(stats.failed, 1);
+  });
+
+  it('accepts a Promise<ResultableStream> as input', async () => {
+    const stream = makeStream({ stopReason: 'stop', usage: { input: 1, output: 1 } });
+    const streamPromise = Promise.resolve(stream);
+    const { fn, captured } = makeMockFetch();
+
+    wrapStreamForF4(streamPromise, { ...baseF4, fetchFn: fn });
+    await flushAsync();
+
+    assert.strictEqual(captured.length, 1, 'settle fires after the stream promise resolves');
+  });
+
+  it('respects custom timeoutMs (AbortSignal fires)', async () => {
+    const stream = makeStream({ stopReason: 'stop' });
+    // Mock fetch that ignores abort and resolves slowly — should be aborted
+    let aborted = false;
+    const fn = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      return new Promise<Response>((resolve, reject) => {
+        const signal = init?.signal;
+        const timer = setTimeout(() => resolve(new Response(null, { status: 200 })), 1000);
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            aborted = true;
+            clearTimeout(timer);
+            reject(new Error('aborted'));
+          });
+        }
+      });
+    }) as unknown as typeof fetch;
+
+    const stats: F4Stats = { fired: 0, succeeded: 0, failed: 0 };
+    wrapStreamForF4(stream, { ...baseF4, fetchFn: fn, timeoutMs: 20 }, stats);
+
+    // Wait long enough for timeout to fire but not the 1s resolve
+    await new Promise((r) => setTimeout(r, 100));
+
+    assert.strictEqual(aborted, true, 'AbortSignal must fire after timeoutMs');
+    assert.strictEqual(stats.failed, 1, 'aborted settle counts as failed');
+  });
+});


### PR DESCRIPTION
## Summary

PR 4 of 5 in the OpenClaw provider rebuild. Ships the **client-side F4 settle wrapper** (fully unit-tested) and a **3-arg `ctx.streamFn` smoke check** that catches the pi-coding-agent@0.63.0 regression class.

**Stack:** #263 → #264 → #265 → this PR. Merge in that order.

## What changed

| File | Change |
|---|---|
| `src/f4-wrapper.ts` (new) | `wrapStreamForF4(stream, f4Context, stats?)` — observes inner stream's `.result()` Promise, fires fire-and-forget POST to `/v1/escrow/settle` on completion. Settle failures (timeout, 404, network) logged but never crash the stream consumer. |
| `src/index.ts` | Re-export `wrapStreamForF4`, `F4Context`, `F4Stats`, `ResultableStream`. Add 3-arg smoke check in wrapStreamFn guard. |
| `tests/f4-wrapper.test.ts` (new) | 10 new tests: returns-stream-unchanged, normal-completion POST, error/aborted status mapping, missing-usage handling, stream-failure non-blocking, 404 non-blocking, network-error non-blocking, Promise input, AbortSignal timeout, stats accounting. |
| `src/signer.ts` | Update escrow-deposit warning message to reflect current state (F4 wrapper landed; gateway endpoint pending). |
| `README.md` | Rewrite "Phase 3 note on escrow" → "Escrow accounting (F4)" section explaining the two claim paths (gateway auto-claim, `wrapStreamForF4`). |
| `package.json` | Register `tests/f4-wrapper.test.ts` in the `test` script. |

Total: 6 files changed, 441 insertions(+), 15 deletions(-).

## Why not wire F4 into the plugin's own wrapStreamFn body?

Extracting `service_id` from the 402 PaymentRequired payload requires `@solvela/signer-core` changes (decode base64 payment header → parse encoded Solana transaction → extract escrow `service_id` seed). That signer-core surface is best changed *alongside* the gateway `/v1/escrow/settle` endpoint, where the wire-contract for `service_id` encoding gets pinned.

Shipping the wrapper now (exported via the plugin's public API, fully unit-tested) means consumers and future PRs can use it immediately — no half-state in the hot path.

## CI expectations

When stacked on #263 + #264 + #265:
- ✅ install
- ✅ typecheck (0 errors)
- ✅ typecheck-tests (0 errors)
- ✅ test (**70/70** — was 60 in #265; +10 F4 wrapper tests)
- ✅ build
- ✅ guard-install-scripts
- ✅ audit
- ✅ guard-deprecated-openclaw-imports

## Smoke check details (the new warning)

```typescript
if (ctx.streamFn.length === 0) {
  process.stderr.write(
    '[solvela-openclaw] WARN: ctx.streamFn arity is 0 — expected (model, context, options). ' +
      'May indicate the OpenClaw runtime swapped the wrapped streamFn with a rest-arg stub. ' +
      'See openclaw/openclaw#55760 for the pi-coding-agent 0.63.0 regression class.\n',
  );
}
```

Pragmatic warn (not throw) — `Function.length` can be 0 for valid rest-param wrappers — but the combination of (a) sitting in the `wrapStreamFn` hook and (b) arity 0 has been a real production-defect signal in OpenClaw extensions.

## Test plan

- [ ] CI shows all 8 jobs green on this PR (when stacked).
- [ ] Local: `npm run typecheck && npm run typecheck:tests && npm test && npm run build` all pass.
- [ ] `wrapStreamForF4` is importable: `import { wrapStreamForF4 } from '@solvela/openclaw-provider'` resolves.

## What this does NOT do

- Does not deploy the gateway-side `/v1/escrow/settle` endpoint. That's a separate (Rust) PR.
- Does not wire F4 into the plugin's own `wrapStreamFn` body (requires signer-core changes — paired with gateway endpoint).
- Does not flip `private: false`. Publishing waits for OpenClaw LTS (per [project-openclaw-direction-2026-05 memory](https://github.com/solvela-ai/solvela/blob/main/.claude/projects/-home-kennethdixon-projects-solvela/memory/project_openclaw_direction_2026_05.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)