### PR TITLE
build(sdks): auto-bootstrap @solvela/signer-core via prebuild/pretest hooks

### DIFF
--- a/sdks/ai-sdk-provider/package.json
+++ b/sdks/ai-sdk-provider/package.json
@@ -34,10 +34,11 @@
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "generate-models": "tsx scripts/generate-models.ts",
-    "prebuild": "npm run generate-models",
+    "prebuild": "node ../signer-core/scripts/ensure-built.mjs && npm run generate-models",
     "check:docs": "tsx scripts/check-docs-for-leaked-keys.ts",
     "lint": "tsc --noEmit",
-    "size": "size-limit"
+    "size": "size-limit",
+    "pretest": "node ../signer-core/scripts/ensure-built.mjs"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "2.0.47",

--- a/sdks/mcp/package.json
+++ b/sdks/mcp/package.json
@@ -12,7 +12,9 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "node --test tests/server.test.ts tests/contract.test.ts tests/session.test.ts tests/escrow.test.ts"
+    "test": "node --test tests/server.test.ts tests/contract.test.ts tests/session.test.ts tests/escrow.test.ts",
+    "prebuild": "node ../signer-core/scripts/ensure-built.mjs",
+    "pretest": "node ../signer-core/scripts/ensure-built.mjs"
   },
   "keywords": [
     "mcp",

--- a/sdks/openclaw-provider/package.json
+++ b/sdks/openclaw-provider/package.json
@@ -11,11 +11,12 @@
   },
   "scripts": {
     "generate:models": "node --import tsx/esm scripts/generate-models.ts",
-    "prebuild": "npm run generate:models",
+    "prebuild": "node ../signer-core/scripts/ensure-built.mjs && npm run generate:models",
     "build": "tsc",
     "test": "node --import tsx/esm --test tests/index.test.ts tests/signer.test.ts tests/manifest.test.ts tests/models.test.ts tests/registry.test.ts tests/f4-wrapper.test.ts",
     "typecheck": "tsc --noEmit",
-    "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
+    "typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
+    "pretest": "node ../signer-core/scripts/ensure-built.mjs"
   },
   "keywords": [
     "openclaw",

--- a/sdks/signer-core/scripts/ensure-built.mjs
+++ b/sdks/signer-core/scripts/ensure-built.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Build sdks/signer-core/dist if missing.
+//
+// Called by consumer packages (sdks/mcp, sdks/openclaw-provider, sdks/ai-sdk-provider)
+// as a prebuild / pretest hook because npm does not auto-build `file:` deps. CI handles
+// this with explicit workflow steps; this script gives local dev the same behavior so
+// `npm --prefix sdks/<consumer> run build` works on a fresh clone without a manual
+// `cd ../signer-core && npm ci && npm run build` dance first.
+//
+// Fast path: if `dist/` already exists, exits silently. To force a rebuild, run
+// `npm run build` in sdks/signer-core/ directly or delete its dist directory.
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+if (existsSync(resolve(root, 'dist'))) process.exit(0);
+
+process.stderr.write('[ensure-built] Bootstrapping @solvela/signer-core (file: dep — npm does not auto-build)…\n');
+execSync('npm ci --no-audit --no-fund && npm run build', { cwd: root, stdio: 'inherit' });


### PR DESCRIPTION
## Summary

Surfaced today while closing #135 (the migration that issue tracked was already done via #137 + #144). Fresh-clone walk in any consumer SDK still hit a real friction: `npm install && npm run build` failed with `Cannot find module '@solvela/signer-core'` because npm doesn't auto-build `file:` workspace deps.

CI already handles this with an explicit "Build signer-core dist/" step in each consumer's workflow yaml. Local dev had no equivalent — every fresh checkout required a manual `cd sdks/signer-core && npm ci && npm run build` first.

This PR brings local dev to parity:

- **New:** `sdks/signer-core/scripts/ensure-built.mjs` — fast-path script. Exits 0 if `dist/` exists; otherwise runs `npm ci && npm run build` in signer-core.
- **Wired as `prebuild` + `pretest` hooks** in `sdks/mcp`, `sdks/openclaw-provider`, `sdks/ai-sdk-provider`. For consumers with an existing prebuild (openclaw, ai-sdk), the bootstrap is prepended via `&&` so model generation still runs.

## Verification

Tested on a totally cold state (`find sdks/signer-core/dist -delete; find sdks/mcp/node_modules -mindepth 1 -delete`) for each consumer:

\`\`\`
$ npm --prefix sdks/mcp install                  # ok
$ npm --prefix sdks/mcp run build                # prebuild fires bootstrap → tsc
$ npm --prefix sdks/mcp test                     # pretest fires bootstrap → 86/86 pass
$ npm --prefix sdks/openclaw-provider run build  # prebuild: bootstrap + generate:models + tsc
$ npm --prefix sdks/ai-sdk-provider run build    # prebuild: bootstrap + generate-models + tsup
\`\`\`

Warm runs are silent no-ops (script exits 0 immediately when `dist/` exists).

## CI impact

Workflows unchanged. The explicit "Build signer-core dist/" step in `mcp.yml` / `openclaw-provider.yml` / `ai-sdk-provider.yml` still runs first as before; the new prebuild hook then no-ops on the (now-existing) dist. Zero net cost.

Optional follow-up (separate PR, if this proves stable): drop the now-redundant explicit CI step.

## Files

- `sdks/signer-core/scripts/ensure-built.mjs` (new, 21 lines)
- `sdks/mcp/package.json` (+2 lines: `prebuild`, `pretest`)
- `sdks/openclaw-provider/package.json` (+1 modified, +1 new: chain bootstrap into existing `prebuild`, add `pretest`)
- `sdks/ai-sdk-provider/package.json` (same pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build system initialization to ensure dependencies are properly established before compilation and testing across SDK packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->