### PR TITLE
docs: clean up archived-repo refs + fix H5/H6 install instructions

### DIFF
--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -231,7 +231,7 @@ data: [DONE]
         "fmt"
         "log"
 
-        solvela "github.com/solvela-ai/solvela-go"
+        solvela "github.com/solvela-ai/solvela/sdks/go"
     )
 
     func main() {

--- a/dashboard/content/docs/concepts/architecture.mdx
+++ b/dashboard/content/docs/concepts/architecture.mdx
@@ -50,10 +50,10 @@ protocol (wire types, zero deps)
 | Component | Location | Purpose |
 |-----------|----------|---------|
 | Anchor escrow program | `programs/escrow/` | Trustless USDC-SPL escrow with deposit, claim, and refund — **not** a workspace member |
-| Python SDK | [`solvela-ai/solvela-python`](https://github.com/solvela-ai/solvela-python) | `solvela` package on PyPI |
-| TypeScript SDK | [`solvela-ai/solvela-ts`](https://github.com/solvela-ai/solvela-ts) | `@solvela/sdk` npm package |
-| Go SDK | [`solvela-ai/solvela-go`](https://github.com/solvela-ai/solvela-go) | `github.com/solvela-ai/solvela-go` Go module |
-| MCP server | `sdks/mcp/` | Model Context Protocol adapter |
+| Python SDK | [`sdks/python/`](https://github.com/solvela-ai/solvela/tree/main/sdks/python) | `solvela-sdk` package on PyPI |
+| TypeScript SDK | [`sdks/typescript/`](https://github.com/solvela-ai/solvela/tree/main/sdks/typescript) | `@solvela/sdk` npm package |
+| Go SDK | [`sdks/go/`](https://github.com/solvela-ai/solvela/tree/main/sdks/go) | `github.com/solvela-ai/solvela/sdks/go` Go module |
+| MCP server | [`sdks/mcp/`](https://github.com/solvela-ai/solvela/tree/main/sdks/mcp) | Model Context Protocol adapter |
 | Dashboard | `dashboard/` | Next.js 16 + Tailwind + Recharts, 5 pages |
 
 ## Configuration Files

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -262,9 +262,10 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
   </Tab>
   <Tab value="solvela CLI">
     ```bash
-    # Set your private key
-    export SOLVELA_SOLANA_PRIVATE_KEY=<your-base58-private-key>
+    # One-time: generate a wallet at ~/.solvela/wallet.json and fund it with USDC-SPL
+    solvela wallet init
 
+    # Each call signs from ~/.solvela/wallet.json automatically (no env var needed)
     solvela chat --model openai/gpt-4o "Explain Solana in one sentence."
     ```
   </Tab>

--- a/dashboard/content/docs/sdks/go.mdx
+++ b/dashboard/content/docs/sdks/go.mdx
@@ -6,14 +6,14 @@ description: Go client for Solvela with functional-option configuration and tran
 
 `solvela-go` is the official Go SDK for the Solvela gateway. Context-aware, goroutine-safe, dataclass-style typed, and handles the x402 payment handshake transparently when a `Signer` is wired in.
 
-- **Module:** [`github.com/solvela-ai/solvela-go`](https://pkg.go.dev/github.com/solvela-ai/solvela-go)
-- **Source:** [`solvela-ai/solvela-go`](https://github.com/solvela-ai/solvela-go)
+- **Module:** [`github.com/solvela-ai/solvela/sdks/go`](https://pkg.go.dev/github.com/solvela-ai/solvela/sdks/go)
+- **Source:** [`sdks/go/`](https://github.com/solvela-ai/solvela/tree/main/sdks/go) in the monorepo
 - **Go:** 1.23+
 
 ## Installation
 
 ```bash
-go get github.com/solvela-ai/solvela-go
+go get github.com/solvela-ai/solvela/sdks/go
 ```
 
 The SDK depends only on the standard library plus `github.com/mr-tron/base58`. No Solana SDK is pulled in by default — that decision is left to the `Signer` implementation you plug in.
@@ -32,7 +32,7 @@ import (
 	"fmt"
 	"log"
 
-	solvela "github.com/solvela-ai/solvela-go"
+	solvela "github.com/solvela-ai/solvela/sdks/go"
 )
 
 func main() {
@@ -70,7 +70,7 @@ Without a `Signer`, paid endpoints return `*PaymentRequiredError` on the first c
 import (
 	"time"
 
-	solvela "github.com/solvela-ai/solvela-go"
+	solvela "github.com/solvela-ai/solvela/sdks/go"
 )
 
 client, err := solvela.NewClient(wallet, signer,
@@ -123,7 +123,7 @@ client, err := solvela.NewClient(wallet, signer,
     	"fmt"
     	"log"
 
-    	solvela "github.com/solvela-ai/solvela-go"
+    	solvela "github.com/solvela-ai/solvela/sdks/go"
     )
 
     func main() {
@@ -383,7 +383,7 @@ Wire amounts (`PaymentAccept.Amount`) are decimal strings in atomic USDC units (
 
 ## Smoke harness
 
-A 100-line smoke test in [`scripts/smoke/main.go`](https://github.com/solvela-ai/solvela-go/blob/main/scripts/smoke/main.go) exercises the wire contract against a live gateway: it lists models, asserts at least one reports streaming + paid input pricing, and issues an unsigned chat to verify the 402 round-trip parses cleanly. Run it before tagging a release:
+A 100-line smoke test in [`sdks/go/scripts/smoke/main.go`](https://github.com/solvela-ai/solvela/blob/main/sdks/go/scripts/smoke/main.go) exercises the wire contract against a live gateway: it lists models, asserts at least one reports streaming + paid input pricing, and issues an unsigned chat to verify the 402 round-trip parses cleanly. Run it before tagging a release:
 
 ```bash
 SOLVELA_GATEWAY_URL=https://staging.solvela.ai go run ./scripts/smoke
@@ -394,5 +394,5 @@ SOLVELA_GATEWAY_URL=https://staging.solvela.ai go run ./scripts/smoke
 `WithTimeout(d)` (default 180s) caps every HTTP call. Cancel an in-flight `Chat` by cancelling the `context.Context` you pass in — the underlying `http.Client` honors `ctx.Done()` and surfaces the cancellation as either `ctx.Err()` or `*TimeoutError`.
 
 <Note>
-  Source: [`solvela-ai/solvela-go`](https://github.com/solvela-ai/solvela-go). The canonical chat-flow entry point is [`client.go`](https://github.com/solvela-ai/solvela-go/blob/main/client.go); the smoke harness lives at [`scripts/smoke/main.go`](https://github.com/solvela-ai/solvela-go/blob/main/scripts/smoke/main.go). See also [x402 Protocol](/docs/concepts/x402) for the underlying payment flow.
+  Source: [`sdks/go/`](https://github.com/solvela-ai/solvela/tree/main/sdks/go) in the monorepo. The canonical chat-flow entry point is [`client.go`](https://github.com/solvela-ai/solvela/blob/main/sdks/go/client.go); the smoke harness lives at [`sdks/go/scripts/smoke/main.go`](https://github.com/solvela-ai/solvela/blob/main/sdks/go/scripts/smoke/main.go). See also [x402 Protocol](/docs/concepts/x402) for the underlying payment flow.
 </Note>

--- a/dashboard/content/docs/sdks/mcp.mdx
+++ b/dashboard/content/docs/sdks/mcp.mdx
@@ -10,39 +10,66 @@ The Solvela MCP server exposes the gateway's capabilities as MCP tools, enabling
 
 ## Installation
 
+The MCP server is **not published to npm** today (`package.json` is marked
+`private: true`). Build it from the monorepo:
+
 ```bash
-npx @solvela/mcp
+git clone https://github.com/solvela-ai/solvela.git
+cd solvela/sdks/mcp
+npm install
+npm run build
+# Built artifact: dist/index.js
 ```
 
-Or install globally:
+Run it directly to confirm the build:
 
 ```bash
-npm install -g @solvela/mcp
-solvela-mcp
+node dist/index.js
 ```
 
 ## Configuration
 
-Set these environment variables before starting the server:
+The server reads these environment variables on startup:
+
+| Variable | Required | Description |
+|---|---|---|
+| `SOLANA_WALLET_KEY` | Yes (for paid calls) | Base58-encoded Solana keypair secret |
+| `SOLANA_RPC_URL` | Yes (for paid calls) | Solana JSON-RPC endpoint |
+| `SOLVELA_API_URL` | No | Gateway base URL (default `https://api.solvela.ai`) |
+| `SOLVELA_SESSION_BUDGET` | No | Per-session USDC cap (e.g. `2.00`) |
+| `SOLVELA_TIMEOUT_MS` | No | HTTP timeout for gateway calls |
+| `SOLVELA_SIGNING_MODE` | No | `auto` / `escrow` / `direct` / `off` (default `auto`) |
+| `SOLVELA_ESCROW_PROGRAM_ID` | If `escrow` mode | Escrow program ID on Solana mainnet |
+| `SOLVELA_RECIPIENT_WALLET` | If `escrow` mode | Gateway recipient pubkey |
 
 ```bash
 export SOLVELA_API_URL=https://api.solvela.ai
-export SOLVELA_SOLANA_PRIVATE_KEY=<base58-private-key>
+export SOLANA_WALLET_KEY=<base58-keypair-secret>
+export SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
 ```
+
+<Warning>
+`SOLANA_WALLET_KEY` is the full Solana keypair secret. Treat it like any other
+production credential — never commit it to source, and prefer a secrets manager
+or your host's encrypted env-var store over a plaintext shell profile.
+</Warning>
 
 ## Claude Desktop integration
 
-Add to your `claude_desktop_config.json`:
+Add an entry to `claude_desktop_config.json` that points at your locally-built
+`dist/index.js` (absolute path required — `npx` is not available because the
+package is not on npm):
 
 ```json
 {
   "mcpServers": {
     "solvela": {
-      "command": "npx",
-      "args": ["@solvela/mcp"],
+      "command": "node",
+      "args": ["/absolute/path/to/solvela/sdks/mcp/dist/index.js"],
       "env": {
         "SOLVELA_API_URL": "https://api.solvela.ai",
-        "SOLVELA_SOLANA_PRIVATE_KEY": "<your-private-key>"
+        "SOLANA_WALLET_KEY": "<base58-keypair-secret>",
+        "SOLANA_RPC_URL": "https://api.mainnet-beta.solana.com"
       }
     }
   }

--- a/dashboard/content/docs/sdks/python.mdx
+++ b/dashboard/content/docs/sdks/python.mdx
@@ -7,7 +7,7 @@ description: Async-first Python client for Solvela with built-in Solana signing 
 `solvela-sdk` is the official Python SDK for the Solvela gateway. It's async-only, dataclass-typed, and handles the x402 payment handshake transparently when a `Signer` is configured.
 
 - **Package:** [`solvela-sdk` on PyPI](https://pypi.org/project/solvela-sdk/)
-- **Source:** [`solvela-ai/solvela-python`](https://github.com/solvela-ai/solvela-python)
+- **Source:** [`sdks/python/`](https://github.com/solvela-ai/solvela/tree/main/sdks/python) in the monorepo
 - **Python:** 3.10+
 
 ## Installation
@@ -301,5 +301,5 @@ class MyCustomSigner(Signer):
 `ClientConfig.timeout` (default 180s) caps every HTTP call. Cancel an in-flight `chat()` by cancelling the surrounding asyncio task — `httpx` propagates cancellation through cleanly.
 
 <Note>
-  Source: [`solvela-ai/solvela-python`](https://github.com/solvela-ai/solvela-python). The canonical chat-flow entry point is [`src/solvela/client.py`](https://github.com/solvela-ai/solvela-python/blob/main/src/solvela/client.py); a 60-line end-to-end smoke test lives at [`scripts/smoke.py`](https://github.com/solvela-ai/solvela-python/blob/main/scripts/smoke.py). See also [x402 Protocol](/docs/concepts/x402) for the underlying payment flow.
+  Source: [`sdks/python/`](https://github.com/solvela-ai/solvela/tree/main/sdks/python) in the monorepo. The canonical chat-flow entry point is [`src/solvela/client.py`](https://github.com/solvela-ai/solvela/blob/main/sdks/python/src/solvela/client.py); a 60-line end-to-end smoke test lives at [`scripts/smoke.py`](https://github.com/solvela-ai/solvela/blob/main/sdks/python/scripts/smoke.py). See also [x402 Protocol](/docs/concepts/x402) for the underlying payment flow.
 </Note>

--- a/dashboard/content/docs/sdks/rust.mdx
+++ b/dashboard/content/docs/sdks/rust.mdx
@@ -19,13 +19,18 @@ cargo build --release -p solvela-cli
 
 ## Configuration
 
-The CLI reads configuration from environment variables:
+The CLI binds one environment variable:
 
 ```bash
-export SOLVELA_API_URL=https://api.solvela.ai
-export SOLVELA_SOLANA_PRIVATE_KEY=<base58-private-key>   # for paid requests
-export RUST_LOG=info  # optional logging
+export SOLVELA_API_URL=https://api.solvela.ai   # optional; default https://api.solvela.ai
+export RUST_LOG=info                             # optional logging
 ```
+
+The wallet is **not** read from an environment variable — there is no
+`SOLVELA_SOLANA_PRIVATE_KEY` or similar. The CLI loads the keypair from
+`~/.solvela/wallet.json` on every paid command. Initialize one with
+`solvela wallet init` (see [`solvela wallet`](#solvela-wallet) below) and fund
+the printed address with USDC-SPL + a small amount of SOL before signing.
 
 ## Commands
 
@@ -64,10 +69,12 @@ solvela health
 
 ### `solvela wallet`
 
-Display wallet information and USDC balance.
+Manage the local wallet at `~/.solvela/wallet.json`. Three subcommands:
 
 ```bash
-solvela wallet
+solvela wallet init     # Generate a new Solana keypair and print the address to fund
+solvela wallet status   # Show address + USDC-SPL balance
+solvela wallet export   # Print the base58 secret key (handle with care)
 ```
 
 ### `solvela stats`

--- a/dashboard/content/docs/sdks/typescript.mdx
+++ b/dashboard/content/docs/sdks/typescript.mdx
@@ -3,30 +3,36 @@ title: TypeScript SDK
 description: TypeScript/Node.js client for Solvela with automatic x402 payment handling
 ---
 
-The Solvela TypeScript SDK lives in its own repository:
-[**github.com/solvela-ai/solvela-ts**](https://github.com/solvela-ai/solvela-ts).
+The Solvela TypeScript SDK lives in the monorepo at
+[`sdks/typescript/`](https://github.com/solvela-ai/solvela/tree/main/sdks/typescript).
 
 ## Status
 
+<Warning>
 The currently-published `@solvela/sdk@0.2.x` on npm is **not yet wire-compatible
 with the production gateway at `api.solvela.ai`**. The `PaymentPayload` envelope
-it emits does not match the shape the gateway deserializes. Track the standalone
-repo for a future release that aligns with the gateway wire format before using
-it for production payments.
+it emits does not match the shape the gateway deserializes. A republish that
+aligns with the v2 wire format is pending; until then, do not use `@solvela/sdk`
+for production payments.
+</Warning>
 
 If you're building inside this monorepo and need x402 signing today, depend on
 [`@solvela/signer-core`](https://github.com/solvela-ai/solvela/tree/main/sdks/signer-core)
 directly — that's what `sdks/mcp/`, `sdks/openclaw-provider/`, and
-`sdks/ai-sdk-provider/` use to talk to the gateway.
+`sdks/ai-sdk-provider/` use to talk to the gateway. Outside the monorepo,
+drive the gateway directly with `fetch`/`curl` (see the [Quickstart](/docs/quickstart)
+cURL tab and [Payment Flow](/docs/concepts/payment-flow)).
 
 ## Documentation
 
-- **Source:** [github.com/solvela-ai/solvela-ts](https://github.com/solvela-ai/solvela-ts)
+- **Source:** [`sdks/typescript/`](https://github.com/solvela-ai/solvela/tree/main/sdks/typescript) in the monorepo
 - **npm package:** [@solvela/sdk](https://www.npmjs.com/package/@solvela/sdk) (pre-1.0; see status above)
 
-## What changed
+## History
 
-The TypeScript SDK was previously vendored under `sdks/typescript/` in the
-solvela monorepo. That snapshot was retired in favor of a canonical standalone
-repository so SDK fixes (signer hardening, x402 protocol updates, ergonomics)
-can ship in lockstep with the npm release.
+The TypeScript SDK previously lived in a standalone repository at
+`solvela-ai/solvela-ts`. It was consolidated into the monorepo on
+[2026-05-12 (PR #259)](https://github.com/solvela-ai/solvela/pull/259) so
+wire-format drift between the gateway and SDK becomes a same-PR CI failure
+rather than a post-hoc incident. The standalone repository is archived; clones
+of the old URL land on a redirect README.


### PR DESCRIPTION
## Summary

Follow-up to [#268](https://github.com/solvela-ai/solvela/pull/268). Same docs-accuracy theme — fixes the audit findings called out as natural follow-ups in that PR's description, plus two HIGH-severity audit items (H5/H6) that involved broken install/config instructions.

### Archived-repo URL substitutions (5 files in original queue)

- `sdks/go.mdx` — module link, source link, \`go get\`, smoke-harness blob link, footer Source + client.go blob link
- `sdks/python.mdx` — source link + footer client.py and smoke.py blob links
- `sdks/typescript.mdx` — **section rewrite**: the History paragraph said the TS SDK "was previously vendored under sdks/typescript and retired in favor of a standalone repo." That's the exact opposite of reality. PR #259 (2026-05-12) consolidated the TS SDK *into* the monorepo. Rewritten so the History section now describes the actual move correctly.
- `concepts/architecture.mdx` — Supporting Components table rows; also fixed the Python row's PyPI package name (\`solvela\` → \`solvela-sdk\` — the actual published name).
- `api/chat-completions.mdx` — Go import in the example code block.

### H5 — false \`SOLVELA_SOLANA_PRIVATE_KEY\` claim (2 files)

The CLI doesn't read that env var. Verified against \`crates/cli/src/main.rs\` (only \`SOLVELA_API_URL\` is bound) and \`crates/cli/src/commands/wallet.rs\` (wallet path hardcoded to \`~/.solvela/wallet.json\`).

- \`sdks/rust.mdx\` — replaced the Configuration env-var block. Also corrected \`solvela wallet\` section (it has \`init\`/\`status\`/\`export\` subcommands, not a bare \`solvela wallet\` call).
- \`quickstart.mdx\` — CLI tab in the signing step also exported the same false env var. Replaced with \`solvela wallet init\` + automatic-signing flow. (Not in original queue scope but same finding — leaving it would orphan the false claim.)

### H6 — nonexistent \`@solvela/mcp\` npm package (1 file)

\`sdks/mcp/package.json\` is marked \`"private": true\`; the package is 404 on npm. Verified MCP server env-var contract by grepping \`process.env[...]\` in \`sdks/mcp/src/\`: real wallet var is \`SOLANA_WALLET_KEY\`, RPC is \`SOLANA_RPC_URL\`, gateway is \`SOLVELA_API_URL\` — none of which match the current docs.

- \`sdks/mcp.mdx\` — full rewrite of Installation, Configuration, and Claude Desktop sections. Monorepo build flow (\`git clone\` → \`npm install && npm run build\` → \`node dist/index.js\`). Claude Desktop integration uses \`node /absolute/path/\` pointed at the built artifact.

## Out of scope (deliberate)

- \`README.md\` \`solvela-gateway.fly.dev\` references — branding/hostname cleanup, different theme.
- \`@solvela/sdk\` wire-compat republish — package-side work.
- crates.io README republishes — package-side work (all 5 crates ship \`readme = false\`).
- Marketing-site fixes — product-positioning decisions, not docs accuracy.

## Test plan

- [x] \`npm --prefix dashboard test\` — 100/100 pass
- [x] \`npm --prefix dashboard run build\` — 50/50 static pages generated; MDX parses clean
- [x] \`grep -rn 'solvela-ai/solvela-(go|ts|python)' dashboard/content/docs\` — only hit is the History paragraph in typescript.mdx that names the old standalone repo when describing the move (citation, not a broken link)
- [x] \`grep -rn 'SOLVELA_SOLANA_PRIVATE_KEY' dashboard/content/docs\` — only hit is the explicit "there is no \`SOLVELA_SOLANA_PRIVATE_KEY\` or similar" negation in rust.mdx
- [x] \`grep -rn 'npx @solvela/mcp' dashboard/content/docs\` — zero hits
- [ ] Required CI: Rust, Smoke, Security audit, Docker build (gates pass on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)