### PR TITLE
docs(audit): phase 2C — integrations READMEs + OpenClaw layering note

### DIFF
--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -13,7 +13,15 @@ _(no loose files — see subdirectories)_
 | Directory | Purpose |
 |-----------|---------|
 | `elizaos/` | ElizaOS plugin (TypeScript) — exposes Solvela as an action + provider (see `elizaos/AGENTS.md`) |
-| `openclaw/` | OpenClaw integration (TypeScript) — routes OpenClaw requests through Solvela (see `openclaw/AGENTS.md`) |
+| `openclaw/` | OpenClaw integration (TypeScript) — routes OpenClaw requests through Solvela via the older `intercept` hook (see `openclaw/AGENTS.md`) |
+
+> **Two OpenClaw plugins coexist on purpose.** This directory ships
+> `@solvela/router` (intercept-style, v0.1.0, stable). The newer
+> `@solvela/openclaw-provider` (wrapStreamFn-style, v1.0.0-draft, not yet
+> published) lives at `../sdks/openclaw-provider/`. Don't merge them —
+> they target different OpenClaw plugin contracts. See
+> `openclaw/README.md` for the user-facing "which one to install"
+> decision matrix.
 
 ## For AI Agents
 

--- a/integrations/elizaos/README.md
+++ b/integrations/elizaos/README.md
@@ -1,0 +1,59 @@
+# @solvela/elizaos-plugin
+
+[ElizaOS](https://github.com/elizaOS/eliza) plugin that lets agents pay for LLM calls through [Solvela](https://solvela.ai) — Solana-native USDC-SPL payments via the [x402 protocol](https://x402.org).
+
+## Status
+
+**Pre-release (v0.1.0).** The plugin currently handles the free-tier and 402-discovery paths only — see [Limitations](#limitations) below. The `chat` action returns a clear payment-required message instead of attempting an unsigned retry. Wallet signing through ElizaOS's runtime needs more work before this plugin can complete a paid request end-to-end.
+
+If you need a working ElizaOS → paid Solvela integration today, drop down a layer and call `@solvela/sdk` directly from a custom Eliza action — that SDK signs payments automatically.
+
+## What it exposes
+
+| Kind | Name | Description |
+|---|---|---|
+| Action | `CHAT_VIA_SOLVELA` | Sends a chat completion through Solvela. Triggers on similes like `llm call`, `ai inference`, `model query`, `ask ai`. |
+| Provider | `gatewayProvider` | Surfaces Solvela gateway context for the runtime. |
+
+## Install
+
+```bash
+npm install @solvela/elizaos-plugin
+```
+
+Register the plugin in your ElizaOS agent character / configuration:
+
+```typescript
+import { solvelaPlugin } from '@solvela/elizaos-plugin';
+
+export const character = {
+  // ...
+  plugins: [solvelaPlugin],
+};
+```
+
+## Settings
+
+Both settings are read via ElizaOS `runtime.getSetting()`, not `process.env` — wire them up the same way you wire any other ElizaOS setting (`secrets`, character settings, etc.).
+
+| Setting | Required | Default | Description |
+|---|---|---|---|
+| `SOLVELA_GATEWAY_URL` | Yes | — | Solvela gateway base URL (e.g. `https://api.solvela.ai`) |
+| `SOLVELA_DEFAULT_MODEL` | No | `auto` | Model ID, alias, or routing profile (`auto`, `eco`, `premium`, `free`) |
+
+## Limitations
+
+- **Wallet signing is not implemented.** When the gateway returns `402 Payment Required`, the action returns a human-readable cost summary instead of signing and retrying. Sign-and-retry support is tracked but unscheduled.
+- **No test suite yet.** `npm test` prints a placeholder. Production use should pin the published version and add your own integration tests.
+
+## Development
+
+```bash
+cd integrations/elizaos
+npm install
+npm run build
+```
+
+## License
+
+MIT

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,77 @@
+# @solvela/router
+
+OpenClaw plugin that routes outbound LLM requests through the [Solvela](https://solvela.ai) gateway. Every routed call is paid for in USDC-SPL on Solana via the [x402 protocol](https://x402.org) — no API keys, no accounts, just a wallet.
+
+## Two OpenClaw plugins — which one do you want?
+
+The Solvela monorepo ships **two** OpenClaw plugins with different shapes. Pick the one that matches your OpenClaw version and how you want to integrate.
+
+| Plugin | Path | OpenClaw hook | Status |
+|---|---|---|---|
+| **`@solvela/router`** (this package) | `integrations/openclaw/` | `intercept` / `interceptStream` | Stable v0.1.0 OSS plugin. Works against older OpenClaw versions and supports the classic intercept pattern. |
+| **`@solvela/openclaw-provider`** | `sdks/openclaw-provider/` | `wrapStreamFn` | Newer first-class **provider** plugin — registers Solvela in OpenClaw's model picker so users select it like any other LLM. Built on OpenClaw's post-refactor `wrapStreamFn` contract. `1.0.0-draft`, not yet on npm; publish gated on the OpenClaw LTS announcement. |
+
+If you're on a recent OpenClaw and want users to see "Solvela" in the model picker, use **`@solvela/openclaw-provider`** (once it ships). If you want a drop-in plugin that intercepts existing LLM calls without UI changes, use this package.
+
+## Install
+
+```bash
+openclaw plugins install @solvela/router
+```
+
+Or as a library:
+
+```bash
+npm install @solvela/router
+```
+
+## Required environment variables
+
+| Variable | Description |
+|---|---|
+| `LLM_ROUTER_API_URL` | Solvela gateway base URL (e.g. `https://api.solvela.ai`) |
+| `LLM_ROUTER_WALLET_KEY` | Base58-encoded Solana private key used to sign x402 payments |
+
+## Optional environment variables
+
+| Variable | Description |
+|---|---|
+| `SOLANA_RPC_URL` | Solana RPC endpoint. Required when `@solana/web3.js` is installed locally and the plugin needs to sign on-chain transactions. |
+
+## Usage as a library
+
+```typescript
+import { createRouter } from '@solvela/router';
+
+const router = createRouter();
+const response = await router.chat([
+  { role: 'user', content: 'Hello!' },
+]);
+console.log(response.choices[0].message.content);
+```
+
+`createRouter()` returns a `SolvelaClient` instance. The class also exposes `chatStream()` for SSE streaming.
+
+## Usage as an OpenClaw plugin
+
+The default export is an `OpenClawPlugin` factory. OpenClaw loads it and calls `intercept` on every outbound LLM request; returning a response short-circuits the default provider and routes the call through Solvela instead.
+
+```typescript
+import createPlugin from '@solvela/router';
+
+const plugin = createPlugin();
+// OpenClaw calls plugin.intercept(request) / plugin.interceptStream(request)
+```
+
+## Development
+
+```bash
+cd integrations/openclaw
+npm install
+npm run build
+npm test
+```
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Phase 2C of the 2026-05-14 docs audit punch list — closes the Tier B integrations cluster. Phase 1 = #285, Phase 2A = #286, Phase 2B = #287.

Two integrations (\`openclaw\`, \`elizaos\`) previously had no user-facing READMEs, and the naming overlap between the two OpenClaw plugins was confusing without docs explaining the layering.

- **\`integrations/openclaw/README.md\` (new).** Documents \`@solvela/router\` v0.1.0 — the intercept-style OpenClaw plugin — with env vars (\`LLM_ROUTER_API_URL\`, \`LLM_ROUTER_WALLET_KEY\`), library + plugin usage, and a lead "Two OpenClaw plugins — which one do you want?" decision matrix comparing it against \`@solvela/openclaw-provider\` (wrapStreamFn-style, \`1.0.0-draft\`, not yet published) so users can pick the right one for their OpenClaw version.
- **\`integrations/elizaos/README.md\` (new).** Documents \`@solvela/elizaos-plugin\` v0.1.0 — the \`CHAT_VIA_SOLVELA\` action + \`gatewayProvider\`, ElizaOS-style settings (\`SOLVELA_GATEWAY_URL\`, \`SOLVELA_DEFAULT_MODEL\` via \`runtime.getSetting()\`), and a "Status: Pre-release" + "Limitations" pair making it explicit that wallet signing isn't implemented yet (the action returns a cost summary on 402, per \`src/actions/chat.ts:44-48\`).
- **\`integrations/AGENTS.md\`.** One short callout under "Subdirectories" pointing AI agents (and humans) at the dual-OpenClaw layering and the new openclaw README decision matrix.

**What's NOT in this PR:** the \`@solvela/router\` → \`@solvela/openclaw\` package rename. That's a publishing-strategy decision (deprecation window, npm dist-tag handling, the existing \`LLM_ROUTER_*\` env vars in \`integrations/openclaw/src/config.ts\`) rather than an audit fix. Documenting the layering is the lower-risk move and matches the deprecation-on-a-schedule pattern already in \`integrations/openclaw/src/index.ts:36-37\` (the \`Rcr*\` aliases are scheduled to retire 2026-08-01). Happy to follow up with the rename in its own PR if that's the call.

3 files, +145/−1 (2 new READMEs, 1 short AGENTS.md addition). No code, npm-package, or runtime changes.

## Audit closeout

This closes the Tier B portion of the docs audit:

- Phase 1 (Tier A): #285 — 4 blocking fixes
- Phase 2A (Tier B docs site): #286 — 5 drift fixes
- Phase 2B (Tier B top-level): #287 — 4 drift fixes
- Phase 2C (Tier B integrations): this PR — 3 drift fixes

The Tier C polish list (~10 items: SDK README badges + License sections, BACKERS placeholder framing, SECURITY.md "offline" wording, Anthropic model-id form standardization, etc.) is parked as an optional separate sweep.

## Test plan

- [ ] Required CI checks (Rust fmt/clippy/test, Smoke, Security audit, Docker build) all green
- [ ] GitHub renders both new READMEs on their directory pages
- [ ] No merge conflicts with #285/#286/#287 (this PR only touches \`integrations/\` files)