### PR TITLE
fix(sdks/rust): no-echo TTY reads for mnemonic + keypair imports (#322)

### DIFF
--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -1980,6 +1980,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,6 +3333,7 @@ dependencies = [
  "clap",
  "futures",
  "reqwest",
+ "rpassword",
  "serde_json",
  "solvela-client",
  "solvela-client-cli-args",
@@ -4007,6 +4029,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -51,6 +51,7 @@ tower-http = { version = "0.6", features = ["limit"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
+rpassword = "7"
 
 # Observability
 tracing = "0.1"

--- a/sdks/rust/crates/solvela-client-cli/Cargo.toml
+++ b/sdks/rust/crates/solvela-client-cli/Cargo.toml
@@ -21,6 +21,7 @@ solvela-client-cli-args = { path = "../solvela-client-cli-args", version = "0.2"
 solvela-protocol = { workspace = true }
 reqwest = { workspace = true }
 clap = { workspace = true }
+rpassword = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/sdks/rust/crates/solvela-client-cli/src/commands/wallet.rs
+++ b/sdks/rust/crates/solvela-client-cli/src/commands/wallet.rs
@@ -57,7 +57,7 @@ fn do_create(wallet_file: &str, force: bool) -> Result<(Wallet, String, PathBuf)
 }
 
 fn import_mnemonic(wallet_args: &WalletArgs, force: bool) -> Result<(), String> {
-    let phrase = read_stdin_line("Enter seed phrase: ")?;
+    let phrase = read_secret_line("Enter seed phrase: ")?;
     let (address, path) = do_import_mnemonic(&phrase, &wallet_args.wallet_file, force)?;
 
     println!("Imported address: {address}");
@@ -84,7 +84,7 @@ fn do_import_mnemonic(
 }
 
 fn import_keypair(wallet_args: &WalletArgs, force: bool) -> Result<(), String> {
-    let b58 = read_stdin_line("Enter base58 keypair: ")?;
+    let b58 = read_secret_line("Enter base58 keypair: ")?;
     let (address, path) = do_import_keypair(&b58, &wallet_args.wallet_file, force)?;
 
     println!("Imported address: {address}");
@@ -181,6 +181,14 @@ fn read_stdin_line(prompt: &str) -> Result<String, String> {
         .map_err(|e| format!("failed to read stdin: {e}"))?;
 
     Ok(line)
+}
+
+// Reads a secret without echoing to the terminal so mnemonics/keypairs don't
+// leak into scrollback, shell history, or screen-recording buffers (#322).
+// On non-TTY stdin (piped input), rpassword reads the line as-is — that path
+// is acceptable because the secret never reaches a terminal in the first place.
+fn read_secret_line(prompt: &str) -> Result<String, String> {
+    rpassword::prompt_password(prompt).map_err(|e| format!("failed to read secret: {e}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Replace plain stdin line read with `rpassword::prompt_password` for the two secret-bearing CLI prompts: `solvela-client wallet import-mnemonic` and `import-keypair`.
- Adds `rpassword = \"7\"` to the workspace + `solvela-client-cli` crate. Echo is suppressed on TTY input; piped stdin still works (no terminal echo risk in that path).
- Scope: **problem 1 of two** in #322. The non-Unix wallet-write fail-open behavior is the same issue's problem 2 and will land as a separate PR.

## Why

The existing `read_stdin_line` helper echoes input back to the terminal, leaving BIP-39 mnemonics and base58 keypairs in:

- Terminal scrollback
- Shell history (if pasted into a wrapping command)
- Tmux / screen capture buffers
- Screen-recording / over-the-shoulder observation

CodeRabbit flagged this during the solvela-client → monorepo consolidation review (PR #316); it was inherited from the standalone repo and explicitly deferred to keep the consolidation diff scoped.

## Design notes

- Inner validation functions (`do_import_mnemonic`, `do_import_keypair`) take `phrase: &str` and are unchanged — existing unit tests still exercise the validation/save paths.
- Only the outer wrappers swap to `read_secret_line`, a thin private helper that wraps `rpassword::prompt_password`.
- The `export` y/N confirmation still uses `read_stdin_line` — that prompt is not a secret.
- **Non-TTY behavior:** rpassword reads piped input as-is. The threat model (scrollback exposure) doesn't apply to piped input — the secret never reaches a terminal. No `--stdin` flag added (avoids breaking scripted automation).

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace` — 149 tests pass, including all 16 wallet-command tests
- [ ] Manual: \`solvela-client wallet import-mnemonic\` no longer prints the seed phrase as the user types it
- [ ] Manual: \`echo \"<phrase>\" | solvela-client wallet import-mnemonic\` still works (piped path)

## Out of scope (follow-up)

- #322 problem 2: non-Unix wallet-write should return \`Err\` instead of \`tracing::warn!\` + write fail-open

Refs: #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)