### PR TITLE
fix(sdks/rust): discriminate Solana RPC errors instead of collapsing to Ok(0) (#323)

### DIFF
--- a/sdks/rust/crates/solvela-client-cli/src/commands/doctor.rs
+++ b/sdks/rust/crates/solvela-client-cli/src/commands/doctor.rs
@@ -114,7 +114,17 @@ async fn check_rpc(http: &reqwest::Client, rpc_url: &str) -> bool {
 
     match http.post(rpc_url).json(&rpc_body).send().await {
         Ok(resp) if resp.status().is_success() => {
-            let json: serde_json::Value = resp.json().await.unwrap_or_default();
+            // Fail closed on parse errors and ambiguous responses (no numeric
+            // `result`, no `error`). The prior `unwrap_or_default()` + permissive
+            // else-branch reported "RPC reachable" for garbage payloads, which
+            // hid real outages from operators running `doctor`. See issue #323.
+            let json: serde_json::Value = match resp.json().await {
+                Ok(v) => v,
+                Err(e) => {
+                    println!("[FAIL] Solana RPC response parse error: {e}");
+                    return false;
+                }
+            };
             if let Some(slot) = json.get("result").and_then(serde_json::Value::as_u64) {
                 println!("[ok]  Solana RPC reachable: slot {slot}");
                 true
@@ -122,8 +132,8 @@ async fn check_rpc(http: &reqwest::Client, rpc_url: &str) -> bool {
                 println!("[FAIL] Solana RPC error: {json}");
                 false
             } else {
-                println!("[WARN] Solana RPC reachable but unexpected response");
-                true
+                println!("[FAIL] Solana RPC returned unexpected response: {json}");
+                false
             }
         }
         Ok(resp) => {

--- a/sdks/rust/crates/solvela-client/src/balance.rs
+++ b/sdks/rust/crates/solvela-client/src/balance.rs
@@ -19,6 +19,8 @@ enum BalanceError {
     HttpStatus(u16),
     #[error("failed to parse RPC response: {0}")]
     ParseResponse(String),
+    #[error("RPC returned error: {0}")]
+    RpcError(String),
 }
 
 /// Default poll interval: 30 seconds.
@@ -196,9 +198,16 @@ impl BalanceMonitor {
             .await
             .map_err(|e| BalanceError::ParseResponse(e.to_string()))?;
 
-        // Account not found -> balance is 0
-        if json.get("error").is_some() {
-            return Ok(0.0);
+        // Discriminate the benign "account does not exist" case from real RPC
+        // errors (rate limits, auth failures, malformed requests). Silently
+        // collapsing every error to Ok(0) masks rate-limited endpoints as
+        // "always zero balance" instead of surfacing them to the monitor loop.
+        // See issue #323.
+        if let Some(error) = json.get("error") {
+            if crate::rpc_error::is_account_not_found(&json) {
+                return Ok(0.0);
+            }
+            return Err(BalanceError::RpcError(error.to_string()));
         }
 
         Ok(json["result"]["value"]["uiAmount"].as_f64().unwrap_or(0.0))
@@ -311,6 +320,68 @@ mod tests {
         assert_ne!(balance, u64::MAX, "balance should have been updated");
         assert_eq!(balance, 5_000_000);
 
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_account_not_found_returns_zero_balance() {
+        // Canonical Solana error for a non-existent ATA — must collapse to Ok(0)
+        // so the monitor reports an honest zero rather than masking real outages.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": { "code": -32602, "message": "Invalid param: could not find account" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let state = Arc::new(AtomicU64::new(u64::MAX));
+        let wallet_address = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+        let monitor = BalanceMonitor::new(Arc::clone(&state), &mock_server.uri(), &wallet_address)
+            .poll_interval(Duration::from_millis(50));
+
+        let handle = tokio::spawn(monitor.run());
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // u64::MAX is the "never polled" sentinel; account-not-found must overwrite
+        // it with 0, distinguishing "honest zero balance" from "never polled".
+        assert_eq!(state.load(Ordering::Relaxed), 0);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_does_not_overwrite_last_known_balance() {
+        // A real RPC error (rate limit, auth failure, etc.) must NOT be silenced
+        // to Ok(0) — the monitor preserves the last known balance and the error
+        // surfaces via the tracing::error! arm in run().
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": { "code": -32005, "message": "Server is busy" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Seed with a known balance so we can verify it's preserved across the error.
+        let state = Arc::new(AtomicU64::new(7_500_000));
+        let wallet_address = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+        let monitor = BalanceMonitor::new(Arc::clone(&state), &mock_server.uri(), &wallet_address)
+            .poll_interval(Duration::from_millis(50));
+
+        let handle = tokio::spawn(monitor.run());
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        assert_eq!(
+            state.load(Ordering::Relaxed),
+            7_500_000,
+            "rate-limit error must not overwrite the last known balance"
+        );
         handle.abort();
     }
 

--- a/sdks/rust/crates/solvela-client/src/client.rs
+++ b/sdks/rust/crates/solvela-client/src/client.rs
@@ -674,9 +674,18 @@ impl SolvelaClient {
             .await
             .map_err(|e| ClientError::BalanceError(format!("failed to parse RPC response: {e}")))?;
 
-        // Account not found → balance is 0
-        if json.get("error").is_some() {
-            return Ok(0.0);
+        // Discriminate the benign "account does not exist" case from real RPC
+        // errors (rate limits, auth failures, malformed requests). Silently
+        // returning Ok(0) on every error makes a malfunctioning RPC look like
+        // an empty wallet, which is a confusing operator experience and hides
+        // outages from retry loops. See issue #323.
+        if let Some(error) = json.get("error") {
+            if crate::rpc_error::is_account_not_found(&json) {
+                return Ok(0.0);
+            }
+            return Err(ClientError::BalanceError(format!(
+                "RPC returned error: {error}"
+            )));
         }
 
         let ui_amount = json["result"]["value"]["uiAmount"].as_f64().unwrap_or(0.0);
@@ -1089,6 +1098,45 @@ mod tests {
 
         let balance = client.usdc_balance().await.unwrap();
         assert!((balance - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_usdc_balance_propagates_real_rpc_errors() {
+        // A non-account-not-found RPC error (e.g., rate limit) must propagate as
+        // Err(ClientError::BalanceError), not be silenced to Ok(0). See #323.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": { "code": -32005, "message": "Server is busy" }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: "http://unused".to_string(),
+                rpc_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let result = client.usdc_balance().await;
+        assert!(result.is_err(), "rate-limit error must propagate as Err");
+        match result.unwrap_err() {
+            ClientError::BalanceError(msg) => {
+                assert!(
+                    msg.contains("Server is busy"),
+                    "error should surface the upstream message: {msg}"
+                );
+            }
+            other => panic!("expected ClientError::BalanceError, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/sdks/rust/crates/solvela-client/src/lib.rs
+++ b/sdks/rust/crates/solvela-client/src/lib.rs
@@ -4,6 +4,7 @@ pub mod client;
 pub mod config;
 pub mod error;
 pub(crate) mod quality;
+pub(crate) mod rpc_error;
 #[allow(dead_code)] // SessionInfo::escalated and cleanup_expired are reserved for future use
 pub(crate) mod session;
 pub(crate) mod signer;

--- a/sdks/rust/crates/solvela-client/src/rpc_error.rs
+++ b/sdks/rust/crates/solvela-client/src/rpc_error.rs
@@ -1,0 +1,97 @@
+//! Helpers for discriminating Solana JSON-RPC error responses.
+//!
+//! Solana RPC's `getTokenAccountBalance` returns a JSON-RPC error with
+//! `code = -32602` and a message containing `"could not find account"` when
+//! the SPL token account does not exist on chain. That case is benign for
+//! balance lookups — a missing ATA means a zero balance, and callers can
+//! treat it as `Ok(0)`. Every other error code (rate limit, auth failure,
+//! malformed request, internal server error, etc.) is a real failure that
+//! must be propagated; silencing them to `Ok(0)` makes a malfunctioning RPC
+//! indistinguishable from an empty wallet. See issue #323.
+
+use serde_json::Value;
+
+/// Returns true if the JSON-RPC response represents a missing-account error
+/// for `getTokenAccountBalance` (or sibling balance-fetch methods) — that is,
+/// `code == -32602` with a message indicating the account does not exist.
+///
+/// The message-substring check is necessary because `-32602` ("Invalid params")
+/// is a catch-all code that Solana RPC also returns for malformed pubkeys,
+/// unsupported commitment levels, etc. Only the canonical "could not find
+/// account" / "Account does not exist" variants are benign.
+pub(crate) fn is_account_not_found(json: &Value) -> bool {
+    let Some(error) = json.get("error") else {
+        return false;
+    };
+    let code = error.get("code").and_then(Value::as_i64).unwrap_or(0);
+    if code != -32602 {
+        return false;
+    }
+    let msg = error
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    msg.contains("could not find account") || msg.contains("Account does not exist")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn canonical_account_not_found_message_matches() {
+        let json = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "code": -32602, "message": "Invalid param: could not find account" }
+        });
+        assert!(is_account_not_found(&json));
+    }
+
+    #[test]
+    fn helius_variant_message_matches() {
+        let json = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "code": -32602, "message": "Account does not exist" }
+        });
+        assert!(is_account_not_found(&json));
+    }
+
+    #[test]
+    fn other_neg_32602_does_not_match() {
+        let json = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "code": -32602, "message": "Invalid param: unrecognized commitment" }
+        });
+        assert!(!is_account_not_found(&json));
+    }
+
+    #[test]
+    fn rate_limit_does_not_match() {
+        let json = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "code": -32005, "message": "Server is busy" }
+        });
+        assert!(!is_account_not_found(&json));
+    }
+
+    #[test]
+    fn no_error_field_does_not_match() {
+        let json = json!({ "jsonrpc": "2.0", "id": 1, "result": { "value": null } });
+        assert!(!is_account_not_found(&json));
+    }
+
+    #[test]
+    fn missing_code_does_not_match() {
+        let json = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "message": "could not find account" }
+        });
+        assert!(!is_account_not_found(&json));
+    }
+}


### PR DESCRIPTION
## Summary

- Three call sites in the Rust SDK (`balance.rs::fetch_balance`, `client.rs::usdc_balance_of`, `doctor.rs::check_rpc`) silently mapped **any** Solana RPC error to a zero balance / reachable RPC. A rate-limited endpoint or auth failure looked identical to an empty wallet.
- New `rpc_error::is_account_not_found` helper matches the canonical Solana signature (`code = -32602` + message containing `could not find account` or `Account does not exist`). Only that exact case still collapses to `Ok(0)`; every other error propagates.
- `doctor.rs` swaps `unwrap_or_default()` for an explicit match and fails closed on ambiguous-success responses.

## Why

From #323 — surfaced by CodeRabbit on the consolidation PR #316, inherited from the standalone solvela-client repo. Severity:low because the happy path works in production, but the failure mode is observability: a malfunctioning RPC produces "your wallet appears empty" + "your RPC seems fine" instead of the actual outage.

## Changes

| File | Change |
| --- | --- |
| `solvela-client/src/rpc_error.rs` (new) | `pub(crate) fn is_account_not_found(json)` — message-substring discrimination over `-32602`. 6 unit tests. |
| `solvela-client/src/balance.rs` | Adds `BalanceError::RpcError(String)`; calls helper. Real RPC errors now hit the existing `Err(e) => error!(...)` arm in `run()` and preserve the last known balance instead of overwriting to zero. |
| `solvela-client/src/client.rs` | Same shape; propagates as `ClientError::BalanceError(...)`. |
| `solvela-client-cli/src/commands/doctor.rs` | `unwrap_or_default()` → explicit match; ambiguous-success branch now prints `[FAIL]` and returns `false`. |

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — 158 tests pass (was 149; +9 new)
- [x] Built-in regression guard: existing \`test_usdc_balance_returns_zero_for_missing_account\` (canonical \`-32602\` + \"Invalid param: could not find account\") still returns \`Ok(0.0)\` — confirms the discrimination logic preserves the benign case.

### New test coverage

| Test | What it asserts |
| --- | --- |
| \`rpc_error::canonical_account_not_found_message_matches\` | Standard Solana RPC error → matched |
| \`rpc_error::helius_variant_message_matches\` | Helius-style "Account does not exist" → matched |
| \`rpc_error::other_neg_32602_does_not_match\` | -32602 + unrecognized-commitment message → NOT matched (so it propagates) |
| \`rpc_error::rate_limit_does_not_match\` | -32005 "Server is busy" → NOT matched |
| \`rpc_error::no_error_field_does_not_match\` | Success response → NOT matched |
| \`rpc_error::missing_code_does_not_match\` | Error object without \`code\` → NOT matched |
| \`balance::test_account_not_found_returns_zero_balance\` | wiremock: canonical error → \`AtomicU64\` updated to 0 (overwrites the never-polled \`u64::MAX\` sentinel) |
| \`balance::test_rate_limit_does_not_overwrite_last_known_balance\` | wiremock: -32005 error → seeded balance preserved, not zeroed |
| \`client::test_usdc_balance_propagates_real_rpc_errors\` | wiremock: -32005 → \`Err(ClientError::BalanceError)\` carrying \"Server is busy\" |

## Risk

Behavior change for any caller that was relying on the old fail-open semantics. Surveyed call sites:

- \`balance.rs::run()\` — already has an \`Err(e) => error!(...)\` arm that preserves the last known balance. Now exercised for more error shapes; no signature change.
- \`client.rs\` external callers (\`solvela-client-cli/src/commands/{wallet,doctor}.rs\`) — both already \`match\` on \`Result<f64, ClientError>\`. They now see more \`Err\` variants but no code changes are required.
- \`doctor.rs\` — output text and return-value semantics tightened: parse error and ambiguous response now print \`[FAIL]\` and return \`false\`. Intentional.

Refs: #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)