### PR TITLE
fix(mcp): close remaining audit findings — empty choices, stack traces, http warn, PDA placeholder

### DIFF
--- a/sdks/mcp/src/client.ts
+++ b/sdks/mcp/src/client.ts
@@ -128,9 +128,12 @@ export class GatewayClient {
 
   constructor(opts: GatewayClientOptions = {}) {
     if (!opts.apiUrl && !process.env['SOLVELA_API_URL'] && process.env['RCR_API_URL']) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[solvela-mcp] RCR_API_URL is deprecated; set SOLVELA_API_URL instead. RCR_API_URL will be removed by 2026-08-01.',
+      // T-3C: use process.stderr.write — consistent with the rest of the file.
+      // `console.warn` routes through any logging framework patching `console`,
+      // which can swallow or re-route the deprecation message.
+      process.stderr.write(
+        '[solvela-mcp] RCR_API_URL is deprecated; set SOLVELA_API_URL instead. ' +
+        'RCR_API_URL will be removed by 2026-08-01.\n',
       );
     }
     this.apiUrl = (
@@ -139,6 +142,30 @@ export class GatewayClient {
       process.env['RCR_API_URL'] ?? // backward-compat fallback (warning emitted above)
       'https://api.solvela.ai'
     ).replace(/\/$/, '');
+
+    // T-3D: warn loudly on plaintext http:// gateway URLs. The 402 response is
+    // attacker-controllable when transport isn't TLS — a MITM can substitute
+    // its own pay_to and amount even though PaymentExpectations (PR #272)
+    // will refuse to sign mismatches. Allow http://localhost / 127.0.0.1 /
+    // *.local for dev silently; warn otherwise. Set SOLVELA_INSECURE_HTTP=1
+    // to suppress the warning once you've acknowledged the risk.
+    if (this.apiUrl.startsWith('http://') && process.env['SOLVELA_INSECURE_HTTP'] !== '1') {
+      const hostMatch = /^http:\/\/([^/:]+)/.exec(this.apiUrl);
+      const host = hostMatch?.[1] ?? '';
+      const isDevHost =
+        host === 'localhost' ||
+        host === '127.0.0.1' ||
+        host === '[::1]' ||
+        host.endsWith('.local') ||
+        host.endsWith('.localhost');
+      if (!isDevHost) {
+        process.stderr.write(
+          `[solvela-mcp] WARN: gateway URL ${this.apiUrl} is plaintext HTTP. ` +
+          `A MITM could swap pay_to/amount in the 402 response. Use https:// in production, ` +
+          `or set SOLVELA_INSECURE_HTTP=1 to silence this warning.\n`,
+        );
+      }
+    }
     this.sessionBudget = opts.sessionBudget;
     this.timeoutMs = opts.timeoutMs ?? 60_000;
     this.signingMode = opts.signingMode ?? 'auto';

--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -32,7 +32,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { GatewayClient, type ChatMessage } from './client.js';
+import { GatewayClient, type ChatMessage, type ChatResponse } from './client.js';
 import { getTools } from './tools.js';
 import { createSessionStore } from './session.js';
 import { createPaymentHeader, decodePaymentHeader, isStubTransaction } from '@solvela/signer-core';
@@ -182,7 +182,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         messages.push({ role: 'user', content: prompt });
 
         const response = await client.chat(model, messages, { maxTokens: max_tokens, temperature });
-        const reply = response.choices[0]?.message.content ?? '';
+        const reply = extractReply(response);
 
         return {
           content: [
@@ -211,7 +211,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         messages.push({ role: 'user', content: prompt });
 
         const response = await client.chat(profile, messages, { maxTokens: max_tokens });
-        const reply = response.choices[0]?.message.content ?? '';
+        const reply = extractReply(response);
 
         return {
           content: [
@@ -500,8 +500,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 new PublicKey(escrowProgramId),
               );
               escrowPda = pda.toBase58();
-            } catch {
-              escrowPda = '(derivation failed — see agent_pubkey + service_id)';
+            } catch (pdaErr) {
+              // T-3E: previously stored a placeholder string in escrowPda. That
+              // value could be mistaken for a real account address downstream.
+              // Leave escrowPda empty and log the failure to stderr — the
+              // tool response now reports `escrow_pda_derivation_error` instead.
+              const msg = pdaErr instanceof Error ? pdaErr.message : String(pdaErr);
+              process.stderr.write(
+                `[solvela-mcp] WARN: PDA derivation failed (agent=${agentPubkey}): ${msg}\n`,
+              );
+              escrowPda = '';
             }
           }
         });
@@ -513,7 +521,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               text: JSON.stringify(
                 {
                   deposit_tx_signature: depositTxSignature,
+                  // T-3E: escrow_pda is empty when off-chain derivation failed.
+                  // Callers should branch on derivation_error rather than parse this.
                   escrow_pda: escrowPda,
+                  escrow_pda_derivation_error: escrowPda === '' ? true : undefined,
                   amount_deposited_usdc: amount.toFixed(6),
                   session_deposits_total_usdc: newTotal.toFixed(6),
                   session_deposits_cap_usdc: maxEscrowSession.toFixed(6),
@@ -533,6 +544,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   } catch (err) {
     if (err instanceof McpError) throw err;
 
+    // T-3B: log full stack to stderr before re-wrapping — McpError surfaces
+    // only `.message` to the host, which makes it impossible to correlate
+    // signing failures vs. gateway failures vs. parse failures vs. unexpected
+    // crashes. Stderr is out-of-band on stdio transport so this is safe.
+    if (err instanceof Error && err.stack) {
+      process.stderr.write(`[solvela-mcp] ERROR: ${err.stack}\n`);
+    }
     const message = err instanceof Error ? err.message : String(err);
     throw new McpError(ErrorCode.InternalError, message);
   }
@@ -541,6 +559,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * T-3F: extract the first assistant message from a chat response, throwing
+ * on an empty `choices` array.
+ *
+ * Background: the previous shape `response.choices[0]?.message.content ?? ''`
+ * silently turned an empty-choices response into a successful tool call with
+ * blank text. That happens when a provider error is wrapped in a 200 by the
+ * gateway, when a future schema change adds an `errors`-only response, or
+ * when the gateway stubs a response in a misconfigured dev environment. The
+ * MCP host saw "success, empty answer" instead of "the request failed."
+ *
+ * Throwing `McpError(InternalError, ...)` lets the host surface the failure
+ * to its UI and lets the user retry; the alternative (a blank reply) burned
+ * the user's budget on a non-response.
+ */
+function extractReply(response: ChatResponse): string {
+  if (!Array.isArray(response.choices) || response.choices.length === 0) {
+    throw new McpError(
+      ErrorCode.InternalError,
+      'Gateway returned a chat response with no choices — provider error wrapped in 200, ' +
+      'stubbed gateway response, or schema mismatch. Check the gateway logs.',
+    );
+  }
+  return response.choices[0].message.content ?? '';
+}
 
 function formatUsage(response: { model: string; usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number } }): string {
   const u = response.usage;

--- a/sdks/mcp/tests/server.test.ts
+++ b/sdks/mcp/tests/server.test.ts
@@ -398,6 +398,70 @@ describe('GatewayClient', () => {
     const c = new GatewayClient({ apiUrl: 'http://test.local' });
     assert.equal(c.spendSummary().budget_remaining, null);
   });
+
+  // -------------------------------------------------------------------------
+  // T-3D: plaintext http:// gateway URL — warn unless SOLVELA_INSECURE_HTTP=1
+  // or the host is localhost/127.0.0.1/.local.
+  // -------------------------------------------------------------------------
+
+  function captureStderr(): { restore: () => void; output: () => string } {
+    const original = process.stderr.write.bind(process.stderr);
+    let captured = '';
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+      return true;
+    };
+    return {
+      restore: () => {
+        process.stderr.write = original;
+      },
+      output: () => captured,
+    };
+  }
+
+  it('T-3D: warns on plaintext http:// gateway URL with non-dev host', () => {
+    const cap = captureStderr();
+    try {
+      new GatewayClient({ apiUrl: 'http://attacker.example' });
+      assert.match(cap.output(), /WARN: gateway URL http:\/\/attacker\.example is plaintext HTTP/);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it('T-3D: does NOT warn on http://localhost or 127.0.0.1', () => {
+    for (const host of ['http://localhost:8402', 'http://127.0.0.1:8402', 'http://api.local']) {
+      const cap = captureStderr();
+      try {
+        new GatewayClient({ apiUrl: host });
+        assert.doesNotMatch(cap.output(), /WARN: gateway URL/, `should not warn for ${host}`);
+      } finally {
+        cap.restore();
+      }
+    }
+  });
+
+  it('T-3D: SOLVELA_INSECURE_HTTP=1 silences the warning', () => {
+    process.env['SOLVELA_INSECURE_HTTP'] = '1';
+    const cap = captureStderr();
+    try {
+      new GatewayClient({ apiUrl: 'http://attacker.example' });
+      assert.doesNotMatch(cap.output(), /WARN: gateway URL/);
+    } finally {
+      cap.restore();
+      delete process.env['SOLVELA_INSECURE_HTTP'];
+    }
+  });
+
+  it('T-3D: does NOT warn on https://', () => {
+    const cap = captureStderr();
+    try {
+      new GatewayClient({ apiUrl: 'https://api.solvela.ai' });
+      assert.doesNotMatch(cap.output(), /WARN: gateway URL/);
+    } finally {
+      cap.restore();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundle of small fixes from the 2026-05-14 multi-agent audit. Each is independently small; together they close five of the remaining findings.

| ID | File:line | Finding |
|----|-----------|---------|
| T-3B | `index.ts:533-538` | Lost stack traces — re-wrapping every non-McpError as `McpError(InternalError, err.message)` discarded the cause chain. Now logs `err.stack` to stderr before re-wrapping. |
| T-3C | `client.ts:132` | `console.warn` → `process.stderr.write` for consistency. |
| T-3D | `client.ts` constructor | Warn on plaintext `http://` gateway URLs unless host is dev (`localhost` / `127.0.0.1` / `.local`) or `SOLVELA_INSECURE_HTTP=1` is set. A MITM can swap `pay_to`/`amount` in the 402 response. |
| T-3E | `index.ts:493-505` | PDA derivation placeholder string replaced with empty + `escrow_pda_derivation_error: true` + stderr WARN. Prevents a downstream agent from treating a `'(derivation failed — ...)'` string as an account address. |
| T-3F | `index.ts:185, 214` | Empty `choices[]` silent success — `extractReply()` helper throws `McpError(InternalError, ...)` instead of returning a blank tool response. |

## Tests

Four T-3D cases:
1. Warn on `http://attacker.example` (non-dev host)
2. No warn on `http://localhost:8402`, `http://127.0.0.1:8402`, `http://api.local`
3. `SOLVELA_INSECURE_HTTP=1` silences the warning
4. No warn on `https://api.solvela.ai`

T-3F (empty choices) is enforced at the helper level; exercised any time a real chat response comes back. T-3B (stderr stack logging) is observational and not asserted in tests.

## Independence

Branches off `main`; does not depend on #272, #274, or #275. Touches `client.ts` constructor (different region than #272/#274) and `index.ts` dispatcher tail (different region than #275).

## Test plan

- [x] `npm test` — 73/73 green
- [x] `npx tsc --noEmit` — clean
- [ ] CI green

## Deferred to a follow-up

The two `escrow.test.ts` test bugs flagged in the audit:
- `escrow.test.ts:302` asserts `process.env` equality rather than calling the handler
- `escrow.test.ts:403` re-implements `parseStrictUsdc` inline

Both need refactoring that's bigger than the surgical fixes here. Not blocking; tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)