### PR TITLE
fix(gateway): emit PaymentRequired at top level on 402 (closes #217)

### DIFF
--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -1,6 +1,7 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde_json::json;
+use solvela_x402::types::PaymentRequired;
 
 /// Gateway-level errors returned as HTTP responses.
 ///
@@ -18,10 +19,34 @@ pub enum GatewayError {
     #[error("payment required")]
     PaymentRequired,
 
+    /// Emit a 402 with the x402-spec-compliant `PaymentRequired` body
+    /// at the top level (NOT wrapped in the OpenAI-style error envelope).
+    /// Used when the client hasn't presented a payment header yet and the
+    /// gateway needs to advertise the cost + accepted schemes. Issue #217
+    /// fix: previously this payload was stringified into
+    /// `InvalidPayment(json_string)` and double-encoded inside
+    /// `{ error: { message: "<json>" } }`, which violated the x402 spec.
+    ///
+    /// `InvalidPayment(String)` remains for short messages tied to a
+    /// specific failure ("bad signature", "expired", "resource mismatch")
+    /// — those keep the OpenAI envelope shape because they carry a single
+    /// diagnostic string, not a structured challenge.
+    ///
+    /// `Box`ed to keep the enum small: `PaymentRequired` is ~208 bytes
+    /// (Vec + multiple Strings), and every `Result<_, GatewayError>` along
+    /// the request path would otherwise carry that footprint. The boxed
+    /// allocation only happens on the 402 cold path.
+    #[error("payment challenge")]
+    PaymentChallenge(Box<PaymentRequired>),
+
     /// Inner string is forwarded to the client verbatim in the 402 response
-    /// body — used for both user-friendly error messages ("transaction has
-    /// already been used", "Payment verification failed", etc.) and the
-    /// serialized `PaymentRequired` challenge payload.
+    /// body — used for user-friendly error messages tied to a specific
+    /// failure ("transaction has already been used", "Payment verification
+    /// failed", "resource mismatch", etc.).
+    ///
+    /// For the *challenge* payload (no payment presented yet), use
+    /// `PaymentChallenge(PaymentRequired)` so the body is emitted at the
+    /// top level per the x402 spec, not stringified into this envelope.
     ///
     /// Constructors MUST NOT pass through:
     /// - raw provider/facilitator/RPC error bodies (those go through
@@ -49,6 +74,17 @@ pub enum GatewayError {
 
 impl IntoResponse for GatewayError {
     fn into_response(self) -> Response {
+        // PaymentChallenge emits the x402-spec body directly (no OpenAI
+        // envelope), so it bypasses the (status, error_type, message)
+        // tuple machinery the other variants share. See variant docs.
+        if let GatewayError::PaymentChallenge(payment_required) = &self {
+            return (
+                StatusCode::PAYMENT_REQUIRED,
+                axum::Json(payment_required.as_ref()),
+            )
+                .into_response();
+        }
+
         let (status, error_type, message) = match &self {
             GatewayError::ModelNotFound(msg) => {
                 (StatusCode::NOT_FOUND, "model_not_found", msg.clone())
@@ -90,6 +126,12 @@ impl IntoResponse for GatewayError {
                     "internal_error",
                     "Internal server error".to_string(),
                 )
+            }
+            // Handled by the `if let` short-circuit above. The arm exists
+            // purely so the inner match stays exhaustive without an `_`
+            // wildcard that would silently swallow any future variant.
+            GatewayError::PaymentChallenge(_) => {
+                unreachable!("PaymentChallenge is handled by the early return above")
             }
         };
 
@@ -238,6 +280,76 @@ mod tests {
             GatewayError::Internal("crash".to_string()).to_string(),
             "internal error: crash"
         );
+        assert_eq!(
+            GatewayError::PaymentChallenge(Box::new(build_test_payment_required())).to_string(),
+            "payment challenge"
+        );
+    }
+
+    /// Build a minimal valid `PaymentRequired` for tests that need to
+    /// construct the `PaymentChallenge` variant. Synthetic values only.
+    fn build_test_payment_required() -> PaymentRequired {
+        use solvela_x402::types::{CostBreakdown, PaymentAccept, Resource};
+        PaymentRequired {
+            x402_version: 2,
+            resource: Resource {
+                url: "/v1/chat/completions".to_string(),
+                method: "POST".to_string(),
+            },
+            accepts: vec![PaymentAccept {
+                scheme: "exact".to_string(),
+                network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".to_string(),
+                amount: "10500".to_string(),
+                asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                pay_to: "TestRecipient11111111111111111111111111111".to_string(),
+                max_timeout_seconds: 300,
+                escrow_program_id: None,
+            }],
+            cost_breakdown: CostBreakdown {
+                provider_cost: "0.010000".to_string(),
+                platform_fee: "0.000500".to_string(),
+                total: "0.010500".to_string(),
+                currency: "USDC".to_string(),
+                fee_percent: 5,
+            },
+            error: "Payment required".to_string(),
+        }
+    }
+
+    /// Issue #217: the `PaymentChallenge` variant emits `PaymentRequired`
+    /// at the top level (x402-spec compliant) — NOT wrapped in the
+    /// OpenAI-style `{ error: { type, message } }` envelope that every
+    /// other variant uses. Lock that contract here so a future refactor
+    /// that "uniformizes" the response shape is loud.
+    #[tokio::test]
+    async fn test_payment_challenge_emits_top_level_payment_required() {
+        let (status, json) = error_response(GatewayError::PaymentChallenge(Box::new(
+            build_test_payment_required(),
+        )))
+        .await;
+
+        assert_eq!(status, StatusCode::PAYMENT_REQUIRED);
+
+        // Top-level fields per x402 spec.
+        assert_eq!(json["x402_version"], 2);
+        assert!(json["accepts"].is_array());
+        assert_eq!(json["accepts"][0]["scheme"], "exact");
+        assert_eq!(json["accepts"][0]["amount"], "10500");
+        assert_eq!(json["cost_breakdown"]["total"], "0.010500");
+        assert_eq!(json["cost_breakdown"]["currency"], "USDC");
+        assert_eq!(json["cost_breakdown"]["fee_percent"], 5);
+        assert_eq!(json["resource"]["url"], "/v1/chat/completions");
+        assert_eq!(json["error"], "Payment required");
+
+        // Crucial: no OpenAI-style envelope wrapping. The `error` field is
+        // a plain string at top level, not an object. A future regression
+        // that re-wraps the body in `{ error: { type, message: "<json>" } }`
+        // would make `error` an object and trip this assertion.
+        assert!(
+            !json["error"].is_object(),
+            "PaymentChallenge must NOT wrap the PaymentRequired in the OpenAI envelope; \
+             got top-level `error` as object: {json}"
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -246,6 +358,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_all_errors_have_consistent_structure() {
+        // NOTE: `PaymentChallenge` is *deliberately* excluded — it emits the
+        // x402-spec `PaymentRequired` body at the top level, which by design
+        // does not carry the `error.type`/`error.message` envelope every
+        // other variant shares. See `test_payment_challenge_emits_top_level_payment_required`.
         let errors: Vec<GatewayError> = vec![
             GatewayError::ModelNotFound("x".to_string()),
             GatewayError::ProviderError("x".to_string()),

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -235,10 +235,10 @@ pub async fn chat_completions(
             error: "Payment required".to_string(),
         };
 
-        return Err(GatewayError::InvalidPayment(
-            serde_json::to_string(&payment_required)
-                .unwrap_or_else(|_| "payment required".to_string()),
-        ));
+        // Emit the PaymentRequired body at the top level of the 402 response
+        // per x402 spec — NOT wrapped in the OpenAI-style error envelope.
+        // See `GatewayError::PaymentChallenge` doc and issue #217.
+        return Err(GatewayError::PaymentChallenge(Box::new(payment_required)));
     }
 
     // Step 4: Payment present — try to decode and verify via Facilitator

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -230,10 +230,11 @@ pub async fn proxy_service(
             error: "Payment required".to_string(),
         };
 
-        return Err(GatewayError::InvalidPayment(
-            serde_json::to_string(&payment_required)
-                .unwrap_or_else(|_| "payment required".to_string()),
-        ));
+        // Emit the PaymentRequired body at the top level of the 402 response
+        // per x402 spec — NOT wrapped in the OpenAI-style error envelope.
+        // Mirrors `routes::chat::chat_completions`. See
+        // `GatewayError::PaymentChallenge` doc and issue #217.
+        return Err(GatewayError::PaymentChallenge(Box::new(payment_required)));
     }
 
     // Step 4: Payment present — decode and verify
@@ -1163,14 +1164,17 @@ mod tests {
         let state = make_state_with_service(Some(0.01), false, true, None);
         let err = call_expect_err(state, "test-svc", HeaderMap::new()).await;
         match err {
-            GatewayError::InvalidPayment(body) => {
-                let json: serde_json::Value =
-                    serde_json::from_str(&body).expect("body must be PaymentRequired JSON");
-                assert_eq!(json["accepts"][0]["amount"], "10500");
-                assert_eq!(json["accepts"][0]["asset"], USDC_MINT);
-                assert_eq!(json["cost_breakdown"]["currency"], "USDC");
+            // Issue #217: 402 now carries a top-level `PaymentRequired`
+            // via the `PaymentChallenge` variant, not a stringified-JSON
+            // body inside `InvalidPayment`. Assertions read the same
+            // fields off the struct directly.
+            GatewayError::PaymentChallenge(pr) => {
+                // pr: Box<PaymentRequired> — auto-derefs for field access.
+                assert_eq!(pr.accepts[0].amount, "10500");
+                assert_eq!(pr.accepts[0].asset, USDC_MINT);
+                assert_eq!(pr.cost_breakdown.currency, "USDC");
             }
-            other => panic!("expected InvalidPayment with PaymentRequired body, got {other:?}"),
+            other => panic!("expected PaymentChallenge with PaymentRequired body, got {other:?}"),
         }
     }
 

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -686,12 +686,10 @@ async fn test_chat_returns_402_without_payment() {
     assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let payment_info: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    // The error message contains the serialized PaymentRequired JSON
-    let error_msg = json["error"]["message"].as_str().unwrap();
-    let payment_info: serde_json::Value = serde_json::from_str(error_msg).unwrap();
-
+    // Issue #217: 402 body is the PaymentRequired at the top level
+    // (x402-spec compliant), not wrapped in the OpenAI error envelope.
     assert_eq!(payment_info["x402_version"], 2);
     assert!(payment_info["accepts"].is_array());
     assert!(payment_info["cost_breakdown"]["total"].is_string());
@@ -962,11 +960,8 @@ async fn test_402_response_contains_x402_fields() {
     assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-
-    // Parse the embedded PaymentRequired JSON from the error message
-    let error_msg = json["error"]["message"].as_str().unwrap();
-    let pr: serde_json::Value = serde_json::from_str(error_msg).unwrap();
+    // Issue #217: PaymentRequired is the top-level 402 body.
+    let pr: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     // x402 version
     assert_eq!(pr["x402_version"], 2);
@@ -1442,9 +1437,8 @@ async fn test_402_offers_escrow_when_configured() {
     assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let error_msg = json["error"]["message"].as_str().unwrap();
-    let pr: serde_json::Value = serde_json::from_str(error_msg).unwrap();
+    // Issue #217: PaymentRequired is the top-level 402 body.
+    let pr: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     let accepts = pr["accepts"].as_array().unwrap();
     assert_eq!(
@@ -1484,9 +1478,8 @@ async fn test_402_no_escrow_when_not_configured() {
     assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let error_msg = json["error"]["message"].as_str().unwrap();
-    let pr: serde_json::Value = serde_json::from_str(error_msg).unwrap();
+    // Issue #217: PaymentRequired is the top-level 402 body.
+    let pr: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     let accepts = pr["accepts"].as_array().unwrap();
     assert_eq!(accepts.len(), 1, "should only offer exact scheme");
@@ -1975,11 +1968,8 @@ async fn test_chat_with_tools_returns_402() {
     assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-
-    // The error message contains the serialized PaymentRequired JSON
-    let error_msg = json["error"]["message"].as_str().unwrap();
-    let payment_info: serde_json::Value = serde_json::from_str(error_msg).unwrap();
+    // Issue #217: PaymentRequired is the top-level 402 body.
+    let payment_info: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(payment_info["x402_version"], 2);
     assert!(payment_info["accepts"].is_array());
@@ -3952,11 +3942,9 @@ async fn test_proxy_returns_402_with_cost_breakdown() {
     assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-
-    // The 402 response is wrapped inside the error.message as serialized JSON
-    let error_msg = json["error"]["message"].as_str().unwrap();
-    let payment_info: serde_json::Value = serde_json::from_str(error_msg).unwrap();
+    // Issue #217: services proxy 402 body is the PaymentRequired at the
+    // top level (mirrors the chat completions route fix).
+    let payment_info: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(payment_info["x402_version"], 2);
     assert_eq!(payment_info["error"], "Payment required");


### PR DESCRIPTION
## Summary

Fixes #217 — the gateway's 402 responses currently double-encode the `PaymentRequired` challenge as a string inside the OpenAI-style error envelope:

```json
{ "error": { "type": "invalid_payment", "message": "<JSON PaymentRequired>" } }
```

This violates the x402 spec (which expects `PaymentRequired` at the top level) and broke every SDK that follows the spec — until PR #302 made the strict in-repo consumers (`@solvela/ai-sdk-provider`, `solvela-cli`) dual-shape. With those parsers in place, this PR flips the gateway emission unilaterally.

## Approach

Add a dedicated `GatewayError::PaymentChallenge(Box<PaymentRequired>)` variant. Its `IntoResponse` short-circuits the existing `(status, error_type, message)` envelope machinery and emits the `PaymentRequired` directly as the 402 body:

```json
{
  "x402_version": 2,
  "resource": {...},
  "accepts": [...],
  "cost_breakdown": {...},
  "error": "Payment required"
}
```

`InvalidPayment(String)` is retained for short messages tied to a specific failure (`bad signature`, `expired`, `resource mismatch`, etc.) that legitimately belong in the OpenAI envelope — they carry a single diagnostic string, not a structured challenge.

The new variant is `Box`ed because `PaymentRequired` is ~208 bytes (Vec + multiple Strings); without the Box, every `Result<_, GatewayError>` along the request path would pay that footprint. Clippy's `result_large_err` lint enforces this.

## Changes

- **`crates/gateway/src/error.rs`** — new `PaymentChallenge(Box<PaymentRequired>)` variant + early-return arm in `IntoResponse`. New unit test `test_payment_challenge_emits_top_level_payment_required` locks in the contract by asserting the top-level shape AND explicitly rejecting any return to the envelope (`!json["error"].is_object()`).
- **`crates/gateway/src/routes/chat/mod.rs`** — switch the no-payment-header branch from `InvalidPayment(stringified)` to `PaymentChallenge(Box::new(pr))`.
- **`crates/gateway/src/routes/proxy.rs`** — same flip for the services marketplace proxy. Unit test `proxy_returns_402_with_payment_required_when_no_header` updated to match on `PaymentChallenge` and read fields off the struct directly.
- **`crates/gateway/tests/integration.rs`** — 5 integration tests that previously decoded the wrapped envelope now read PaymentRequired fields off the top-level body directly.

## Safety

PR #302 (already merged) made the AI SDK provider and Rust CLI parsers dual-shape. The in-repo Python and TypeScript SDKs were already forward-compat via existing `_unwrap_payment_required_envelope` helpers. External SDKs (e.g. solvela-python) ship their own forward-compat unwrap helpers per the issue's analysis.

Closes #217.

## Test plan
- [x] `cargo test -p gateway --lib` — 508/508 pass (was 507 + 1 new `PaymentChallenge` test).
- [x] `cargo test -p gateway --test integration` — 129/129 pass (5 tests updated to read top-level).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p gateway --all-targets --all-features -- -D warnings` — clean (Box satisfies `result_large_err`).

Local `escrow_queue` DB-bound tests fail with the same Postgres auth error on `main` (unrelated env state); CI runs them against a service container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment challenge (402) responses now return payment information directly at the response top level, improving API consistency and standards compliance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/303)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->