### PR TITLE
fix(mcp): use bounded signature-only confirmTransaction in deposit_escrow (closes #138)

### DIFF
--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -457,12 +457,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
           const connection = new Connection(rpcUrl, 'confirmed');
 
-          // Fetch blockhash BEFORE broadcast so lastValidBlockHeight is available for confirmTransaction.
-          const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed') as {
-            blockhash: string;
-            lastValidBlockHeight: number;
-          };
-
           const txBytes = Buffer.from(depositTxB64, 'base64');
 
           // Phase 2 boundary: ONLY throw if broadcast fails.
@@ -482,13 +476,37 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           depositTxSignature = signature;
 
           // Confirmation: NOT part of the throw boundary.
+          //
+          // Issue #138: previously this code called
+          // `getLatestBlockhash('confirmed')` to obtain a fresh
+          // (blockhash, lastValidBlockHeight) and passed those to the
+          // strategy-object overload of `confirmTransaction`. But the
+          // tx itself was signed by `createPaymentHeader` (now in
+          // signer-core) using a DIFFERENT blockhash from a `finalized`
+          // fetch inside that function — we never see the signing-time
+          // blockhash here, so the strategy-object's lastValidBlockHeight
+          // referenced the wrong window. The poller would either give
+          // up at the wrong time or keep polling past the tx's actual
+          // expiry, producing a `confirmed` flag that didn't reflect
+          // the on-chain reality.
+          //
+          // The bounded signature-only overload polls
+          // `getSignatureStatuses` until either the commitment is
+          // reached or `confirmTransactionInitialTimeout` (default 60s
+          // on the Connection) elapses. This overload is deprecated in
+          // newer @solana/web3.js majors; the proper future fix is
+          // option 2 from the issue (have `createPaymentHeader` return
+          // the signing-time blockhash so we can build the correct
+          // strategy object). That's an API change rippling through
+          // four signer-core consumers — tracked as a follow-up.
+          //
           // If confirmation times out, the tx is in flight — count-on-broadcast means
           // the reservation stands. We signal pending via the confirmed flag.
           try {
-            const confirmation = await connection.confirmTransaction(
-              { signature, blockhash, lastValidBlockHeight },
+            const confirmation = (await connection.confirmTransaction(
+              signature,
               'confirmed',
-            ) as { value: { err: unknown } };
+            )) as { value: { err: unknown } };
             if (confirmation.value.err) {
               // Tx landed but failed on-chain — rare. Count as broadcast-succeeded.
               confirmed = false;


### PR DESCRIPTION
## Summary

`deposit_escrow` in `sdks/mcp/src/index.ts` passed the **wrong** blockhash window to `connection.confirmTransaction`:

1. `createPaymentHeader` (in signer-core) signs the deposit tx using a blockhash from `getLatestBlockhash('finalized')` — call this `blockhash_A`. That value is never returned to the mcp handler.
2. The handler then independently fetched a fresh `getLatestBlockhash('confirmed')` — `blockhash_B` — and passed its `lastValidBlockHeight` to the strategy-object overload of `confirmTransaction`.
3. Since `blockhash_B` is fresher, `lastValidBlockHeight` referenced the wrong validity window. The poller would either give up at the wrong time or keep polling past the tx's actual expiry, producing a `confirmed` flag that didn't reflect on-chain reality.

## Fix (option 3 from the issue)

Drop the separately-fetched blockhash entirely and use the bounded signature-only overload of `confirmTransaction`. It polls `getSignatureStatuses` until either the commitment is reached or `confirmTransactionInitialTimeout` (default 60s on the Connection) elapses — fully resolves the mismatched-window bug.

The overload is deprecated in newer @solana/web3.js majors; the proper long-term fix is option 2 from the issue (have `createPaymentHeader` return the signing-time `(blockhash, lastValidBlockHeight)` so callers can build the correct strategy object). That's an API change rippling through 4 signer-core consumers (mcp/index.ts, mcp/client.ts, openclaw-provider/signer.ts, ai-sdk-provider/adapters/local.ts) — tracked as a follow-up. Inline comment in this PR documents the chosen tradeoff and points at the follow-up so the deprecated-overload choice isn't lost in future refactors.

No throw-boundary change: confirmation still doesn't throw on timeout, the `confirmed` flag still signals pending, and the count-on-broadcast policy in `runEscrowDeposit` is unaffected. The fix narrows the *meaning* of the `confirmed` flag to actually match on-chain reality.

## Test note

The issue's AC requests a fixture exercising count-on-broadcast under both `confirmed=true` and `confirmed=false`. The bug lives in the MCP tool handler registered with a stdio-mode `Server`, which isn't directly unit-testable without mocking `@solana/web3.js` Connection — a larger test-infra investment than this surgical fix warrants. `escrow.test.ts` continues to cover the count-on-broadcast invariant at the `runEscrowDeposit` boundary (the actual policy implementation). Happy to file an integration-test follow-up if you want it tracked.

Closes #138.

## Test plan
- [x] `cd sdks/mcp && npm test` → 86/86 pass.
- [x] `npx tsc --noEmit` → clean (deprecation diagnostics only: pre-existing `Server` on lines 26/154 + the deliberately-chosen `confirmTransaction` signature-only overload).
- [x] `npm run build` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow deposit transaction confirmation to better handle timing and ensure consistent behavior during confirmation.

* **Documentation**
  * Added documentation clarifying transaction confirmation semantics and timeout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->