### PR TITLE
chore(escrow): declare program mainnet-only in Anchor.toml + docs

### DIFF
--- a/programs/escrow/AGENTS.md
+++ b/programs/escrow/AGENTS.md
@@ -56,13 +56,17 @@ cd programs/escrow && cargo build-sbf
 This produces the same `.so` artifact and runs the same SBF compilation pipeline that `anchor build` invokes — just without Anchor's outer wrapping. Verified to produce a valid program in this repo's tooling configuration.
 
 ### Deployment Checklist
-The `mainnet` feature flag selects which USDC mint the deployed program accepts at compile time. **Mainnet deploys MUST be built with `--features mainnet`** — without it, the program targets the devnet USDC mint and would silently reject all mainnet USDC deposits with `mint mismatch`.
+
+**Cluster policy: mainnet-only.** The on-chain program ID
+`9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU` is hardcoded in `src/lib.rs` via `declare_id!` and is only deployed to mainnet-beta. `Anchor.toml` intentionally omits `[programs.localnet]` and `[programs.devnet]` sections so `anchor deploy --provider.cluster {localnet,devnet}` fails fast with a "program not found" error instead of silently targeting the mainnet ID on the wrong cluster. Local integration tests run via LiteSVM (`tests/integration.rs`), not `anchor deploy`. Devnet rehearsal would require per-cluster keypairs and cluster-conditional `declare_id!` — track that as its own scoped effort if/when needed (see closed issue #120 path A).
+
+The `mainnet` feature flag selects which USDC mint the deployed program accepts at compile time. **Mainnet deploys MUST be built with `--features mainnet`** — without it, the program targets the devnet USDC mint (`4zMM…`) and would silently reject all mainnet USDC deposits with `mint mismatch`. This feature flag is independent of the cluster policy above and exists only because the same source compiles for both LiteSVM (default, devnet mint) and mainnet deploys.
 
 ```bash
 # Mainnet deploy — selects EPjFW…USDC mint
 cargo build-sbf -- --features mainnet
 
-# Devnet / local-validator deploy (default) — selects 4zMM…USDC mint
+# LiteSVM / test build (no on-chain deploy) — selects 4zMM…USDC mint
 cargo build-sbf
 ```
 
@@ -73,7 +77,7 @@ cargo expand --features mainnet | grep 'USDC_MINT.*=' | head -1
 # Expect: pub const USDC_MINT: Pubkey = pubkey!("EPjFW…");
 ```
 
-There is no on-chain self-check for which mint the deployed bytecode references — the program would happily accept the configured-at-compile-time mint, mainnet or devnet. The discipline lives in this checklist.
+There is no on-chain self-check for which mint the deployed bytecode references — the program would happily accept the configured-at-compile-time mint. The discipline lives in this checklist.
 
 ### Lint Notes (informational)
 `cargo clippy --all-targets -- -D warnings` against this crate emits ~14 `unexpected cfg condition value` warnings on newer Rust toolchains. These originate inside Anchor 0.31.1's macro-generated code (`#[program]`, `#[derive(Accounts)]`) and don't reflect any issue with this program's source. Workspace clippy (`cargo clippy --workspace`) doesn't surface them because escrow is not a workspace member. Either tolerate the noise locally, or add `RUSTFLAGS="--cap-lints=warn"` to your dev shell.

--- a/programs/escrow/Anchor.toml
+++ b/programs/escrow/Anchor.toml
@@ -5,11 +5,16 @@ anchor_version = "0.31.1"
 seeds = true
 skip-lint = false
 
-[programs.localnet]
-solvela_escrow = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
-
-[programs.devnet]
-solvela_escrow = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+# Cluster policy: this program is mainnet-only. The on-chain program ID
+# 9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU is hardcoded in
+# src/lib.rs via declare_id! and is only deployed to mainnet-beta. Local
+# integration tests use LiteSVM (programs/escrow/tests/integration.rs),
+# not `anchor deploy` against a real localnet validator. Devnet rehearsal
+# requires fresh per-cluster keypairs and cluster-conditional declare_id!
+# — see issue #120 path A. The [programs.localnet] / [programs.devnet]
+# sections are intentionally absent so `anchor deploy --provider.cluster
+# {localnet,devnet}` fails fast with "program not found" instead of
+# silently targeting the mainnet ID on the wrong cluster.
 
 [programs.mainnet]
 solvela_escrow = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"


### PR DESCRIPTION
## Summary

`Anchor.toml` listed the same on-chain program ID (`9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`) under all three cluster sections — `[programs.localnet]`, `[programs.devnet]`, and `[programs.mainnet]`. The program is hardcoded mainnet-only via `declare_id!` in `src/lib.rs:67`, no automation deploys it elsewhere, and the LiteSVM integration suite uses an in-process validator (not `anchor deploy`). The localnet/devnet entries existed only as silent footguns: `anchor deploy --provider.cluster devnet` would attempt to write the mainnet program ID on devnet, fail with an error pointing at the program ID (not the cluster mismatch), and waste diagnostic time.

This PR takes the **path B** resolution from #120: explicit single-cluster declaration. Path A (per-cluster keypairs + cluster-conditional `declare_id!`) requires its own focused effort and is only worth opening when devnet rehearsal becomes a real cadence — flagged for the future via the in-file policy comments.

## Changes

- **`programs/escrow/Anchor.toml`** — remove `[programs.localnet]` and `[programs.devnet]` sections; replace with a policy comment explaining mainnet-only intent. `anchor deploy --provider.cluster {localnet,devnet}` will now fail fast with "program not found" instead of silently targeting mainnet.
- **`programs/escrow/AGENTS.md`** — Deployment Checklist now opens with an explicit "Cluster policy: mainnet-only" paragraph that names the policy and points at the reasoning. Reworded the build-snippet's "Devnet / local-validator deploy (default)" comment to "LiteSVM / test build (no on-chain deploy)" — the prior wording implied devnet was a real deploy cadence, which it isn't.

No code logic changes. No on-chain program changes. The mainnet program ID and account layout are untouched.

Closes #120.

## Test plan
- [x] `python3 -c 'import tomllib; tomllib.load(open(\"programs/escrow/Anchor.toml\",\"rb\"))'` → parses; `programs` section now contains only `mainnet`.
- [x] `cargo test --manifest-path programs/escrow/Cargo.toml` → 9/9 unit tests pass (Anchor.toml not consumed by `cargo test`; sanity check that nothing collaterally broke).
- [ ] Acceptance: `anchor deploy --provider.cluster devnet` fails fast with "program not found" (path B AC bullet 3). Not run locally — requires the Anchor CLI + a wallet pointed at devnet. Behaviour is what's documented in the new policy comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment checklist documentation clarifying mainnet-only configuration and required `--features mainnet` build flag to prevent USDC mint mismatches.

* **Chores**
  * Removed localnet and devnet cluster configurations to enforce mainnet-only deployments and enable fast failure if deployed to incorrect clusters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/301)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->