### PR TITLE
docs: fix audit-flagged falsities (envelope, SDK overview, rate limits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ const response = await client.chat('openai/gpt-4o', 'Hello!');
 ### Go
 
 ```bash
-go get github.com/solvela-ai/solvela-go
+go get github.com/solvela-ai/solvela/sdks/go
 ```
 
 ```go
@@ -321,10 +321,10 @@ cargo test --manifest-path programs/escrow/Cargo.toml
 # SDK tests (mcp + ai-sdk-provider + openclaw-provider live in this repo)
 cd sdks/mcp && npm test
 
-# Standalone SDK repos:
-#   Python:     https://github.com/solvela-ai/solvela-python
-#   TypeScript: https://github.com/solvela-ai/solvela-ts
-#   Go:         https://github.com/solvela-ai/solvela-go
+# In-repo SDK test suites:
+#   Python:     (cd sdks/python && pytest)
+#   TypeScript: (cd sdks/typescript && npm test)
+#   Go:         (cd sdks/go && go test ./...)
 ```
 
 ### Lint
@@ -388,14 +388,14 @@ crates/
 programs/
   escrow/           Anchor escrow program (deposit/claim/refund, PDA vault)
 sdks/
-  python/           pip install solvela-sdk (canonical source: github.com/solvela-ai/solvela-python)
-  go/               go get github.com/solvela-ai/solvela-go
+  python/           pip install solvela-sdk
+  typescript/       npm install @solvela/sdk
+  go/               go get github.com/solvela-ai/solvela/sdks/go
   cli-npm/          @solvela/cli — npm-distributed wrapper around the Rust CLI (pre-release)
   mcp/              Claude Code MCP server
   signer-core/      Shared x402 parser + payment-signer primitives
   ai-sdk-provider/  Vercel AI SDK provider for Solvela
   openclaw-provider/ OpenClaw plugin (Solvela as first-class LLM provider)
-# TypeScript SDK lives at github.com/solvela-ai/solvela-ts (npm: @solvela/sdk)
 config/
   models.toml       Model registry + pricing
   default.toml      Gateway configuration

--- a/dashboard/content/docs/api/errors.mdx
+++ b/dashboard/content/docs/api/errors.mdx
@@ -153,4 +153,4 @@ See [x402 Protocol](/docs/concepts/x402) for the full flow.
 
 **Cause:** Too many requests from this IP or wallet within the rate limit window.
 
-**Fix:** Back off and retry. The gateway ceiling is approximately 400 RPS. Use exponential backoff for retries.
+**Fix:** Back off and retry. The default ceiling is **60 requests per 60-second sliding window** per wallet/IP — use the `X-RateLimit-Reset` header to time retries rather than a fixed backoff. See [Rate Limits](/docs/api/rate-limits).

--- a/dashboard/content/docs/api/index.mdx
+++ b/dashboard/content/docs/api/index.mdx
@@ -63,7 +63,7 @@ All endpoints accept and return `application/json`. Streaming responses use SSE 
 
 ## Rate limiting
 
-The gateway enforces per-IP and per-wallet rate limits. The default ceiling is approximately 400 RPS. Exceeding the limit returns `429 Too Many Requests`.
+The gateway enforces per-IP and per-wallet rate limits. The default is **60 requests per 60-second sliding window** per wallet (and the same per IP, before wallet identity is established). Always read `X-RateLimit-Limit` and `X-RateLimit-Reset` from response headers rather than hardcoding expected values. Exceeding the limit returns `429 Too Many Requests`. Enterprise API keys can override these limits — see [Rate Limits](/docs/api/rate-limits).
 
 ## Error format
 

--- a/dashboard/content/docs/concepts/payment-flow.mdx
+++ b/dashboard/content/docs/concepts/payment-flow.mdx
@@ -28,32 +28,58 @@ If you are using the TypeScript, Python, Rust, or Go SDK, you never need to impl
   </Step>
 
   <Step title="Parse the 402 response">
-    The 402 body contains everything your client needs to construct a valid payment.
+    The 402 body wraps the `PaymentRequired` object inside an OpenAI-style `error.message` field as a JSON string. Parse `error.message` as JSON to access the fields.
 
-    ```json title="402 response body"
+    ```json title="402 response body (wire shape)"
     {
-      "x402_version": 1,
-      "cost_breakdown": {
-        "provider_cost": "0.000150",
-        "platform_fee": "0.000008",
-        "total": "0.000158",
-        "currency": "USDC",
-        "fee_percent": 5.0
-      },
-      "accepts": [
-        {
-          "scheme": "exact",
-          "network": "solana",
-          "amount": "158",
-          "asset": "USDC-SPL",
-          "pay_to": "<recipient_wallet>",
-          "max_timeout_seconds": 300
-        }
-      ]
+      "error": {
+        "type": "invalid_payment",
+        "message": "{\"x402_version\":2,\"resource\":{\"url\":\"/v1/chat/completions\",\"method\":\"POST\"},\"accepts\":[{\"scheme\":\"exact\",\"network\":\"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\",\"amount\":\"2625\",\"asset\":\"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\"pay_to\":\"<gateway-recipient-wallet>\",\"max_timeout_seconds\":300},{\"scheme\":\"escrow\",\"network\":\"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\",\"amount\":\"2625\",\"asset\":\"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\"pay_to\":\"<gateway-recipient-wallet>\",\"max_timeout_seconds\":300,\"escrow_program_id\":\"9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU\"}],\"cost_breakdown\":{\"provider_cost\":\"0.002500\",\"platform_fee\":\"0.000125\",\"total\":\"0.002625\",\"currency\":\"USDC\",\"fee_percent\":5},\"error\":\"Payment required\"}"
+      }
     }
     ```
 
-    Your client should read `accepts[0].amount` for the atomic-unit value and `accepts[0].pay_to` for the destination wallet. The `max_timeout_seconds` field tells you how long the signed transaction will be accepted before expiring.
+    Once you `JSON.parse(error.message)`, the inner `PaymentRequired` looks like:
+
+    ```json title="Parsed PaymentRequired"
+    {
+      "x402_version": 2,
+      "resource": { "url": "/v1/chat/completions", "method": "POST" },
+      "accepts": [
+        {
+          "scheme": "exact",
+          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "amount": "2625",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "pay_to": "<gateway-recipient-wallet>",
+          "max_timeout_seconds": 300
+        },
+        {
+          "scheme": "escrow",
+          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "amount": "2625",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "pay_to": "<gateway-recipient-wallet>",
+          "max_timeout_seconds": 300,
+          "escrow_program_id": "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+        }
+      ],
+      "cost_breakdown": {
+        "provider_cost": "0.002500",
+        "platform_fee": "0.000125",
+        "total": "0.002625",
+        "currency": "USDC",
+        "fee_percent": 5
+      },
+      "error": "Payment required"
+    }
+    ```
+
+    <Warning>
+    The `asset` field is the **SPL mint address** of the token being requested, not a symbolic name. For mainnet USDC this is always `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Verify this byte-for-byte in your client before signing — older drafts of the protocol used the literal string `"USDC-SPL"` and clients hardcoded against that will silently skip mint validation. The `network` field uses CAIP-2 form (`solana:<cluster-genesis-hash>`); the trailing identifier is the mainnet cluster genesis hash.
+    </Warning>
+
+    Your client should read `accepts[0].amount` for the atomic-unit value, `accepts[0].pay_to` for the destination wallet, and `accepts[0].asset` for the SPL mint. The `max_timeout_seconds` field tells you how long the signed transaction will be accepted before expiring.
   </Step>
 
   <Step title="Sign the Solana transaction">
@@ -66,18 +92,20 @@ If you are using the TypeScript, Python, Rust, or Go SDK, you never need to impl
     </Warning>
   </Step>
 
-  <Step title="Resubmit with the PAYMENT-SIGNATURE header">
-    Resend the original request body with the signed transaction encoded as base58 in the `PAYMENT-SIGNATURE` header.
+  <Step title="Resubmit with the payment-signature header">
+    Build a `PaymentPayload` JSON object containing your signed transaction, base64-encode the JSON, and resend the original request with the encoded value in the `payment-signature` header.
 
     ```bash title="Paid request"
     curl -X POST https://api.solvela.ai/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "PAYMENT-SIGNATURE: 5UfgJ4...Kx29mQ" \
+      -H "payment-signature: <base64-encoded-PaymentPayload-JSON>" \
       -d '{
         "model": "auto",
         "messages": [{ "role": "user", "content": "Hello" }]
       }'
     ```
+
+    The `PaymentPayload` envelope itself contains `scheme`, `network`, and a `payload` field with the base58-encoded signed transaction bytes. The outer header value is base64-encoded JSON; the inner signed transaction is base58. See [x402 Protocol](/docs/concepts/x402) for the exact shape.
   </Step>
 
   <Step title="Receive the LLM response">
@@ -130,10 +158,10 @@ The `accepts` array may contain one or both payment schemes. Choose based on you
     ```json
     {
       "scheme": "exact",
-      "network": "solana",
-      "amount": "158",
-      "asset": "USDC-SPL",
-      "pay_to": "GatewayWa11et...",
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "amount": "2625",
+      "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "pay_to": "<gateway-recipient-wallet>",
       "max_timeout_seconds": 300
     }
     ```
@@ -148,11 +176,12 @@ The `accepts` array may contain one or both payment schemes. Choose based on you
     ```json
     {
       "scheme": "escrow",
-      "network": "solana",
-      "amount": "158",
-      "asset": "USDC-SPL",
-      "escrow_program": "EscrowProg...",
-      "max_timeout_seconds": 300
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "amount": "2625",
+      "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "pay_to": "<gateway-recipient-wallet>",
+      "max_timeout_seconds": 300,
+      "escrow_program_id": "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
     }
     ```
   </Tab>

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -12,9 +12,9 @@ description: Make your first paid API call to Solvela in 5 minutes
 
 Before you start, you need:
 
-- A **Solana wallet** with a keypair (e.g. generated with `solana-keygen new`)
+- A **Solana wallet** with a keypair (e.g. generated with `solana-keygen new` or `solvela wallet new`)
 - **USDC-SPL** in that wallet on Solana mainnet (mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)
-- A small amount of **SOL** for transaction fees (about 0.002 SOL per call)
+- A small amount of **SOL** for transaction fees (Solana base fee is 5,000 lamports per signature — roughly 0.000005 SOL per call)
 
 </Step>
 
@@ -37,7 +37,7 @@ The SDKs handle the payment handshake automatically. Pick your language:
   </Tab>
   <Tab value="Go">
     ```bash
-    go get github.com/solvela-ai/solvela-go
+    go get github.com/solvela-ai/solvela/sdks/go
     ```
   </Tab>
   <Tab value="None (cURL)">
@@ -96,7 +96,7 @@ First, send a request without any payment header. The gateway will respond with 
         "fmt"
         "log"
 
-        solvela "github.com/solvela-ai/solvela-go"
+        solvela "github.com/solvela-ai/solvela/sdks/go"
     )
 
     func main() {
@@ -203,7 +203,7 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
       // or pass it as a constructor option
     });
 
-    const reply = await client.chat('gpt-4o', 'Explain Solana in one sentence.');
+    const reply = await client.chat('openai/gpt-4o', 'Explain Solana in one sentence.');
     console.log(reply);
     console.log('Spent:', client.getSessionSpent(), 'USDC');
     ```
@@ -220,7 +220,7 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
         client = SolvelaClient(wallet=wallet, signer=signer)
 
         response = await client.chat(ChatRequest(
-            model='gpt-4o',
+            model='openai/gpt-4o',
             messages=[ChatMessage(role=Role.USER, content='Explain Solana in one sentence.')],
         ))
         print(response.choices[0].message.content)
@@ -265,7 +265,7 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
     # Set your private key
     export SOLVELA_SOLANA_PRIVATE_KEY=<your-base58-private-key>
 
-    solvela chat --model gpt-4o "Explain Solana in one sentence."
+    solvela chat --model openai/gpt-4o "Explain Solana in one sentence."
     ```
   </Tab>
 </Tabs>
@@ -283,7 +283,7 @@ curl https://api.solvela.ai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "payment-signature: <base64-encoded-PaymentPayload>" \
   -d '{
-    "model": "gpt-4o",
+    "model": "openai/gpt-4o",
     "messages": [{"role": "user", "content": "Explain Solana in one sentence."}]
   }'
 ```

--- a/dashboard/content/docs/sdks/index.mdx
+++ b/dashboard/content/docs/sdks/index.mdx
@@ -6,30 +6,41 @@ description: Client libraries for Solvela — TypeScript, Python, Go, Rust CLI, 
 
 Official SDKs are available for four languages plus an MCP server. All SDKs handle the x402 payment handshake automatically — pass a private key and the SDK signs transactions for you.
 
+<Warning>
+**The TypeScript SDK is not wire-compatible with the live gateway today.** The currently-published `@solvela/sdk@0.2.x` on npm predates the v2 payment envelope and will not complete a real payment against `api.solvela.ai`. Until a new SDK release ships, TypeScript users have two working options:
+
+- Use the [`@solvela/signer-core`](/docs/sdks/typescript) primitives from the monorepo (`sdks/signer-core/`) to parse the 402 envelope and sign payments yourself.
+- Drive the gateway directly with `curl` or `fetch` — see the [Quickstart](/docs/quickstart) cURL tab and [Payment Flow](/docs/concepts/payment-flow).
+
+The Python, Go, and Rust CLI SDKs are wire-aligned with the live gateway.
+</Warning>
+
 ## Comparison
 
 | Language | Package | Install | x402 Auto-payment | Async |
 |----------|---------|---------|-------------------|-------|
-| TypeScript | `@solvela/sdk` | `npm install @solvela/sdk` | Yes | Yes |
+| TypeScript ⚠ | `@solvela/sdk` | `npm install @solvela/sdk` | Pre-1.0, wire-incompat (see above) | Yes |
 | Python | `solvela-sdk` | `pip install solvela-sdk` | Yes | Yes (async-only) |
-| Go | `github.com/solvela-ai/solvela-go` | `go get github.com/solvela-ai/solvela-go` | Yes (BYO Signer) | Yes (context-based) |
+| Go | `github.com/solvela-ai/solvela/sdks/go` | `go get github.com/solvela-ai/solvela/sdks/go` | Yes (BYO Signer) | Yes (context-based) |
 | Rust CLI | `solvela-cli` | `cargo install solvela-cli` | Yes | — |
-| MCP Server | `@solvela/mcp` | `npx @solvela/mcp` | Yes | — |
+| MCP Server | (in-monorepo, not on npm) | see [MCP page](/docs/sdks/mcp) | Yes | — |
 
 ## Source code
 
-The first-party language SDKs each live in their own repository; adapter SDKs live in this monorepo under `sdks/`:
+All four language SDKs live in the [`solvela-ai/solvela`](https://github.com/solvela-ai/solvela) monorepo under `sdks/`. The standalone single-SDK repositories were consolidated and archived 2026-05-12; legacy clone URLs redirect to the new monorepo paths.
 
-- TypeScript/Node.js SDK — [`solvela-ai/solvela-ts`](https://github.com/solvela-ai/solvela-ts)
-- Python SDK (async-only) — [`solvela-ai/solvela-python`](https://github.com/solvela-ai/solvela-python)
-- Go SDK — [`solvela-ai/solvela-go`](https://github.com/solvela-ai/solvela-go)
-- `sdks/mcp/` — MCP server (this repo)
-- `sdks/ai-sdk-provider/`, `sdks/openclaw-provider/`, `sdks/cli-npm/` — Vercel AI SDK provider, OpenClaw provider, and npm CLI shim (this repo)
+- TypeScript/Node.js SDK — [`sdks/typescript/`](https://github.com/solvela-ai/solvela/tree/main/sdks/typescript)
+- Python SDK (async-only) — [`sdks/python/`](https://github.com/solvela-ai/solvela/tree/main/sdks/python)
+- Go SDK — [`sdks/go/`](https://github.com/solvela-ai/solvela/tree/main/sdks/go)
+- MCP server — [`sdks/mcp/`](https://github.com/solvela-ai/solvela/tree/main/sdks/mcp)
+- Vercel AI SDK provider, OpenClaw provider, npm CLI shim, signer-core primitives — [`sdks/ai-sdk-provider/`](https://github.com/solvela-ai/solvela/tree/main/sdks/ai-sdk-provider), [`sdks/openclaw-provider/`](https://github.com/solvela-ai/solvela/tree/main/sdks/openclaw-provider), [`sdks/cli-npm/`](https://github.com/solvela-ai/solvela/tree/main/sdks/cli-npm), [`sdks/signer-core/`](https://github.com/solvela-ai/solvela/tree/main/sdks/signer-core)
+
+The wallet-client Rust crate (`solvela-client`) and its `solvela` CLI binary remain at [`solvela-ai/solvela-client`](https://github.com/solvela-ai/solvela-client) pending a separate consolidation.
 
 <CardGroup>
-  <Card title="TypeScript" description="solvela-ai/solvela-ts (pre-1.0; not yet wire-aligned with prod gateway)" href="/docs/sdks/typescript" />
+  <Card title="TypeScript" description="@solvela/sdk — pre-1.0; not yet wire-aligned with prod gateway (see warning above)" href="/docs/sdks/typescript" />
   <Card title="Python" description="pip install solvela-sdk — async-first client with built-in Solana signing" href="/docs/sdks/python" />
-  <Card title="Go" description="go get github.com/solvela-ai/solvela-go — context-aware, goroutine-safe; ships an UnimplementedSigner stub (bring your own)" href="/docs/sdks/go" />
+  <Card title="Go" description="go get github.com/solvela-ai/solvela/sdks/go — context-aware, goroutine-safe; ships an UnimplementedSigner stub (bring your own)" href="/docs/sdks/go" />
   <Card title="Rust CLI" description="cargo install solvela-cli — interactive chat, model listing, health checks" href="/docs/sdks/rust" />
-  <Card title="MCP Server" description="npx @solvela/mcp — expose Solvela to MCP-compatible AI agents" href="/docs/sdks/mcp" />
+  <Card title="MCP Server" description="In-monorepo MCP server — expose Solvela to MCP-compatible AI agents" href="/docs/sdks/mcp" />
 </CardGroup>


### PR DESCRIPTION
## Summary

Fixes four HIGH-severity findings from the 2026-05-13 docs accuracy audit of `docs.solvela.ai` + the monorepo README. Each was independently capable of costing a developer real time or money. Live wire-shape values were verified by curl against `api.solvela.ai` before being written into the docs.

- **Payment Flow doc** (`dashboard/content/docs/concepts/payment-flow.mdx`) — replace stale `x402_version: 1` envelope with the live v2 shape (CAIP-2 network string, SPL mint address as `asset` instead of the literal `"USDC-SPL"`, real escrow program ID, OpenAI-style `error.message` JSON-string wrapper). Add a Warning calling out the `"USDC-SPL"` historical literal so clients that hardcoded against it don't silently skip mint validation. Fix the resubmit step: header is base64-encoded `PaymentPayload` JSON (lowercased `payment-signature`), not base58 raw transaction. Rename `escrow_program` → `escrow_program_id`.
- **SDK overview** (`dashboard/content/docs/sdks/index.mdx`) — add a prominent Warning that `@solvela/sdk@0.2.x` is wire-incompat with the live gateway (deep TS page already warned; overview didn't, and overview is the first page TS users read). Repoint Go install/module at the monorepo path. Rewrite Source-code list so all four language SDKs live under `sdks/`; archived side-repo links removed. MCP row no longer points at the nonexistent `@solvela/mcp` npm package.
- **Quickstart** (`dashboard/content/docs/quickstart.mdx`) — replace unprefixed `gpt-4o` (which returns `model_not_found` on the live gateway) with `openai/gpt-4o` in TS/Python/CLI/curl examples. Fix the SOL prereq math ("0.002 SOL per call" → ~0.000005 SOL; Solana base fee is 5,000 lamports). Point Go install + import at the monorepo path.
- **Rate limits** (`dashboard/content/docs/api/index.mdx`, `dashboard/content/docs/api/errors.mdx`) — replace "approximately 400 RPS" with the actual default of 60 requests per 60-second sliding window per wallet/IP. Verified against live `X-RateLimit-Limit: 60` / `X-RateLimit-Reset: 60` headers. The 400 RPS claim overstated the limit by ~400x and would push devs to size load tests that immediately 429.
- **Monorepo README** (`README.md`) — replace `go get github.com/solvela-ai/solvela-go` (3 locations) with the monorepo path. Update test-instructions comment block and Project Structure block to remove archived side-repo references.

## Out of scope (deliberate)

The same archived-repo URL pattern still appears in `dashboard/content/docs/sdks/{go,typescript,python}.mdx`, `dashboard/content/docs/concepts/architecture.mdx`, and `dashboard/content/docs/api/chat-completions.mdx`. Those are a natural follow-up PR. Marketing-site fixes (broken hero Quick Start, "audited flows" badge, unsubstantiated uptime/p50 numbers, missing `www` DNS) and package-republish work (`@solvela/sdk` wire-compat, crates.io READMEs) are tracked separately.

## Test plan

- [x] `npm --prefix dashboard test` — 100/100 pass
- [x] `npm --prefix dashboard run build` — 50/50 static pages generated; all MDX parses clean
- [x] Live envelope re-verified via `curl -i -X POST https://api.solvela.ai/v1/chat/completions ...` immediately before writing the new JSON examples
- [ ] Required CI: Rust, Smoke, Security audit, Docker build (gates pass on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)