### PR TITLE
docs(readme): use api.solvela.ai for developer-facing gateway references

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Solvela is deployed on Fly.io:
 
 | Resource | URL / Name |
 |----------|------------|
-| Gateway | `solvela-gateway.fly.dev` |
+| Gateway | `api.solvela.ai` (Fly app: `solvela-gateway`) |
 | PostgreSQL | `solvela-db` (Fly Postgres 17.2) |
 | Redis | `solvela-cache` (Upstash, ord + iad) |
 
@@ -424,7 +424,7 @@ fly secrets set -a solvela-gateway OPENAI_API_KEY=... ANTHROPIC_API_KEY=...
 
 # Check status
 fly status -a solvela-gateway
-curl https://solvela-gateway.fly.dev/health
+curl https://api.solvela.ai/health
 ```
 
 See [`STATUS.md`](./STATUS.md) for live shipping status and [`CHANGELOG.md`](./CHANGELOG.md) for chronological history.


### PR DESCRIPTION
## Summary

Third docs-accuracy PR after [#268](https://github.com/solvela-ai/solvela/pull/268) and [#270](https://github.com/solvela-ai/solvela/pull/270). Two README substitutions of the underlying Fly app hostname (`solvela-gateway.fly.dev`) with the public hostname (`api.solvela.ai`) on developer-facing surfaces.

The Fly app name is correct for operators running `fly` commands; the fly.dev hostname is the underlying Fly.io app URL. Neither belongs in dev-facing copy when there's a public CNAME (`api.solvela.ai`) that's the contract endpoint.

## Changes (2 lines, README only)

- **Deployment resource table** — Gateway row changed from `\`solvela-gateway.fly.dev\`` to `\`api.solvela.ai\` (Fly app: \`solvela-gateway\`)`. Operators still see the Fly app name they need for the `fly deploy -a ...` commands below; devs see the URL.
- **Post-deploy smoke curl** — `curl https://solvela-gateway.fly.dev/health` → `curl https://api.solvela.ai/health`. The meaningful smoke check is whether the public LB + domain routing wire up.

## Out of scope (intentional)

- `fly.toml` Fly app definitions — those stay.
- `fly deploy -a solvela-gateway` and sibling commands — correct Fly CLI usage referencing the Fly app name, not the fly.dev hostname.
- `CHANGELOG.md:288` historical entry — accurate at the time it was written; editing historical changelog entries is bad form.

## Test plan

- [x] `grep -rn 'solvela-gateway\\.fly\\.dev' --include='*.md' --include='*.mdx' --include='*.toml' ... <repo>` — only remaining hit is the CHANGELOG.md:288 historical entry described above
- [x] No source code touched; no build needed
- [ ] Required CI: Rust, Smoke, Security audit, Docker build (gates pass on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)