### PR TITLE
chore: disable CodeRabbit auto-review (opt-in via @coderabbitai review)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+# CodeRabbit configuration for solvela-ai/solvela.
+#
+# Policy: auto-review disabled — CR is opt-in via `@coderabbitai review` in
+# a PR comment. Rationale: blanket auto-review on the Rust + Solana stack
+# produced more noise than signal in initial testing (see PR #316, 2026-05-16:
+# 16 "actionable" findings flagged, with several hallucinated APIs,
+# duplicated nitpicks across files, and missed project conventions
+# documented in CLAUDE.md). Reach for CR on security-sensitive or
+# wire-contract PRs; let the rest go through normal review.
+#
+# Re-enabling auto-review is a one-line change (`auto_review.enabled: true`).
+
+language: en-US
+
+reviews:
+  # Don't let CR mark reviews as "Changes requested" — that gates merging
+  # via branch protection in ways we don't want a bot to control.
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: false
+    drafts: false
+
+chat:
+  # Still respond to explicit `@coderabbitai review` / `pause` / `resolve`
+  # commands on PRs and issues.
+  auto_reply: true


### PR DESCRIPTION
## Summary
Add `.coderabbit.yaml` with `reviews.auto_review.enabled: false`. CodeRabbit is now opt-in: trigger with `@coderabbitai review` in a PR comment when you want a second look. Explicit `pause` / `resolve` / `ignore` commands still work via `chat.auto_reply: true`.

## Why
One day of CR auto-review on this Rust + Solana stack produced mixed-signal output. PR #316 (Rust SDK consolidation, 2026-05-16) was the test case:

**Real catches (3-4):**
- Missing top-level `permissions:` block on `.github/workflows/sdks-rust.yml`
- Mnemonic stdin echo without no-echo terminal read
- `balance.rs` swallows all RPC errors as `Ok(0)`
- Non-Unix wallet file write without enforced ACLs

**Mixed / wrong (4-5):**
- `Duration::from_mins(1)` flagged as "non-existent API" — stable since Rust 1.81 (our MSRV is 1.91); CI compiles clean
- `Cargo.toml` `repository` URL flagged as stale — already fixed in the consolidation commit; CR reviewed against outdated state
- Cache key collision warning on `(model, messages)` — that's an intentional, documented wallet-agnostic cache design (CLAUDE.md rule #16)
- Same `from_mins` finding duplicated across three files, inflating the "actionable" count

**Preference nits (5+):** structured tracing, `checked_add` for a u64 request counter, `Option<Option<T>>` builder tri-state, const for divider width.

## Operational cost
CR's `COMMENTED` review with 16 actionable items blocked the Solvela-bot's auto-approve heuristic on #316 (bot approved #314 and #317 within minutes; deliberately skipped #316). The review body is immutable, so `@coderabbitai pause + resolve` cleared CR's state but didn't free the bot's gate. Net effect: CR added one round of review friction and one operational block, in exchange for ~3 catches that would have been found in normal review.

## Decision
Keep CR available (already paid for it; the explicit-invocation mode is useful for security-sensitive PRs) but make it opt-in. Re-enabling is a one-line config change.

## Test plan
- [x] Verified `.coderabbit.yaml` schema against [CodeRabbit docs](https://docs.coderabbit.ai/getting-started/configure-coderabbit) (top-level `reviews.auto_review.enabled`, `chat.auto_reply`)
- [ ] After merge: open a test PR and confirm CR does NOT auto-review
- [ ] After merge: comment `@coderabbitai review` on a test PR and confirm CR responds