### PR TITLE
docs(cli): document SOLANA_RPC_URL; fix --stream ghost flag

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -17,7 +17,12 @@ cargo install solvela-cli
 # Optional: defaults to https://api.solvela.ai
 export SOLVELA_API_URL=https://api.solvela.ai
 
-solvela wallet init                 # generate a Solana keypair
+# Required for any paid command (signs the USDC-SPL transaction).
+# Public endpoint is fine for a smoke test; use Helius/QuickNode/Triton
+# for real usage to avoid rate limits.
+export SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+
+solvela wallet init                 # generate a Solana keypair (fund the printed address with USDC + a little SOL)
 solvela chat --model auto "hello"   # ask the smart router to pick a model
 solvela models                      # list available models + per-token pricing
 solvela doctor                      # check config + gateway reachability

--- a/dashboard/content/docs/sdks/rust.mdx
+++ b/dashboard/content/docs/sdks/rust.mdx
@@ -19,12 +19,18 @@ cargo build --release -p solvela-cli
 
 ## Configuration
 
-The CLI binds one environment variable:
+The CLI reads these environment variables:
 
 ```bash
-export SOLVELA_API_URL=https://api.solvela.ai   # optional; default https://api.solvela.ai
-export RUST_LOG=info                             # optional logging
+export SOLVELA_API_URL=https://api.solvela.ai              # optional; default https://api.solvela.ai
+export SOLANA_RPC_URL=https://api.mainnet-beta.solana.com  # required for any paid command (signs USDC-SPL tx)
+export RUST_LOG=info                                       # optional logging
 ```
+
+`SOLANA_RPC_URL` is required whenever the CLI has to sign a payment
+(`solvela chat`, `solvela recover`). The public Solana endpoint above
+works for a smoke test, but its rate limits will throttle real usage —
+point at your own Helius/QuickNode/Triton RPC for anything beyond that.
 
 The wallet is **not** read from an environment variable — there is no
 `SOLVELA_SOLANA_PRIVATE_KEY` or similar. The CLI loads the keypair from
@@ -44,11 +50,14 @@ solvela chat "Explain Solana in one sentence."
 # Specify a model
 solvela chat --model gpt-4o "Explain Solana in one sentence."
 
-# Use a routing profile
+# Use a routing profile (eco, auto, premium, free)
 solvela chat --model auto "Complex analysis task..."
 
-# Streaming output
-solvela chat --stream "Write a short story about a Rust programmer."
+# Skip the cost-confirmation prompt (for scripted use)
+solvela chat --yes "Write a short story about a Rust programmer."
+
+# Force a specific payment scheme (default: prefer escrow over exact)
+solvela chat --scheme exact "Quick one-shot question."
 ```
 
 ### `solvela models`


### PR DESCRIPTION
## Summary
- Two docs (`dashboard/content/docs/sdks/rust.mdx`, `crates/cli/README.md`) listed only `SOLVELA_API_URL` and `RUST_LOG`. They omitted `SOLANA_RPC_URL`, which `solvela chat` and `solvela recover` actually require to sign a USDC-SPL transaction (see `crates/cli/src/commands/chat.rs:143-151`). Following the docs verbatim produced a confusing error on the first paid command.
- The Rust SDK doc also showed `solvela chat --stream …`, but `--stream` is not a real flag — `chat` only accepts `--model`, `--yes`, `--scheme` (see `crates/cli/src/main.rs:40-52`). Replaced with examples of the real flags.

This is the immediate fix; a follow-up PR (`feat/audit-docs-phase-1`) will add a CI gate that mechanically verifies every CLI example and env-var reference in the docs against the source of truth so this class of drift fails the build rather than landing in production.

## Test plan
- [x] `git diff` reviewed — content-only, no code changes
- [ ] CI green (lint, build, docs)
- [ ] Manual: render `dashboard/content/docs/sdks/rust.mdx` locally and confirm the config block reads cleanly
- [ ] Verify `solvela chat --help` flag list matches what the doc now shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)