### PR TITLE
docs(escrow): document service_id nonce-mixing as a security invariant (closes #118)

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -32,6 +32,17 @@ fn select_payment_scheme<'a>(
 }
 
 /// Generate a unique 32-byte service_id by hashing the request body + random nonce.
+///
+/// Issue #118 security invariant: the nonce is load-bearing. Without it,
+/// two identical request bodies would produce the same service_id →
+/// same escrow PDA → same vault ATA, all derivable off-chain *before*
+/// the deposit broadcasts (front-running ATA creation, confidentiality
+/// leak via on-chain correlation of vault address to specific prompts).
+/// The on-chain program treats `service_id` as opaque bytes, so this is
+/// a purely off-chain discipline — do NOT remove the nonce mix here.
+/// Regression test: `tests::test_generate_service_id_unique_with_nonce`.
+/// See `crates/x402/src/escrow/AGENTS.md` "service_id MUST mix a
+/// per-request CSPRNG nonce" for the parallel TS-side implementation.
 fn generate_service_id(request_body: &[u8]) -> Result<[u8; 32]> {
     let mut hasher = Sha256::new();
     hasher.update(request_body);

--- a/crates/x402/src/escrow/AGENTS.md
+++ b/crates/x402/src/escrow/AGENTS.md
@@ -30,6 +30,23 @@ _(none)_
 - Use checked arithmetic everywhere (`checked_add`, `checked_sub`) — escrow deals with funds.
 - Fire-and-forget claim submission: the gateway writes to `claim_queue` synchronously, but a background task drains it. Never block a user request on claim settlement.
 
+#### `service_id` MUST mix a per-request CSPRNG nonce (security invariant)
+
+`crates/x402/src/escrow/` accepts `service_id: [u8; 32]` as an input — derivation is the client's responsibility. **Clients MUST mix a per-request CSPRNG nonce into the `service_id` hash**, not derive it as a pure function of `request_body` alone. Without the nonce, two identical request bodies produce the same `service_id` → the same escrow PDA → the same vault ATA, all of which are computable off-chain from `(agent_pubkey, service_id_derivation_rule, USDC_MINT)` *before* the deposit broadcasts. That enables:
+
+1. **Front-running ATA creation** — an attacker pre-creates the vault ATA. Post-#115 this no longer breaks claim, but is still a confusion vector.
+2. **Confidentiality leak** — an on-chain observer who knows the derivation rule can correlate vault addresses to specific prompts/models. Service traffic patterns become decoderable from the public ledger.
+3. **Pre-deposit grief** — pre-creating the vault ATA with dust skews telemetry counters.
+
+The on-chain program treats `service_id` as opaque bytes, so this is a purely off-chain discipline. The nonce becomes part of the off-chain receipt and is persisted alongside the deposit (e.g. in `claim_queue.service_id`) so the gateway can re-derive PDAs at claim time.
+
+Current implementations:
+
+- **Rust CLI**: `crates/cli/src/commands/chat.rs::generate_service_id` — SHA-256 of `(request_body, 8-byte CSPRNG nonce via getrandom)`. Regression test: `tests::test_generate_service_id_unique_with_nonce`.
+- **TS signer-core**: `sdks/signer-core/src/sign.ts::buildEscrowPaymentHeader` — SHA-256 of `(bodyBytes, 8-byte CSPRNG via node:crypto.randomBytes)`. Regression test: `'service_id differs across calls (random component)'` in `sdks/signer-core/tests/sign.test.ts`.
+
+If you add a new client (Go SDK, in-tree gateway test fixture, etc.), mirror the same `SHA-256(body || nonce)` shape and add an `identical_body_distinct_service_ids` regression test. Filed under issue #118.
+
 ### Testing Requirements
 ```bash
 cargo test -p x402 escrow

--- a/crates/x402/src/escrow/AGENTS.md
+++ b/crates/x402/src/escrow/AGENTS.md
@@ -35,7 +35,7 @@ _(none)_
 `crates/x402/src/escrow/` accepts `service_id: [u8; 32]` as an input — derivation is the client's responsibility. **Clients MUST mix a per-request CSPRNG nonce into the `service_id` hash**, not derive it as a pure function of `request_body` alone. Without the nonce, two identical request bodies produce the same `service_id` → the same escrow PDA → the same vault ATA, all of which are computable off-chain from `(agent_pubkey, service_id_derivation_rule, USDC_MINT)` *before* the deposit broadcasts. That enables:
 
 1. **Front-running ATA creation** — an attacker pre-creates the vault ATA. Post-#115 this no longer breaks claim, but is still a confusion vector.
-2. **Confidentiality leak** — an on-chain observer who knows the derivation rule can correlate vault addresses to specific prompts/models. Service traffic patterns become decoderable from the public ledger.
+2. **Confidentiality leak** — an on-chain observer who knows the derivation rule can correlate vault addresses to specific prompts/models. Service traffic patterns become decodable from the public ledger.
 3. **Pre-deposit grief** — pre-creating the vault ATA with dust skews telemetry counters.
 
 The on-chain program treats `service_id` as opaque bytes, so this is a purely off-chain discipline. The nonce becomes part of the off-chain receipt and is persisted alongside the deposit (e.g. in `claim_queue.service_id`) so the gateway can re-derive PDAs at claim time.

--- a/sdks/signer-core/src/sign.ts
+++ b/sdks/signer-core/src/sign.ts
@@ -218,6 +218,19 @@ async function buildEscrowPaymentHeader(
   requestBody: string | undefined,
 ): Promise<EscrowInner> {
   const bodyBytes = Buffer.from(requestBody ?? '', 'utf-8');
+  // Issue #118 security invariant: the service_id MUST mix a per-request
+  // CSPRNG nonce, not be a pure function of requestBody alone. Without
+  // the nonce, two identical request bodies would produce the same
+  // service_id → same escrow PDA → same vault ATA, all derivable
+  // off-chain *before* the deposit broadcasts (front-running ATA
+  // creation, confidentiality leak via on-chain correlation of vault
+  // address to specific prompts). The on-chain program treats
+  // service_id as opaque bytes, so this is a purely off-chain
+  // discipline — do NOT remove `random` thinking it's unused. The
+  // matching test is 'service_id differs across calls (random
+  // component)' in tests/sign.test.ts. See also
+  // `crates/x402/src/escrow/AGENTS.md` "service_id MUST mix a
+  // per-request CSPRNG nonce".
   const random = randomBytes(8);
   const serviceId = createHash('sha256').update(bodyBytes).update(random).digest();
   const serviceIdB64 = serviceId.toString('base64');


### PR DESCRIPTION
## Summary

The two existing `service_id` derivation sites already mix a CSPRNG nonce — the *code-level* part of #118's acceptance criteria was satisfied before the issue was filed:

| Site | Mix | Regression test |
|---|---|---|
| `crates/cli/src/commands/chat.rs::generate_service_id` | SHA-256(body \|\| 8B CSPRNG via `getrandom`) | `tests::test_generate_service_id_unique_with_nonce` (identical bodies → distinct service_ids) |
| `sdks/signer-core/src/sign.ts::buildEscrowPaymentHeader` | SHA-256(body \|\| 8B CSPRNG via `randomBytes`) | `'service_id differs across calls (random component)'` in `tests/sign.test.ts` |

What was missing was **documentation** of the requirement, so a future contributor (or AI agent) doesn't strip the nonce mix during a cleanup pass thinking the `random` argument is unused.

## Changes

- **`crates/x402/src/escrow/AGENTS.md`** — new `####`-level subsection under "Working In This Directory" titled "`service_id` MUST mix a per-request CSPRNG nonce (security invariant)". Explains the three attack vectors the nonce defeats (front-running ATA creation, on-chain confidentiality leak, pre-deposit grief via telemetry skew), names both current implementations + their regression tests, and instructs future SDK authors to mirror the shape.

- **`sdks/signer-core/src/sign.ts`** — 12-line block comment above the `randomBytes(8)` / `update(random)` lines. Explains why the nonce is load-bearing and explicitly says **"do NOT remove `random` thinking it's unused"**. Cross-refs the AGENTS.md section and the matching test name.

- **`crates/cli/src/commands/chat.rs`** — parallel `///` docstring expansion on `generate_service_id` with the same rationale. The pre-existing one-liner didn't capture the *security* WHY.

No code-logic change. Behavior is identical; the nonce continues to be mixed exactly as before. Wire format unchanged. On-chain program unchanged.

## Acceptance criteria check (from #118)

- [x] Two consecutive deposits with identical request bodies produce different `service_id` — already enforced + tested on both Rust and TS sides.
- [x] Gateway can still match deposits to claims — nonce becomes part of the `service_id` itself which is persisted in `claim_queue.service_id` (no separate nonce storage needed).
- [x] Wire format compatible — `service_id` still 32 bytes, no on-chain program change.
- [x] `crates/x402/src/escrow/AGENTS.md` documents the requirement — this PR.
- [x] Tests covering "identical body, different service_ids" — already exist in both `crates/cli` and `sdks/signer-core`.

Closes #118.

## Test plan
- [x] `cd sdks/signer-core && npm run typecheck` → clean
- [x] `cd sdks/signer-core && npm test` → 84/84 pass
- [x] `cargo test -p solvela-cli commands::chat::tests::test_generate_service_id` → 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "For AI Agents" guidance section specifying that escrow service IDs must mix a per-request CSPRNG nonce with the request body (e.g., SHA-256(body || nonce)) to avoid deterministic/address-correlation risks.
  * Clarified security rationale (front-running, confidentiality, telemetry risks) and recommended regression test shape.
  * Added inline clarifying comments in implementations to mirror the documented invariant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->