### PR TITLE
docs: tier-A audit fixes (TS SDK 0.2.2, metric prefix, env var, init_if_needed)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ const TOKEN_2022_PROGRAM_ID: &str = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
 - [ ] Use typed `Account<'info, T>` — never `UncheckedAccount` without explicit owner check
 - [ ] Every authority field validated with `has_one` or explicit `Signer<'info>`
 - [ ] PDA seeds include user-specific key — never shared across users
-- [ ] No `init_if_needed` — use `init` to prevent reinitialization attacks
+- [ ] Default to `init`; only use `init_if_needed` for a documented reason (e.g. recreating an agent's USDC ATA that may have been closed for rent reclamation — see `programs/escrow/` refund path). Reinitialization-attack vector must be ruled out explicitly
 - [ ] CPIs use `Program<'info, Token>` — never accept arbitrary program accounts
 - [ ] Checked arithmetic throughout: `checked_add`, `checked_sub`, `checked_mul`
 - [ ] Account closure uses Anchor `close =` constraint — prevents revival attacks

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Environment variables use the `SOLVELA_` prefix. Provider API keys follow the st
 | `SOLVELA_SOLANA_RECIPIENT_WALLET` | Yes | USDC payment destination (base58) |
 | `SOLVELA_SOLANA_FEE_PAYER_KEY` | For escrow | Hot wallet key for claim transactions |
 | `SOLVELA_SOLANA_ESCROW_PROGRAM_ID` | For escrow | Anchor escrow program ID |
-| `SOLVELA_SERVER_PORT` | No | Gateway port (default: `8402`) |
+| `SOLVELA_PORT` | No | Gateway port (default: `8402`) |
 | `SOLVELA_ADMIN_TOKEN` | No | Admin auth for `/metrics` and `/v1/escrow/health` |
 | `DATABASE_URL` | No | PostgreSQL connection string |
 | `REDIS_URL` | No | Redis connection string |

--- a/dashboard/content/docs/operations/monitoring.mdx
+++ b/dashboard/content/docs/operations/monitoring.mdx
@@ -39,76 +39,76 @@ scrape_configs:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `rcr_requests_total` | Counter | `method`, `path`, `status` | Total HTTP requests. Excludes `/metrics` to avoid scrape feedback loops. |
-| `rcr_request_duration_seconds` | Histogram | `method`, `path` | End-to-end request processing time including provider latency. |
-| `rcr_active_requests` | Gauge | -- | Number of currently in-flight requests. Uses a drop guard for safety. |
+| `solvela_requests_total` | Counter | `method`, `path`, `status` | Total HTTP requests. Excludes `/metrics` to avoid scrape feedback loops. |
+| `solvela_request_duration_seconds` | Histogram | `method`, `path` | End-to-end request processing time including provider latency. |
+| `solvela_active_requests` | Gauge | -- | Number of currently in-flight requests. Uses a drop guard for safety. |
 
 ### Payment Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `rcr_payments_total` | Counter | `status` | Payment outcomes. Status values: `verified` (valid payment), `cached` (cached response), `free` (free model), `none` (402 returned), `failed` (verification failed). |
-| `rcr_payment_amount_usdc` | Histogram | -- | Distribution of payment amounts in USDC. |
-| `rcr_replay_rejections_total` | Counter | -- | Number of rejected replay attacks. |
+| `solvela_payments_total` | Counter | `status` | Payment outcomes. Status values: `verified` (valid payment), `cached` (cached response), `free` (free model), `none` (402 returned), `failed` (verification failed). |
+| `solvela_payment_amount_usdc` | Histogram | -- | Distribution of payment amounts in USDC. |
+| `solvela_replay_rejections_total` | Counter | -- | Number of rejected replay attacks. |
 
 ### Provider Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `rcr_provider_request_duration_seconds` | Histogram | `provider` | Upstream provider response time. Provider values: `openai`, `anthropic`, `google`, `xai`, `deepseek`. |
-| `rcr_provider_errors_total` | Counter | `provider`, `error_type` | Provider errors. Error types: `timeout`, `auth`, `rate_limit`, `server_error`, `unknown`. |
+| `solvela_provider_request_duration_seconds` | Histogram | `provider` | Upstream provider response time. Provider values: `openai`, `anthropic`, `google`, `xai`, `deepseek`. |
+| `solvela_provider_errors_total` | Counter | `provider`, `error_type` | Provider errors. Error types: `timeout`, `auth`, `rate_limit`, `server_error`, `unknown`. |
 
 ### Cache Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `rcr_cache_total` | Counter | `result` | Cache outcomes. Result values: `hit` (served from cache), `miss` (not cached), `skip` (caching disabled or streaming). |
+| `solvela_cache_total` | Counter | `result` | Cache outcomes. Result values: `hit` (served from cache), `miss` (not cached), `skip` (caching disabled or streaming). |
 
 ### Escrow Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `rcr_escrow_claims_total` | Counter | `result` | Claim settlement outcomes. Result values: `success`, `failure`. |
-| `rcr_escrow_queue_depth` | Gauge | -- | Number of pending claims waiting to be processed. |
+| `solvela_escrow_claims_total` | Counter | `result` | Claim settlement outcomes. Result values: `success`, `failure`. |
+| `solvela_escrow_queue_depth` | Gauge | -- | Number of pending claims waiting to be processed. |
 
 ### Infrastructure Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `rcr_fee_payer_balance_sol` | Gauge | `pubkey` | SOL balance of each fee payer wallet. Monitors tx fee funding. |
-| `rcr_service_health` | Gauge | `service_id` | External service health. 1.0 = healthy, 0.0 = unhealthy. |
+| `solvela_fee_payer_balance_sol` | Gauge | `pubkey` | SOL balance of each fee payer wallet. Monitors tx fee funding. |
+| `solvela_service_health` | Gauge | `service_id` | External service health. 1.0 = healthy, 0.0 = unhealthy. |
 
 ## Grafana Dashboard Suggestions
 
 ### Overview Panel
 
-- **Request rate**: `rate(rcr_requests_total[5m])` by `status`
-- **Error rate**: `rate(rcr_requests_total{status=~"5.."}[5m]) / rate(rcr_requests_total[5m])`
-- **Active requests**: `rcr_active_requests`
-- **P95 latency**: `histogram_quantile(0.95, rate(rcr_request_duration_seconds_bucket[5m]))`
+- **Request rate**: `rate(solvela_requests_total[5m])` by `status`
+- **Error rate**: `rate(solvela_requests_total{status=~"5.."}[5m]) / rate(solvela_requests_total[5m])`
+- **Active requests**: `solvela_active_requests`
+- **P95 latency**: `histogram_quantile(0.95, rate(solvela_request_duration_seconds_bucket[5m]))`
 
 ### Payment Panel
 
-- **Payment success rate**: `rate(rcr_payments_total{status="verified"}[5m]) / rate(rcr_payments_total[5m])`
-- **Revenue (USDC/min)**: `rate(rcr_payment_amount_usdc_sum[5m]) * 60`
-- **402 rate**: `rate(rcr_payments_total{status="none"}[5m])`
-- **Replay rejections**: `rate(rcr_replay_rejections_total[5m])`
+- **Payment success rate**: `rate(solvela_payments_total{status="verified"}[5m]) / rate(solvela_payments_total[5m])`
+- **Revenue (USDC/min)**: `rate(solvela_payment_amount_usdc_sum[5m]) * 60`
+- **402 rate**: `rate(solvela_payments_total{status="none"}[5m])`
+- **Replay rejections**: `rate(solvela_replay_rejections_total[5m])`
 
 ### Provider Panel
 
-- **Provider latency by provider**: `histogram_quantile(0.95, rate(rcr_provider_request_duration_seconds_bucket[5m])) by (provider)`
-- **Provider error rate**: `rate(rcr_provider_errors_total[5m]) by (provider, error_type)`
-- **Cache hit rate**: `rate(rcr_cache_total{result="hit"}[5m]) / rate(rcr_cache_total[5m])`
+- **Provider latency by provider**: `histogram_quantile(0.95, rate(solvela_provider_request_duration_seconds_bucket[5m])) by (provider)`
+- **Provider error rate**: `rate(solvela_provider_errors_total[5m]) by (provider, error_type)`
+- **Cache hit rate**: `rate(solvela_cache_total{result="hit"}[5m]) / rate(solvela_cache_total[5m])`
 
 ### Escrow Panel
 
-- **Claim queue depth**: `rcr_escrow_queue_depth`
-- **Claim success rate**: `rate(rcr_escrow_claims_total{result="success"}[5m]) / rate(rcr_escrow_claims_total[5m])`
-- **Fee payer balances**: `rcr_fee_payer_balance_sol` by `pubkey`
+- **Claim queue depth**: `solvela_escrow_queue_depth`
+- **Claim success rate**: `rate(solvela_escrow_claims_total{result="success"}[5m]) / rate(solvela_escrow_claims_total[5m])`
+- **Fee payer balances**: `solvela_fee_payer_balance_sol` by `pubkey`
 
 ### Service Health Panel
 
-- **Service health**: `rcr_service_health` by `service_id` (1 = up, 0 = down)
+- **Service health**: `solvela_service_health` by `service_id` (1 = up, 0 = down)
 
 ## Alerting Rules
 
@@ -120,8 +120,8 @@ groups:
     rules:
       - alert: HighErrorRate
         expr: |
-          rate(rcr_requests_total{status=~"5.."}[5m])
-          / rate(rcr_requests_total[5m]) > 0.05
+          rate(solvela_requests_total{status=~"5.."}[5m])
+          / rate(solvela_requests_total[5m]) > 0.05
         for: 5m
         labels:
           severity: critical
@@ -131,7 +131,7 @@ groups:
       - alert: HighLatency
         expr: |
           histogram_quantile(0.95,
-            rate(rcr_request_duration_seconds_bucket[5m])
+            rate(solvela_request_duration_seconds_bucket[5m])
           ) > 10
         for: 5m
         labels:
@@ -140,7 +140,7 @@ groups:
           summary: "P95 latency above 10 seconds"
 
       - alert: EscrowQueueBacklog
-        expr: rcr_escrow_queue_depth > 100
+        expr: solvela_escrow_queue_depth > 100
         for: 10m
         labels:
           severity: warning
@@ -148,7 +148,7 @@ groups:
           summary: "Escrow claim queue depth above 100"
 
       - alert: FeePayerLowBalance
-        expr: rcr_fee_payer_balance_sol < 0.1
+        expr: solvela_fee_payer_balance_sol < 0.1
         for: 5m
         labels:
           severity: critical
@@ -157,7 +157,7 @@ groups:
 
       - alert: ProviderDown
         expr: |
-          rate(rcr_provider_errors_total{error_type="server_error"}[5m]) > 0.5
+          rate(solvela_provider_errors_total{error_type="server_error"}[5m]) > 0.5
         for: 5m
         labels:
           severity: warning
@@ -165,7 +165,7 @@ groups:
           summary: "Provider returning server errors"
 
       - alert: ReplayAttackSpike
-        expr: rate(rcr_replay_rejections_total[5m]) > 1
+        expr: rate(solvela_replay_rejections_total[5m]) > 1
         for: 5m
         labels:
           severity: warning
@@ -173,7 +173,7 @@ groups:
           summary: "Elevated replay attack attempts"
 
       - alert: ServiceUnhealthy
-        expr: rcr_service_health == 0
+        expr: solvela_service_health == 0
         for: 5m
         labels:
           severity: warning

--- a/dashboard/content/docs/sdks/index.mdx
+++ b/dashboard/content/docs/sdks/index.mdx
@@ -6,20 +6,15 @@ description: Client libraries for Solvela — TypeScript, Python, Go, Rust CLI, 
 
 Official SDKs are available for four languages plus an MCP server. All SDKs handle the x402 payment handshake automatically — pass a private key and the SDK signs transactions for you.
 
-<Warning>
-**The TypeScript SDK is not wire-compatible with the live gateway today.** The currently-published `@solvela/sdk@0.2.x` on npm predates the v2 payment envelope and will not complete a real payment against `api.solvela.ai`. Until a new SDK release ships, TypeScript users have two working options:
-
-- Use the [`@solvela/signer-core`](/docs/sdks/typescript) primitives from the monorepo (`sdks/signer-core/`) to parse the 402 envelope and sign payments yourself.
-- Drive the gateway directly with `curl` or `fetch` — see the [Quickstart](/docs/quickstart) cURL tab and [Payment Flow](/docs/concepts/payment-flow).
-
-The Python, Go, and Rust CLI SDKs are wire-aligned with the live gateway.
-</Warning>
+<Note>
+`@solvela/sdk@0.2.2` (published 2026-05-14) ships the v2 wire-format fix and is wire-aligned with the live gateway. Pin to `^0.2.2` — earlier `0.2.x` releases predate the v2 payment envelope and will not complete a real payment against `api.solvela.ai`.
+</Note>
 
 ## Comparison
 
 | Language | Package | Install | x402 Auto-payment | Async |
 |----------|---------|---------|-------------------|-------|
-| TypeScript ⚠ | `@solvela/sdk` | `npm install @solvela/sdk` | Pre-1.0, wire-incompat (see above) | Yes |
+| TypeScript | `@solvela/sdk` | `npm install @solvela/sdk@^0.2.2` | Yes | Yes |
 | Python | `solvela-sdk` | `pip install solvela-sdk` | Yes | Yes (async-only) |
 | Go | `github.com/solvela-ai/solvela/sdks/go` | `go get github.com/solvela-ai/solvela/sdks/go` | Yes (BYO Signer) | Yes (context-based) |
 | Rust CLI | `solvela-cli` | `cargo install solvela-cli` | Yes | — |
@@ -38,7 +33,7 @@ All four language SDKs live in the [`solvela-ai/solvela`](https://github.com/sol
 The wallet-client Rust crate (`solvela-client`) and its `solvela` CLI binary remain at [`solvela-ai/solvela-client`](https://github.com/solvela-ai/solvela-client) pending a separate consolidation.
 
 <CardGroup>
-  <Card title="TypeScript" description="@solvela/sdk — pre-1.0; not yet wire-aligned with prod gateway (see warning above)" href="/docs/sdks/typescript" />
+  <Card title="TypeScript" description="@solvela/sdk@^0.2.2 — async client with automatic x402 signing and built-in Solana wallet support" href="/docs/sdks/typescript" />
   <Card title="Python" description="pip install solvela-sdk — async-first client with built-in Solana signing" href="/docs/sdks/python" />
   <Card title="Go" description="go get github.com/solvela-ai/solvela/sdks/go — context-aware, goroutine-safe; ships an UnimplementedSigner stub (bring your own)" href="/docs/sdks/go" />
   <Card title="Rust CLI" description="cargo install solvela-cli — interactive chat, model listing, health checks" href="/docs/sdks/rust" />

--- a/dashboard/content/docs/sdks/typescript.mdx
+++ b/dashboard/content/docs/sdks/typescript.mdx
@@ -8,25 +8,22 @@ The Solvela TypeScript SDK lives in the monorepo at
 
 ## Status
 
-<Warning>
-The currently-published `@solvela/sdk@0.2.x` on npm is **not yet wire-compatible
-with the production gateway at `api.solvela.ai`**. The `PaymentPayload` envelope
-it emits does not match the shape the gateway deserializes. A republish that
-aligns with the v2 wire format is pending; until then, do not use `@solvela/sdk`
-for production payments.
-</Warning>
+<Note>
+`@solvela/sdk@0.2.2` (published 2026-05-14) ships the v2 wire-format fix and is
+wire-aligned with the production gateway at `api.solvela.ai`. Pin to `^0.2.2` —
+earlier `0.2.x` releases emit a `PaymentPayload` envelope shape the gateway
+no longer accepts.
+</Note>
 
-If you're building inside this monorepo and need x402 signing today, depend on
+For low-level use inside or outside the monorepo, the
 [`@solvela/signer-core`](https://github.com/solvela-ai/solvela/tree/main/sdks/signer-core)
-directly — that's what `sdks/mcp/`, `sdks/openclaw-provider/`, and
-`sdks/ai-sdk-provider/` use to talk to the gateway. Outside the monorepo,
-drive the gateway directly with `fetch`/`curl` (see the [Quickstart](/docs/quickstart)
-cURL tab and [Payment Flow](/docs/concepts/payment-flow)).
+package exposes the x402 parser + payment-signer primitives that
+`sdks/mcp/`, `sdks/openclaw-provider/`, and `sdks/ai-sdk-provider/` build on.
 
 ## Documentation
 
 - **Source:** [`sdks/typescript/`](https://github.com/solvela-ai/solvela/tree/main/sdks/typescript) in the monorepo
-- **npm package:** [@solvela/sdk](https://www.npmjs.com/package/@solvela/sdk) (pre-1.0; see status above)
+- **npm package:** [@solvela/sdk](https://www.npmjs.com/package/@solvela/sdk) (current: `0.2.2`)
 
 ## History
 


### PR DESCRIPTION
## Summary

Phase 1 of the 2026-05-14 docs audit punch list — the four Tier A (blocking / actively misleading) findings.

- **TS SDK wire-compat warnings dropped.** `docs/sdks/index.mdx` and `docs/sdks/typescript.mdx` were still warning readers off `@solvela/sdk` ("not yet wire-compatible … do not use for production payments"). `@solvela/sdk@0.2.2` shipped today (#284) with the v2 wire fix and is the recommended pin. Both pages now say so.
- **Prometheus metric prefix corrected.** `docs/operations/monitoring.mdx` used `rcr_*` for every metric name, PromQL query, and alert rule (36 occurrences). The gateway only emits `solvela_*` (verified across `crates/gateway/src/**/*.rs` + `crates/x402/src/escrow/claim_processor.rs`). Any reader copy-pasting these into Prometheus/Grafana was getting zero series.
- **`SOLVELA_SERVER_PORT` → `SOLVELA_PORT`.** `README.md`'s env-var table row named a variable that doesn't exist in `crates/gateway/src/main.rs`. The gateway reads `SOLVELA_PORT` (with `RCR_PORT` fallback).
- **`AGENTS.md` Anchor checklist softened.** The absolute "No `init_if_needed` — use `init`" item contradicted the deployed escrow program, which uses `init_if_needed` deliberately in the refund path to recreate agent USDC ATAs that were closed for rent reclamation (`SECURITY.md:113`, #160). Replaced with "default to `init`; only use `init_if_needed` for a documented reason" so an agent following the checklist doesn't try to undo a shipped mitigation.

No code, metric, env var, or SDK API surface changed — docs catching up to ground truth.

Phases 2/3 of the audit (~30 drift + polish items) will follow as separate PRs.

## Test plan

- [ ] Vercel preview build of `dashboard/` green (MDX parses, `<Note>` renders)
- [ ] `grep -r "rcr_" dashboard/content/docs/` returns nothing
- [ ] `grep "SOLVELA_SERVER_PORT" README.md` returns nothing
- [ ] Required CI checks (Rust fmt/clippy/test, Smoke, Security audit, Docker build) all green — docs-only changes shouldn't touch these but they gate merge