### PR TITLE
fix(docs): repair four broken site links flagged by user

### DIFF
--- a/dashboard/content/docs/sdks/ai-sdk.mdx
+++ b/dashboard/content/docs/sdks/ai-sdk.mdx
@@ -468,7 +468,7 @@ No. Every request requires a valid wallet adapter. For testing, use `createLocal
 
 **Q: What model IDs are available?**
 
-See the [Models reference](https://docs.solvela.ai/models) or query the `/v1/models` endpoint:
+See the [Models reference](https://docs.solvela.ai/docs/api/models) or query the `/v1/models` endpoint:
 
 ```bash
 curl https://api.solvela.ai/v1/models \

--- a/dashboard/src/app/components/docs/mdx/link-map.tsx
+++ b/dashboard/src/app/components/docs/mdx/link-map.tsx
@@ -3,72 +3,47 @@ import Link from 'next/link'
 interface LinkItem {
   label: string
   href: string
+  description?: string
 }
 
-interface LinkColumn {
-  heading: string
+interface LinkMapProps {
+  eyebrow?: string
+  heading?: string
   links: LinkItem[]
 }
 
-const COLUMNS: LinkColumn[] = [
-  {
-    heading: 'Get started',
-    links: [
-      { label: 'Quickstart', href: '/docs/quickstart' },
-      { label: 'Architecture', href: '/docs/architecture' },
-      { label: 'Request Flow', href: '/docs/request-flow' },
-      { label: 'Payment Flow', href: '/docs/payment-flow' },
-    ],
-  },
-  {
-    heading: 'Protocol',
-    links: [
-      { label: 'x402 Overview', href: '/docs/x402-overview' },
-      { label: 'Smart Router', href: '/docs/architecture#smart-router' },
-    ],
-  },
-  {
-    heading: 'Integrate',
-    links: [
-      { label: 'TypeScript SDK', href: '/docs/sdk-typescript' },
-      { label: 'Python SDK', href: '/docs/sdk-python' },
-      { label: 'Rust SDK', href: '/docs/sdk-rust' },
-      { label: 'Go SDK', href: '/docs/sdk-go' },
-    ],
-  },
-]
-
-export function LinkMap() {
+export function LinkMap({
+  eyebrow = 'Documentation',
+  heading = 'Explore the docs',
+  links,
+}: LinkMapProps) {
+  if (!links || links.length === 0) return null
   return (
     <div className="not-prose my-12">
-      <p className="eyebrow mb-3">Documentation</p>
+      <p className="eyebrow mb-3">{eyebrow}</p>
       <h2 className="font-serif text-[2.25rem] font-medium text-[var(--heading-color)] mb-8 leading-tight tracking-tight">
-        Explore the docs
+        {heading}
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-x-12 gap-y-10">
-        {COLUMNS.map((col) => (
-          <div key={col.heading}>
-            <p className="font-serif text-[17px] text-[var(--heading-color)] mb-4 font-medium">
-              {col.heading}
-            </p>
-            <ul className="space-y-3">
-              {col.links.map((link) => (
-                <li key={link.href}>
-                  <Link
-                    href={link.href}
-                    className="group inline-flex items-center gap-1.5 text-[17px] text-[var(--foreground)]/75 hover:text-[var(--heading-color)] transition-colors font-serif"
-                  >
-                    <span>{link.label}</span>
-                    <span
-                      aria-hidden="true"
-                      className="text-[var(--muted-foreground)] group-hover:text-[var(--accent-salmon)] transition-colors"
-                    >
-                      →
-                    </span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
+        {links.map((link) => (
+          <div key={link.href}>
+            <Link
+              href={link.href}
+              className="group inline-flex items-center gap-1.5 text-[17px] text-[var(--foreground)] hover:text-[var(--accent-salmon)] transition-colors font-serif font-medium"
+            >
+              <span>{link.label}</span>
+              <span
+                aria-hidden="true"
+                className="text-[var(--muted-foreground)] group-hover:text-[var(--accent-salmon)] transition-colors"
+              >
+                →
+              </span>
+            </Link>
+            {link.description ? (
+              <p className="mt-2 text-[15px] leading-relaxed text-[var(--muted-foreground)]">
+                {link.description}
+              </p>
+            ) : null}
           </div>
         ))}
       </div>

--- a/dashboard/src/app/components/docs/mdx/upgrade-cta.tsx
+++ b/dashboard/src/app/components/docs/mdx/upgrade-cta.tsx
@@ -20,7 +20,7 @@ export function UpgradeCta() {
           this page plus the dashboard.
         </p>
         <Link
-          href="https://solvela.ai/pricing"
+          href="https://docs.solvela.ai/docs/concepts/pricing"
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1.5 px-4 py-2 text-[14px] font-medium bg-[#1F1E1D] text-[#FAF9F5] border border-[#1F1E1D] rounded-md hover:opacity-90 transition-opacity"

--- a/dashboard/src/components/landing/landing-footer.tsx
+++ b/dashboard/src/components/landing/landing-footer.tsx
@@ -32,7 +32,7 @@ export function LandingFooter() {
               { label: 'docs', href: DOCS_URL },
               { label: 'app', href: APP_URL },
               { label: 'quickstart', href: `${DOCS_URL}/docs/quickstart` },
-              { label: 'changelog', href: `${DOCS_URL}/docs/changelog` },
+              { label: 'changelog', href: `${GITHUB_URL}/blob/main/CHANGELOG.md` },
             ]}
           />
 


### PR DESCRIPTION
## Summary

User reported a `https://docs.solvela.ai/docs/x402-overview` 404. A targeted link audit (run after the six-PR audit closeout #285-#290) surfaced four distinct bugs across the marketing landing, the MDX components, and the docs corpus.

### Four fixes

1. **\`dashboard/src/components/landing/landing-footer.tsx:35\`** — the "changelog" footer link pointed at \`\${DOCS_URL}/docs/changelog\`, but no \`/docs/changelog\` page exists. Repointed at \`\${GITHUB_URL}/blob/main/CHANGELOG.md\` — the canonical source.

2. **\`dashboard/src/app/components/docs/mdx/upgrade-cta.tsx:23\`** — the "View pricing →" button on every enterprise docs page linked to \`https://solvela.ai/pricing\`, which 404s (no \`/pricing\` route exists in \`dashboard/src/app/\`). The \`UpgradeCta\` component is rendered from **7 enterprise MDX pages**, so this is high-visibility. Repointed at \`https://docs.solvela.ai/docs/concepts/pricing\`.

3. **\`dashboard/src/app/components/docs/mdx/link-map.tsx\` — architectural bug.** The component was rendered from \`enterprise/index.mdx:14\` with \`eyebrow\`/\`heading\`/\`links\` props (each link has \`href\`/\`label\`/\`description\`), but the implementation took **zero parameters** and rendered a hardcoded \`COLUMNS\` array with **9 broken paths** that no longer match the docs hierarchy:
   - \`/docs/architecture\` → real: \`/docs/concepts/architecture\`
   - \`/docs/request-flow\` → \`/docs/concepts/request-flow\`
   - \`/docs/payment-flow\` → \`/docs/concepts/payment-flow\`
   - \`/docs/x402-overview\` → \`/docs/concepts/x402\` _(user's reported 404)_
   - \`/docs/sdk-typescript\` → \`/docs/sdks/typescript\`
   - \`/docs/sdk-python\` → \`/docs/sdks/python\`
   - \`/docs/sdk-rust\` → \`/docs/sdks/rust\`
   - \`/docs/sdk-go\` → \`/docs/sdks/go\`
   - \`/docs/architecture#smart-router\` (cascade)
   
   Refactored to accept \`eyebrow\`/\`heading\`/\`links\` props with optional per-link \`description\`. Drops \`COLUMNS\` entirely (it was dead code the MDX call site was already trying to override). \`enterprise/index.mdx\` now renders with the 6 enterprise feature links it always intended to render — Organizations, Teams, API Keys, Audit Logs, Budgets, Analytics — all of which actually exist.

4. **\`dashboard/content/docs/sdks/ai-sdk.mdx:471\`** — the "Models reference" link pointed at \`https://docs.solvela.ai/models\`. The \`docs.solvela.ai\` middleware (\`dashboard/src/proxy.ts:23-29\`) rewrites bare paths to \`/docs/<path>\`, so this resolved to \`/docs/models\` which doesn't exist. Repointed at the canonical \`/docs/api/models\` page.

### Coverage

Audited every \`href=\` in \`dashboard/src/**/*.{tsx,ts}\`, every markdown link in \`dashboard/content/docs/**/*.mdx\`, and every Solvela-domain URL in the repo's root markdown files. Cross-referenced against the dashboard route set (\`src/app/**/page.tsx\`) and the docs slug set (every \`.mdx\` under \`content/docs/\`). Remaining links resolved clean. Anchor targets verified: \`#custom-signers\`, \`#tiers\`, \`#client-initiated-settle-f4\` all exist on their target pages.

4 files, +34/−59. No code logic changes — URL/href fixes plus one prop-honest component refactor.

## Test plan

- [ ] Required CI checks green (Rust fmt/clippy/test, Smoke, Security audit, Docker build, Vercel build)
- [ ] Vercel preview renders \`/docs/enterprise\` with the LinkMap component showing 6 working links (each with description)
- [ ] \`grep -rE "(docs/x402-overview|docs/sdk-typescript|docs/sdk-python|docs/sdk-rust|docs/sdk-go|docs/architecture|docs/request-flow|docs/payment-flow|docs/changelog|solvela\\.ai/pricing|docs\\.solvela\\.ai/models)" dashboard/src dashboard/content\` returns nothing