### PR TITLE
docs(mcp): replace stale npm install instructions with build-from-source (closes #81)

### DIFF
--- a/sdks/mcp/README.md
+++ b/sdks/mcp/README.md
@@ -49,15 +49,27 @@ The manual JSON snippets for each host are below as a fallback reference.
 
 ## Installation
 
-```bash
-npm install -g @solvela/mcp-server
-```
-
-Or run directly:
+The MCP server is **not published to npm** today (`package.json` is marked
+`private: true`). Build it from the monorepo:
 
 ```bash
-npx @solvela/mcp-server
+git clone https://github.com/solvela-ai/solvela.git
+cd solvela/sdks/mcp
+npm install
+npm run build
+# Built artifact: dist/index.js
 ```
+
+Run it directly to confirm the build:
+
+```bash
+node dist/index.js
+```
+
+The manual JSON snippets below use absolute paths to that built `dist/index.js`
+— `npx @solvela/mcp-server` is not available because the package is not on
+npm. The `solvela mcp install --host=<host>` flow shown in the Quickstart above
+handles the absolute path resolution for you.
 
 ## Setup with Claude Code
 
@@ -67,8 +79,8 @@ Add to your Claude Code MCP configuration (`.claude/settings.json` or project-le
 {
   "mcpServers": {
     "solvela": {
-      "command": "npx",
-      "args": ["@solvela/mcp-server"],
+      "command": "node",
+      "args": ["/absolute/path/to/solvela/sdks/mcp/dist/index.js"],
       "env": {
         "SOLVELA_API_URL": "http://localhost:8402",
         "SOLVELA_SESSION_BUDGET": "1.00",
@@ -92,8 +104,8 @@ Add to your Claude Desktop config (`claude_desktop_config.json`):
 {
   "mcpServers": {
     "solvela": {
-      "command": "npx",
-      "args": ["@solvela/mcp-server"],
+      "command": "node",
+      "args": ["/absolute/path/to/solvela/sdks/mcp/dist/index.js"],
       "env": {
         "SOLVELA_API_URL": "http://localhost:8402",
         "SOLVELA_SESSION_BUDGET": "1.00",
@@ -118,8 +130,8 @@ Add to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
   "mcpServers": {
     "solvela": {
       "type": "stdio",
-      "command": "npx",
-      "args": ["@solvela/mcp-server"],
+      "command": "node",
+      "args": ["/absolute/path/to/solvela/sdks/mcp/dist/index.js"],
       "env": {
         "SOLVELA_API_URL": "http://localhost:8402",
         "SOLVELA_SESSION_BUDGET": "1.00",


### PR DESCRIPTION
## Summary

#81 was filed against the docs site (`@solvela/mcp` not on npm). PR #270 quietly fixed `dashboard/content/docs/sdks/mcp.mdx` as part of a broader docs audit but didn't reference #81 — and didn't touch `sdks/mcp/README.md`, which has the same shape of bug under the slightly different name the package actually uses (`@solvela/mcp-server`). Both npm names return 404; the package is `private: true` in `package.json`.

This PR finishes option 2 ("update the docs") for the remaining surface: the package README that GitHub repo-browse renders and that (any future) npm package page would render.

## Changes

Aligns `sdks/mcp/README.md` with the canonical doc-site posture from PR #270:

- **Installation** — replaces `npm install -g @solvela/mcp-server` / `npx @solvela/mcp-server` with the explicit "not published to npm" disclaimer + git clone / npm install / `npm run build` / `node dist/index.js` sequence.
- **Setup with Claude Code / Claude Desktop / Cursor** — each config block switches from `"command": "npx", "args": ["@solvela/mcp-server"]` to `"command": "node", "args": ["/absolute/path/to/solvela/sdks/mcp/dist/index.js"]`, matching the canonical doc page.
- Brief paragraph between Installation and the three Setup sections explains the absolute-path requirement and points at the `solvela mcp install --host=<host>` flow (already documented in the existing Quickstart) as the path that handles absolute paths automatically.

The Quickstart section (lines 7-49) is unchanged — it was already correct (recommends the Solvela CLI's MCP installer as the primary path).

Two remaining `@solvela/mcp-server` references are intentional: the H1 title (the package's actual internal name) and a new disclaimer that explicitly says "`npx @solvela/mcp-server` is not available because the package is not on npm."

## Status of #81's options

| Option | Status |
|---|---|
| 1. Publish `@solvela/mcp` (or `@solvela/mcp-server`) | Not done — separate decision, when/if taken the docs flip back to npm-install instructions |
| 2. Update the docs | ✅ docs site fixed by #270; this PR finishes the README |
| 3. Remove the MCP page | Not taken — page is honest about state, no need to remove |

Closes #81.

## Test plan

- [x] `grep -n "@solvela/mcp-server\|npm install -g @solvela\|npx @solvela/mcp" sdks/mcp/README.md` → only the H1 title and the new disclaimer remain. No misleading install commands.
- [x] No code touched; doc-only change. No tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised MCP server installation and configuration instructions with updated quick-start guidance
  * Updated setup examples for Claude Code, Claude Desktop, and Cursor integrations
  * Modified installation workflow to build from the monorepo and run the compiled application locally

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->