### PR TITLE
fix(mcp): runtime-validate tool call arguments instead of blind-casting

### DIFF
--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -35,6 +35,7 @@ import {
 import { GatewayClient, type ChatMessage } from './client.js';
 import { getTools } from './tools.js';
 import { createSessionStore } from './session.js';
+import { validateArgs } from './validate-args.js';
 import { createPaymentHeader, decodePaymentHeader, isStubTransaction } from '@solvela/signer-core';
 import type { PaymentRequired, PaymentAccept } from '@solvela/signer-core';
 import { Connection, PublicKey } from '@solana/web3.js';
@@ -169,13 +170,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case 'chat': {
-        const { model, prompt, system, max_tokens, temperature } = args as {
+        // T-3A: runtime-validate args before dispatch — MCP schema is advisory.
+        const { model, prompt, system, max_tokens, temperature } = validateArgs<{
           model: string;
           prompt: string;
           system?: string;
           max_tokens?: number;
           temperature?: number;
-        };
+        }>('chat', args, {
+          model: { kind: 'string', required: true },
+          prompt: { kind: 'string', required: true },
+          system: { kind: 'string', required: false },
+          max_tokens: { kind: 'number', required: false },
+          temperature: { kind: 'number', required: false },
+        });
 
         const messages: ChatMessage[] = [];
         if (system) messages.push({ role: 'system', content: system });
@@ -199,12 +207,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'smart_chat': {
-        const { prompt, profile = 'auto', system, max_tokens } = args as {
+        // T-3A: validate + enforce profile enum. The schema declares the enum
+        // but nothing stopped a host from sending profile='premium!!' which
+        // would have flowed straight into client.chat() as a model id.
+        const { prompt, profile = 'auto', system, max_tokens } = validateArgs<{
           prompt: string;
-          profile?: string;
+          profile?: 'eco' | 'auto' | 'premium' | 'free';
           system?: string;
           max_tokens?: number;
-        };
+        }>('smart_chat', args, {
+          prompt: { kind: 'string', required: true },
+          profile: { kind: 'stringEnum', required: false, values: ['eco', 'auto', 'premium', 'free'] },
+          system: { kind: 'string', required: false },
+          max_tokens: { kind: 'number', required: false },
+        });
 
         const messages: ChatMessage[] = [];
         if (system) messages.push({ role: 'system', content: system });
@@ -243,7 +259,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'list_models': {
-        const { filter } = args as { filter?: string };
+        // T-3A: filter is optional but, if present, must be a string —
+        // otherwise filter.toLowerCase() below blows up with TypeError.
+        const { filter } = validateArgs<{ filter?: string }>('list_models', args ?? {}, {
+          filter: { kind: 'string', required: false },
+        });
         const modelsResp = await client.listModels();
 
         let models = modelsResp.data;
@@ -274,7 +294,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'spending': {
-        const { reset = false } = (args ?? {}) as { reset?: boolean };
+        // T-3A: reset must be a real boolean — `reset: "true"` would silently
+        // become truthy and clear the session file via client.resetSession().
+        const { reset = false } = validateArgs<{ reset?: boolean }>('spending', args ?? {}, {
+          reset: { kind: 'boolean', required: false },
+        });
 
         if (reset) {
           await client.resetSession();

--- a/sdks/mcp/src/validate-args.ts
+++ b/sdks/mcp/src/validate-args.ts
@@ -1,0 +1,107 @@
+/**
+ * Runtime validation for MCP tool call arguments.
+ *
+ * MCP tool schemas (`inputSchema` JSON Schema on Tool definitions) are
+ * advisory — the SDK does not enforce them before the server's
+ * `CallToolRequestSchema` handler runs. A misbehaving or upgraded host
+ * can therefore call a tool with arguments that disagree with the schema
+ * (wrong types, missing required fields, profile values outside the
+ * declared enum). The handler used to `args as { ... }` blind-cast and
+ * propagate junk values downstream (e.g. `client.chat(42, ...)`).
+ *
+ * This helper performs minimal, message-shaped checks and throws
+ * `McpError(InvalidParams, ...)` on mismatch so the host gets a clean
+ * JSON-RPC error instead of a downstream surprise.
+ *
+ * Scope:
+ *   - string / number / boolean primitives
+ *   - string enums
+ *   - required vs optional
+ *
+ * NOT covered (call-site concerns):
+ *   - inter-field invariants (e.g. amount > 0)
+ *   - format validation (regex)
+ *   - the deposit_escrow tool already does its own stricter check on
+ *     `amount_usdc` and is not migrated here
+ */
+
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+
+export type FieldSpec =
+  | { kind: 'string'; required: boolean }
+  | { kind: 'number'; required: boolean }
+  | { kind: 'boolean'; required: boolean }
+  | { kind: 'stringEnum'; required: boolean; values: readonly string[] };
+
+export type Schema = Record<string, FieldSpec>;
+
+/**
+ * Validate `args` against `schema` and return it as the typed shape.
+ *
+ * Throws `McpError(InvalidParams, ...)` if:
+ *   - `args` is not a plain object
+ *   - a required field is missing or `undefined`
+ *   - a present field has the wrong type
+ *   - a stringEnum field has a value outside the declared values
+ *
+ * Optional fields that are `undefined` pass through (the consumer's
+ * destructuring default — e.g. `profile = 'auto'` — still applies).
+ */
+export function validateArgs<T>(toolName: string, args: unknown, schema: Schema): T {
+  if (typeof args !== 'object' || args === null || Array.isArray(args)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `${toolName}: arguments must be an object, got ${args === null ? 'null' : Array.isArray(args) ? 'array' : typeof args}`,
+    );
+  }
+  const obj = args as Record<string, unknown>;
+  for (const [field, spec] of Object.entries(schema)) {
+    const val = obj[field];
+    if (val === undefined) {
+      if (spec.required) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `${toolName}: missing required field '${field}'`,
+        );
+      }
+      continue;
+    }
+    switch (spec.kind) {
+      case 'string':
+        if (typeof val !== 'string') {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `${toolName}: field '${field}' must be a string, got ${typeof val}`,
+          );
+        }
+        break;
+      case 'number':
+        // Reject NaN/Infinity. The JSON parser cannot produce these directly,
+        // but a Number(...) coercion upstream could.
+        if (typeof val !== 'number' || !Number.isFinite(val)) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `${toolName}: field '${field}' must be a finite number, got ${typeof val === 'number' ? String(val) : typeof val}`,
+          );
+        }
+        break;
+      case 'boolean':
+        if (typeof val !== 'boolean') {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `${toolName}: field '${field}' must be a boolean, got ${typeof val}`,
+          );
+        }
+        break;
+      case 'stringEnum':
+        if (typeof val !== 'string' || !spec.values.includes(val)) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `${toolName}: field '${field}' must be one of ${spec.values.map((v) => `'${v}'`).join('|')}, got ${JSON.stringify(val)}`,
+          );
+        }
+        break;
+    }
+  }
+  return obj as T;
+}

--- a/sdks/mcp/tests/server.test.ts
+++ b/sdks/mcp/tests/server.test.ts
@@ -19,6 +19,8 @@ import assert from 'node:assert/strict';
 
 import { GatewayClient } from '../src/client.ts';
 import { TOOLS } from '../src/tools.ts';
+import { validateArgs } from '../src/validate-args.ts';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 // ---------------------------------------------------------------------------
 // Ensure signing key is absent for all tests (without-key mode)
@@ -438,6 +440,140 @@ describe('TOOLS', () => {
   it('all tools have non-empty descriptions', () => {
     for (const tool of TOOLS) {
       assert.ok(tool.description && tool.description.length > 10, `Tool ${tool.name} has no description`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateArgs — runtime guard for MCP tool dispatch (T-3A)
+// ---------------------------------------------------------------------------
+
+describe('validateArgs', () => {
+  const chatSchema = {
+    model: { kind: 'string', required: true },
+    prompt: { kind: 'string', required: true },
+    system: { kind: 'string', required: false },
+    max_tokens: { kind: 'number', required: false },
+    temperature: { kind: 'number', required: false },
+  } as const;
+
+  const smartSchema = {
+    prompt: { kind: 'string', required: true },
+    profile: { kind: 'stringEnum', required: false, values: ['eco', 'auto', 'premium', 'free'] },
+  } as const;
+
+  it('passes through valid args (chat)', () => {
+    const out = validateArgs<{ model: string; prompt: string }>(
+      'chat',
+      { model: 'openai/gpt-4o', prompt: 'Hi' },
+      chatSchema,
+    );
+    assert.equal(out.model, 'openai/gpt-4o');
+    assert.equal(out.prompt, 'Hi');
+  });
+
+  it('rejects missing required field with InvalidParams', () => {
+    try {
+      validateArgs('chat', { model: 'openai/gpt-4o' }, chatSchema);
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.ok(err instanceof McpError);
+      assert.equal((err as McpError).code, ErrorCode.InvalidParams);
+      assert.match((err as McpError).message, /missing required field 'prompt'/);
+    }
+  });
+
+  it('rejects wrong-type required field (model: number) with InvalidParams', () => {
+    // The audit's example: args = { model: 42 } would flow into client.chat(42, ...)
+    // without this guard.
+    try {
+      validateArgs('chat', { model: 42, prompt: 'Hi' }, chatSchema);
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.ok(err instanceof McpError);
+      assert.equal((err as McpError).code, ErrorCode.InvalidParams);
+      assert.match((err as McpError).message, /field 'model' must be a string, got number/);
+    }
+  });
+
+  it('rejects wrong-type optional field (max_tokens: string) with InvalidParams', () => {
+    try {
+      validateArgs('chat', { model: 'x', prompt: 'y', max_tokens: '100' }, chatSchema);
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.match((err as McpError).message, /field 'max_tokens' must be a finite number, got string/);
+    }
+  });
+
+  it('rejects NaN as a number field', () => {
+    try {
+      validateArgs('chat', { model: 'x', prompt: 'y', temperature: NaN }, chatSchema);
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.match((err as McpError).message, /temperature.*finite number/);
+    }
+  });
+
+  it('allows omitted optional fields', () => {
+    const out = validateArgs<{ model: string; prompt: string }>(
+      'chat',
+      { model: 'x', prompt: 'y' },
+      chatSchema,
+    );
+    assert.equal(out.model, 'x');
+  });
+
+  it('rejects bad enum value (smart_chat profile = "premium!!")', () => {
+    try {
+      validateArgs('smart_chat', { prompt: 'hi', profile: 'premium!!' }, smartSchema);
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.ok(err instanceof McpError);
+      assert.equal((err as McpError).code, ErrorCode.InvalidParams);
+      assert.match((err as McpError).message, /profile.*must be one of 'eco'\|'auto'\|'premium'\|'free'/);
+    }
+  });
+
+  it('accepts each declared enum value', () => {
+    for (const p of ['eco', 'auto', 'premium', 'free']) {
+      const out = validateArgs<{ prompt: string; profile?: string }>(
+        'smart_chat',
+        { prompt: 'hi', profile: p },
+        smartSchema,
+      );
+      assert.equal(out.profile, p);
+    }
+  });
+
+  it('rejects non-object args (null, array, primitive)', () => {
+    for (const bad of [null, [], 'string', 42, true]) {
+      try {
+        validateArgs('chat', bad, chatSchema);
+        assert.fail(`expected throw for ${JSON.stringify(bad)}`);
+      } catch (err) {
+        assert.ok(err instanceof McpError, `not an McpError: ${err}`);
+        assert.match((err as McpError).message, /arguments must be an object/);
+      }
+    }
+  });
+
+  it('boolean field — accepts true/false, rejects "true" string', () => {
+    const out = validateArgs<{ reset?: boolean }>(
+      'spending',
+      { reset: true },
+      { reset: { kind: 'boolean', required: false } },
+    );
+    assert.equal(out.reset, true);
+
+    try {
+      validateArgs(
+        'spending',
+        { reset: 'true' },
+        { reset: { kind: 'boolean', required: false } },
+      );
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.match((err as McpError).message, /reset.*must be a boolean, got string/);
     }
   });
 });


### PR DESCRIPTION
## Summary

MCP tool schemas (`inputSchema` on `Tool` definitions) are advisory — the SDK does not enforce them before the server's `CallToolRequestSchema` handler runs. The dispatcher in `index.ts` was casting `args as { model: string; prompt: string; ... }` with no runtime check. A misbehaving or upgraded host sending `{ model: 42, prompt: 'x' }` would flow `42` straight into `client.chat(model, ...)`. The audit (typescript-reviewer H3 + type-design M2) flagged five sites; the `deposit_escrow` branch was the only one already doing the right thing.

## Changes

- **New `src/validate-args.ts`** — small `validateArgs` helper covering string / number / boolean / stringEnum + required/optional. Throws `McpError(ErrorCode.InvalidParams, ...)` so hosts get a clean JSON-RPC error.
- **Applied to `chat`, `smart_chat`, `list_models`, `spending`** in `src/index.ts`.
- **`smart_chat` profile enum is now enforced** — the schema declared `['eco','auto','premium','free']` but the handler accepted any string and would have passed `profile: 'premium!!'` into `client.chat()` as a model ID.
- `wallet_status` takes no args; `deposit_escrow` keeps its inline regex check on `amount_usdc` — out of scope here.

## Tests

10 new cases for `validateArgs` covering:
- pass-through on valid args
- missing required field → `InvalidParams`
- wrong-type required field (`model: 42`) → `InvalidParams`
- wrong-type optional field (`max_tokens: "100"`)
- `NaN` rejected as a number
- omitted optional fields pass
- bad enum value (`profile: "premium!!"`) → enumerates allowed values
- every declared enum value accepted
- non-object args (`null`, `[]`, primitives) rejected
- boolean true/false vs `"true"` string

79/79 tests pass.

## Independence from #272, #274

This PR branches off `main` and does not depend on either open PR. It touches `src/index.ts` (the dispatcher branches) and adds a new file; the open PRs touch `src/client.ts` and a different region of `src/index.ts` (PR #272's `new GatewayClient({...})` block).

## Test plan

- [x] `npm test` in `sdks/mcp` — 79/79 green (10 new validateArgs tests)
- [x] `npx tsc --noEmit` — clean
- [ ] CI green

## Out of scope

Remaining audit follow-ups (URL scheme validation, lost stack traces, empty `choices[]` silent success, PDA placeholder string, type branding) — tracked as PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)