### PR TITLE
fix(mcp): close two escrow.test.ts bugs deferred from #277

### DIFF
--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -36,6 +36,7 @@ import { GatewayClient, type ChatMessage, type ChatResponse } from './client.js'
 import { getTools } from './tools.js';
 import { createSessionStore } from './session.js';
 import { validateArgs } from './validate-args.js';
+import { parseStrictUsdc } from './parse-amount.js';
 import { createPaymentHeader, decodePaymentHeader, isStubTransaction } from '@solvela/signer-core';
 import type { PaymentRequired, PaymentAccept } from '@solvela/signer-core';
 import { Connection, PublicKey } from '@solana/web3.js';
@@ -366,21 +367,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           max_timeout_seconds?: number;
         };
 
-        // H3: Strict amount parsing — reject scientific notation, trailing garbage, non-positive.
-        // Regex accepts only plain decimal strings: digits optionally followed by '.' + digits.
-        if (!/^\d+(\.\d+)?$/.test(amount_usdc)) {
-          throw new McpError(
-            ErrorCode.InvalidParams,
-            `amount_usdc must be a positive decimal number (e.g. "5.00"), got: ${JSON.stringify(amount_usdc)}`,
-          );
-        }
-        const amount = Number(amount_usdc);
-        if (!Number.isFinite(amount) || amount <= 0) {
-          throw new McpError(
-            ErrorCode.InvalidParams,
-            `amount_usdc must be positive, got: ${amount_usdc}`,
-          );
-        }
+        // H3: Strict amount parsing — extracted to parseStrictUsdc so the
+        // tests can import the real function instead of re-implementing the
+        // regex inline (audit finding; previously a regex change would not
+        // have failed the parseStrictUsdc tests).
+        const amount = parseStrictUsdc(amount_usdc);
 
         // Per-call cap
         if (amount > maxEscrowDeposit) {

--- a/sdks/mcp/src/parse-amount.ts
+++ b/sdks/mcp/src/parse-amount.ts
@@ -1,0 +1,38 @@
+/**
+ * Strict parser for USDC amount strings supplied by MCP tool callers.
+ *
+ * Accepts only plain decimal strings — digits with an optional fractional
+ * part. Rejects:
+ *   - scientific notation ("1e10")
+ *   - trailing/leading garbage ("5.00abc", " 5")
+ *   - negatives ("-1.5")
+ *   - zero ("0", "0.0")
+ *   - the "Infinity"/"NaN" literals (rejected by the regex, never reach Number())
+ *
+ * Throws `McpError(InvalidParams, ...)` on any rejection so the MCP host
+ * surfaces a clean JSON-RPC error.
+ *
+ * Extracted from the inline check inside the `deposit_escrow` tool handler
+ * so it can be imported and unit-tested directly. The previous shape — a
+ * verbatim copy of the regex inside the test file — meant a change to the
+ * production regex would not have failed the tests.
+ */
+
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+
+export function parseStrictUsdc(raw: string, fieldName = 'amount_usdc'): number {
+  if (!/^\d+(\.\d+)?$/.test(raw)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `${fieldName} must be a positive decimal number (e.g. "5.00"), got: ${JSON.stringify(raw)}`,
+    );
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `${fieldName} must be positive, got: ${raw}`,
+    );
+  }
+  return n;
+}

--- a/sdks/mcp/tests/escrow.test.ts
+++ b/sdks/mcp/tests/escrow.test.ts
@@ -17,6 +17,7 @@ import * as path from 'node:path';
 
 import { GatewayClient } from '../src/client.ts';
 import { createSessionStore } from '../src/session.ts';
+import { parseStrictUsdc } from '../src/parse-amount.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -291,34 +292,13 @@ describe('deposit_escrow session cap persistence', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Escrow mode gate (SOLVELA_ESCROW_MODE env var) — simulated validation
+// SOLVELA_ESCROW_MODE gate — previously three tests here asserted
+// `process.env['SOLVELA_ESCROW_MODE'] === 'enabled'` (JS string equality, not
+// any SDK code path). They would have passed even if index.ts deleted its
+// escrow gating entirely. Removed in favour of the `getTools()` block below,
+// which exercises the real production path. (Audit finding; deferred from
+// PR #277.)
 // ---------------------------------------------------------------------------
-
-describe('deposit_escrow SOLVELA_ESCROW_MODE gate', () => {
-  afterEach(() => {
-    delete process.env['SOLVELA_ESCROW_MODE'];
-  });
-
-  it('escrow is disabled when SOLVELA_ESCROW_MODE is not set', () => {
-    delete process.env['SOLVELA_ESCROW_MODE'];
-    const enabled = process.env['SOLVELA_ESCROW_MODE'] === 'enabled';
-    assert.equal(enabled, false, 'escrow should be disabled when env var is unset');
-  });
-
-  it('escrow is enabled when SOLVELA_ESCROW_MODE=enabled', () => {
-    process.env['SOLVELA_ESCROW_MODE'] = 'enabled';
-    const enabled = process.env['SOLVELA_ESCROW_MODE'] === 'enabled';
-    assert.equal(enabled, true, 'escrow should be enabled when env var is "enabled"');
-  });
-
-  it('any other SOLVELA_ESCROW_MODE value is invalid', () => {
-    const invalidValues = ['true', '1', 'yes', 'on', 'ENABLED'];
-    for (const val of invalidValues) {
-      const enabled = val === 'enabled';
-      assert.equal(enabled, false, `"${val}" should not be treated as enabled`);
-    }
-  });
-});
 
 // ---------------------------------------------------------------------------
 // getTools() — deposit_escrow appears only when escrow is enabled
@@ -397,19 +377,9 @@ describe('spending tool reset flag', () => {
 // ---------------------------------------------------------------------------
 
 describe('deposit_escrow strict amount parsing (H3)', () => {
-  // These tests validate the regex-first parse logic that index.ts uses.
-  // The regex is: /^\d+(\.\d+)?$/ — only accepts plain decimal strings.
-
-  function parseStrictUsdc(raw: string): number {
-    if (!/^\d+(\.\d+)?$/.test(raw)) {
-      throw new Error(`amount_usdc must be a positive decimal number, got: ${JSON.stringify(raw)}`);
-    }
-    const n = Number(raw);
-    if (!Number.isFinite(n) || n <= 0) {
-      throw new Error(`amount_usdc must be positive, got: ${raw}`);
-    }
-    return n;
-  }
+  // Tests the REAL parseStrictUsdc imported from src/parse-amount.ts.
+  // Previously this block re-implemented the regex inline — a production
+  // regex change would not have failed these tests (audit finding).
 
   it('plain decimal "5.00" is accepted', () => {
     assert.equal(parseStrictUsdc('5.00'), 5.0);


### PR DESCRIPTION
## Summary

Both findings from the 2026-05-14 audit's pr-test-analyzer:

1. **Three tests in `deposit_escrow SOLVELA_ESCROW_MODE gate`** (lines 297–321 in the previous file) asserted `process.env['SOLVELA_ESCROW_MODE'] === 'enabled'` — JS string equality, not any SDK code path. They would have passed even if `index.ts` deleted its escrow gating entirely. **Removed** — the `getTools()` block below already covers the real production path.

2. **`deposit_escrow strict amount parsing (H3)`** re-implemented the parse regex inline as a test-local helper. A production regex change would not have failed the tests. **Extracted** the real function to `src/parse-amount.ts` and have the test import it.

## Changes

- **New `src/parse-amount.ts`** — exports `parseStrictUsdc(raw, fieldName?)` which throws `McpError(InvalidParams, ...)` on rejection. Drop-in replacement for the inline regex+Number check in `index.ts`.
- **`src/index.ts`** — `deposit_escrow` handler now calls `parseStrictUsdc(amount_usdc)` instead of inline regex+Number+two-throws. Net -10 lines.
- **`tests/escrow.test.ts`** — removed three dead env-equality tests; replaced inline `parseStrictUsdc` test helper with `import { parseStrictUsdc } from '../src/parse-amount.ts'`. Net -34 lines.

## Independence

Branches off `main`. Does not depend on the four other open PRs (#272, #274, #275, #277).

## Test plan

- [x] `npm test` — 66 pass, 0 fail (down from 69; three dead tests removed)
- [x] `npx tsc --noEmit` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)