### PR TITLE
chore(sdk-typescript): add LICENSE, prep 0.2.2 for npm publish

### DIFF
--- a/sdks/typescript/LICENSE
+++ b/sdks/typescript/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Solvela
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -14,8 +14,7 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE",
-    "SECURITY.md"
+    "LICENSE"
   ],
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

`@solvela/sdk@0.2.2` in \`sdks/typescript/\` is otherwise publish-ready (wire fix is in source, 138 vitest tests green, dist is fresh, uuid override landed in #282). The remaining blocker was a manifest/disk mismatch: \`package.json\` listed \`LICENSE\` and \`SECURITY.md\` in its \`files\` allowlist, but neither file existed on disk. npm silently omits missing entries, so the tarball would have shipped without any license file.

## Changes

- Add \`sdks/typescript/LICENSE\` — copy of \`sdks/ai-sdk-provider/LICENSE\` (same MIT text the other SDK packages ship).
- Drop \`SECURITY.md\` from \`files\` allowlist. No other SDK package ships a per-package security policy; the repo-root \`SECURITY.md\` is discoverable via the manifest's \`homepage\`/\`repository\` URLs.

## Verification

\`npm pack --dry-run\` confirms tarball now contains:
- LICENSE: 1.1kB
- README.md: 2.2kB
- package.json: 1.4kB
- dist/: included

## Operator follow-up

After merge: \`(cd sdks/typescript && npm publish)\` from a fresh \`main\` checkout to ship 0.2.2. That closes the long-standing \`@solvela/sdk@0.2.1\` wire-incompat (see prior memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)