### PR TITLE
docs(marketing): drop unsubstantiated claims + fix SDK snippets

### DIFF
--- a/dashboard/src/components/landing/config.ts
+++ b/dashboard/src/components/landing/config.ts
@@ -8,10 +8,12 @@ export const APP_URL = 'https://app.solvela.ai'
 export const QUICKSTART_URL = 'https://docs.solvela.ai/docs/quickstart'
 export const ESCROW_PROGRAM_ID = '9neDHouXgEgHZDde5Sp'
 
+// Uptime and p50 latency were removed pending a public status page;
+// claiming SLA-shaped numbers without one is the kind of statement
+// enterprise procurement will challenge. Re-add with hard data
+// behind them, not before.
 export const METRICS = [
-  { label: 'uptime', value: 99.98, suffix: '%', decimals: 2 },
-  { label: 'p50 latency', value: 38, suffix: 'ms', decimals: 0 },
-  { label: 'models', value: 26, suffix: '+', decimals: 0 },
+  { label: 'models', value: 25, suffix: '+', decimals: 0 },
   { label: 'platform fee', value: 5, suffix: '%', decimals: 0 },
 ]
 

--- a/dashboard/src/components/landing/escrow-sequence.tsx
+++ b/dashboard/src/components/landing/escrow-sequence.tsx
@@ -149,7 +149,7 @@ export function EscrowSequence() {
               usdc-spl
             </span>
             <span className="rounded-md border border-border px-2 py-1">
-              audited flows
+              open-source flows
             </span>
           </div>
 

--- a/dashboard/src/components/landing/inline-metrics.tsx
+++ b/dashboard/src/components/landing/inline-metrics.tsx
@@ -2,11 +2,11 @@ import { CountUp } from './count-up'
 import { METRICS } from './config'
 
 // Asymmetric widths break the "identical-tile grid" template. The first
-// tile (uptime) gets the most room; the last (platform fee) is compact.
+// tile gets the most room and the salmon left rail.
 export function InlineMetrics() {
   return (
     <div
-      className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-border bg-[var(--border)] sm:grid-cols-[1.2fr_1fr_1fr_0.9fr]"
+      className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-border bg-[var(--border)] sm:grid-cols-[1.4fr_1fr]"
     >
       {METRICS.map((m, i) => (
         <div

--- a/dashboard/src/components/landing/landing-footer.tsx
+++ b/dashboard/src/components/landing/landing-footer.tsx
@@ -61,7 +61,7 @@ export function LandingFooter() {
             title="solvela"
             links={[
               { label: 'github', href: GITHUB_URL },
-              { label: 'status', href: `${APP_URL}/overview` },
+              { label: 'status', href: 'https://api.solvela.ai/health' },
               { label: 'security', href: `${DOCS_URL}/docs/operations/security` },
             ]}
           />

--- a/dashboard/src/components/landing/landing-ticker.tsx
+++ b/dashboard/src/components/landing/landing-ticker.tsx
@@ -4,9 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 
 const TICKER_ITEMS = [
   'ESCROW · 9neDHouXgEgHZDde5Sp',
-  'p50 · 38ms',
-  'p99 · 184ms',
-  '26 models · 5 providers',
+  '25+ models · 5 providers',
   '5% flat fee',
   'mainnet · x402 · usdc-spl',
   'a2a · agent-card · /.well-known',

--- a/dashboard/src/components/landing/sdk-samples.ts
+++ b/dashboard/src/components/landing/sdk-samples.ts
@@ -16,18 +16,22 @@ export const SAMPLES: Sample[] = [
     id: 'ts',
     label: 'typescript',
     lang: 'typescript',
-    install: 'npm i @solvela/sdk',
-    status: 'live',
-    code: `import { Solvela } from '@solvela/sdk'
+    install: 'npm i @solvela/sdk  # republish pending — use curl today',
+    status: 'soon',
+    code: `// @solvela/sdk@0.2.x predates the current wire format and will
+// not complete a real payment against api.solvela.ai. Republish is
+// pending. Drive the gateway directly until the new SDK ships:
 
-const solvela = new Solvela({ keypair: wallet })
-
-const reply = await solvela.chat.completions.create({
-  model: 'auto',
-  messages: [{ role: 'user', content: 'hi' }],
+const res = await fetch('https://api.solvela.ai/v1/chat/completions', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    model: 'auto',
+    messages: [{ role: 'user', content: 'hi' }],
+  }),
 })
-
-// 402 handshake + escrow claim handled for you.`,
+// 402 first, then sign + retry with the payment-signature header.
+// Full handshake: docs.solvela.ai/quickstart`,
   },
   {
     id: 'vercel',
@@ -52,7 +56,7 @@ const { text } = await generateText({
     id: 'py',
     label: 'python',
     lang: 'python',
-    install: 'pip install solvela',
+    install: 'pip install solvela-sdk',
     status: 'live',
     code: `from solvela import Solvela
 
@@ -67,7 +71,7 @@ reply = solvela.chat.completions.create(
     id: 'go',
     label: 'go',
     lang: 'go',
-    install: 'go get github.com/solvela-ai/solvela-go',
+    install: 'go get github.com/solvela-ai/solvela/sdks/go',
     status: 'live',
     code: `client := solvela.New(solvela.WithKeypair(wallet))
 
@@ -107,15 +111,16 @@ const reply = await model.invoke('summarize this transcript in one sentence.')`,
     id: 'mcp',
     label: 'mcp',
     lang: 'json',
-    install: 'npx @solvela/mcp',
-    status: 'live',
+    install: 'git clone solvela-ai/solvela && cd sdks/mcp && npm i && npm run build',
+    status: 'alpha',
     code: `// works in claude code, cursor, and openclaw — drop into .mcp.json
+// npm publish pending; point at your local build of dist/index.js
 {
   "mcpServers": {
     "solvela": {
-      "command": "npx",
-      "args": ["@solvela/mcp"],
-      "env": { "SOLVELA_WALLET": "<keypair.json>" }
+      "command": "node",
+      "args": ["<repo>/sdks/mcp/dist/index.js"],
+      "env": { "SOLANA_WALLET_KEY": "<base58-keypair-secret>" }
     }
   }
 }`,


### PR DESCRIPTION
## Summary

Fourth pass on the 2026-05-13 audit findings. The prior three PRs ([#268](https://github.com/solvela-ai/solvela/pull/268), [#270](https://github.com/solvela-ai/solvela/pull/270), [#271](https://github.com/solvela-ai/solvela/pull/271)) cleaned up docs.solvela.ai + README. This one targets the marketing surface.

Copy decisions were confirmed with the operator before edits:
- TS hero: swap to working curl snippet, mark TS card 'soon'
- "audited flows" badge: replace with "open-source flows"
- Uptime + p50 + p99: drop all 3 numeric claims pending a real status page

## Easy substitutions (Tier 1)

- `sdk-samples.ts` Python: \`pip install solvela\` → \`pip install solvela-sdk\` (correct PyPI package name)
- `sdk-samples.ts` Go: archived \`solvela-ai/solvela-go\` → monorepo path
- `sdk-samples.ts` MCP: \`npx @solvela/mcp\` doesn't exist on npm (package is \`private: true\`). Rewrote to a clone+build flow with the verified env var \`SOLANA_WALLET_KEY\` (from \`sdks/mcp/src/\`). Status flipped to 'alpha'.
- `landing-ticker.tsx`: "26 models" → "25+ models" (live gateway exposes 25)

## Copy decisions (Tier 2)

- **TS hero** — `@solvela/sdk@0.2.x` predates the v2 wire envelope and 402-loops against `api.solvela.ai`. Rewrote install + code to show a working `fetch()` snippet that points at \`docs.solvela.ai/quickstart\` for the full signing path. Card status flipped to 'soon'.
- **`audited flows` badge** — replaced with **`open-source flows`**. No third-party audit exists; BUSL-1.1 gateway + MIT libraries is the actually-differentiating, verifiable claim.
- **Numeric metrics** — dropped \`uptime 99.98%\`, \`p50 38ms\`, and \`p99 184ms\` from both \`METRICS\` (config.ts) and the ticker. Code comment in config.ts explains why: SLA-shaped numbers without a status page lose credibility under enterprise scrutiny. Re-add with hard data behind them.
- **`inline-metrics.tsx` grid** — adjusted from 4-col asymmetric (\`1.2fr 1fr 1fr 0.9fr\`) to 2-col (\`1.4fr 1fr\`) to match the smaller METRICS array. Salmon left-rail still decorates the first tile (now "models").
- **Footer status link** — was pointing at \`app.solvela.ai/overview\` which renders sample data ($247.83 fake spend etc) to anonymous visitors. Repointed at the real public \`api.solvela.ai/health\` JSON endpoint.

## Out of scope (intentional, called out for tracking)

- **\`www.solvela.ai\` DNS** — that's a Vercel domain config + DNS record, not a code change. The \`www\` host has no DNS at all today per the audit, so the README's 308 claim is also wrong; operator task.
- **app.solvela.ai dashboard anonymous-state CTA** — real product work (auth/wallet-connect entry, blank-state the metric tiles). Bigger than a marketing pass.
- **\`@solvela/sdk\` wire-compat republish** + **crates.io README republishes** — package-side work, not docs.

## Test plan

- [x] \`npm --prefix dashboard test\` — 100/100 pass
- [x] \`npm --prefix dashboard run build\` — clean build; all 50 static pages generated
- [ ] Required CI: Rust, Smoke, Security audit, Docker build (gates pass on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)