### PR TITLE
fix(mcp): refund budget reservation on malformed-JSON 200; wrap resp.json() calls

### DIFF
--- a/sdks/mcp/src/client.ts
+++ b/sdks/mcp/src/client.ts
@@ -245,6 +245,11 @@ export class GatewayClient {
       body: bodyStr,
     });
 
+    // HF12: track whether we committed a budget reservation so a malformed
+    // 200 body (caught by parseJson below) can roll the reservation back.
+    // Stays `null` on the initial-200 path where no reservation happened.
+    let costMicroCommitted: number | null = null;
+
     if (resp.status === 402) {
       // HF5: parse402 throws instead of returning null.
       const paymentInfo = parse402(await resp.text());
@@ -279,6 +284,7 @@ export class GatewayClient {
         this.sessionSpentMicro += costMicro;
         await this.persistState();
       });
+      costMicroCommitted = costMicro;
 
       if (this.signingMode === 'off') {
         // off mode: send without payment header; gateway will likely 402 again
@@ -404,19 +410,49 @@ export class GatewayClient {
       throw new Error(`Gateway error ${resp.status}: ${sanitized}`);
     }
 
-    return resp.json() as Promise<ChatResponse>;
+    // HF12: A status-200 with a non-JSON body (proxy timeout HTML page, truncated
+    // response) used to throw an uncaught SyntaxError and silently leave the budget
+    // reservation committed. Catch parse failures, refund the committed cost (if
+    // we came through the 402 path), decrement requestCount, and rethrow with a
+    // descriptive message so the operator can tell parse failure apart from gateway
+    // error apart from signing failure.
+    try {
+      return (await resp.json()) as ChatResponse;
+    } catch (err) {
+      const parseMsg = err instanceof Error ? err.message : String(err);
+      await this.budgetMutex.runExclusive(async () => {
+        if (costMicroCommitted !== null) {
+          this.sessionSpentMicro = Math.max(0, this.sessionSpentMicro - costMicroCommitted);
+        }
+        this.requestCount = Math.max(0, this.requestCount - 1);
+        await this.persistState();
+      });
+      throw new Error(
+        `Gateway returned malformed JSON for chat (status ${resp.status}): ${parseMsg}`,
+      );
+    }
   }
 
   async listModels(): Promise<ModelsResponse> {
     const resp = await this.fetchWithTimeout(`${this.apiUrl}/v1/models`);
     if (!resp.ok) throw new Error(`Failed to list models: ${resp.status}`);
-    return resp.json() as Promise<ModelsResponse>;
+    try {
+      return (await resp.json()) as ModelsResponse;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Gateway returned malformed JSON for /v1/models (status ${resp.status}): ${msg}`);
+    }
   }
 
   async health(): Promise<HealthResponse> {
     const resp = await this.fetchWithTimeout(`${this.apiUrl}/health`);
     if (!resp.ok) throw new Error(`Health check failed: ${resp.status}`);
-    return resp.json() as Promise<HealthResponse>;
+    try {
+      return (await resp.json()) as HealthResponse;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Gateway returned malformed JSON for /health (status ${resp.status}): ${msg}`);
+    }
   }
 
   spendSummary(): SpendSummary {

--- a/sdks/mcp/tests/server.test.ts
+++ b/sdks/mcp/tests/server.test.ts
@@ -448,6 +448,96 @@ describe('GatewayClient', () => {
     }
   });
 
+  // -------------------------------------------------------------------------
+  // HF12: malformed-JSON 200 must refund the committed budget reservation and
+  // surface a descriptive error (not a raw SyntaxError). Audit flagged this
+  // as a silent over-accounting bug: budget was committed at 402 reservation
+  // time but never refunded on parse failure.
+  // -------------------------------------------------------------------------
+
+  it('HF12: chat retry returns 200 with non-JSON body → refunds budget + throws descriptive error', async () => {
+    // Custom mock — mockFetch helper always returns valid JSON; we need a
+    // .json() that throws to simulate a proxy timeout HTML page or a
+    // truncated response body.
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    // @ts-expect-error — intentional mock override
+    globalThis.fetch = async (_url: string, _init?: RequestInit): Promise<Response> => {
+      callCount++;
+      if (callCount === 1) {
+        const bodyStr = JSON.stringify({ error: { message: JSON.stringify(payment402) } });
+        return {
+          status: 402,
+          ok: false,
+          json: () => Promise.resolve(JSON.parse(bodyStr)),
+          text: () => Promise.resolve(bodyStr),
+        } as unknown as Response;
+      }
+      // Retry returns 200 with a malformed body — simulates an HTML proxy page.
+      return {
+        status: 200,
+        ok: true,
+        json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON at position 0')),
+        text: () => Promise.resolve('<html>504 Gateway Timeout</html>'),
+      } as unknown as Response;
+    };
+
+    try {
+      const c = new GatewayClient({ apiUrl: 'http://test.local' });
+      await assert.rejects(
+        () => c.chat('openai/gpt-4o', [{ role: 'user', content: 'Hi' }]),
+        /Gateway returned malformed JSON for chat.*Unexpected token/,
+      );
+      // Budget reservation was committed during 402 handling — must be refunded.
+      assert.equal(c.spendSummary().session_usdc_spent, '0.000000');
+      // requestCount was bumped just before parse — must be rolled back.
+      assert.equal(c.spendSummary().total_requests, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('HF12: chat retry returns non-2xx → budget is refunded (regression for the existing refund path)', async () => {
+    // The refund at client.ts (non-2xx retry) has been live since HF2 but
+    // had no test. Lock the behavior in: 402 → sign → retry 500 → throw + refund.
+    const restore = mockFetch([
+      { status: 402, body: { error: { message: JSON.stringify(payment402) } } },
+      { status: 500, body: { error: 'internal error' } },
+    ]);
+
+    try {
+      const c = new GatewayClient({ apiUrl: 'http://test.local' });
+      await assert.rejects(
+        () => c.chat('openai/gpt-4o', [{ role: 'user', content: 'Hi' }]),
+        /Gateway error 500/,
+      );
+      assert.equal(c.spendSummary().session_usdc_spent, '0.000000');
+      assert.equal(c.spendSummary().total_requests, 0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('HF12: listModels with non-JSON body → throws descriptive error (not raw SyntaxError)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (): Promise<Response> => ({
+      status: 200,
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      text: () => Promise.resolve(''),
+    }) as unknown as Response;
+
+    try {
+      const c = new GatewayClient({ apiUrl: 'http://test.local' });
+      await assert.rejects(
+        () => c.listModels(),
+        /Gateway returned malformed JSON for \/v1\/models.*Unexpected end of JSON input/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('listModels returns model list', async () => {
     const modelsResp = {
       object: 'list',


### PR DESCRIPTION
## Summary

A status-200 with a non-JSON body (proxy timeout HTML page, truncated response, gateway misbehavior) used to throw an uncaught `SyntaxError` from `resp.json() as Promise<ChatResponse>`. The budget reservation committed during 402 handling was **never refunded** on this path, so `spending` reported inflated USDC consumed with no transaction behind it. The audit's pr-test-analyzer also flagged the existing non-2xx retry refund as live-but-untested.

This PR (audit findings **#2, #3** from the 2026-05-14 multi-agent review):

- **client.ts**: hoist `costMicroCommitted: number | null` past the 402 block; wrap the chat success path in try/catch, refund + persist + decrement `requestCount` on parse failure, then throw `Gateway returned malformed JSON for chat (status N): <msg>`.
- **client.ts**: apply the same try/catch + descriptive throw to `listModels()` and `health()` (no budget concern, just better diagnostics — operator can tell parse failure apart from gateway error apart from signing failure).
- **server.test.ts**: three regression tests.

## Tests

1. **HF12 chat parse-fail** — 402 → retry 200 with `.json()` rejecting → asserts both the new error message and `session_usdc_spent === '0.000000'` + `total_requests === 0`.
2. **HF12 non-2xx retry refund** — 402 → retry 500 → asserts the pre-existing HF2 refund landed. Locks the behavior in; the audit identified this as missing.
3. **HF12 listModels parse-fail** — descriptive error covers the `/v1/models` path.

## Independence from PR #272

This PR branches off `main` and does not depend on PR #272 (PaymentExpectations). They touch different lines of `client.ts`; either can merge first.

## Test plan

- [x] `npm test` in `sdks/mcp` — 72/72 pass (3 new HF12 tests)
- [x] `npx tsc --noEmit` — clean
- [ ] CI green
- [ ] Manual: hit a gateway that returns 200 + HTML proxy page (or use the test above as authoritative)

## Out of scope

- The remaining audit findings (gateway-URL scheme validation, runtime arg validation, lost stack traces, empty `choices[]` silent success, PDA placeholder string, type branding) are tracked as separate PRs per the audit punch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)