### PR TITLE
feat(ai-sdk-provider): replace hand-rolled parse-402 allowlist with valibot schema (closes #129)

### DIFF
--- a/sdks/ai-sdk-provider/package-lock.json
+++ b/sdks/ai-sdk-provider/package-lock.json
@@ -12,7 +12,8 @@
         "@ai-sdk/openai-compatible": "2.0.47",
         "@ai-sdk/provider-utils": "^4.0.27",
         "@solvela/signer-core": "file:../signer-core",
-        "bs58": "^5.0.0"
+        "bs58": "^5.0.0",
+        "valibot": "^1.4.0"
       },
       "devDependencies": {
         "@ai-sdk/provider": "^3.0.10",
@@ -42,7 +43,8 @@
       "dependencies": {
         "@solana/spl-token": "^0.4.0",
         "@solana/web3.js": "^1.87.0",
-        "bs58": "^6.0.0"
+        "bs58": "^6.0.0",
+        "valibot": "^1.4.0"
       },
       "devDependencies": {
         "@types/node": "^25.7.0",
@@ -4652,7 +4654,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4679,6 +4681,20 @@
       "version": "6.21.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/valibot": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.0.tgz",
+      "integrity": "sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vite": {
       "version": "8.0.12",

--- a/sdks/ai-sdk-provider/package.json
+++ b/sdks/ai-sdk-provider/package.json
@@ -43,7 +43,8 @@
     "@ai-sdk/openai-compatible": "2.0.47",
     "@ai-sdk/provider-utils": "^4.0.27",
     "@solvela/signer-core": "file:../signer-core",
-    "bs58": "^5.0.0"
+    "bs58": "^5.0.0",
+    "valibot": "^1.4.0"
   },
   "peerDependencies": {
     "@ai-sdk/provider": "^3.0.10",

--- a/sdks/ai-sdk-provider/src/util/parse-402.ts
+++ b/sdks/ai-sdk-provider/src/util/parse-402.ts
@@ -7,32 +7,28 @@
  *      { "error": { "type": "invalid_payment",
  *                   "message": "<JSON PaymentRequired>" } }
  *
- *   2. Direct (x402-spec compliant; target shape after issue #217):
+ *   2. Direct (x402-spec compliant; gateway emits this post-#217):
  *      { "x402_version": 2, "resource": {...}, "accepts": [...],
  *        "cost_breakdown": {...}, "error": "Payment required" }
  *
- * Shape detection is duck-typed: a top-level `error.message` string triggers
- * the envelope path; otherwise we expect `x402_version` + `accepts` at the
- * top level. Both shapes flow through the same allowlist + validation.
+ * Validation is delegated to the valibot schema in `schema.ts` — that
+ * file is the single source of truth for the wire format. Issue #129's
+ * acceptance criteria are met by this two-PR split:
+ *   - PR #304 landed the signer-core half (its own schema, in its own
+ *     package, since signer-core has no allowlist requirement).
+ *   - This file is the ai-sdk-provider half — same library (valibot),
+ *     separate schema because `SolvelaPaymentAccept` in
+ *     `wallet-adapter.ts` is the v1 contract this package commits to,
+ *     and it differs from signer-core's wire type (no escrow_program_id).
  *
- * This dual-shape support is deliberately defensive — issue #217 (gateway
- * still emits envelope today, but plans to switch to direct). Landing this
- * parser change first lets the gateway flip unilaterally without a
- * coordinated SDK release.
- *
- * Allowlist (§4.3 T2-G) is applied here for the wire payload: any field on
- * the top-level `PaymentRequired` other than `x402_version`, `accepts[]`,
- * `cost_breakdown`, `resource`, `error` is stripped; within each `accepts[]`
- * entry only the plan-allowlisted fields survive. Non-allowlisted keys such
- * as `internal_trace_id` never reach the returned object and therefore
- * cannot leak into `SolvelaPaymentError.responseBody` downstream.
- *
- * IMPORTANT: the returned `ParsedPaymentRequired` remains structurally
- * compatible with the already-committed `SolvelaPaymentRequired` from
- * `wallet-adapter.ts` (the contract the adapter consumes). The allowlist
- * only drops unknown/extra fields; every plan-level known field is
- * preserved.
+ * Allowlist behavior (§4.3 T2-G): valibot's default `object()` strips
+ * unknown keys silently. Fields like `internal_trace_id` (top-level),
+ * `debug_hash` (accept), `trace_id` (cost_breakdown), `region`
+ * (resource) never appear in the returned object and therefore cannot
+ * leak into `SolvelaPaymentError.responseBody` downstream.
  */
+
+import { safeParse, type BaseIssue } from 'valibot';
 
 import { SolvelaPaymentError } from '../errors.js';
 import type {
@@ -40,6 +36,10 @@ import type {
   SolvelaPaymentCostBreakdown,
   SolvelaPaymentRequired,
 } from '../wallet-adapter.js';
+import {
+  Envelope402Schema,
+  PaymentRequiredSchema,
+} from './schema.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -78,141 +78,36 @@ export const USDC_MINT_MAINNET =
 const REQUIRED_SCHEME = 'exact';
 
 // ---------------------------------------------------------------------------
-// Type guards and primitive extractors
+// Helpers
 // ---------------------------------------------------------------------------
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
-function isStringField(obj: Record<string, unknown>, key: string): boolean {
-  return typeof obj[key] === 'string';
-}
-
-function isNumberField(obj: Record<string, unknown>, key: string): boolean {
-  return typeof obj[key] === 'number' && Number.isFinite(obj[key] as number);
-}
-
-// ---------------------------------------------------------------------------
-// Allowlist application
-// ---------------------------------------------------------------------------
-
 /**
- * Extract an allowlisted `SolvelaPaymentAccept` from an unknown object.
- * Drops every field not in the plan-level allowlist (T2-G).
- * Throws if required fields are missing or mistyped.
+ * Render valibot's issue list as `path: message; …` so the failing
+ * field is preserved no matter how deeply nested.
  */
-function applyAcceptAllowlist(
-  raw: unknown,
-  index: number,
-  url: string,
-): SolvelaPaymentAccept {
-  if (!isObject(raw)) {
-    throw new SolvelaPaymentError({
-      message: `[solvela] 402 envelope: accepts[${index}] is not an object`,
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-
-  const required: Array<[string, 'string' | 'number']> = [
-    ['scheme', 'string'],
-    ['network', 'string'],
-    ['amount', 'string'],
-    ['asset', 'string'],
-    ['pay_to', 'string'],
-    ['max_timeout_seconds', 'number'],
-  ];
-
-  for (const [key, kind] of required) {
-    const present =
-      kind === 'string' ? isStringField(raw, key) : isNumberField(raw, key);
-    if (!present) {
-      throw new SolvelaPaymentError({
-        message: `[solvela] 402 envelope: accepts[${index}].${key} missing or wrong type`,
-        url,
-        requestBodyValues: undefined,
-      });
-    }
-  }
-
-  // Construct the allowlisted entry (any extra fields are dropped by this
-  // explicit field-by-field copy).
-  return {
-    scheme: raw['scheme'] as string,
-    network: raw['network'] as string,
-    amount: raw['amount'] as string,
-    asset: raw['asset'] as string,
-    pay_to: raw['pay_to'] as string,
-    max_timeout_seconds: raw['max_timeout_seconds'] as number,
-  };
+function formatIssues(issues: readonly BaseIssue<unknown>[]): string {
+  return issues
+    .map((issue) => {
+      const path = issuePath(issue);
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join('; ');
 }
 
-/**
- * Extract an allowlisted `SolvelaPaymentCostBreakdown`.
- * Every field mirrors `wallet-adapter.ts`'s declared shape.
- */
-function applyCostBreakdownAllowlist(
-  raw: unknown,
-  url: string,
-): SolvelaPaymentCostBreakdown {
-  if (!isObject(raw)) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: cost_breakdown is not an object',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-
-  const strings = ['provider_cost', 'platform_fee', 'total', 'currency'];
-  for (const key of strings) {
-    if (!isStringField(raw, key)) {
-      throw new SolvelaPaymentError({
-        message: `[solvela] 402 envelope: cost_breakdown.${key} missing or wrong type`,
-        url,
-        requestBodyValues: undefined,
-      });
-    }
-  }
-  if (!isNumberField(raw, 'fee_percent')) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: cost_breakdown.fee_percent missing or wrong type',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-
-  return {
-    provider_cost: raw['provider_cost'] as string,
-    platform_fee: raw['platform_fee'] as string,
-    total: raw['total'] as string,
-    currency: raw['currency'] as string,
-    fee_percent: raw['fee_percent'] as number,
-  };
-}
-
-/**
- * Extract an allowlisted `resource` object: `{ url: string, method: string }`.
- */
-function applyResourceAllowlist(
-  raw: unknown,
-  url: string,
-): { url: string; method: string } {
-  if (!isObject(raw)) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: resource is not an object',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-  if (!isStringField(raw, 'url') || !isStringField(raw, 'method')) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: resource.url/method missing or wrong type',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-  return { url: raw['url'] as string, method: raw['method'] as string };
+function issuePath(issue: BaseIssue<unknown>): string {
+  if (!issue.path || issue.path.length === 0) return '';
+  return issue.path
+    .map((segment, i) => {
+      const key = (segment as { key?: unknown }).key;
+      if (typeof key === 'number') return `[${key}]`;
+      if (typeof key === 'string') return i === 0 ? key : `.${key}`;
+      return '';
+    })
+    .join('');
 }
 
 // ---------------------------------------------------------------------------
@@ -249,127 +144,75 @@ export function parseGateway402(
   }
 
   // Duck-type shape detection. The envelope shape is identified by a
-  // top-level `error.message` string. The direct shape has `x402_version`
-  // and `accepts` at the top level. We probe envelope first since it's
-  // the current default and a direct-shape body would never coincidentally
-  // carry an `error.message` string at the top level (the direct shape's
+  // top-level `error.message` string; otherwise we expect a direct
+  // PaymentRequired body. Probe envelope first — it's the historical
+  // default, and a direct-shape body would never coincidentally carry
+  // an `error.message` string at the top level (the direct shape's
   // `error` field is a plain string like "Payment required").
   const errorField = body['error'];
   const looksLikeEnvelope =
     isObject(errorField) && typeof errorField['message'] === 'string';
 
-  const inner = looksLikeEnvelope
-    ? extractFromEnvelope(errorField as Record<string, unknown>, url)
-    : extractFromDirect(body, url);
-
-  // Required top-level fields on the extracted payload (both shapes).
-  if (!isNumberField(inner, 'x402_version')) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 body: `x402_version` missing or wrong type',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-  if (!Array.isArray(inner['accepts'])) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 body: `accepts` is not an array',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-  if (!isStringField(inner, 'error')) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 body: `error` missing or wrong type',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-
-  const accepts = (inner['accepts'] as unknown[]).map((entry, i) =>
-    applyAcceptAllowlist(entry, i, url),
-  );
-  const cost_breakdown = applyCostBreakdownAllowlist(inner['cost_breakdown'], url);
-  const resource = applyResourceAllowlist(inner['resource'], url);
-
-  return {
-    x402_version: inner['x402_version'] as number,
-    resource,
-    accepts,
-    cost_breakdown,
-    error: inner['error'] as string,
-  };
-}
-
-/**
- * Extract the inner PaymentRequired from the envelope shape:
- *   { error: { type: "invalid_payment", message: "<JSON>" } }
- */
-function extractFromEnvelope(
-  errorField: Record<string, unknown>,
-  url: string,
-): Record<string, unknown> {
-  const type = errorField['type'];
-  const messageJson = errorField['message'];
-  if (typeof type !== 'string' || typeof messageJson !== 'string') {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: `error.type` or `error.message` missing or wrong type',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-  if (type !== 'invalid_payment') {
-    throw new SolvelaPaymentError({
-      message: `[solvela] 402 envelope: unsupported error.type "${type}"; expected "invalid_payment"`,
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-
   let inner: unknown;
-  try {
-    inner = JSON.parse(messageJson);
-  } catch {
+  if (looksLikeEnvelope) {
+    const envelopeResult = safeParse(Envelope402Schema, body);
+    if (!envelopeResult.success) {
+      throw new SolvelaPaymentError({
+        message: `[solvela] 402 envelope: ${formatIssues(envelopeResult.issues)}`,
+        url,
+        requestBodyValues: undefined,
+      });
+    }
+    // Enforce the historical `error.type === "invalid_payment"` constraint.
+    const type = envelopeResult.output.error.type;
+    if (type !== 'invalid_payment') {
+      throw new SolvelaPaymentError({
+        message: `[solvela] 402 envelope: unsupported error.type "${type}"; expected "invalid_payment"`,
+        url,
+        requestBodyValues: undefined,
+      });
+    }
+    try {
+      inner = JSON.parse(envelopeResult.output.error.message);
+    } catch {
+      throw new SolvelaPaymentError({
+        message: '[solvela] 402 envelope: `error.message` is not valid JSON',
+        url,
+        requestBodyValues: undefined,
+      });
+    }
+    if (!isObject(inner)) {
+      throw new SolvelaPaymentError({
+        message: '[solvela] 402 envelope: inner PaymentRequired is not an object',
+        url,
+        requestBodyValues: undefined,
+      });
+    }
+  } else {
+    inner = body;
+  }
+
+  const innerResult = safeParse(PaymentRequiredSchema, inner);
+  if (!innerResult.success) {
+    // Distinguish the two shapes in the error message so caller debug
+    // output points at the right place. For the direct-shape failure we
+    // also call out the dual-shape rejection so a body that matches
+    // neither shape doesn't read as a partial validation of one.
+    const context = looksLikeEnvelope
+      ? '402 inner PaymentRequired'
+      : '402 body matches neither envelope shape (`error.message` with stringified JSON) nor direct PaymentRequired shape — validation against direct';
     throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: `error.message` is not valid JSON',
+      message: `[solvela] ${context}: ${formatIssues(innerResult.issues)}`,
       url,
       requestBodyValues: undefined,
     });
   }
 
-  if (!isObject(inner)) {
-    throw new SolvelaPaymentError({
-      message: '[solvela] 402 envelope: inner PaymentRequired is not an object',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-
-  return inner;
-}
-
-/**
- * Direct-shape probe: the body itself is the PaymentRequired payload
- * (x402-spec compliant). We don't validate field contents here — the
- * common code path that follows runs the same allowlist + type checks
- * the envelope shape gets.
- */
-function extractFromDirect(
-  body: Record<string, unknown>,
-  url: string,
-): Record<string, unknown> {
-  // Direct shape requires at minimum `x402_version` (number) and `accepts`
-  // (array) at the top level — otherwise we don't recognize the shape and
-  // emit a single clear error pointing at both supported shapes so callers
-  // can diagnose pre-vs-post #217 gateway responses.
-  if (!isNumberField(body, 'x402_version') || !Array.isArray(body['accepts'])) {
-    throw new SolvelaPaymentError({
-      message:
-        '[solvela] 402 body matches neither envelope shape (`error.message` with stringified JSON) nor direct PaymentRequired shape (top-level `x402_version` + `accepts`)',
-      url,
-      requestBodyValues: undefined,
-    });
-  }
-  return body;
+  // valibot's default object() strips unknown keys, so innerResult.output
+  // already contains only the allowlisted fields per the schema. The cast
+  // here just narrows InferOutput<PaymentRequiredSchema> to the public
+  // SolvelaPaymentRequired alias — they are structurally identical.
+  return innerResult.output as ParsedPaymentRequired;
 }
 
 // ---------------------------------------------------------------------------
@@ -383,8 +226,9 @@ function extractFromDirect(
  * @param parsed - Result of `parseGateway402`.
  * @param url    - Request URL for `SolvelaPaymentError.url` on thrown errors.
  *                 Defaults to `''` for callers without URL context.
- * @returns The matching entry plus its `amount` as a `bigint`.
- * @throws SolvelaPaymentError if no entry matches.
+ * @returns `{ accept, cost }` where `cost` is the chosen entry's `amount`
+ *          parsed as a `bigint` (USDC atomic units).
+ * @throws SolvelaPaymentError if no allowlisted entry matches the v1 rule.
  */
 export function selectAccept(
   parsed: ParsedPaymentRequired,
@@ -421,3 +265,7 @@ export function selectAccept(
     requestBodyValues: undefined,
   });
 }
+
+// Re-export the cost_breakdown type for downstream callers that previously
+// imported it from this module's old hand-rolled shape.
+export type ParsedCostBreakdown = SolvelaPaymentCostBreakdown;

--- a/sdks/ai-sdk-provider/src/util/schema.ts
+++ b/sdks/ai-sdk-provider/src/util/schema.ts
@@ -1,0 +1,116 @@
+/**
+ * Valibot schemas for the gateway 402 payload — ai-sdk-provider edition.
+ *
+ * Mirrors `@solvela/signer-core`'s `schema.ts` but with two intentional
+ * differences:
+ *
+ *   1. `PaymentAcceptSchema` does NOT include `escrow_program_id`.
+ *      `SolvelaPaymentAccept` in `wallet-adapter.ts` is the v1 contract
+ *      this package commits to, and v1 is exact-scheme-only. The escrow
+ *      field would survive valibot's default object() (which strips
+ *      unknown keys) but the public type doesn't expose it.
+ *
+ *   2. Errors are wrapped in `SolvelaPaymentError` instead of plain
+ *      `Error`, preserving the existing contract for downstream callers
+ *      that catch and inspect this error type.
+ *
+ * valibot's default `object()` silently strips unknown keys — this gives
+ * the allowlist behavior the previous hand-rolled `applyAcceptAllowlist`
+ * /`applyCostBreakdownAllowlist`/`applyResourceAllowlist` functions used
+ * to enforce explicitly, so unknown fields like `internal_trace_id` /
+ * `debug_hash` / `trace_id` / `region` never reach the output.
+ *
+ * See issue #129 (signer-core half landed in PR #304; this is the
+ * follow-up for the ai-sdk-provider half).
+ */
+
+import {
+  array,
+  finite,
+  minLength,
+  minValue,
+  nonEmpty,
+  number,
+  object,
+  pipe,
+  rawCheck,
+  string,
+  type BaseSchema,
+  type InferOutput,
+} from 'valibot';
+
+/**
+ * Decimal/atomic amount validator. Same rules as signer-core's:
+ *   - non-empty string
+ *   - `Number(s)` is finite + non-negative
+ *
+ * Catches trailing-garbage cases like `"1.5USDC"`, `"0.001SOL"`, plus
+ * the empty-string / null / boolean / array coercion holes that the
+ * pre-schema validator had to defend against with a `typeof` guard.
+ */
+const decimalAmount: BaseSchema<unknown, string, any> = pipe(
+  string('expected decimal amount string'),
+  nonEmpty('decimal amount must be non-empty'),
+  rawCheck(({ dataset, addIssue }) => {
+    if (dataset.typed) {
+      const n = Number(dataset.value);
+      if (!Number.isFinite(n) || n < 0) {
+        addIssue({
+          message: `invalid numeric amount "${dataset.value}" (must parse to a finite non-negative number)`,
+        });
+      }
+    }
+  }),
+);
+
+export const CostBreakdownSchema = object({
+  provider_cost: decimalAmount,
+  platform_fee: decimalAmount,
+  total: decimalAmount,
+  currency: pipe(string(), nonEmpty()),
+  fee_percent: pipe(number(), finite(), minValue(0)),
+});
+
+export const PaymentAcceptSchema = object({
+  scheme: pipe(string(), nonEmpty()),
+  network: pipe(string(), nonEmpty()),
+  amount: decimalAmount,
+  asset: pipe(string(), nonEmpty()),
+  pay_to: pipe(string(), nonEmpty()),
+  max_timeout_seconds: pipe(number(), finite(), minValue(0)),
+});
+
+export const ResourceSchema = object({
+  url: string(),
+  method: string(),
+});
+
+export const PaymentRequiredSchema = object({
+  x402_version: pipe(number(), finite(), minValue(0)),
+  resource: ResourceSchema,
+  accepts: pipe(array(PaymentAcceptSchema), minLength(1, 'accepts must be non-empty')),
+  cost_breakdown: CostBreakdownSchema,
+  error: string(),
+});
+
+/**
+ * The 402 envelope shape: `{ error: { type: "invalid_payment", message: "<JSON>" } }`.
+ * Outer-structure-only — the inner `message` string is JSON-parsed by
+ * the parser and re-validated against `PaymentRequiredSchema`.
+ */
+export const Envelope402Schema = object({
+  error: object({
+    type: pipe(string(), nonEmpty()),
+    message: string(),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Schema-derived types (internal). The public-facing `ParsedPaymentRequired`
+// in `parse-402.ts` still aliases `SolvelaPaymentRequired` from
+// `wallet-adapter.ts` — the schema output is structurally compatible.
+// ---------------------------------------------------------------------------
+export type ParsedAccept = InferOutput<typeof PaymentAcceptSchema>;
+export type ParsedCostBreakdown = InferOutput<typeof CostBreakdownSchema>;
+export type ParsedResource = InferOutput<typeof ResourceSchema>;
+export type ParsedPayment = InferOutput<typeof PaymentRequiredSchema>;

--- a/sdks/ai-sdk-provider/tests/unit/parse-402.test.ts
+++ b/sdks/ai-sdk-provider/tests/unit/parse-402.test.ts
@@ -347,6 +347,47 @@ describe('parseGateway402', () => {
     expect(() => parseGateway402(garbage)).toThrow(SolvelaPaymentError);
   });
 
+  it('rejects accept.amount with trailing garbage at parse time (not at selectAccept)', () => {
+    // Issue #129: the pre-schema parser accepted any non-empty string for
+    // `accepts[i].amount` and only caught format errors when `BigInt()`
+    // was called in `selectAccept` — fine for the chosen accept, but a
+    // malformed amount on a non-selected accept (`scheme="exact"`, but
+    // listed alongside other entries) would slip past validation and
+    // could surface as a runtime crash deeper in the pipeline. The
+    // valibot `decimalAmount` validator catches it at parse time.
+    const envelope = buildEnvelope({
+      accepts: [
+        {
+          scheme: 'exact',
+          network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          amount: '2625USDC', // trailing currency suffix
+          asset: USDC_MINT_MAINNET,
+          pay_to: 'RecipientWallet',
+          max_timeout_seconds: 300,
+        },
+      ],
+    });
+    expect(() => parseGateway402(envelope)).toThrow(SolvelaPaymentError);
+    expect(() => parseGateway402(envelope)).toThrow(/accepts\[0\]\.amount/);
+  });
+
+  it('rejects cost_breakdown.fee_percent that is not a number', () => {
+    // Schema enforces `number()` on fee_percent. Previously this would
+    // have been a hand-coded `typeof` check that's easy to forget when
+    // extending the wire format.
+    const envelope = buildEnvelope({
+      cost_breakdown: {
+        provider_cost: '0.002500',
+        platform_fee: '0.000125',
+        total: '0.002625',
+        currency: 'USDC',
+        fee_percent: '5' as unknown as number, // string, not number
+      },
+    });
+    expect(() => parseGateway402(envelope)).toThrow(SolvelaPaymentError);
+    expect(() => parseGateway402(envelope)).toThrow(/cost_breakdown\.fee_percent/);
+  });
+
   it('throws SolvelaPaymentError when error.type is missing', () => {
     const envelope = {
       error: {


### PR DESCRIPTION
## Summary

PR #304 landed the valibot refactor for `@solvela/signer-core`. This follow-up does the same for `@solvela/ai-sdk-provider`, closing #129's remaining acceptance criterion (ai-sdk-provider's parse-402 either reuses the schema or has its own using the same library).

The two packages keep **separate schemas** rather than ai-sdk-provider importing signer-core's, for one deliberate reason: `SolvelaPaymentAccept` in `wallet-adapter.ts` is this package's v1 contract and it differs from signer-core's wire type — no `escrow_program_id`, because v1 only supports the exact scheme. A shared schema would either lock signer-core out of escrow support or leak the escrow field into a type the ai-sdk-provider explicitly doesn't expose.

## Changes

- **New `src/util/schema.ts`** — `PaymentRequiredSchema`, `PaymentAcceptSchema`, `CostBreakdownSchema`, `ResourceSchema`, `Envelope402Schema`. Same `decimalAmount` discipline as signer-core (Number()-finite-non-negative check inside `rawCheck` over `string()`+`nonEmpty()` — so empty strings, nulls, booleans, arrays never reach the numeric check). `PaymentAcceptSchema` intentionally omits `escrow_program_id` to match the public `SolvelaPaymentAccept`.

- **`src/util/parse-402.ts`** — replaces the ~150-line hand-rolled `applyAcceptAllowlist`/`applyCostBreakdownAllowlist`/`applyResourceAllowlist` trio with `safeParse(PaymentRequiredSchema, ...)`. valibot's default `object()` silently strips unknown keys → the strip-extras behavior the previous code enforced explicitly is preserved verbatim, so `internal_trace_id`, `debug_hash`, `trace_id`, `region` still never reach the output. Dual-shape detection (envelope vs direct, from PR #302) preserved. Envelope-side `error.type !== "invalid_payment"` check preserved. Error messages move to valibot's `path: message` format (e.g. `accepts[1].scheme: Invalid type: Expected string but received null`). `selectAccept` is unchanged (its error wording is part of this package's public contract).

- **`tests/unit/parse-402.test.ts`** — +2 new tests covering classes the hand-rolled validator missed:
  - `rejects accept.amount with trailing garbage at parse time` — previously `"2625USDC"` slipped past `applyAcceptAllowlist` and only failed when `BigInt()` was called inside `selectAccept`. The schema's `decimalAmount` catches it at parse stage, which matters for *non-selected* accepts.
  - `rejects cost_breakdown.fee_percent that is not a number` — previously enforced in three different allowlist functions; now declared once.

## Acceptance criteria from #129 (final)

| AC | Status |
|---|---|
| Schema declared in a single source-of-truth file | ✅ `src/util/schema.ts` for ai-sdk-provider; `src/schema.ts` for signer-core (PR #304) |
| Types derived from the schema | ✅ `InferOutput<typeof ...>` used internally; public `ParsedPaymentRequired` continues to alias `SolvelaPaymentRequired` |
| `parse402` uses the schema; ad-hoc casts removed | ✅ (both packages) |
| ai-sdk-provider reuses schema OR same library | ✅ same library (valibot), separate schema (justified above) |
| Existing tests pass + new tests cover uncovered class | ✅ 353/353 pass (was 351, +2 new) |
| No regression in error-message clarity | ✅ valibot path-based messages preserve / improve clarity |
| Bundle-size impact documented | ✅ see below |

## Bundle size

- `dist/util/schema.js`: ~3.4kb (same content as signer-core's mirror)
- `dist/util/parse-402.js`: shrinks from ~7kb hand-rolled to ~3.9kb (allowlist code deleted)
- valibot tree-shaken with the named imports used here (`object, array, string, number, finite, minValue, minLength, nonEmpty, pipe, rawCheck, safeParse`): ~1kb min+gz per the library's published metrics

Net runtime cost: roughly neutral or slightly down — the deleted allowlist code is bigger than valibot's pulled-in footprint.

## Test plan
- [x] `npm test` in `sdks/ai-sdk-provider/`: 353/353 pass.
- [x] `npx tsc --noEmit` in `sdks/ai-sdk-provider/`: clean.
- [x] `npm run build` in `sdks/ai-sdk-provider/`: clean (~21KB dist).
- [x] `npm test` in `sdks/signer-core/` (sanity, since both packages now use valibot): 84/84 pass — unaffected.

Closes #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation and error handling for HTTP 402 payment error responses with improved error messages that specify which fields failed validation.
  * Improved payload parsing with stricter data validation for greater reliability.

* **Tests**
  * Added unit tests validating payment data requirements and error reporting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/305)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->