### PR TITLE
docs(audit): note how to set ANTHROPIC_API_KEY repo secret

### DIFF
--- a/.github/workflows/docs-audit-pr.yml
+++ b/.github/workflows/docs-audit-pr.yml
@@ -64,6 +64,26 @@ jobs:
           base_sha="${{ github.event.pull_request.base.sha }}"
           echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"
 
+      - name: Diag — probe api.anthropic.com (temporary)
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set +e
+          http=$(curl -sS -o /tmp/anth.body -w "%{http_code}" \
+            -X POST https://api.anthropic.com/v1/messages \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -d '{"model":"claude-haiku-4-5-20251001","max_tokens":5,"messages":[{"role":"user","content":"hi"}]}')
+          curl_rc=$?
+          echo "curl exit: $curl_rc"
+          echo "HTTP status: $http"
+          echo "--- response body (sk-* prefixes redacted defensively) ---"
+          head -c 800 /tmp/anth.body | sed -E 's/(sk-[a-zA-Z0-9_-]{4})[a-zA-Z0-9_-]+/\1***REDACTED***/g'
+          echo
+          echo "--- end body ---"
+
       - name: Run pr_diff
         if: steps.gate.outputs.skip != 'true'
         env:

--- a/.github/workflows/docs-audit-pr.yml
+++ b/.github/workflows/docs-audit-pr.yml
@@ -64,26 +64,6 @@ jobs:
           base_sha="${{ github.event.pull_request.base.sha }}"
           echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"
 
-      - name: Diag — probe api.anthropic.com (temporary)
-        if: steps.gate.outputs.skip != 'true'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          set +e
-          http=$(curl -sS -o /tmp/anth.body -w "%{http_code}" \
-            -X POST https://api.anthropic.com/v1/messages \
-            -H "anthropic-version: 2023-06-01" \
-            -H "content-type: application/json" \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -d '{"model":"claude-haiku-4-5-20251001","max_tokens":5,"messages":[{"role":"user","content":"hi"}]}')
-          curl_rc=$?
-          echo "curl exit: $curl_rc"
-          echo "HTTP status: $http"
-          echo "--- response body (sk-* prefixes redacted defensively) ---"
-          head -c 800 /tmp/anth.body | sed -E 's/(sk-[a-zA-Z0-9_-]{4})[a-zA-Z0-9_-]+/\1***REDACTED***/g'
-          echo
-          echo "--- end body ---"
-
       - name: Run pr_diff
         if: steps.gate.outputs.skip != 'true'
         env:

--- a/scripts/audit-docs/agentic/README.md
+++ b/scripts/audit-docs/agentic/README.md
@@ -82,6 +82,14 @@ The `.github/workflows/docs-audit-pr.yml` workflow runs `pr_diff` on every PR
 Add the `ANTHROPIC_API_KEY` repo secret to enable. Without it, the workflow
 runs to the gate step and exits cleanly (no comment, no failure).
 
+Set the secret from the terminal (the value reads from stdin, so it doesn't
+land in shell history or in chat):
+
+```bash
+gh secret set ANTHROPIC_API_KEY --repo solvela-ai/solvela
+gh secret list --repo solvela-ai/solvela | grep ANTHROPIC   # verify
+```
+
 JSON output (for piping into the same `Finding`-shaped pipeline as Phase 1):
 
 ```bash


### PR DESCRIPTION
## Summary

Two-line clarification in the agentic README spelling out the exact `gh secret set` command for `ANTHROPIC_API_KEY`. The value reads from stdin, so secrets don't land in shell history.

Also intentionally a **smoke test** for the `pr_diff suggestions` workflow now that the `ANTHROPIC_API_KEY` secret is set on the repo. If the workflow is wired correctly, it should post a sticky comment on this PR within ~30 seconds of CI starting.

## Test plan

- [ ] `pr_diff suggestions` workflow runs and posts a sticky comment
- [ ] Comment starts with the sentinel `<!-- audit-docs-pr-comment -->`
- [ ] Comment references this docs change in its `Why:` field (or correctly reports "no doc updates suggested" since this PR only edits the audit-docs README itself)

After verification, this can be merged or closed — the actual doc change is small and useful either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)