### PR TITLE
feat(dashboard): 308 redirect /pricing → /docs/concepts/pricing (closes #82)

### DIFF
--- a/dashboard/next.config.mjs
+++ b/dashboard/next.config.mjs
@@ -9,6 +9,26 @@ const config = {
   turbopack: {
     root: __dirname,
   },
+  // /pricing → internal docs page redirect.
+  //
+  // The apex `solvela.ai/pricing` URL has never existed (no `pricing/`
+  // route under `dashboard/src/app/`), but external links — twitter
+  // bios, blog posts, prior enterprise-docs CTAs — used to point at
+  // it. Those references in `dashboard/content/docs/` are gone (see
+  // PR #270 + the Next.js 16 migration), but anything cached
+  // externally still 404s. Soft-handoff to the existing internal
+  // pricing docs page (`/docs/concepts/pricing`) — covers gateway-
+  // fee math, the model-pricing table, and the `/pricing` API
+  // endpoint — until/unless a dedicated apex marketing page is
+  // built. `permanent: true` emits HTTP 308 so browsers, proxies,
+  // and search engines can cache the handoff. See issue #82.
+  redirects: async () => [
+    {
+      source: '/pricing',
+      destination: '/docs/concepts/pricing',
+      permanent: true,
+    },
+  ],
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
## Summary

The apex `solvela.ai/pricing` URL has never existed (no `pricing/` route under `dashboard/src/app/`), but external links — twitter bios, blog mentions, the enterprise-docs CTAs that #82 was filed against — used to point at it.

**The 7 enterprise pages flagged in the issue have already been swept.** `grep "solvela.ai/pricing" dashboard/content/docs/enterprise/` returns no matches; remaining `pricing` links in the docs point at the internal `/docs/concepts/pricing` page or the gateway's `api.solvela.ai/pricing` JSON endpoint. That fix landed quietly in PR #270 (and/or the earlier Next.js 16 migration) without closing #82.

What remained: cached external references — search engines, prior social posts, third-party blogs — still 404 on the apex.

This PR closes that gap with a single `redirects()` entry in `dashboard/next.config.mjs`:

```js
{ source: '/pricing', destination: '/docs/concepts/pricing', permanent: true }
```

`permanent: true` emits HTTP 308 — the right semantic since the handoff is stable (destination exists, has covered fee math + the model-pricing table + the `/pricing` API endpoint, and isn't going anywhere). 308 is cacheable, so browsers / proxies / search engines absorb the redirect once.

## #82's three options

| Option | Status |
|---|---|
| 1. Build apex `/pricing` marketing page | Not done — separate product/marketing decision. When/if taken, this redirect goes away. |
| 2. Repoint enterprise-doc CTAs | Already done in PR #270 / Next.js 16 migration. |
| 3. Remove CTAs / soft-handoff cached links | **This PR** — 308 serves the same purpose: cached `/pricing` links resolve cleanly instead of 404. |

No new route/page added. No content change. Inline comment in `next.config.mjs` documents the WHY so a future cleanup PR doesn't strip the redirect thinking it's stale.

## Test plan
- [x] `cd dashboard && npm run build` → clean. The `redirects()` async function returns a one-element array; Next.js's build-time config validator would error on a malformed shape, so a clean build is the confirmation that the rule registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated routing configuration to redirect the `/pricing` path to `/docs/concepts/pricing`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->