### PR TITLE
fix(sdks/rust): fail closed on non-Unix wallet write (#322)

### DIFF
--- a/sdks/rust/crates/solvela-client-cli-args/src/lib.rs
+++ b/sdks/rust/crates/solvela-client-cli-args/src/lib.rs
@@ -126,22 +126,39 @@ pub fn save_wallet(path: &str, keypair_bytes: &[u8], force: bool) -> Result<Path
         ));
     }
 
+    // Fail closed on platforms where we cannot enforce owner-only ACLs at
+    // file-create time. The previous behavior (write + tracing::warn!) left
+    // the keypair on disk with whatever default ACL the platform applied —
+    // potentially world-readable on shared hosts. See issue #322 problem 2.
+    #[cfg(not(unix))]
+    {
+        let _ = keypair_bytes;
+        return Err(format!(
+            "refusing to write wallet file at {}: owner-only ACL enforcement \
+             is not implemented on this platform. Set the SOLVELA_WALLET_KEY \
+             env var with a base58-encoded keypair instead, or run on a Unix host.",
+            expanded.display()
+        ));
+    }
+
     // Ensure parent directory exists
+    #[cfg(unix)]
     if let Some(parent) = expanded.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("failed to create directory {}: {e}", parent.display()))?;
     }
 
-    // Serialize as JSON byte array (Solana CLI format)
-    let json = serde_json::to_string(&keypair_bytes)
-        .map_err(|e| format!("failed to serialize keypair: {e}"))?;
-
-    // Write with restricted permissions from the start (0o600) to avoid
-    // a window where the file is world-readable before chmod.
+    // Serialize as JSON byte array (Solana CLI format) and write with
+    // owner-only permissions. Reached only on Unix — the non-Unix branch
+    // above returned Err.
     #[cfg(unix)]
     {
         use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
+        let json = serde_json::to_string(&keypair_bytes)
+            .map_err(|e| format!("failed to serialize keypair: {e}"))?;
+        // Restrict permissions at create time so there's no window in which
+        // the file is world-readable before chmod.
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -151,29 +168,8 @@ pub fn save_wallet(path: &str, keypair_bytes: &[u8], force: bool) -> Result<Path
             .map_err(|e| format!("failed to create {}: {e}", expanded.display()))?;
         file.write_all(json.as_bytes())
             .map_err(|e| format!("failed to write {}: {e}", expanded.display()))?;
+        Ok(expanded)
     }
-
-    #[cfg(not(unix))]
-    {
-        // MEDIUM-3: on non-Unix (Windows in particular) we cannot enforce
-        // 0600-equivalent ACLs without pulling in extra dependencies. Warn
-        // loudly so operators know the wallet file is created with whatever
-        // default ACL the platform applies (typically inherited from the
-        // parent directory and potentially world-readable on shared hosts).
-        // TODO: implement proper Windows ACL hardening via the
-        // `windows-permissions` crate or `OpenOptionsExt::access_mode` so
-        // the file is restricted to the current user only. See audit
-        // finding MEDIUM-3.
-        std::fs::write(&expanded, &json)
-            .map_err(|e| format!("failed to write {}: {e}", expanded.display()))?;
-        tracing::warn!(
-            path = %expanded.display(),
-            "wallet file created without owner-only ACL on non-Unix platform; \
-             treat the file location as sensitive (MEDIUM-3)"
-        );
-    }
-
-    Ok(expanded)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- On non-Unix platforms (Windows, WASI), `save_wallet` now returns `Err` instead of writing the keypair file with `tracing::warn!`. The previous fail-open behavior left the keypair on disk with whatever default ACL the platform applied — potentially world-readable on shared hosts.
- The error message references the refused path and directs the user to either run on a Unix host or use the `SOLVELA_WALLET_KEY` env var (base58-encoded keypair in process memory, not on disk).
- Directory-create side effect is now gated to `cfg(unix)` so a refused write doesn't leave a stray empty parent directory behind.
- Scope: **problem 2 of two** in #322. Problem 1 (no-echo TTY reads) is in #325.

## Why

This is the second half of the CodeRabbit finding from PR #316. The non-Unix path was explicitly tagged `MEDIUM-3` in the prior audit and carried a `TODO` to add proper Windows ACL hardening via the `windows-permissions` crate. Rather than pulling in a Windows-specific crypto dep, the simpler and safer move is to fail closed — Solvela is Solana-native and primarily Linux/macOS; we don't need to silently degrade the security model for an unsupported platform.

## What I considered and rejected

- **Implementing Windows ACLs via `windows-permissions`**: adds a platform-specific dep, more code to audit, and the bytes still touch disk in cleartext (only the ACL changes). Failing closed eliminates an entire failure mode.
- **Leaving warn+write with louder log**: doesn't address the real risk — operators don't read warnings in non-interactive pipelines.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — 149 tests pass; Unix path tests (\`test_save_wallet_creates_file\`, \`test_save_wallet_refuses_overwrite\`) unchanged
- [ ] Manual on Linux/macOS: \`solvela-client wallet create\` still works end-to-end
- [ ] Manual on Windows / WASI: \`solvela-client wallet create\` now returns the new \`refusing to write wallet file at ...\` error instead of writing

> Note: I couldn't add a cross-target check to CI here without a mingw toolchain on the runner. The cfg-gated logic is simple enough that visual review + clippy on Linux gives reasonable coverage; happy to add a Windows job in a follow-up if reviewers want stronger enforcement.

## Out of scope

- Adding a Windows CI job that exercises the new Err path.
- Refactoring \`load_wallet\` (which only \`tracing::warn!\`s on insecure-perms; loading is read-only so the fail-open concern doesn't apply there).

Refs: #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)