### PR TITLE
build(ai-sdk-provider): bump undici 7 → 8 in integration test transport (closes #157)

### DIFF
--- a/.github/workflows/ai-sdk-provider.yml
+++ b/.github/workflows/ai-sdk-provider.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: sdks/ai-sdk-provider/package-lock.json
       - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
@@ -46,11 +46,12 @@ jobs:
     needs: docs-key-leak-check
     strategy:
       matrix:
-        # Node 18 dropped: vitest 4.x and other dev tooling import
-        # `node:util.styleText`, which was added in Node 20.12. Runtime
-        # code (sign.ts) only needs Node 14+; engines.node in package.json
-        # remains permissive for consumers.
-        node: ['20']
+        # Node 20 dropped: undici 8 (devDep, mocks integration-test transport
+        # via MockAgent) requires engines.node >= 22.19. Node 20 went EOL
+        # April 2026; Node 22 is the current LTS. Runtime code (sign.ts)
+        # only needs Node 14+; engines.node in package.json remains
+        # permissive for consumers (undici is dev-only).
+        node: ['22']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -71,7 +72,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: sdks/ai-sdk-provider/package-lock.json
       - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
@@ -88,7 +89,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: sdks/ai-sdk-provider/package-lock.json
       - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
@@ -104,11 +105,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Node 18 dropped: vitest 4.x and other dev tooling import
-        # `node:util.styleText`, which was added in Node 20.12. Runtime
-        # code (sign.ts) only needs Node 14+; engines.node in package.json
-        # remains permissive for consumers.
-        node: ['20']
+        # Node 20 dropped: undici 8 (devDep, mocks integration-test transport
+        # via MockAgent) requires engines.node >= 22.19. Node 20 went EOL
+        # April 2026; Node 22 is the current LTS. Runtime code (sign.ts)
+        # only needs Node 14+; engines.node in package.json remains
+        # permissive for consumers (undici is dev-only).
+        node: ['22']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -129,11 +131,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Node 18 dropped: vitest 4.x and other dev tooling import
-        # `node:util.styleText`, which was added in Node 20.12. Runtime
-        # code (sign.ts) only needs Node 14+; engines.node in package.json
-        # remains permissive for consumers.
-        node: ['20']
+        # Node 20 dropped: undici 8 (devDep, mocks integration-test transport
+        # via MockAgent) requires engines.node >= 22.19. Node 20 went EOL
+        # April 2026; Node 22 is the current LTS. Runtime code (sign.ts)
+        # only needs Node 14+; engines.node in package.json remains
+        # permissive for consumers (undici is dev-only).
+        node: ['22']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -155,7 +158,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: sdks/ai-sdk-provider/package-lock.json
       - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
@@ -173,7 +176,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: sdks/ai-sdk-provider/package-lock.json
       - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
@@ -209,7 +212,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: sdks/ai-sdk-provider/package-lock.json
       - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"

--- a/sdks/ai-sdk-provider/package-lock.json
+++ b/sdks/ai-sdk-provider/package-lock.json
@@ -25,7 +25,7 @@
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.6.0",
-        "undici": "^7.0.0",
+        "undici": "^8.3.0",
         "vitest": "^4.1.6"
       },
       "engines": {
@@ -4670,11 +4670,13 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/sdks/ai-sdk-provider/package.json
+++ b/sdks/ai-sdk-provider/package.json
@@ -62,7 +62,7 @@
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.6.0",
-    "undici": "^7.0.0",
+    "undici": "^8.3.0",
     "vitest": "^4.1.6"
   },
   "size-limit": [

--- a/sdks/ai-sdk-provider/tests/integration/mock-gateway.ts
+++ b/sdks/ai-sdk-provider/tests/integration/mock-gateway.ts
@@ -43,6 +43,7 @@ import {
   MockAgent,
   getGlobalDispatcher,
   setGlobalDispatcher,
+  fetch as undiciFetch,
   type Dispatcher,
 } from 'undici';
 import type { Interceptable, MockInterceptor } from 'undici/types/mock-interceptor';
@@ -159,9 +160,18 @@ export interface MockGatewayHandle {
  */
 export function installMockGateway(baseUrl: string): MockGatewayHandle {
   const previousDispatcher: Dispatcher = getGlobalDispatcher();
+  // undici 8 isolated the global dispatcher to symbol `.2`; Node 22's built-in
+  // fetch still uses `.1`, and the v1-mirror via Dispatcher1Wrapper does NOT
+  // bridge MockAgent's interceptor matching. So MockAgent interceptors are
+  // invisible to `globalThis.fetch` (requests hit the real network and time
+  // out). Swap globalThis.fetch for undici's own fetch — which definitively
+  // dispatches through whatever MockAgent we installed via setGlobalDispatcher.
+  // Restored in reset() below.
+  const previousFetch = globalThis.fetch;
   const agent = new MockAgent({ connections: 1 });
   agent.disableNetConnect();
   setGlobalDispatcher(agent);
+  globalThis.fetch = undiciFetch as typeof globalThis.fetch;
 
   // Extract just the origin (scheme + host + optional port) for agent.get().
   const origin = new URL(baseUrl).origin;
@@ -219,6 +229,7 @@ export function installMockGateway(baseUrl: string): MockGatewayHandle {
     try {
       agent.assertNoPendingInterceptors();
     } finally {
+      globalThis.fetch = previousFetch;
       setGlobalDispatcher(previousDispatcher);
       await agent.close();
       calls.length = 0;


### PR DESCRIPTION
## Summary

Closes #157. Picks up the bump that dependabot opened in #106 and we deferred because integration tests fell over on undici 8.

### Root cause (now confirmed empirically)

undici 8 isolated the global dispatcher to a new internal symbol (`undici.globalDispatcher.2`, [nodejs/undici#4827](https://github.com/nodejs/undici/pull/4827)) and added a `Dispatcher1Wrapper` mirror so Node 22's bundled-undici fetch (still on the `.1` symbol) can keep using `setGlobalDispatcher()`. The mirror bridges handler callbacks for plain `Agent` but **does not bridge MockAgent's interceptor matching** — so on Node 22, `globalThis.fetch` no longer routes through any `MockAgent` installed via `setGlobalDispatcher`.

Minimal repro on Node v22.22.0:

\`\`\`
--- test: globalThis.fetch (Node native) ---
FAILED: fetch failed
--- test: undici.fetch (npm undici 8.x) ---
status: 200 json: { ok: true }
\`\`\`

That's 85 of 353 tests dropping — every test that exercised the mock gateway via the provider's default fetch.

### Fix

Contained in `tests/integration/mock-gateway.ts`: alongside `setGlobalDispatcher(agent)`, also swap `globalThis.fetch` for undici's own `fetch` (which definitively dispatches through whatever agent is global). Save and restore the original on `reset()`. No per-test changes needed — 12 integration test files inherit the fix.

### Node matrix bump

undici 8 has `engines.node >= 22.19.0`. The workflow matrix moved 20 → 22 (three matrix blocks + six hardcoded `node-version: '20'` in non-matrix jobs aligned to '22'). Node 20 went EOL April 2026; Node 22 is the current LTS. Runtime stays Node 14+ via the per-call \`sign.ts\` path; `engines.node` in the published package is unchanged (undici is dev-only, consumers are unaffected).

## Test plan

- [x] `npm --prefix sdks/ai-sdk-provider test` — **353/353 pass** (was 268/353 before fix)
- [x] `npm --prefix sdks/ai-sdk-provider run typecheck` — clean
- [x] `npm --prefix sdks/ai-sdk-provider run lint` — clean
- [x] `npm --prefix sdks/ai-sdk-provider run build` — clean
- [ ] CI on this PR runs the same gates on Node 22

## Files

- `sdks/ai-sdk-provider/package.json` — undici `^7.0.0` → `^8.3.0`
- `sdks/ai-sdk-provider/package-lock.json` — regenerated
- `sdks/ai-sdk-provider/tests/integration/mock-gateway.ts` — +11 lines (import `undiciFetch`, save/swap/restore `globalThis.fetch`)
- `.github/workflows/ai-sdk-provider.yml` — Node matrix 20 → 22 (3 blocks) + 6 non-matrix Node-version pins aligned to '22'; comment refreshed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated minimum Node.js version requirement to Node 22
  * Updated `undici` dependency to the latest compatible version

* **Tests**
  * Improved integration test reliability to ensure mock gateway interceptors function correctly

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solvela-ai/solvela/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->