### PR TITLE
fix(mcp): pin signing recipient + amount cap via PaymentExpectations

### DIFF
--- a/sdks/mcp/src/client.ts
+++ b/sdks/mcp/src/client.ts
@@ -16,7 +16,7 @@ import {
   isStubHeader,
   sanitizeGatewayError,
 } from '@solvela/signer-core';
-import type { PaymentRequired, PaymentAccept } from '@solvela/signer-core';
+import type { PaymentRequired, PaymentAccept, PaymentExpectations } from '@solvela/signer-core';
 import type { SessionStore, SessionState } from './session.js';
 
 export type { PaymentRequired, PaymentAccept };
@@ -93,6 +93,18 @@ export interface GatewayClientOptions {
   signingMode?: 'auto' | 'escrow' | 'direct' | 'off';
   /** Optional session persistence store. When provided, sessionSpent survives restarts. */
   sessionStore?: SessionStore;
+  /**
+   * Pinned recipient pubkey. When set, the SDK refuses to sign any 402
+   * whose chosen accept has a `pay_to` other than this value — defending
+   * against a phishing gateway / DNS hijack pointing payments at an
+   * attacker wallet. STRONGLY RECOMMENDED for production deployments.
+   */
+  expectedRecipient?: string;
+  /**
+   * Pinned escrow program ID. When set AND the chosen scheme is `escrow`,
+   * the SDK refuses to sign if `escrow_program_id` does not match.
+   */
+  expectedEscrowProgramId?: string;
 }
 
 /**
@@ -106,6 +118,8 @@ export class GatewayClient {
   private readonly sessionBudget?: number;
   private readonly timeoutMs: number;
   private readonly signingMode: 'auto' | 'escrow' | 'direct' | 'off';
+  private readonly expectedRecipient?: string;
+  private readonly expectedEscrowProgramId?: string;
   /**
    * Integer micro-USDC counters (1 USDC = 1_000_000 micro-USDC).
    * Using integers prevents floating-point drift (e.g. 7 × 0.1 ≠ 0.7 in IEEE-754).
@@ -143,6 +157,8 @@ export class GatewayClient {
     this.timeoutMs = opts.timeoutMs ?? 60_000;
     this.signingMode = opts.signingMode ?? 'auto';
     this.sessionStore = opts.sessionStore;
+    this.expectedRecipient = opts.expectedRecipient;
+    this.expectedEscrowProgramId = opts.expectedEscrowProgramId;
     // Kick off the load immediately so the first mutex entry doesn't add latency.
     this.sessionStatePromise = opts.sessionStore
       ? opts.sessionStore.load().catch((err) => {
@@ -282,9 +298,24 @@ export class GatewayClient {
         const filteredPaymentInfo = { ...paymentInfo, accepts: filteredAccepts };
         const privateKey = process.env['SOLANA_WALLET_KEY'];
 
+        // SEC-H1: bound what the gateway can ask us to sign. `maxAmount` is
+        // always known (we just budget-reserved it). `recipient` and
+        // `escrowProgramId` are only enforced if the caller pinned them via
+        // env config — without pinning, an attacker who controls the 402
+        // response can still substitute their own pay_to, but the maxAmount
+        // cap stops them from inflating the cost beyond the cost_breakdown
+        // total the budget mutex already authorized.
+        const expected: PaymentExpectations = { maxAmount: BigInt(costMicro) };
+        if (this.expectedRecipient !== undefined) {
+          expected.recipient = this.expectedRecipient;
+        }
+        if (this.expectedEscrowProgramId !== undefined) {
+          expected.escrowProgramId = this.expectedEscrowProgramId;
+        }
+
         let paymentHeader: string;
         try {
-          paymentHeader = await createPaymentHeader(filteredPaymentInfo, url, privateKey, bodyStr);
+          paymentHeader = await createPaymentHeader(filteredPaymentInfo, url, privateKey, bodyStr, expected);
         } catch (err) {
           // HF2: Refund the reserved budget — signer never succeeded.
           await this.budgetMutex.runExclusive(async () => {

--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -138,6 +138,11 @@ const client = new GatewayClient({
   timeoutMs,
   signingMode,
   sessionStore,
+  // SEC-H1: pin recipient + escrow program ID so a phishing 402 cannot
+  // redirect signed transfers. Empty strings are normalized to undefined so
+  // unset env vars do not collide with valid base58 pubkeys at validation.
+  expectedRecipient: escrowRecipientWallet || undefined,
+  expectedEscrowProgramId: escrowProgramId || undefined,
 });
 
 // ---------------------------------------------------------------------------

--- a/sdks/mcp/tests/server.test.ts
+++ b/sdks/mcp/tests/server.test.ts
@@ -356,6 +356,98 @@ describe('GatewayClient', () => {
     }
   });
 
+  // -------------------------------------------------------------------------
+  // SEC-H1: PaymentExpectations — refuse-to-sign on phishing 402 responses.
+  // The chosen accept's pay_to and amount come from the gateway, which is
+  // attacker-controllable (DNS hijack, MITM, misconfigured host config). The
+  // client MUST refuse to sign when those values diverge from caller
+  // expectations and MUST refund the budget reservation it made before
+  // attempting to sign.
+  // -------------------------------------------------------------------------
+
+  it('SEC-H1: rejects 402 whose pay_to does not match expectedRecipient (and refunds budget)', async () => {
+    const phishing402 = {
+      ...payment402,
+      accepts: [{
+        ...payment402.accepts[0],
+        pay_to: 'AttackerWa11et1111111111111111111111111111111', // 43 chars, valid base58 shape
+      }],
+    };
+
+    const restore = mockFetch([
+      { status: 402, body: { error: { message: JSON.stringify(phishing402) } } },
+    ]);
+
+    try {
+      const c = new GatewayClient({
+        apiUrl: 'http://test.local',
+        expectedRecipient: '11111111111111111111111111111111', // what the caller pinned
+      });
+      await assert.rejects(
+        () => c.chat('openai/gpt-4o', [{ role: 'user', content: 'Hi' }]),
+        /Payment signing failed:.*recipient mismatch/,
+      );
+      // Budget reservation made before signing must be refunded after refusal.
+      assert.equal(c.spendSummary().session_usdc_spent, '0.000000');
+      assert.equal(c.spendSummary().total_requests, 0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('SEC-H1: rejects 402 whose amount exceeds the cost_breakdown.total cap (and refunds budget)', async () => {
+    // Gateway returns a believable cost_breakdown.total but an inflated
+    // accepts[0].amount — the SDK must catch this via maxAmount: BigInt(costMicro)
+    // because the budget mutex authorized only the cost_breakdown amount.
+    const inflated402 = {
+      ...payment402,
+      accepts: [{
+        ...payment402.accepts[0],
+        amount: '99999999999', // way more than the 2500 micro-USDC in cost_breakdown
+      }],
+      // cost_breakdown.total stays at '0.002500' so the budget reservation
+      // computes costMicro = 2500. The signer must refuse the 99999999999.
+    };
+
+    const restore = mockFetch([
+      { status: 402, body: { error: { message: JSON.stringify(inflated402) } } },
+    ]);
+
+    try {
+      const c = new GatewayClient({ apiUrl: 'http://test.local' });
+      await assert.rejects(
+        () => c.chat('openai/gpt-4o', [{ role: 'user', content: 'Hi' }]),
+        /Payment signing failed:.*amount cap exceeded/,
+      );
+      assert.equal(c.spendSummary().session_usdc_spent, '0.000000');
+      assert.equal(c.spendSummary().total_requests, 0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('SEC-H1: matching expectedRecipient passes through (stub-mode 200)', async () => {
+    // Sanity check the positive path: when pay_to matches, the SDK proceeds
+    // normally. Without this we couldn't tell whether expectedRecipient
+    // works at all vs. always rejects.
+    const restore = mockFetch([
+      { status: 402, body: { error: { message: JSON.stringify(payment402) } } },
+      { status: 200, body: chatResp },
+    ]);
+
+    try {
+      const c = new GatewayClient({
+        apiUrl: 'http://test.local',
+        expectedRecipient: payment402.accepts[0].pay_to,
+      });
+      const resp = await c.chat('openai/gpt-4o', [{ role: 'user', content: 'Hi' }]);
+      assert.equal(resp.choices[0].message.content, 'Paid reply');
+      assert.equal(c.spendSummary().session_usdc_spent, '0.002500');
+    } finally {
+      restore();
+    }
+  });
+
   it('listModels returns model list', async () => {
     const modelsResp = {
       object: 'list',


### PR DESCRIPTION
## Summary

A 402 response is supplied by the remote gateway and may be attacker-controlled (phishing gateway, DNS hijack, MITM, misconfigured MCP host config pointing at a malicious URL). The MCP SDK was calling `createPaymentHeader` without the `expected` argument, so the signer would sign whatever `pay_to` / `amount` the 402 returned. This is the SEC-H1 finding from the 2026-05-14 multi-agent audit.

This PR wires `PaymentExpectations` into the chat-path call:

- **`maxAmount = BigInt(costMicro)`** — the budget mutex already authorized exactly this many atomic units; the signer now refuses anything larger. Always enforced.
- **`recipient`** — pinned to `SOLVELA_RECIPIENT_WALLET` when set. Enforced when configured.
- **`escrowProgramId`** — pinned to `SOLVELA_ESCROW_PROGRAM_ID` when set. Enforced when configured and the chosen scheme is escrow.

Both env vars already existed in `index.ts` (lines 99–100) for the escrow-tool gating path; this PR just threads them into the GatewayClient constructor.

`validateAccept` inside signer-core runs **before** any private-key bytes are touched and throws `SigningError` on mismatch, which the existing refund-clamp logic catches and rolls the budget reservation back. No new error-handling shape needed.

## What this does *not* fix

- Without setting `SOLVELA_RECIPIENT_WALLET`, the recipient is still gateway-controlled. The `maxAmount` cap is the only enforced bound. A startup WARN encouraging users to pin the recipient is a follow-up.
- The remaining audit findings (gateway-URL scheme validation, `resp.json()` unsafe casts, lost stack traces, empty-choices silent success, PDA placeholder string, type branding) are tracked as separate PRs per the audit punch list.

## Test plan

- [x] `npm test` in `sdks/mcp` — 72/72 pass (3 new SEC-H1 tests)
- [x] `npx tsc --noEmit` — clean
- [ ] CI green
- [ ] Manual: with a real gateway, confirm chat still flows when `SOLVELA_RECIPIENT_WALLET` matches `pay_to`

## New tests

`tests/server.test.ts`:
1. **`SEC-H1: rejects 402 whose pay_to does not match expectedRecipient`** — phishing recipient → `SigningError` → budget refunded to `0.000000`.
2. **`SEC-H1: rejects 402 whose amount exceeds the cost_breakdown.total cap`** — gateway inflates `accepts[0].amount` while keeping `cost_breakdown.total` believable → caught by `maxAmount` → budget refunded.
3. **`SEC-H1: matching expectedRecipient passes through`** — happy-path sanity check so the refuse-path tests aren't proving "always rejects."

These also exercise the previously-untested signing-error refund path (`client.ts:290`, the refund clamp from #149) — pr-test-analyzer flagged it as a regression-target with no coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)