### PR TITLE
ci(escrow): lint with --all-features in clippy job (follow-up to #314)

### DIFF
--- a/.github/workflows/escrow.yml
+++ b/.github/workflows/escrow.yml
@@ -43,7 +43,7 @@ jobs:
       - run: cargo fmt --all -- --check
 
   clippy:
-    name: cargo clippy --all-targets -- -D warnings
+    name: cargo clippy --all-targets --features … -- -D warnings
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,13 @@ jobs:
           components: clippy
       # Enabled after #114 cleared the 14 anchor-macro `unexpected_cfgs`
       # warnings via [lints.rust].check-cfg in programs/escrow/Cargo.toml.
-      - run: cargo clippy --all-targets -- -D warnings
+      #
+      # Feature set covers every non-sbf feature so lints inside
+      # feature-gated code paths get checked (e.g. mainnet's USDC mint
+      # swap). `sbf` is excluded because tests/integration.rs and
+      # tests/helpers.rs `include_bytes!` target/deploy/solvela_escrow.so,
+      # which doesn't exist outside the sbf-build job.
+      - run: cargo clippy --all-targets --features mainnet,cpi,no-entrypoint,no-idl,no-log-ix-name -- -D warnings
 
   unit:
     name: Unit tests (no .so required)


### PR DESCRIPTION
## Summary

Addresses [CodeRabbit's nitpick](https://github.com/solvela-ai/solvela/pull/314#pullrequestreview-2944237853) on the freshly-landed escrow clippy gate (PR #314): the job was running `cargo clippy --all-targets -- -D warnings` without enabling any features, so lints inside `#[cfg(feature = "…")]`-gated code (e.g. the `mainnet` USDC mint swap in `lib.rs:46`) weren't being checked.

This PR adds all non-`sbf` features to the clippy invocation:

\`\`\`yaml
- run: cargo clippy --all-targets --features mainnet,cpi,no-entrypoint,no-idl,no-log-ix-name -- -D warnings
\`\`\`

`sbf` stays excluded — `tests/integration.rs` and `tests/helpers.rs` `include_bytes!` the on-chain `.so`, which is only produced by the `sbf-build` job and isn't available in a clippy-only step.

## Test plan

- [x] Locally: `cargo clippy --all-targets --features mainnet,cpi,no-entrypoint,no-idl,no-log-ix-name -- -D warnings` → clean, no new lints
- [ ] CI: the updated `clippy` job runs on this PR

## Files

- `.github/workflows/escrow.yml` — clippy run line + 6-line comment explaining the feature choice (+8/-2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to enhance code quality checks and improve workflow documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->