### PR TITLE
chore(ts-sdk): bump 0.2.2 to ship monorepo metadata fix

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solvela/sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solvela/sdk",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@solana/spl-token": "^0.4",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solvela/sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TypeScript SDK for Solvela — Solana-native AI agent payment gateway",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- The published `@solvela/sdk@0.2.1` on npm still has `repository.url`, `homepage`, and `bugs.url` pointing at the archived `solvela-ai/solvela-ts` repository — those fields were corrected in-tree post-publish but the package was never republished.
- This bump exists purely to ship that metadata. No source changes; `npm run build` (tsc) still green.
- **Wire-format incompatibility with the v2 envelope is unchanged** and will be addressed in a separate PR (per session direction).

## Verified state

- In-tree `package.json` already points at `solvela-ai/solvela` with `directory: "sdks/typescript"` (line 26).
- Live registry shows the stale archived URLs — confirmed via `curl https://registry.npmjs.org/@solvela/sdk/latest`.
- Build: `npm run build` (tsc) emits no errors.

## Operator follow-up after merge

```bash
cd sdks/typescript
npm publish   # 0.2.2 (was 0.2.1)
```

## Test plan

- [x] `npm run build` (tsc) passes
- [ ] CI green on push
- [ ] After publish: `curl https://registry.npmjs.org/@solvela/sdk/latest` shows `solvela-ai/solvela` URLs + `directory: "sdks/typescript"`