### PR TITLE
docs(sdks): document bigint-buffer CVE rationale for the 3 TS SDK packages (closes #136)

### DIFF
--- a/sdks/AGENTS.md
+++ b/sdks/AGENTS.md
@@ -25,6 +25,39 @@ _(no loose files — see subdirectories)_
 - x402 contract: send request → receive 402 with `payment_required` body → sign USDC-SPL transfer → retry with `PAYMENT-SIGNATURE: <base64-or-json>` header.
 - 5% platform fee is already baked into the 402 response's `cost_breakdown` — SDKs surface it, don't recompute it.
 
+#### Known npm audit advisories — `bigint-buffer` ecosystem block
+
+All three TypeScript SDKs (`mcp`, `openclaw-provider`, `ai-sdk-provider`) report the same 3-advisory chain on `npm audit`, all rooted in a single CVE:
+
+| pkg | severity | source |
+|---|---|---|
+| `bigint-buffer` | high | [GHSA-3gc7-fjrx-p6mg](https://github.com/advisories/GHSA-3gc7-fjrx-p6mg) — buffer overflow in `toBigIntLE()` |
+| `@solana/buffer-layout-utils` | high | transitive via `bigint-buffer` |
+| `@solana/spl-token` | high | transitive via `@solana/buffer-layout-utils` |
+
+**No upstream fix exists.** `bigint-buffer`'s maintainer hasn't patched the vulnerability. The npm-suggested "fix" (`@solana/spl-token` 0.1.8) is a semver-major regression that drops modern SPL features the SDKs depend on. This is a Solana-ecosystem-wide block — every project that depends on `@solana/web3.js` v1 + `@solana/spl-token` for SPL operations inherits the same chain.
+
+**Reachability analysis:**
+
+`toBigIntLE()` is called by `@solana/buffer-layout-utils` during SPL account-state decode and instruction-data encode. In our SDKs:
+
+- **Outbound transfers** (the hot path): instruction buffers are constructed by `@solana/spl-token`'s typed builders from values we own (amount, mint, recipient pubkey). No untrusted bytes flow through `toBigIntLE()` here.
+- **Account-state decode**: none of the three SDKs decode arbitrary remote SPL accounts on the hot path. mcp's deposit flow constructs and broadcasts; signer-core builds the deposit tx; openclaw-provider/ai-sdk-provider wrap signer-core. The CVE's exploit prerequisite (attacker-controlled buffer feeding `toBigIntLE()`) is therefore not reachable through the SDK surfaces we expose.
+
+The vulnerability is reportable but not exploitable in our usage. Accept as an ecosystem-wide tolerated risk.
+
+**CI compromise:** the three SDK workflows (`.github/workflows/{mcp,openclaw-provider,ai-sdk-provider}.yml`) all run `npm audit --production --audit-level=critical` rather than `--audit-level=high`. This catches CRITICAL regressions while tolerating the known 3-advisory High chain. Inline comments in each workflow point at this section.
+
+**Re-evaluate when** ANY of:
+
+- `bigint-buffer` ships a patched release (track via the GHSA page or `npm view bigint-buffer versions`).
+- The SDK migrates to `@solana/web3.js` v2 (different transitive graph; CVE may not apply).
+- A peer package outside the three TS SDKs (e.g. dashboard, cli-npm shim, python) starts depending on `@solana/spl-token` or `bigint-buffer` directly (currently they don't — verified via `grep '"@solana/spl-token"' dashboard/package.json sdks/cli-npm/package.json`).
+
+If a re-evaluation determines the advisory is exploitable in a new use case, flip the CI from `--audit-level=critical` back to `--audit-level=high` *in the same PR* that addresses the actual vulnerability.
+
+Related: PR #134 (surfaced the warning), issue #136 (this triage).
+
 ### Testing Requirements
 Each SDK has its own test runner — see its `AGENTS.md`.
 


### PR DESCRIPTION
## Summary

Triage of #136 (npm audit on mcp + openclaw-provider after @solvela/sdk@0.2.x install). Investigation confirms all three TS SDK packages (mcp, openclaw-provider, ai-sdk-provider) report the same 3-advisory chain on `npm audit`, all rooted in a single CVE:

| pkg | severity | source |
|---|---|---|
| `bigint-buffer` | high | [GHSA-3gc7-fjrx-p6mg](https://github.com/advisories/GHSA-3gc7-fjrx-p6mg) — buffer overflow in `toBigIntLE()` |
| `@solana/buffer-layout-utils` | high | transitive via `bigint-buffer` |
| `@solana/spl-token` | high | transitive via `@solana/buffer-layout-utils` |

No upstream fix exists. The npm-suggested remediation (`@solana/spl-token` 0.1.8) is a semver-major regression that drops modern SPL features the SDKs depend on. Solana-ecosystem-wide block.

## What's already in place

All three SDK workflows (`.github/workflows/{mcp,openclaw-provider,ai-sdk-provider}.yml`) already run `npm audit --production --audit-level=critical` rather than `--audit-level=high`. This satisfies the #136 "forward-looking CI guard" AC — CRITICAL regressions still fail CI; the known High chain is tolerated.

## What was missing

A canonical doc so future auditors don't re-litigate. This PR adds a `####`-subsection to `sdks/AGENTS.md` covering:

1. **The 3-advisory table** with provenance and the GHSA link.
2. **Reachability analysis** — `toBigIntLE()` is called by `@solana/buffer-layout-utils` during SPL account decode and instruction encode. In our SDKs: outbound transfers construct instruction buffers from values we own (amount, mint, recipient pubkey) — no untrusted bytes; none of the three SDKs decode arbitrary remote SPL accounts on the hot path. The CVE's exploit prerequisite (attacker-controlled buffer feeding `toBigIntLE()`) is therefore not reachable through the surfaces we expose. Reportable, not exploitable in our usage.
3. **Re-evaluate when** — three concrete triggers:
   - `bigint-buffer` ships a patched release
   - SDKs migrate to `@solana/web3.js` v2 (different transitive graph)
   - A peer package outside the three TS SDKs starts depending on `@solana/spl-token` or `bigint-buffer` directly (currently none do — verified via grep)

## On the AC

The original AC ("0 high or critical") is strictly unachievable until the Solana ecosystem patches bigint-buffer or migrates to web3.js v2. Reframing the practical posture as **"0 critical + a documented High chain with reachability analysis"** matches what's actually defensible. The doc IS the deliverable.

Also verified: ai-sdk-provider currently has the same 3-advisory chain (the issue's claim it had 0 was true at filing time; later transitive changes pulled it in). The doc covers it explicitly so the AC's "no regression" applies to the same baseline as the other two.

No code change. No CI change.

Closes #136.

## Test plan
- [x] `npm audit --json` on all 3 SDK packages → identical 3-advisory chain confirmed
- [x] `grep '"@solana/spl-token"' dashboard/package.json sdks/cli-npm/package.json` → no matches, confirming the "peer packages don't depend on the vulnerable chain" claim in the re-evaluation triggers
- [x] No CI workflows changed; the existing `--audit-level=critical` posture across mcp.yml + openclaw-provider.yml + ai-sdk-provider.yml continues to gate CRITICAL regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation detailing known security audit findings in the SDK dependencies and their reachability assessment for transaction handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->