### PR TITLE
docs(escrow): reconcile init_if_needed AGENTS.md stance with code (closes #116)

### DIFF
--- a/programs/escrow/AGENTS.md
+++ b/programs/escrow/AGENTS.md
@@ -26,7 +26,7 @@ Trustless USDC-SPL escrow. Agents deposit USDC into a PDA keyed by `(agent, serv
 
 ### Working In This Directory
 - PDA seeds: `[b"escrow", agent.key().as_ref(), &service_id]` — keep in sync with `crates/x402/src/escrow/pda.rs`.
-- Run the full Anchor security checklist (root `AGENTS.md`): typed accounts, has_one validations, no `init_if_needed`, checked arithmetic, account closure via `close =`, duplicate-account guard.
+- Run the full Anchor security checklist (root `AGENTS.md`): typed accounts, has_one validations, checked arithmetic, account closure via `close =`, duplicate-account guard. **`init_if_needed` exception**: permitted only for Associated Token Accounts (`associated_token::*`) because ATA addresses are deterministic from `(mint, owner)` — re-init of an existing ATA is a safe no-op (Anchor checks `is_initialized` first) and an attacker can't substitute a different account. The program uses this exception in `deposit.rs` (vault), `claim.rs` (provider + agent token accounts), and `refund.rs` (agent token account). Do not extend it to arbitrary accounts; the root AGENTS.md checklist's "Reinitialization-attack vector must be ruled out explicitly" applies.
 - Account sizing uses `#[derive(InitSpace)]` + `8 + Escrow::INIT_SPACE` (8-byte discriminator prefix).
 - Never mutate this program's state layout without a versioned migration plan — existing on-chain accounts will become unreadable.
 

--- a/programs/escrow/src/instructions/deposit.rs
+++ b/programs/escrow/src/instructions/deposit.rs
@@ -138,6 +138,16 @@ pub struct Deposit<'info> {
     pub agent_token_account: Account<'info, TokenAccount>,
 
     /// Vault ATA owned by the escrow PDA (destination of funds).
+    /// `init_if_needed` because the escrow PDA seeds include
+    /// `service_id`, so different requests from the same agent need
+    /// distinct vault ATAs — the first deposit for a given service_id
+    /// creates the vault; if a prior escrow with the *same* service_id
+    /// somehow leaves a vault around (it shouldn't — claim/refund close
+    /// it), re-init is a safe no-op because Anchor checks
+    /// `is_initialized` first. The ATA address is uniquely determined
+    /// by `(mint, escrow_pda)` so an attacker can't substitute a
+    /// different account. See `programs/escrow/AGENTS.md`
+    /// "init_if_needed exception".
     #[account(
         init_if_needed,
         payer = agent,


### PR DESCRIPTION
## Summary

`programs/escrow/AGENTS.md:29` listed "no `init_if_needed`" as a flat Anchor security rule, but the program uses the flag at 4 ATA sites:

- `deposit.rs:142` (vault)
- `claim.rs:178` (provider_token_account)
- `claim.rs:191` (agent_token_account, refund leg)
- `refund.rs:107` (agent_token_account)

Root `AGENTS.md:128` already has the nuanced version — "Default to `init`; only use `init_if_needed` for a documented reason" — so only the escrow-scoped file was out of sync. The escrow usage is genuinely safe (ATA addresses are deterministic from `(mint, owner)`, re-init is a no-op via Anchor's `is_initialized` check, attacker can't substitute a different account), but the doc/code drift means contributors following the AGENTS.md checklist literally either propose ineffective "fixes" or learn to ignore the checklist.

## Changes (Path A per #116)

- **`programs/escrow/AGENTS.md`** — Rewrite the line from a flat "no `init_if_needed`" to an explicit ATA exception with rationale. Names the 4 code sites so reviewers can locate them. Reiterates the root checklist's "Reinitialization-attack vector must be ruled out explicitly" so the exception doesn't get casually extended to arbitrary accounts.
- **`programs/escrow/src/instructions/deposit.rs`** — Add the missing inline rationale comment to the vault ATA. The other 3 sites already carry rationale comments inline; this one was the outlier. Now all 4 sites are self-documenting and cross-reference the AGENTS.md exception.

No code logic changes. No on-chain program changes. `Escrow::INIT_SPACE`, instruction discriminators, and wire format are unaffected.

Closes #116.

## Test plan
- [x] `cargo check --manifest-path programs/escrow/Cargo.toml --lib` → compiles cleanly (14 pre-existing Anchor 0.31 `unexpected_cfgs` warnings, scope of #114).
- [x] `cargo test --manifest-path programs/escrow/Cargo.toml --test unit` → 9/9 pass (unchanged).
- [ ] No SBF integration run needed locally — this is a docs + comment edit, no behavior change. CI's new escrow workflow (#306) will exercise the full suite against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reinforced AI agent guidance with explicit security requirements and clarified safe exceptions for deterministic token account operations.
  * Enhanced inline documentation explaining re-initialization safety patterns, deterministic account addressing, and why operations on existing accounts are guaranteed safe.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->