### PR TITLE
docs(audit): phase 2A drift sweep — TS SDK API, model registry, escrow settle

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,10 +247,15 @@ npm install @solvela/sdk
 ```
 
 ```typescript
-import { LLMClient } from '@solvela/sdk';
+import { SolvelaClient, ChatRequest, ChatMessage } from '@solvela/sdk';
 
-const client = new LLMClient();
-const response = await client.chat('openai/gpt-4o', 'Hello!');
+const client = new SolvelaClient({
+  config: { gatewayUrl: 'https://api.solvela.ai' },
+});
+const response = await client.chat(
+  new ChatRequest('openai/gpt-4o', [new ChatMessage('user', 'Hello!')]),
+);
+console.log(response.choices[0].message.content);
 ```
 
 ### Go

--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -157,29 +157,32 @@ data: [DONE]
   </Tab>
   <Tab value="TypeScript">
     ```typescript
-    import { LLMClient } from '@solvela/sdk';
+    import { SolvelaClient, ChatRequest, ChatMessage } from '@solvela/sdk';
 
-    const client = new LLMClient({
-      apiUrl: 'https://api.solvela.ai',
-      // private key signs payments automatically
+    const client = new SolvelaClient({
+      config: { gatewayUrl: 'https://api.solvela.ai' },
+      // wallet + signer load from SOLANA_PRIVATE_KEY by default
     });
 
     // Simple one-shot
-    const text = await client.chat('auto', 'What is Solana?');
-    console.log(text);
+    const simple = await client.chat(
+      new ChatRequest('auto', [new ChatMessage('user', 'What is Solana?')]),
+    );
+    console.log(simple.choices[0].message.content);
 
-    // Full request with options
-    const response = await client.chatCompletion({
-      model: 'openai/gpt-4o',
-      messages: [
-        { role: 'system', content: 'You are a blockchain expert.' },
-        { role: 'user', content: 'Explain proof of history.' },
-      ],
-      maxTokens: 500,
-      temperature: 0.7,
-    });
+    // Full request with options (maxTokens, temperature)
+    const response = await client.chat(
+      new ChatRequest(
+        'openai/gpt-4o',
+        [
+          new ChatMessage('system', 'You are a blockchain expert.'),
+          new ChatMessage('user', 'Explain proof of history.'),
+        ],
+        /* maxTokens */ 500,
+        /* temperature */ 0.7,
+      ),
+    );
     console.log(response.choices[0].message.content);
-    console.log('Spent:', client.getSessionSpent(), 'USDC');
     ```
   </Tab>
   <Tab value="Python">

--- a/dashboard/content/docs/api/index.mdx
+++ b/dashboard/content/docs/api/index.mdx
@@ -58,6 +58,7 @@ All endpoints accept and return `application/json`. Streaming responses use SSE 
 | `GET` | `/v1/supported` | Supported payment networks and schemes |
 | `GET` | `/v1/nonce` | Fetch a durable nonce for replay-safe transactions |
 | `POST` | `/v1/images/generations` | Image generation (OpenAI-compatible) |
+| `POST` | `/v1/escrow/settle` | Client-initiated early escrow claim after stream completion (see [Escrow → F4 settle](/docs/concepts/escrow#client-initiated-settle-f4)) |
 | `GET` | `/.well-known/agent.json` | A2A AgentCard for agent discovery |
 | `POST` | `/a2a` | A2A protocol JSON-RPC endpoint |
 

--- a/dashboard/content/docs/api/models.mdx
+++ b/dashboard/content/docs/api/models.mdx
@@ -71,6 +71,7 @@ For a full pricing table, see [Pricing](/docs/concepts/pricing).
 | `openai/gpt-oss-120b` | OpenAI | $0.00 | $0.00 |
 | `anthropic/claude-opus-4-20250514` | Anthropic | $5.00 | $25.00 |
 | `anthropic/claude-sonnet-4-20250514` | Anthropic | $3.00 | $15.00 |
+| `anthropic-claude-sonnet-4-5` | Anthropic | $3.00 | $15.00 |
 | `anthropic/claude-haiku-4-5-20251001` | Anthropic | $1.00 | $5.00 |
 | `google/gemini-3.1-pro` | Google | $2.00 | $12.00 |
 | `google/gemini-2.5-flash` | Google | $0.30 | $2.50 |

--- a/dashboard/content/docs/concepts/escrow.mdx
+++ b/dashboard/content/docs/concepts/escrow.mdx
@@ -91,6 +91,37 @@ When choosing the escrow scheme, the `payment-signature` header contains a `Paym
 }
 ```
 
+## Client-initiated settle (F4)
+
+By default the gateway claims escrow at request end. For streaming responses, clients can drop reconciliation latency from minutes (auto-timeout) to milliseconds by calling `POST /v1/escrow/settle` once the stream completes — the gateway computes the actual cost from the reported token counts and fires the claim immediately.
+
+This endpoint is what `@solvela/openclaw-provider`'s `wrapStreamForF4` wrapper calls after each `wrapStreamFn` invocation finishes.
+
+```http title="POST /v1/escrow/settle"
+{
+  "service_id":           "<base64 32-byte service id, same value used in the deposit>",
+  "agent_pubkey":         "<base58 Solana pubkey of the depositor>",
+  "model":                "openai/gpt-4o",
+  "status":               "completed",
+  "actual_prompt_tokens":     128,
+  "actual_completion_tokens": 256
+}
+```
+
+**Behavior:**
+
+- `status: "completed"` with both `actual_*_tokens` fields → gateway looks up the model in the registry, computes the actual atomic-USDC cost, and enqueues a claim. The escrow program rejects over-claims on-chain, so the cost is bounded by the deposit regardless of what the client reports.
+- `status: "error"` → gateway logs the error and fires no claim. The deposit is reconciled by the escrow program's on-chain auto-timeout refund path (same as the pre-F4 flow). No `actual_*_tokens` fields are needed.
+- Missing tokens with `status: "completed"`, unknown `model`, or non-finite pricing → `400`.
+
+**Idempotency:** when PostgreSQL is configured, the durable claim queue dedupes by `(service_id, agent)`. Without a database, a duplicate settle call can produce a second on-chain claim attempt; the escrow program rejects the second because the deposit account is already drained.
+
+**Auth (v1):** the endpoint is fire-and-forget. The on-chain escrow program is the source of truth — a misrouted settle (wrong `agent_pubkey` or `service_id`) fails at the chain layer, logged but not surfaced to the client. Future hardening (HMAC over the body, or an agent signature over `(service_id, model, status, tokens)`) is tracked but not yet shipped.
+
+<Note>
+  As of 2026-05-14, the F4 wrapper in `@solvela/openclaw-provider` is unit-tested but not yet invoked from the plugin's hot path because `@solvela/signer-core` does not yet expose `service_id` from the encoded payment-header transaction. Until that lands, escrow accounting still relies on the on-chain auto-timeout refund. See [`STATUS.md` Known follow-ups](https://github.com/solvela-ai/solvela/blob/main/STATUS.md#known-follow-ups).
+</Note>
+
 ## Refund behavior
 
 If the gateway fails to claim within `max_timeout_seconds`, the agent can invoke the `refund` instruction on the escrow program to reclaim their deposit. The refund path is enforced on-chain by the Anchor program — no trust in the gateway is required.

--- a/dashboard/content/docs/concepts/pricing.mdx
+++ b/dashboard/content/docs/concepts/pricing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pricing
-description: Per-token USDC pricing across all 26+ models with 5% platform fee
+description: Per-token USDC pricing across all 26 models with 5% platform fee
 ---
 
 
@@ -53,7 +53,12 @@ All prices are USDC per million tokens (provider cost before the 5% fee).
 |-------|----------|-------------|--------------|---------|
 | Claude Opus 4.6 | `anthropic/claude-opus-4-20250514` | $5.00 | $25.00 | 200K |
 | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-20250514` | $3.00 | $15.00 | 200K |
+| Claude Sonnet 4.5 | `anthropic-claude-sonnet-4-5` | $3.00 | $15.00 | 200K |
 | Claude Haiku 4.5 | `anthropic/claude-haiku-4-5-20251001` | $1.00 | $5.00 | 200K |
+
+<Note>
+  Sonnet 4.5 shares its upstream `model_id` with Sonnet 4.6 (`claude-sonnet-4-20250514`). The registry-key form `anthropic-claude-sonnet-4-5` is the unambiguous identifier; the `provider/model_id` slash form resolves to whichever entry is loaded last and is best avoided for Sonnet specifically.
+</Note>
 
 ### Google
 

--- a/dashboard/content/docs/index.mdx
+++ b/dashboard/content/docs/index.mdx
@@ -39,7 +39,7 @@ The gateway is OpenAI-compatible, so any existing code that targets the OpenAI A
 ## Key capabilities
 
 <CardGroup>
-  <Card title="26+ models across 5 providers" description="OpenAI, Anthropic, Google, xAI, and DeepSeek — all behind one endpoint with unified USDC pricing." href="/docs/api/models" />
+  <Card title="26 models across 5 providers" description="OpenAI, Anthropic, Google, xAI, and DeepSeek — all behind one endpoint with unified USDC pricing." href="/docs/api/models" />
   <Card title="Smart routing" description="Set model to 'auto', 'eco', or 'premium' and the gateway picks the right model for your prompt's complexity." href="/docs/concepts/smart-router" />
   <Card title="Escrow payments" description="Trustless on-chain escrow with deposit/claim/refund — no upfront full payment required." href="/docs/concepts/escrow" />
   <Card title="OpenAI-compatible" description="Drop-in replacement for the OpenAI API. Change the base URL and add payment handling." href="/docs/api/chat-completions" />

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ description: Make your first paid API call to Solvela in 5 minutes
 
 Before you start, you need:
 
-- A **Solana wallet** with a keypair (e.g. generated with `solana-keygen new` or `solvela wallet new`)
+- A **Solana wallet** with a keypair (e.g. generated with `solana-keygen new` or `solvela wallet init`)
 - **USDC-SPL** in that wallet on Solana mainnet (mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)
 - A small amount of **SOL** for transaction fees (Solana base fee is 5,000 lamports per signature — roughly 0.000005 SOL per call)
 
@@ -56,16 +56,18 @@ First, send a request without any payment header. The gateway will respond with 
 <Tabs items={['TypeScript', 'Python', 'Go', 'cURL']}>
   <Tab value="TypeScript">
     ```typescript
-    import { LLMClient } from '@solvela/sdk';
+    import { SolvelaClient, ChatRequest, ChatMessage } from '@solvela/sdk';
 
-    const client = new LLMClient({
-      apiUrl: 'https://api.solvela.ai',
+    const client = new SolvelaClient({
+      config: { gatewayUrl: 'https://api.solvela.ai' },
     });
 
     // The SDK automatically handles the 402 flow —
-    // you only need a private key to sign.
-    const reply = await client.chat('auto', 'What is x402?');
-    console.log(reply);
+    // you only need a private key (via env or a Signer) to sign.
+    const response = await client.chat(
+      new ChatRequest('auto', [new ChatMessage('user', 'What is x402?')]),
+    );
+    console.log(response.choices[0].message.content);
     ```
   </Tab>
   <Tab value="Python">
@@ -194,18 +196,20 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
 <Tabs items={['TypeScript', 'Python', 'Go', 'solvela CLI']}>
   <Tab value="TypeScript">
     ```typescript
-    import { LLMClient } from '@solvela/sdk';
+    import { SolvelaClient, ChatRequest, ChatMessage } from '@solvela/sdk';
 
-    // Pass your private key — the SDK signs automatically.
-    const client = new LLMClient({
-      apiUrl: 'https://api.solvela.ai',
-      // private key is read from SOLANA_PRIVATE_KEY env var in the SDK,
-      // or pass it as a constructor option
+    // The SDK reads SOLANA_PRIVATE_KEY from env by default, or you can
+    // pass an explicit `wallet` + `signer` in the constructor options.
+    const client = new SolvelaClient({
+      config: { gatewayUrl: 'https://api.solvela.ai' },
     });
 
-    const reply = await client.chat('openai/gpt-4o', 'Explain Solana in one sentence.');
-    console.log(reply);
-    console.log('Spent:', client.getSessionSpent(), 'USDC');
+    const response = await client.chat(
+      new ChatRequest('openai/gpt-4o', [
+        new ChatMessage('user', 'Explain Solana in one sentence.'),
+      ]),
+    );
+    console.log(response.choices[0].message.content);
     ```
   </Tab>
   <Tab value="Python">


### PR DESCRIPTION
## Summary

Phase 2A of the 2026-05-14 docs audit punch list — Tier B (drift) items scoped to docs.solvela.ai content + the root README's TS sample. Phase 1 (Tier A blocking) is #285.

Five drift findings, all docs-only:

- **TS SDK examples were fictional.** \`LLMClient\` is not exported by \`@solvela/sdk\` — the SDK exports \`SolvelaClient\` (verified against \`sdks/typescript/src/client.ts:49\` and the SDK's own README). The current docs also called \`client.chatCompletion(...)\` and \`client.getSessionSpent()\` which don't exist anywhere on the public surface. Replaced all 4 affected code blocks (quickstart.mdx ×2, api/chat-completions.mdx, README.md) with samples that use the real \`SolvelaClient\` + \`ChatRequest\` + \`ChatMessage\` API.
- **Sonnet 4.5 was missing from the model tables.** Both \`api/models.mdx\` and \`concepts/pricing.mdx\` listed 25 of the 26 registry entries. Added Sonnet 4.5 using its registry-key form (\`anthropic-claude-sonnet-4-5\`) since the \`provider/model_id\` slash form collides with Sonnet 4.6 — they share \`claude-sonnet-4-20250514\` upstream and the registry's last-write-wins makes the slash form unstable for disambiguation. Added a \`<Note>\` explaining this.
- **"26+ models" → "26 models"** in \`index.mdx\` and \`concepts/pricing.mdx\` frontmatter. Registry has exactly 26.
- **\`solvela wallet new\` → \`solvela wallet init\`** in \`quickstart.mdx\` prerequisites. The \`new\` subcommand was never registered; same page's later usage and \`crates/cli/README.md\` both use \`init\`.
- **\`POST /v1/escrow/settle\` documented for the first time.** Shipped 2026-05-13 (#267) and not yet referenced anywhere in \`dashboard/content/docs/\`. Added a row to \`api/index.mdx\`'s "Other endpoints" table and a new "Client-initiated settle (F4)" section in \`concepts/escrow.mdx\` covering the wire contract, behavior on \`status=completed\` vs \`status=error\`, idempotency, and the v1 fire-and-forget auth model. Source of truth: \`crates/gateway/src/routes/escrow_settle.rs\`. Included a \`<Note>\` flagging the STATUS.md follow-up that \`@solvela/signer-core\` still needs to expose \`service_id\` before the F4 wrapper can call this endpoint from the plugin hot path.

8 files, +90/−40. No code, SDK API, or gateway endpoint changes — docs catching up to ground truth.

Phases 2B (README/STATUS/CONTRIBUTING drift) and 2C (integrations naming + missing READMEs) to follow as separate PRs.

## Test plan

- [ ] Vercel preview build of \`dashboard/\` green; MDX parses; \`<Note>\` callouts render
- [ ] \`/docs/concepts/escrow#client-initiated-settle-f4\` anchor resolves (linked from \`api/index.mdx\`)
- [ ] \`grep -nE "LLMClient|getSessionSpent|apiUrl:" dashboard/content/docs/ README.md\` returns no SDK-API calls
- [ ] Model table rows in \`api/models.mdx\` and \`concepts/pricing.mdx\` both show Sonnet 4.5
- [ ] Required CI checks (Rust fmt/clippy/test, Smoke, Security audit, Docker build) all green