### PR TITLE
docs(audit): phase 2D — SDK README polish + signer-core README

### DIFF
--- a/sdks/cli-npm/README.md
+++ b/sdks/cli-npm/README.md
@@ -62,6 +62,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.solvela.xyz | sh
 cargo install solvela-cli
 ```
 
+## Documentation
+
+[docs.solvela.ai/sdks/rust](https://docs.solvela.ai/sdks/rust) — full reference for the `solvela` CLI commands and wallet flows (this npm package is a distribution shim around the same Rust binary).
+
 ## License
 
 MIT

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -56,9 +56,9 @@ func main() {
 
 The core SDK (transport, caching, sessions, quality checking, streaming, balance monitoring) is fully implemented and tested.
 
-**`KeypairSigner` is not yet implemented.** The bundled `KeypairSigner` type returns an error when `SignPayment` is called — it is a placeholder, not a working signer. To make payments you have two options:
+**`UnimplementedSigner` is the bundled placeholder.** It exists so the SDK compiles and the rest of the surface area (transport, caching, sessions, streaming) can be exercised, but `SignPayment` returns an error — it is **not** a working signer. To make real payments you have two options:
 
-1. **Use a different SDK** — the [Python SDK](https://github.com/solvela-ai/solvela-python) and TypeScript SDK include working `KeypairSigner` implementations backed by their respective Solana libraries.
+1. **Use a different SDK** — the [Python SDK](https://github.com/solvela-ai/solvela/tree/main/sdks/python) and [TypeScript SDK](https://github.com/solvela-ai/solvela/tree/main/sdks/typescript) include working `KeypairSigner` implementations backed by their respective Solana libraries.
 2. **Implement a custom `Signer`** — the `Signer` interface is pluggable. Provide your own implementation using `crypto/ed25519` (already in the Go standard library) and a Solana JSON-RPC client of your choice.
 
 ```go
@@ -129,6 +129,10 @@ go test ./... -v -count=1
 # Live tests (requires running gateway)
 go test ./... -v -tags=live
 ```
+
+## Documentation
+
+[docs.solvela.ai/sdks/go](https://docs.solvela.ai/sdks/go) — full reference, context patterns, custom Signer guide.
 
 ## License
 

--- a/sdks/mcp/README.md
+++ b/sdks/mcp/README.md
@@ -146,6 +146,7 @@ All configuration is via environment variables:
 | `SOLVELA_TIMEOUT_MS` | `60000` | Request timeout in milliseconds |
 | `SOLVELA_SIGNING_MODE` | `auto` | Payment signing mode: `auto`, `escrow`, `direct`, or `off` |
 | `SOLVELA_ALLOW_DEV_BYPASS` | — | Set to `1` to silence the dev_bypass_payment gateway warning |
+| `SOLVELA_INSECURE_HTTP` | — | Set to `1` to silence the MITM warning when `SOLVELA_API_URL` is plaintext `http://`. Loopback and `*.local` hosts skip the warning unconditionally. |
 | `SOLVELA_ESCROW_MODE` | — | Set to `enabled` to expose the `deposit_escrow` tool |
 | `SOLVELA_MAX_ESCROW_DEPOSIT` | `5.0` | Per-call deposit cap in USDC (applies only when escrow mode is enabled) |
 | `SOLVELA_MAX_ESCROW_SESSION` | `20.0` | Cumulative session deposit cap in USDC (applies only when escrow mode is enabled) |

--- a/sdks/openclaw-provider/README.md
+++ b/sdks/openclaw-provider/README.md
@@ -143,3 +143,11 @@ npm test                  # Run all tests
 **Do not publish** until Phase 4 approval. The `package.json` version is
 `1.0.0-draft` to signal pre-release status. Publishing is gated on private
 user testing (Phase 3) and a go/no-go from the user before Phase 4 distribution.
+
+## Documentation
+
+[docs.solvela.ai/sdks](https://docs.solvela.ai/sdks) — Solvela SDK index. (Dedicated OpenClaw provider page is pending publish.)
+
+## License
+
+MIT

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -102,6 +102,10 @@ SOLVELA_LIVE_TESTS=1 pytest tests/live/ -v
 ruff check src/ tests/
 ```
 
+## Documentation
+
+[docs.solvela.ai/sdks/python](https://docs.solvela.ai/sdks/python) — full reference, async patterns, error handling.
+
 ## License
 
 MIT

--- a/sdks/signer-core/README.md
+++ b/sdks/signer-core/README.md
@@ -1,0 +1,39 @@
+# @solvela/signer-core
+
+Shared x402 protocol primitives for the Solvela ecosystem — payment signing, 402 parsing, scheme filtering, stub-header guards, and error sanitization. This is the single source of truth other Solvela TypeScript packages use to stay wire-compatible with the production gateway.
+
+## Status
+
+**Internal package (`private: true` in `package.json`)**. Used by `sdks/mcp/`, `sdks/openclaw-provider/`, and `sdks/ai-sdk-provider/` as a workspace dependency. Not published to npm. If you need to sign x402 payments from your own application, depend on [`@solvela/sdk`](../typescript) instead — it bundles a `KeypairSigner` built on these primitives.
+
+## What's inside
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `createPaymentHeader` | function | Build a base64-encoded `payment-signature` header. Accepts optional `PaymentExpectations` so a phishing 402 can't redirect funds to a different recipient or escrow program (highly recommended). |
+| `decodePaymentHeader` | function | Round-trip helper for tests/debug. |
+| `parse402` | function | Parse a `402 Payment Required` body — accepts both the envelope shape (`{ error: { message: <json> } }`) and the direct shape. Throws on malformed input. |
+| `filterAccepts` | function | Scheme-based filter over a `PaymentRequired.accepts[]` list with mode support (`auto` / `escrow` / `direct` / `off`). |
+| `isStubHeader`, `isStubTransaction` | function | Detect stub payment headers and stub markers in extracted transactions — guards against sending unsigned placeholder payloads. |
+| `sanitizeGatewayError` | function | Slice + redact gateway error bodies before logging or surfacing them. |
+| `redactBase58`, `redactHex` | function | Byte-pattern redactors for log output. |
+| `SigningError` | error | Thrown by `createPaymentHeader` on signing failure. |
+| `PaymentRequired`, `PaymentAccept`, `CostBreakdown`, `PaymentExpectations` | type | Wire-format types matching the gateway's 402 response shape. |
+
+## Why it exists
+
+Three TypeScript packages need to sign x402 payments against the same gateway: the MCP server, the OpenClaw provider, and the Vercel AI SDK provider. Duplicating the wire-format logic across all three caused a real incident — the 2026-05-11 `ModelInfo` zero-fill — so the signing primitives now live in one place with their own tests and CI. Changes here are picked up by all three consumers in a single PR; cross-package drift fails CI rather than shipping silently.
+
+## Development
+
+```bash
+cd sdks/signer-core
+npm install
+npm run build         # tsc
+npm test              # node:test runners across parse-402, scheme-filter, stub-guard, redact, sign
+npm run typecheck     # tsc --noEmit
+```
+
+## License
+
+MIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -10,7 +10,7 @@ AI agents pay for LLM API calls with USDC-SPL on Solana via the x402 protocol.
 npm install @solvela/sdk
 ```
 
-Requires Node.js 18+.
+Requires Node.js 20.19+ (matches the `engines.node` constraint in `package.json`). Earlier Node versions are not tested and may fail at install or import time.
 
 ## Quick Start
 
@@ -97,6 +97,10 @@ const client = new SolvelaClient({
   },
 });
 ```
+
+## Documentation
+
+[docs.solvela.ai/sdks/typescript](https://docs.solvela.ai/sdks/typescript) — full reference, error handling, streaming and OpenAI-compat patterns.
 
 ## License
 


### PR DESCRIPTION
## Summary

Phase 2D of the 2026-05-14 docs audit. Catches the SDK README cluster — six per-SDK fixes plus one new README. Sibling PRs in the audit stack: #285 (Phase 1 Tier A), #286 (Phase 2A docs site), #287 (Phase 2B top-level), #288 (Phase 2C integrations).

Six fix areas across the 8-package `sdks/` tree:

- **`sdks/typescript/README.md`.** Node version claim "Node.js 18+" → "Node.js 20.19+" to match the \`engines.node\` constraint in package.json. The mismatch had Node 18–20.18 installs failing without a clear error.
- **`sdks/go/README.md`.** Signer type rename in the Status section: \`KeypairSigner\` → \`UnimplementedSigner\` (the actual exported Go type at \`sdks/go/signer.go:19,27,40\`). \`docs.solvela.ai/sdks/go\` already had the correct name; only the SDK's own README was wrong. Users copying \`KeypairSigner\` from this README got an undefined-identifier error. Also updated the Python SDK link from the archived \`solvela-ai/solvela-python\` repo to the live monorepo path, and added a matching TypeScript SDK link.
- **`sdks/mcp/README.md`.** Added \`SOLVELA_INSECURE_HTTP\` row to the env vars table. Introduced in #277 (MCP audit closeout per STATUS.md 2026-05-14) but never made it into the README. Read at \`sdks/mcp/src/client.ts:166,179\` to silence the MITM warning for plaintext \`http://\` gateway URLs.
- **`sdks/openclaw-provider/README.md`.** Added standard \`## License\` MIT footer. Every other SDK README has one; only this and signer-core were missing.
- **`sdks/signer-core/README.md` (new).** Previously no README at all. Documents what \`@solvela/signer-core\` exposes (\`createPaymentHeader\`, \`decodePaymentHeader\`, \`parse402\`, \`filterAccepts\`, stub-header guards, error sanitization, redactors, \`SigningError\` + the wire-format types), why the package exists (the 2026-05-11 \`ModelInfo\` zero-fill drove consolidating wire-format logic into one place), and that it's an internal workspace package (\`private: true\`) — external consumers should depend on \`@solvela/sdk\`.
- **`sdks/{typescript,python,go,openclaw-provider,cli-npm}/README.md`.** Added \`## Documentation\` cross-links to the matching \`docs.solvela.ai\` page (or \`/docs/sdks\` index for the two packages without dedicated pages — openclaw-provider has none yet; cli-npm wraps the Rust CLI so its docs live at \`/sdks/rust\`). MCP and ai-sdk-provider already had cross-links.

7 files, +67/−3. No code, env-var, or SDK API changes — docs catching up to ground truth.

PR E (top-level polish — SECURITY "offline" wording, README MSRV badge / SDK lineup, BACKERS empty-tier framing, elizaos test placeholder, landing OG image) is the final audit PR.

## Test plan

- [ ] Required CI checks (Rust fmt/clippy/test, Smoke, Security audit, Docker build) all green
- [ ] No conflicts with #285/#286/#287/#288 (this PR only touches files under \`sdks/\`)
- [ ] New \`sdks/signer-core/README.md\` renders on the directory page
- [ ] All new \`## Documentation\` links resolve on \`docs.solvela.ai\`