### PR TITLE
feat(ai-sdk-provider,cli): dual-shape 402 parsing (PR 1 of #217)

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -94,18 +94,41 @@ pub async fn run(
     }
 
     // --- 402 Payment Required ---
+    //
+    // Accept BOTH 402 body shapes the gateway may emit (issue #217):
+    //
+    //   1. Envelope (legacy, current default):
+    //      { "error": { "type": "invalid_payment",
+    //                   "message": "<JSON PaymentRequired>" } }
+    //
+    //   2. Direct (x402-spec compliant; target shape post-#217):
+    //      { "x402_version": 2, "resource": {...}, "accepts": [...],
+    //        "cost_breakdown": {...}, "error": "Payment required" }
+    //
+    // Shape detection is duck-typed: a top-level `error.message` string
+    // triggers the envelope path; otherwise we attempt direct deserialization.
+    // This dual-shape support lets the gateway flip unilaterally without a
+    // coordinated CLI release.
     let error_body: serde_json::Value = resp.json().await?;
-    // Surface a clear actionable error when `error.message` is missing or
-    // non-string. Otherwise the empty-string fallback flowed straight into
-    // serde_json::from_str("") which returns "EOF while parsing a value"
-    // — accurate but useless for the user trying to debug a malformed
-    // 402 response from the gateway.
-    let error_msg = error_body["error"]["message"].as_str().ok_or_else(|| {
-        anyhow::anyhow!("gateway 402 response missing error.message field; raw body: {error_body}")
-    })?;
 
-    let payment_required: PaymentRequired = serde_json::from_str(error_msg)
-        .context("failed to parse PaymentRequired from 402 response")?;
+    let payment_required: PaymentRequired = if let Some(error_msg) =
+        error_body["error"]["message"].as_str()
+    {
+        // Shape 1: envelope.
+        serde_json::from_str(error_msg)
+            .context("failed to parse PaymentRequired from 402 envelope.message")?
+    } else {
+        // Shape 2: direct PaymentRequired at top level. The serde_json error
+        // here is surfaced via `with_context` so a body that matches neither
+        // shape gets a single clear "neither shape matched" message instead
+        // of two cascading errors.
+        serde_json::from_value(error_body.clone()).with_context(|| {
+            format!(
+                "gateway 402 body matched neither envelope shape (`error.message` with stringified JSON) \
+                 nor direct PaymentRequired shape (top-level `x402_version` + `accepts`); raw body: {error_body}"
+            )
+        })?
+    };
 
     // Show cost breakdown.
     let cb = &payment_required.cost_breakdown;
@@ -448,6 +471,86 @@ mod tests {
         assert!(
             result.is_ok(),
             "chat payment flow should succeed with --yes"
+        );
+    }
+
+    /// Issue #217: dual-shape 402 parser. The CLI must decode a 402 body
+    /// emitted in the x402-spec-compliant direct shape
+    /// `{ x402_version, accepts, cost_breakdown, … }` exactly the same as
+    /// the legacy `{ error: { message: "<JSON>" } }` envelope. Mirror of
+    /// `test_chat_402_payment_flow` with only the gateway's 402 body shape
+    /// changed.
+    #[tokio::test]
+    async fn test_chat_402_payment_flow_direct_shape() {
+        let _lock = crate::ENV_MUTEX.lock().await;
+        let _wallet = setup_wallet();
+
+        let mock = MockServer::start().await;
+
+        // Solana RPC getLatestBlockhash mock (same as envelope test).
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "value": {
+                        "blockhash": "11111111111111111111111111111111",
+                        "lastValidBlockHeight": 9999
+                    }
+                }
+            })))
+            .mount(&mock)
+            .await;
+
+        let payment_required = serde_json::json!({
+            "x402_version": 2,
+            "resource": {"url": "/v1/chat/completions", "method": "POST"},
+            "accepts": [{
+                "scheme": "exact",
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "amount": "1000",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "pay_to": "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                "max_timeout_seconds": 300
+            }],
+            "cost_breakdown": {
+                "provider_cost": "0.001000",
+                "platform_fee": "0.000050",
+                "fee_percent": 5,
+                "total": "0.001050",
+                "currency": "USDC"
+            },
+            "error": "Payment required"
+        });
+
+        // Mount 402 with the DIRECT shape — body is the PaymentRequired
+        // payload at the top level, no envelope wrapping.
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(402).set_body_json(payment_required))
+            .up_to_n_times(1)
+            .mount(&mock)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(header_exists("PAYMENT-SIGNATURE"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "Paid response!"}}]
+            })))
+            .mount(&mock)
+            .await;
+
+        std::env::set_var("SOLANA_RPC_URL", mock.uri());
+        let _env_guard = EnvGuard("SOLANA_RPC_URL");
+
+        let result = run(&mock.uri(), "auto", "What is Solana?", true, None).await;
+
+        assert!(
+            result.is_ok(),
+            "chat payment flow should succeed against a direct-shape 402: {:?}",
+            result.err()
         );
     }
 

--- a/sdks/ai-sdk-provider/src/util/parse-402.ts
+++ b/sdks/ai-sdk-provider/src/util/parse-402.ts
@@ -1,24 +1,37 @@
 /**
- * 402 gateway envelope parser and v1 scheme selector.
+ * 402 gateway parser and v1 scheme selector.
  *
- * Targets ONLY the gateway envelope emitted by
- * `crates/gateway/src/error.rs:75-80`:
+ * Accepts BOTH 402 body shapes the gateway may emit:
  *
- *   { "error": { "type": "invalid_payment", "message": "<JSON PaymentRequired>" } }
+ *   1. Envelope (legacy, current default):
+ *      { "error": { "type": "invalid_payment",
+ *                   "message": "<JSON PaymentRequired>" } }
  *
- * The direct `{x402_version, accepts, ...}` shape is NOT supported in v1 (T1-B).
+ *   2. Direct (x402-spec compliant; target shape after issue #217):
+ *      { "x402_version": 2, "resource": {...}, "accepts": [...],
+ *        "cost_breakdown": {...}, "error": "Payment required" }
  *
- * Allowlist (§4.3 T2-G) is applied here for the wire envelope: any field on the
- * top-level `PaymentRequired` other than `x402_version`, `accepts[]`,
+ * Shape detection is duck-typed: a top-level `error.message` string triggers
+ * the envelope path; otherwise we expect `x402_version` + `accepts` at the
+ * top level. Both shapes flow through the same allowlist + validation.
+ *
+ * This dual-shape support is deliberately defensive — issue #217 (gateway
+ * still emits envelope today, but plans to switch to direct). Landing this
+ * parser change first lets the gateway flip unilaterally without a
+ * coordinated SDK release.
+ *
+ * Allowlist (§4.3 T2-G) is applied here for the wire payload: any field on
+ * the top-level `PaymentRequired` other than `x402_version`, `accepts[]`,
  * `cost_breakdown`, `resource`, `error` is stripped; within each `accepts[]`
- * entry only the plan-allowlisted fields survive. Non-allowlisted keys such as
- * `internal_trace_id` never reach the returned object and therefore cannot
- * leak into `SolvelaPaymentError.responseBody` downstream.
+ * entry only the plan-allowlisted fields survive. Non-allowlisted keys such
+ * as `internal_trace_id` never reach the returned object and therefore
+ * cannot leak into `SolvelaPaymentError.responseBody` downstream.
  *
  * IMPORTANT: the returned `ParsedPaymentRequired` remains structurally
  * compatible with the already-committed `SolvelaPaymentRequired` from
- * `wallet-adapter.ts` (the contract the adapter consumes). The allowlist only
- * drops unknown/extra fields; every plan-level known field is preserved.
+ * `wallet-adapter.ts` (the contract the adapter consumes). The allowlist
+ * only drops unknown/extra fields; every plan-level known field is
+ * preserved.
  */
 
 import { SolvelaPaymentError } from '../errors.js';
@@ -207,10 +220,12 @@ function applyResourceAllowlist(
 // ---------------------------------------------------------------------------
 
 /**
- * Parse the gateway 402 envelope into a `ParsedPaymentRequired`.
+ * Parse a gateway 402 body into a `ParsedPaymentRequired`.
  *
- * Input shape (the ONLY supported shape):
- *   { error: { type: "invalid_payment", message: "<JSON PaymentRequired>" } }
+ * Accepted input shapes:
+ *   1. Envelope: { error: { type: "invalid_payment",
+ *                           message: "<JSON PaymentRequired>" } }
+ *   2. Direct:   { x402_version, resource, accepts, cost_breakdown, error }
  *
  * @param body - Raw JSON-parsed body from the 402 response.
  * @param url  - The request URL, used to populate `SolvelaPaymentError.url`
@@ -218,7 +233,8 @@ function applyResourceAllowlist(
  *               don't have a URL (legacy / tests); the fetch-wrapper passes
  *               the resolved URL.
  * @returns Allowlisted `ParsedPaymentRequired`.
- * @throws SolvelaPaymentError if the envelope is unrecognized or malformed.
+ * @throws SolvelaPaymentError if neither shape is recognized or the
+ *         extracted payload is malformed.
  */
 export function parseGateway402(
   body: unknown,
@@ -226,21 +242,72 @@ export function parseGateway402(
 ): ParsedPaymentRequired {
   if (!isObject(body)) {
     throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: body is not a JSON object',
+      message: '[solvela] 402 body: not a JSON object',
       url,
       requestBodyValues: undefined,
     });
   }
 
+  // Duck-type shape detection. The envelope shape is identified by a
+  // top-level `error.message` string. The direct shape has `x402_version`
+  // and `accepts` at the top level. We probe envelope first since it's
+  // the current default and a direct-shape body would never coincidentally
+  // carry an `error.message` string at the top level (the direct shape's
+  // `error` field is a plain string like "Payment required").
   const errorField = body['error'];
-  if (!isObject(errorField)) {
+  const looksLikeEnvelope =
+    isObject(errorField) && typeof errorField['message'] === 'string';
+
+  const inner = looksLikeEnvelope
+    ? extractFromEnvelope(errorField as Record<string, unknown>, url)
+    : extractFromDirect(body, url);
+
+  // Required top-level fields on the extracted payload (both shapes).
+  if (!isNumberField(inner, 'x402_version')) {
     throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: missing `error` object',
+      message: '[solvela] 402 body: `x402_version` missing or wrong type',
+      url,
+      requestBodyValues: undefined,
+    });
+  }
+  if (!Array.isArray(inner['accepts'])) {
+    throw new SolvelaPaymentError({
+      message: '[solvela] 402 body: `accepts` is not an array',
+      url,
+      requestBodyValues: undefined,
+    });
+  }
+  if (!isStringField(inner, 'error')) {
+    throw new SolvelaPaymentError({
+      message: '[solvela] 402 body: `error` missing or wrong type',
       url,
       requestBodyValues: undefined,
     });
   }
 
+  const accepts = (inner['accepts'] as unknown[]).map((entry, i) =>
+    applyAcceptAllowlist(entry, i, url),
+  );
+  const cost_breakdown = applyCostBreakdownAllowlist(inner['cost_breakdown'], url);
+  const resource = applyResourceAllowlist(inner['resource'], url);
+
+  return {
+    x402_version: inner['x402_version'] as number,
+    resource,
+    accepts,
+    cost_breakdown,
+    error: inner['error'] as string,
+  };
+}
+
+/**
+ * Extract the inner PaymentRequired from the envelope shape:
+ *   { error: { type: "invalid_payment", message: "<JSON>" } }
+ */
+function extractFromEnvelope(
+  errorField: Record<string, unknown>,
+  url: string,
+): Record<string, unknown> {
   const type = errorField['type'];
   const messageJson = errorField['message'];
   if (typeof type !== 'string' || typeof messageJson !== 'string') {
@@ -258,7 +325,6 @@ export function parseGateway402(
     });
   }
 
-  // The inner PaymentRequired is a JSON-stringified object.
   let inner: unknown;
   try {
     inner = JSON.parse(messageJson);
@@ -278,42 +344,32 @@ export function parseGateway402(
     });
   }
 
-  // Required top-level fields.
-  if (!isNumberField(inner, 'x402_version')) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: `x402_version` missing or wrong type',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-  if (!Array.isArray(inner['accepts'])) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: `accepts` is not an array',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-  if (!isStringField(inner, 'error')) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: inner `error` missing or wrong type',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
+  return inner;
+}
 
-  const accepts = (inner['accepts'] as unknown[]).map((entry, i) =>
-    applyAcceptAllowlist(entry, i, url),
-  );
-  const cost_breakdown = applyCostBreakdownAllowlist(inner['cost_breakdown'], url);
-  const resource = applyResourceAllowlist(inner['resource'], url);
-
-  return {
-    x402_version: inner['x402_version'] as number,
-    resource,
-    accepts,
-    cost_breakdown,
-    error: inner['error'] as string,
-  };
+/**
+ * Direct-shape probe: the body itself is the PaymentRequired payload
+ * (x402-spec compliant). We don't validate field contents here — the
+ * common code path that follows runs the same allowlist + type checks
+ * the envelope shape gets.
+ */
+function extractFromDirect(
+  body: Record<string, unknown>,
+  url: string,
+): Record<string, unknown> {
+  // Direct shape requires at minimum `x402_version` (number) and `accepts`
+  // (array) at the top level — otherwise we don't recognize the shape and
+  // emit a single clear error pointing at both supported shapes so callers
+  // can diagnose pre-vs-post #217 gateway responses.
+  if (!isNumberField(body, 'x402_version') || !Array.isArray(body['accepts'])) {
+    throw new SolvelaPaymentError({
+      message:
+        '[solvela] 402 body matches neither envelope shape (`error.message` with stringified JSON) nor direct PaymentRequired shape (top-level `x402_version` + `accepts`)',
+      url,
+      requestBodyValues: undefined,
+    });
+  }
+  return body;
 }
 
 // ---------------------------------------------------------------------------

--- a/sdks/ai-sdk-provider/tests/unit/parse-402.test.ts
+++ b/sdks/ai-sdk-provider/tests/unit/parse-402.test.ts
@@ -249,9 +249,13 @@ describe('parseGateway402', () => {
     expect(result.resource).not.toHaveProperty('region');
   });
 
-  it('throws SolvelaPaymentError when body is the direct unwrapped x402 shape (not wrapped in envelope)', () => {
-    // The direct { x402_version, accepts, … } shape is NOT supported.
-    // The parser checks for { error: { type, message } } and rejects anything else.
+  it('accepts the direct unwrapped x402 shape (top-level PaymentRequired)', () => {
+    // Issue #217: dual-shape parser. The direct
+    // { x402_version, accepts, cost_breakdown, … } shape is the
+    // x402-spec-compliant body the gateway emits post-#217. Both shapes
+    // must parse to structurally-equivalent ParsedPaymentRequired so the
+    // wallet adapter sees the same contract regardless of which gateway
+    // version emitted the response.
     const directShape = {
       x402_version: 2,
       resource: { url: '/v1/chat/completions', method: 'POST' },
@@ -275,7 +279,72 @@ describe('parseGateway402', () => {
       error: 'Payment required',
     };
 
-    expect(() => parseGateway402(directShape)).toThrow(SolvelaPaymentError);
+    const result = parseGateway402(directShape);
+
+    expect(result.x402_version).toBe(2);
+    expect(result.resource.url).toBe('/v1/chat/completions');
+    expect(result.resource.method).toBe('POST');
+    expect(result.accepts).toHaveLength(1);
+    expect(result.accepts[0].scheme).toBe('exact');
+    expect(result.accepts[0].asset).toBe(USDC_MINT_MAINNET);
+    expect(result.accepts[0].amount).toBe('2625');
+    expect(result.cost_breakdown.total).toBe('0.002625');
+    expect(result.cost_breakdown.fee_percent).toBe(5);
+    expect(result.error).toBe('Payment required');
+  });
+
+  it('direct shape strips extra fields under the allowlist (parity with envelope shape)', () => {
+    const directShapeWithExtras = {
+      x402_version: 2,
+      // extra top-level field
+      internal_trace_id: 'trace-abc-123',
+      resource: {
+        url: '/v1/chat/completions',
+        method: 'POST',
+        // extra resource field
+        region: 'us-east-1',
+      },
+      accepts: [
+        {
+          scheme: 'exact',
+          network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          amount: '2625',
+          asset: USDC_MINT_MAINNET,
+          pay_to: 'RecipientWallet',
+          max_timeout_seconds: 300,
+          // extra accept field
+          debug_hash: 'sha256-abc',
+        },
+      ],
+      cost_breakdown: {
+        provider_cost: '0.002500',
+        platform_fee: '0.000125',
+        total: '0.002625',
+        currency: 'USDC',
+        fee_percent: 5,
+        // extra cost_breakdown field
+        trace_id: 'cb-trace-xyz',
+      },
+      error: 'Payment required',
+    };
+
+    const result = parseGateway402(directShapeWithExtras);
+
+    expect(Object.keys(result).sort()).toEqual(TOP_LEVEL_KEYS);
+    expect(Object.keys(result.accepts[0]).sort()).toEqual(ACCEPT_KEYS);
+    expect(Object.keys(result.cost_breakdown).sort()).toEqual(COST_BREAKDOWN_KEYS);
+    expect(Object.keys(result.resource).sort()).toEqual(RESOURCE_KEYS);
+    expect(result).not.toHaveProperty('internal_trace_id');
+    expect(result.accepts[0]).not.toHaveProperty('debug_hash');
+    expect(result.cost_breakdown).not.toHaveProperty('trace_id');
+    expect(result.resource).not.toHaveProperty('region');
+  });
+
+  it('rejects bodies that match neither envelope nor direct shape', () => {
+    // No `error.message` string AND no top-level `x402_version`+`accepts` —
+    // should fail fast with a message pointing at both supported shapes.
+    const garbage = { unrelated: 'json', shape: { nope: true } };
+    expect(() => parseGateway402(garbage)).toThrow(SolvelaPaymentError);
   });
 
   it('throws SolvelaPaymentError when error.type is missing', () => {


### PR DESCRIPTION
## Summary

Issue #217 plans to flip the gateway from the legacy wrapped 402 envelope to the x402-spec-compliant direct shape. The issue claimed broad forward-compat across SDKs, but a survey showed otherwise:

| Consumer | Shape | Compat today |
|---|---|---|
| `sdks/signer-core/src/parse-402.ts` | dual | ✅ |
| `sdks/python/src/solvela/transport.py` | dual (`_unwrap_payment_required_envelope`) | ✅ |
| `sdks/typescript/src/transport.ts` | dual (`unwrapPaymentRequiredEnvelope`) | ✅ |
| `sdks/ai-sdk-provider/src/util/parse-402.ts` | **envelope-only** | ❌ |
| `crates/cli/src/commands/chat.rs` | **envelope-only** | ❌ |
| `crates/gateway/tests/integration.rs` (3 sites) | asserts envelope shape | ❌ |

A direct gateway flip would crash the AI SDK provider and the CLI verbatim. This PR is the first of a staged rollout:

- **PR 1 (this PR)**: land dual-shape parsing in the two strict consumers. No gateway change. Strictly more permissive — no behavior change today.
- **PR 2 (follow-up)**: flip the gateway + update integration tests to assert the direct shape. Lands on a tolerant fleet.
- **PR 3 (optional, later)**: drop wrapped-shape support from the SDKs once everyone is past PR 2.

## Changes

- **`sdks/ai-sdk-provider/src/util/parse-402.ts`** — refactor `parseGateway402` to duck-type the shape (envelope when `error.message` is a string at the top level; direct otherwise) and route both through the existing allowlist + validation. Header doc rewritten. Public signature unchanged.
- **`sdks/ai-sdk-provider/tests/unit/parse-402.test.ts`** — flip the previously-negative "direct shape rejected" test to a positive test + add an allowlist-parity test for direct shape + a "neither shape matches" rejection test.
- **`crates/cli/src/commands/chat.rs`** — extend the 402-decoding block to try the envelope path first, fall back to direct deserialization. Mirror the existing `test_chat_402_payment_flow` with a `_direct_shape` variant.

No SDK version bump — the parsers are strictly more permissive, no downstream consumer change is required. Version bumps happen on the next normal release cadence.

Refs #217. Does not close it — PR 2 will.

## Test plan
- [x] `npx vitest run` in `sdks/ai-sdk-provider/` — 351/351 tests pass (was 349 before; +3 new direct-shape tests, -1 flipped negative test).
- [x] `cargo test -p solvela-cli` — 190/190 pass (15 in `commands::chat`, including new `test_chat_402_payment_flow_direct_shape`).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p solvela-cli --all-targets --all-features -- -D warnings` — clean.
- [x] `tsc --noEmit` in `sdks/ai-sdk-provider/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment gateway now properly processes payment-required (402) responses in two different response formats, with unified error handling.

* **Tests**
  * Added test coverage for both response format variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/302)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->