### PR TITLE
feat(gateway): POST /v1/escrow/settle — F4 settle endpoint

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -227,6 +227,10 @@ pub fn build_router(state: Arc<AppState>, rate_limiter: RateLimiter) -> Router {
         )
         .route("/v1/escrow/config", get(routes::escrow::escrow_config))
         .route("/v1/escrow/health", get(routes::escrow::escrow_health))
+        .route(
+            "/v1/escrow/settle",
+            post(routes::escrow_settle::handle_settle),
+        )
         .route("/pricing", get(routes::pricing::pricing))
         .route("/health", get(routes::health::health))
         .route("/v1/admin/stats", get(routes::admin_stats::admin_stats))

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -7,7 +7,7 @@
 //! - [`response`] — Debug headers, session tokens, response construction
 
 pub(crate) mod cost;
-mod payment;
+pub(crate) mod payment;
 mod provider;
 mod response;
 

--- a/crates/gateway/src/routes/escrow_settle.rs
+++ b/crates/gateway/src/routes/escrow_settle.rs
@@ -1,0 +1,189 @@
+//! POST /v1/escrow/settle — F4 escrow settle endpoint.
+//!
+//! Called by client-side F4 wrappers (e.g. `@solvela/openclaw-provider`'s
+//! `wrapStreamForF4`) after a stream completes, to trigger the escrow
+//! claim against the actual token usage rather than waiting for the
+//! gateway's timeout-based auto-claim. This brings reconciliation latency
+//! from minutes to milliseconds when both halves of F4 are deployed.
+//!
+//! Wire contract:
+//!   {
+//!     "service_id":           "<gateway-defined encoding, 32 bytes>",
+//!     "agent_pubkey":         "<base58 Solana pubkey>",
+//!     "model":                "<model id, e.g. gpt-4o>",
+//!     "status":               "completed" | "error",
+//!     "actual_prompt_tokens":     <u32, required when status=completed>,
+//!     "actual_completion_tokens": <u32, required when status=completed>
+//!   }
+//!
+//! Behavior:
+//!   - status=completed + tokens present → compute actual cost from the
+//!     model registry, fire escrow claim through the durable queue
+//!     (or fire-and-forget if no DB).
+//!   - status=error → no claim fired. The deposit is reconciled by the
+//!     escrow program's on-chain auto-timeout refund path (same as the
+//!     pre-F4 flow).
+//!   - status=completed without tokens → 400.
+//!   - unknown model → 400.
+//!   - cost overflow / non-finite pricing → 400.
+//!
+//! Auth model (v1):
+//!   The on-chain escrow program enforces that claims only succeed when
+//!   the PDA seeds `[b"escrow", agent, service_id]` match the deposit.
+//!   A misrouted settle (wrong agent_pubkey or service_id) fails at the
+//!   chain layer, logged but not client-visible. This is intentional for
+//!   v1 — settle is fire-and-forget and the chain is the source of
+//!   truth. Future hardening (see TODO comments): HMAC over the request
+//!   body, or an agent signature over (service_id, model, status,
+//!   tokens). Rate limiting is handled by the existing gateway middleware.
+//!
+//! Idempotency:
+//!   `fire_escrow_claim` enqueues the claim via the durable
+//!   `escrow_claim_queue` (when DB is available), which dedupes by
+//!   service_id + agent. Without a DB, duplicate settle requests can
+//!   produce duplicate on-chain claim attempts — the second is rejected
+//!   by the escrow program (deposit account already drained). Wasteful
+//!   but correct.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::routes::chat::cost::compute_actual_atomic_cost;
+use crate::routes::chat::payment::fire_escrow_claim;
+use crate::AppState;
+
+/// Request body for `POST /v1/escrow/settle`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettleRequest {
+    pub service_id: String,
+    pub agent_pubkey: String,
+    pub model: String,
+    pub status: SettleStatus,
+    #[serde(default)]
+    pub actual_prompt_tokens: Option<u32>,
+    #[serde(default)]
+    pub actual_completion_tokens: Option<u32>,
+}
+
+/// Stream-completion status reported by the client F4 wrapper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SettleStatus {
+    Completed,
+    Error,
+}
+
+/// Response body for `POST /v1/escrow/settle`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SettleResponse {
+    pub ok: bool,
+    /// Atomic micro-USDC claim amount fired. Present when status=completed
+    /// and the cost was computable; absent on error-status or skip.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claim_amount: Option<u64>,
+}
+
+/// POST /v1/escrow/settle
+///
+/// See module docs for wire contract, behavior, auth model, and idempotency.
+pub async fn handle_settle(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SettleRequest>,
+) -> Result<Json<SettleResponse>, (StatusCode, Json<serde_json::Value>)> {
+    // status=error: stream failed mid-response. Don't fire a claim — the
+    // on-chain refund path will reconcile the deposit via the auto-timeout.
+    if req.status == SettleStatus::Error {
+        tracing::info!(
+            service_id = %req.service_id,
+            agent = %req.agent_pubkey,
+            model = %req.model,
+            "settle: stream finished with error — no claim fired (auto-timeout will refund)"
+        );
+        return Ok(Json(SettleResponse {
+            ok: true,
+            claim_amount: None,
+        }));
+    }
+
+    // status=completed: tokens are required for cost computation.
+    let (prompt_tokens, completion_tokens) = match (
+        req.actual_prompt_tokens,
+        req.actual_completion_tokens,
+    ) {
+        (Some(p), Some(c)) => (p, c),
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "actual_prompt_tokens and actual_completion_tokens are required when status=completed"
+                })),
+            ));
+        }
+    };
+
+    // Look up model pricing.
+    let model_info = match state.model_registry.get(&req.model) {
+        Some(info) => info,
+        None => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("unknown model: {}", req.model) })),
+            ));
+        }
+    };
+
+    // Compute the actual cost. Returns None on non-finite/negative pricing
+    // or u64 overflow — both indicate a misconfigured model entry.
+    let claim_atomic =
+        match compute_actual_atomic_cost(prompt_tokens, completion_tokens, model_info) {
+            Some(c) => c,
+            None => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "error": "could not compute cost (overflow or non-finite pricing)"
+                    })),
+                ));
+            }
+        };
+
+    // claim_atomic is the actual computed cost. We don't have a separate
+    // deposit-amount upper bound here — the original 402's amount isn't
+    // threaded into settle (the wire contract stays minimal). Pass
+    // claim_atomic as both `claim_atomic` and `client_amount` so
+    // cap_claim_amount becomes a no-op. The escrow program enforces the
+    // "don't claim more than deposited" invariant on-chain.
+    //
+    // TODO(hardening): accept an optional `deposit_amount` field in the
+    // request body so cap_claim_amount can enforce a tighter pre-chain
+    // bound. Today's flow leans on the chain layer to reject over-claims.
+    fire_escrow_claim(
+        &state,
+        "escrow",
+        &Some(req.service_id.clone()),
+        &Some(req.agent_pubkey.clone()),
+        None, // deposit amount unknown at this layer
+        claim_atomic,
+        claim_atomic, // no-op cap (see comment above)
+    );
+
+    tracing::info!(
+        service_id = %req.service_id,
+        agent = %req.agent_pubkey,
+        model = %req.model,
+        prompt_tokens,
+        completion_tokens,
+        claim_atomic,
+        "settle: fired escrow claim with actual usage"
+    );
+
+    Ok(Json(SettleResponse {
+        ok: true,
+        claim_amount: Some(claim_atomic),
+    }))
+}

--- a/crates/gateway/src/routes/mod.rs
+++ b/crates/gateway/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod admin_stats;
 pub mod chat;
 pub mod debug_headers;
 pub mod escrow;
+pub mod escrow_settle;
 pub mod health;
 pub mod images;
 pub mod metrics;

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -5179,3 +5179,178 @@ async fn test_a2a_message_send_no_text_returns_error() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(json["error"].is_object(), "should return JSON-RPC error");
 }
+
+// ---------------------------------------------------------------------------
+// POST /v1/escrow/settle (F4 settle endpoint)
+// ---------------------------------------------------------------------------
+
+async fn post_settle(body: serde_json::Value) -> axum::http::Response<Body> {
+    test_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/escrow/settle")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn settle_body_json(resp: axum::http::Response<Body>) -> serde_json::Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn settle_status_error_returns_ok_with_no_claim() {
+    let resp = post_settle(serde_json::json!({
+        "service_id": "svc_test_error",
+        "agent_pubkey": "AgentPubkey1111111111111111111111111111111111",
+        "model": "any-model",
+        "status": "error"
+    }))
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = settle_body_json(resp).await;
+    assert_eq!(body["ok"], true);
+    assert!(
+        body.get("claim_amount").is_none(),
+        "claim_amount must be absent on error status, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn settle_missing_tokens_on_completed_returns_400() {
+    let resp = post_settle(serde_json::json!({
+        "service_id": "svc_test_missing_tokens",
+        "agent_pubkey": "AgentPubkey1111111111111111111111111111111111",
+        "model": "openai-gpt-4o",
+        "status": "completed"
+    }))
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = settle_body_json(resp).await;
+    let err = body["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("actual_prompt_tokens"),
+        "error must mention required token fields, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn settle_unknown_model_returns_400() {
+    let resp = post_settle(serde_json::json!({
+        "service_id": "svc_test_unknown_model",
+        "agent_pubkey": "AgentPubkey1111111111111111111111111111111111",
+        "model": "no-such-model-xyz",
+        "status": "completed",
+        "actual_prompt_tokens": 10,
+        "actual_completion_tokens": 20
+    }))
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = settle_body_json(resp).await;
+    let err = body["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("unknown model"),
+        "error must mention unknown model, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn settle_completed_with_known_model_returns_claim_amount() {
+    let resp = post_settle(serde_json::json!({
+        "service_id": "svc_test_completed",
+        "agent_pubkey": "AgentPubkey1111111111111111111111111111111111",
+        "model": "openai-gpt-4o",
+        "status": "completed",
+        "actual_prompt_tokens": 1000,
+        "actual_completion_tokens": 500
+    }))
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = settle_body_json(resp).await;
+    assert_eq!(body["ok"], true);
+    let claim = body["claim_amount"].as_u64();
+    assert!(
+        claim.is_some_and(|c| c > 0),
+        "claim_amount must be present and positive, got: {body}"
+    );
+
+    // Sanity-check the cost matches compute_actual_atomic_cost.
+    // gpt-4o: input=2.50 USDC/M, output=10.00 USDC/M, +5% fee
+    // 1000 prompt @ 2.50/M = 2500 micro-USDC
+    // 500 completion @ 10.00/M = 5000 micro-USDC
+    // total before fee: 7500 micro-USDC
+    // after 5% fee: 7500 * 105 / 100 = 7875 micro-USDC
+    assert_eq!(
+        claim.unwrap(),
+        7875,
+        "claim must equal computed cost (1000 in + 500 out at gpt-4o pricing + 5% fee)"
+    );
+}
+
+#[tokio::test]
+async fn settle_zero_tokens_returns_zero_claim() {
+    let resp = post_settle(serde_json::json!({
+        "service_id": "svc_test_zero",
+        "agent_pubkey": "AgentPubkey1111111111111111111111111111111111",
+        "model": "openai-gpt-4o",
+        "status": "completed",
+        "actual_prompt_tokens": 0,
+        "actual_completion_tokens": 0
+    }))
+    .await;
+
+    // Zero tokens compute to zero cost. fire_escrow_claim short-circuits on
+    // claim_amount==0, but the handler still returns 200 with claim_amount=0
+    // (the handler doesn't filter; it forwards whatever cost was computed).
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = settle_body_json(resp).await;
+    assert_eq!(body["ok"], true);
+    assert_eq!(body["claim_amount"].as_u64(), Some(0));
+}
+
+#[tokio::test]
+async fn settle_malformed_json_returns_400() {
+    let resp = test_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/escrow/settle")
+                .header("content-type", "application/json")
+                .body(Body::from("{ not valid json"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.status().is_client_error(),
+        "malformed JSON must return 4xx, got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn settle_unknown_status_returns_400() {
+    let resp = post_settle(serde_json::json!({
+        "service_id": "svc_test_unknown_status",
+        "agent_pubkey": "AgentPubkey1111111111111111111111111111111111",
+        "model": "openai-gpt-4o",
+        "status": "weird-status"
+    }))
+    .await;
+
+    assert!(
+        resp.status().is_client_error(),
+        "unknown status enum value must return 4xx, got {}",
+        resp.status()
+    );
+}


### PR DESCRIPTION
## Summary

PR 5 of 5 in the OpenClaw provider rebuild. Ships the **gateway half of F4** so client wrappers (e.g. `@solvela/openclaw-provider`'s `wrapStreamForF4` from #266) can settle escrow deposits against actual token usage on stream completion. Brings reconciliation latency from minutes (auto-timeout) to milliseconds.

**Stack:** branches from `main`, **orthogonal** to the TS stack (#263 → #264 → #265 → #266). Can merge independently.

## Wire contract

```
POST /v1/escrow/settle
{
  "service_id":               "<gateway-defined encoding, 32 bytes>",
  "agent_pubkey":             "<base58 Solana pubkey>",
  "model":                    "<model id, e.g. openai-gpt-4o>",
  "status":                   "completed" | "error",
  "actual_prompt_tokens":     <u32, required when status=completed>,
  "actual_completion_tokens": <u32, required when status=completed>
}
```

## Behavior

| Input | Outcome |
|---|---|
| `status=completed` + tokens | Compute cost via `compute_actual_atomic_cost`; `fire_escrow_claim` (durable queue or fire-and-forget). `200 {ok, claim_amount}`. |
| `status=error` | No claim fired — on-chain auto-timeout handles refund. `200 {ok}`. |
| `status=completed` without tokens | `400 {error: "actual_prompt_tokens and actual_completion_tokens are required..."}` |
| Unknown model | `400 {error: "unknown model: ..."}` |
| Cost overflow / non-finite pricing | `400 {error: "could not compute cost..."}` |
| Malformed JSON | `4xx` (Axum's JSON extractor) |
| Unknown status enum value | `4xx` (serde) |

## Files changed

| File | Change |
|---|---|
| `crates/gateway/src/routes/escrow_settle.rs` (new) | 189-line handler module. Includes request/response types, the handler fn, and module docs covering wire contract, auth model, idempotency. |
| `crates/gateway/src/routes/mod.rs` | `+pub mod escrow_settle;` |
| `crates/gateway/src/lib.rs` | `+.route("/v1/escrow/settle", post(...))` in `build_router`. |
| `crates/gateway/src/routes/chat/mod.rs` | `mod payment;` → `pub(crate) mod payment;` so `escrow_settle` can call `fire_escrow_claim`. Symmetric with `pub(crate) mod cost;` directly above. |
| `crates/gateway/tests/integration.rs` | +7 integration tests using `tower::ServiceExt::oneshot` (per CLAUDE.md rule #10). |

Total: 5 files changed, 370 insertions(+), 1 deletion(-).

## Auth model (v1)

The on-chain escrow program enforces that claims only succeed when PDA seeds `[b"escrow", agent, service_id]` match the deposit. A misrouted settle (wrong agent_pubkey or service_id) fails at the chain layer, logged but not client-visible. Intentional for v1 — settle is fire-and-forget and the chain is the source of truth.

Future hardening tracked in TODO comments:
- HMAC over the request body, or agent signature over `(service_id, model, status, tokens)`.
- Optional `deposit_amount` field in the request body so `cap_claim_amount` can enforce a tighter pre-chain bound.

Rate limiting is already covered by the existing gateway middleware.

## Idempotency

`fire_escrow_claim` enqueues via the durable `escrow_claim_queue` (when DB is configured), which dedupes by service_id + agent. Without a DB, duplicate settle requests can produce duplicate on-chain claim attempts — the second is rejected by the escrow program (deposit account already drained). Wasteful but correct.

## Quality gates

- ✅ `cargo check -p gateway`
- ✅ `cargo clippy -p gateway --all-targets -- -D warnings`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test -p gateway --test integration` — **129/129 pass** (was 122; +7 new)

## Test plan

- [ ] CI shows the gateway crate's full test matrix green.
- [ ] Local: `cargo test -p gateway --test integration settle_` → 7/7 pass.
- [ ] Local: `cargo clippy -p gateway --all-targets -- -D warnings` clean.

## What this does NOT do

- Does not wire F4 into `@solvela/openclaw-provider`'s `wrapStreamFn` body. That needs `signer-core` to expose `service_id` extracted from the payment header, and is tracked as a follow-up after both this and #266 land.
- Does not add HMAC or signed-body auth (documented as TODO).
- Does not flip `private: false` on the npm package. Publishing waits for OpenClaw LTS per [project-openclaw-direction-2026-05 memory](https://github.com/solvela-ai/solvela/blob/main/.claude/projects/-home-kennethdixon-projects-solvela/memory/project_openclaw_direction_2026_05.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)