### PR TITLE
fix(escrow): clear anchor-macro unexpected_cfgs via check-cfg whitelist (closes #114)

### DIFF
--- a/.github/workflows/escrow.yml
+++ b/.github/workflows/escrow.yml
@@ -42,6 +42,18 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  clippy:
+    name: cargo clippy --all-targets -- -D warnings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      # Enabled after #114 cleared the 14 anchor-macro `unexpected_cfgs`
+      # warnings via [lints.rust].check-cfg in programs/escrow/Cargo.toml.
+      - run: cargo clippy --all-targets -- -D warnings
+
   unit:
     name: Unit tests (no .so required)
     runs-on: ubuntu-latest
@@ -109,15 +121,6 @@ jobs:
       - run: cargo test --features sbf --test integration
 
 # Notes on what's intentionally NOT here:
-#
-# - clippy --all-targets -- -D warnings:  Anchor 0.31's macro crates
-#   (`anchor-attribute-program`, `anchor-derive-accounts`) emit ~14
-#   `unexpected_cfgs` warnings on current rustc that can't be fixed
-#   without an Anchor 0.32+ migration. Tracked in issue #114 (and
-#   #155/#156 for the broader anchor 1.0 plan). Adding clippy with
-#   `-D warnings` today would always fail; without `-D warnings` it
-#   would always pass and add no signal. Re-evaluate after the
-#   anchor upgrade lands.
 #
 # - cargo audit / cargo-deny: the workspace's CI already runs these
 #   against the workspace tree. The escrow crate's dependency set is

--- a/programs/escrow/Cargo.toml
+++ b/programs/escrow/Cargo.toml
@@ -57,3 +57,20 @@ spl-associated-token-account = "6"
 
 [profile.release]
 overflow-checks = true
+
+# Whitelist cfg values that anchor-lang's macros emit but our crate does not
+# declare as features. Without this, rustc's check-cfg lint warns 14 times on
+# every `#[program]` / `#[derive(Accounts)]` expansion. Tracks #114 and
+# upstream Anchor macro check-cfg hygiene — the macro crates still embed
+# these cfgs without check-cfg metadata as of 1.0.2, so an anchor-lang bump
+# would not actually clear the warnings.
+#
+# - feature = "anchor-debug" / "custom-heap" / "custom-panic": Anchor
+#   internal opt-in features we never enable.
+# - target_os = "solana": the SBF on-chain target triple, only set under
+#   `anchor build`. Host-side `cargo check` doesn't see it.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("anchor-debug", "custom-heap", "custom-panic"))',
+    'cfg(target_os, values("solana"))',
+] }

--- a/programs/escrow/tests/unit.rs
+++ b/programs/escrow/tests/unit.rs
@@ -129,9 +129,10 @@ mod tests {
     fn test_max_escrow_slots_is_sane() {
         // ~1 day at 400ms/slot. Doc-checked sanity bound — if someone bumps
         // it beyond a few days, that's a separate decision (would interact
-        // with the agent's deadline guarantee).
-        assert!(solvela_escrow::MAX_ESCROW_SLOTS >= 100_000);
-        assert!(solvela_escrow::MAX_ESCROW_SLOTS <= 1_000_000);
+        // with the agent's deadline guarantee). Compile-time `const _: () =`
+        // form so a bad bump fails the build, not a single test.
+        const _: () = assert!(solvela_escrow::MAX_ESCROW_SLOTS >= 100_000);
+        const _: () = assert!(solvela_escrow::MAX_ESCROW_SLOTS <= 1_000_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #114.

Issue #114 asked to bump anchor-lang 0.31.1 → 0.32+ on the premise that newer macro crates declare check-cfg metadata. **Investigation showed that premise wrong:**

- **0.32.1 is unreachable from our current dep tree** — it pulls `solana-account-info >= 2.3` via `solana-invoke 0.4`, but `litesvm 0.6.1` caps `solana-program-runtime <= 2.2.4`. The only `litesvm` that resolves is 0.12.0, which forces Solana 3.x — the post-crate-split tree deliberately rolled back in #113.
- **Empirical probe on anchor-lang 1.0.2** (latest, with litesvm 0.12.0) still emits 8 of the same 14 warnings — the anchor macro crates do not gate `anchor-debug` / `custom-heap` / `custom-panic` / `target_os = "solana"` with check-cfg metadata even at 1.0.2.

So bumping anchor would be (a) blocked by #113's rollback, and (b) wouldn't actually clear the warnings. The durable fix is rustc's intended escape hatch: declare the cfg values as known-valid via `[lints.rust].check-cfg` in `Cargo.toml`. Other unexpected cfg values still warn — this is whitelist, not blanket-suppress.

Also lands the **clippy CI gate** that `escrow.yml`'s tail comment explicitly deferred until #114 closed:

```yaml
clippy:
  name: cargo clippy --all-targets -- -D warnings
```

Two real lints surfaced (`clippy::assertions_on_constants` in `tests/unit.rs`) — fixed by switching to compile-time `const _: () = assert!(..)` form, which is strictly better: a bad bump of `MAX_ESCROW_SLOTS` now fails the build, not a single test run.

## Acceptance criteria (from #114)

| AC | Status | Note |
|---|---|---|
| `anchor-lang` and `anchor-spl` bumped to 0.32.x or newer | **Reframed** | Not pursued — see "Why we didn't bump anchor" below |
| `anchor build` succeeds and produces a functioning `.so` | n/a — no source change | Existing SBF build path unchanged |
| `cargo test --features sbf` passes the full LiteSVM suite | n/a — no source change | Existing integration tests unchanged |
| `cargo check --tests` emits **zero** `unexpected_cfgs` warnings | ✅ | 14 → 0, locally verified |
| On-chain program ID + account layout unchanged | ✅ | No source changes affect bytecode |

## Why we didn't bump anchor

The bump *cannot* satisfy the AC's "zero unexpected_cfgs warnings" criterion because the warnings come from anchor macro hygiene gaps that span 0.31 through 1.0.2 — not from rustc check-cfg metadata that newer macros declare. The issue's authoring assumption was incorrect; the bump is real work (Solana 3.x toolchain return, litesvm 0.12 API migration, IDL move to PMP) for a partial win. Tracked upstream — see follow-up in the comment below.

## Test plan

All four host-runnable CI jobs verified locally (the two SBF jobs run only in CI with the Anchor toolchain installed):

- [x] `cargo fmt --all -- --check` (escrow crate)
- [x] `cargo clippy --all-targets -- -D warnings` (was previously deferred per workflow comment)
- [x] `cargo test --test unit` — 9/9 pass
- [x] `cargo check --lib --features mainnet`
- [x] `cargo check --tests` — 0 warnings (was 14)
- [ ] `cargo build-sbf` — runs in CI
- [ ] `cargo test --features sbf --test integration` — runs in CI

## Files

- `programs/escrow/Cargo.toml` — `[lints.rust]` with check-cfg whitelist (+17 lines)
- `programs/escrow/tests/unit.rs` — 2 asserts → `const _: () = assert!(..)` (+3/-2 lines)
- `.github/workflows/escrow.yml` — add `clippy` job, remove deferred-clippy comment (+12/-9 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with stricter code quality checks to catch issues earlier in development.
  * Improved build configuration for better compiler compatibility.

* **Tests**
  * Updated validation tests to perform checks earlier in the build process for faster feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->