### PR TITLE
docs(escrow): clarify expiry_slot semantics + boundary regression test

### DIFF
--- a/programs/escrow/src/instructions/deposit.rs
+++ b/programs/escrow/src/instructions/deposit.rs
@@ -21,6 +21,14 @@ pub fn deposit(
     require!(amount > 0, EscrowError::ZeroAmount);
 
     let now = Clock::get()?.slot;
+    // `expiry_slot` semantically denotes the *first expired slot*. At deposit
+    // time we require strict `expiry_slot > now` so the escrow is born with
+    // at least one active slot. Pairs symmetrically with the claim
+    // (`slot < expiry_slot`) and refund (`slot >= expiry_slot`) guards: at
+    // `slot == expiry_slot` claim fails and refund succeeds, so creating an
+    // escrow with `expiry_slot == now` would mean it's born already expired.
+    // The boundary case is locked in by
+    // `tests/integration.rs::test_deposit_expiry_equal_now_fails`.
     require!(expiry_slot > now, EscrowError::InvalidExpiry);
     // Cap the deposit-to-expiry gap so a buggy or adversarial client can't
     // pass `expiry_slot = u64::MAX` and lock the agent out of refund forever.

--- a/programs/escrow/src/state.rs
+++ b/programs/escrow/src/state.rs
@@ -17,8 +17,15 @@ pub struct Escrow {
     pub amount: u64,
     /// 32-byte service/request correlation ID (e.g. SHA-256 of request body).
     pub service_id: [u8; 32],
-    /// Slot at which the agent may reclaim funds if service is not delivered.
-    /// Must be > current slot at deposit time.
+    /// First slot at which the escrow is considered expired. The claim window
+    /// is `slot < expiry_slot` (active before expiry); refund is `slot >=
+    /// expiry_slot` (active at and after expiry); deposit requires
+    /// `expiry_slot > now` (escrow must be born with at least one active
+    /// slot). The three comparison operators differ (`<`, `>=`, `>`) because
+    /// they reference the same boundary from different sides — see the
+    /// inline comment in `instructions/deposit.rs` for the full state
+    /// machine. Boundary regression test:
+    /// `tests/integration.rs::test_deposit_expiry_equal_now_fails`.
     pub expiry_slot: u64,
     /// PDA bump seed.
     pub bump: u8,

--- a/programs/escrow/tests/integration.rs
+++ b/programs/escrow/tests/integration.rs
@@ -272,6 +272,41 @@ fn test_deposit_expiry_in_past_fails() {
 }
 
 #[test]
+fn test_deposit_expiry_equal_now_fails() {
+    // Boundary regression for #119. The deposit guard is strict
+    // (`expiry_slot > now`) because `expiry_slot` denotes the *first expired
+    // slot* — claim is gated on `slot < expiry_slot` and refund on
+    // `slot >= expiry_slot`, so at `slot == expiry_slot` claim fails and
+    // refund succeeds. A deposit at `expiry_slot == now` would create an
+    // escrow that is born already expired (refundable on the next slot
+    // before any provider can claim). This test pins the strict inequality
+    // so a future refactor to `expiry_slot >= now` would be loud.
+    let mut ctx = setup();
+    let service_id = [222u8; 32];
+
+    inject_ata(&mut ctx.svm, &ctx.agent.pubkey(), &ctx.usdc_mint, 1_000_000);
+
+    // Warp to a known slot, then attempt a deposit with expiry == that slot.
+    let now = 100u64;
+    warp_and_refresh(&mut ctx.svm, now);
+
+    let ix = build_deposit_ix(
+        &ctx.program_id,
+        &ctx.agent.pubkey(),
+        &ctx.provider.pubkey(),
+        &ctx.usdc_mint,
+        1_000_000,
+        &service_id,
+        now, // exactly current slot — boundary case
+    );
+    let result = send_tx(&mut ctx.svm, &[ix], &ctx.agent, &[&ctx.agent]);
+    assert!(
+        result.is_err(),
+        "deposit at expiry boundary (expiry_slot == now) must fail (InvalidExpiry)"
+    );
+}
+
+#[test]
 fn test_claim_exceeds_deposit_fails() {
     let mut ctx = setup();
     let service_id = [22u8; 32];


### PR DESCRIPTION
## Summary

Issue #119 flagged the three escrow guards as "asymmetric":

- `deposit:  expiry_slot > now`
- `claim:    slot < expiry_slot`
- `refund:   slot >= expiry_slot`

After tracing the state machine, the asymmetry is cosmetic, not semantic — all three reference the same boundary from different sides. `expiry_slot` denotes the **first expired slot**:

- claim is the window *before* expiry → `slot < expiry_slot`
- refund is the window *at/after* expiry → `slot >= expiry_slot`
- deposit must produce an escrow with ≥1 active slot → `expiry_slot > now` (else it's born already expired)

The handover at `slot == expiry_slot` is clean: claim fails, refund succeeds. No security or fund-safety impact, but the model is fractionally harder to reason about without a clarifying comment. This PR pins the semantics in docs + locks in the boundary with a regression test.

## Changes

- **`programs/escrow/src/state.rs`** — Rewrite the `expiry_slot` docstring to spell out the "first expired slot" semantic and list all three guards in one place.
- **`programs/escrow/src/instructions/deposit.rs`** — Inline comment above the strict guard explaining why deposit uses `>` (consistent with the boundary, not asymmetric).
- **`programs/escrow/tests/integration.rs`** — Add `test_deposit_expiry_equal_now_fails` to lock the strict inequality. Sibling to the existing `test_claim_after_expiry_fails` (which already pins the claim side at the exact boundary) and `test_refund_after_expiry`.

No code logic changes. No wire-format changes. No on-chain account layout changes — `Escrow::INIT_SPACE` is unaffected.

Closes #119.

## Test plan
- [x] `cargo test --manifest-path programs/escrow/Cargo.toml` (unit suite, 9 tests) — pass
- [x] `cargo test --manifest-path programs/escrow/Cargo.toml --features sbf --test integration` (LiteSVM, 24 tests including new boundary test) — pass
- [x] `cargo fmt --manifest-path programs/escrow/Cargo.toml --all -- --check` — clean
- [ ] Pre-existing `unexpected_cfgs` warnings remain (issue #114, Anchor 0.31 macro crates); not introduced or worsened by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)