### PR TITLE
docs(protocol): fix AGENTS.md wire-format default — snake_case, not camelCase

### DIFF
--- a/crates/protocol/src/AGENTS.md
+++ b/crates/protocol/src/AGENTS.md
@@ -28,7 +28,7 @@ _(none)_
 ### Working In This Directory
 - These are public wire types. Adding a field: use `#[serde(default)]` or `Option<T>` so existing clients keep working. Renaming: bump a version, do not silently break.
 - Derive order: `Debug, Clone, Serialize, Deserialize` (Serde last).
-- Use `#[serde(rename_all = "snake_case")]` only when the spec requires it — otherwise rely on default camelCase-via-Serde.
+- Field names serialize as the Rust identifier verbatim — i.e. **snake_case** in idiomatic Rust. Serde does **not** rename by default. The wire format is snake_case across every struct in this crate (`pay_to`, `cost_breakdown`, `x402_version`, `context_window`, `input_cost_per_million`, `supports_streaming`, etc.). Apply `#[serde(rename_all = "camelCase")]` explicitly only if a spec requires camelCase — that is a breaking wire-format change and requires a major version bump and coordinated SDK rollout.
 - Keep modules small — one logical concept per file.
 
 ### Testing Requirements


### PR DESCRIPTION
## Summary

- `crates/protocol/src/AGENTS.md` told contributors Serde's default rename was camelCase. That's wrong — Serde serializes Rust identifiers verbatim, which is snake_case in idiomatic Rust. The actual wire format across this crate is snake_case (`pay_to`, `cost_breakdown`, `x402_version`, `context_window`, `input_cost_per_million`, `supports_streaming`, etc.) — none of the structs carry `rename_all` directives.
- An SDK author following the old guidance would emit/parse camelCase JSON and fail to interoperate with the gateway. The existing `payment.rs` round-trip tests already implicitly assert snake_case (`json.contains("x402_version")`, `json.contains("cost_breakdown")`).
- Updated wording: states snake_case is the default verbatim, names the load-bearing fields, and flags `rename_all = "camelCase"` as a breaking wire-format change requiring a major version bump.

Closes #223.

## Test plan
- [ ] No code change → no new tests. Existing `cargo test -p solvela-protocol` round-trip tests continue to assert the snake_case wire format (e.g. `test_payment_required_serialization`).
- [ ] Docs render fine on GitHub (single bullet edit, no markdown breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)