### PR TITLE
fix(gateway): wrap admin_token in secret-safe newtype (#173 L4 GW)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -45,6 +45,7 @@ hmac = { workspace = true }
 lru = { workspace = true }
 hex = "0.4"
 rand = "0.10"
+zeroize = { workspace = true }
 
 # Utilities
 uuid = { workspace = true }

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -14,6 +14,7 @@ pub mod orgs;
 pub mod payment_util;
 pub mod providers;
 pub mod routes;
+pub mod secret;
 pub mod security;
 pub mod service_health;
 pub mod services;
@@ -81,7 +82,10 @@ pub struct AppState {
     /// `None` when escrow or claim processor is not configured.
     pub escrow_metrics: Option<Arc<solvela_x402::escrow::EscrowMetrics>>,
     /// Admin token for protected endpoints. `None` when not configured.
-    pub admin_token: Option<String>,
+    /// Wrapped in [`secret::AdminToken`] so the value is redacted from `Debug`
+    /// output, zeroized on drop, and only comparable via the constant-time
+    /// `verify` method. See issue #173 (L4 GW).
+    pub admin_token: Option<secret::AdminToken>,
     /// Prometheus metrics handle for rendering the `/metrics` endpoint.
     /// `None` when the recorder failed to install (metrics unavailable).
     pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -436,10 +436,12 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    // Read admin token once at startup
+    // Read admin token once at startup, wrap in the secret-safe newtype so
+    // it is redacted from Debug output and zeroized on drop (see #173 L4 GW).
     let admin_token = env_with_fallback("SOLVELA_ADMIN_TOKEN", "RCR_ADMIN_TOKEN")
         .ok()
-        .filter(|t| !t.is_empty());
+        .filter(|t| !t.is_empty())
+        .map(gateway::secret::AdminToken::new);
 
     // Dev-mode payment bypass — only when SOLVELA_DEV_BYPASS_PAYMENT=true AND not production
     let dev_bypass_payment = if is_production {

--- a/crates/gateway/src/routes/admin_stats.rs
+++ b/crates/gateway/src/routes/admin_stats.rs
@@ -12,7 +12,6 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::security;
 use crate::AppState;
 
 /// Query parameters for the admin stats endpoint.
@@ -99,7 +98,7 @@ pub async fn admin_stats(
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .is_some_and(|token| security::constant_time_eq(token.as_bytes(), admin_token.as_bytes()));
+        .is_some_and(|token| admin_token.verify(token.as_bytes()));
 
     if !authorized {
         return Err((

--- a/crates/gateway/src/routes/escrow.rs
+++ b/crates/gateway/src/routes/escrow.rs
@@ -15,7 +15,6 @@ use serde::Serialize;
 use serde_json::json;
 use tokio::sync::Mutex;
 
-use crate::security;
 use crate::AppState;
 
 /// Cached Solana slot value with a 5-second TTL.
@@ -157,12 +156,12 @@ pub async fn escrow_health(
         }
     };
 
-    // Validate Bearer token
+    // Validate Bearer token via the secret-safe newtype's constant-time compare
     let authorized = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .is_some_and(|token| security::constant_time_eq(token.as_bytes(), admin_token.as_bytes()));
+        .is_some_and(|token| admin_token.verify(token.as_bytes()));
 
     if !authorized {
         return (

--- a/crates/gateway/src/routes/health.rs
+++ b/crates/gateway/src/routes/health.rs
@@ -5,11 +5,11 @@ use axum::http::HeaderMap;
 use axum::Json;
 use serde_json::{json, Value};
 
-use crate::security;
+use crate::secret::AdminToken;
 use crate::AppState;
 
 /// Check whether the request carries a valid admin bearer token.
-fn is_admin_authenticated(headers: &HeaderMap, admin_token: Option<&str>) -> bool {
+fn is_admin_authenticated(headers: &HeaderMap, admin_token: Option<&AdminToken>) -> bool {
     let Some(expected) = admin_token else {
         return false;
     };
@@ -17,7 +17,7 @@ fn is_admin_authenticated(headers: &HeaderMap, admin_token: Option<&str>) -> boo
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .is_some_and(|token| security::constant_time_eq(token.as_bytes(), expected.as_bytes()))
+        .is_some_and(|token| expected.verify(token.as_bytes()))
 }
 
 /// GET /health — gateway readiness check with dependency status.
@@ -83,7 +83,7 @@ pub async fn health(State(state): State<Arc<AppState>>, headers: HeaderMap) -> J
         }
     };
 
-    let authenticated = is_admin_authenticated(&headers, state.admin_token.as_deref());
+    let authenticated = is_admin_authenticated(&headers, state.admin_token.as_ref());
 
     if authenticated {
         Json(json!({
@@ -228,7 +228,7 @@ supports_vision = false
             replay_set: AppState::new_replay_set(),
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
-            admin_token: Some("test-admin-token".to_string()),
+            admin_token: Some(AdminToken::new("test-admin-token".to_string())),
             prometheus_handle: None,
             dev_bypass_payment: false,
         })

--- a/crates/gateway/src/routes/metrics.rs
+++ b/crates/gateway/src/routes/metrics.rs
@@ -11,7 +11,6 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 
-use crate::security;
 use crate::AppState;
 
 /// Prometheus text content type per the exposition format spec.
@@ -36,12 +35,12 @@ pub async fn get_metrics(
         }
     };
 
-    // Validate Bearer token using constant-time comparison
+    // Validate Bearer token via the secret-safe newtype's constant-time compare
     let authorized = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .is_some_and(|token| security::constant_time_eq(token.as_bytes(), admin_token.as_bytes()));
+        .is_some_and(|token| admin_token.verify(token.as_bytes()));
 
     if !authorized {
         return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();

--- a/crates/gateway/src/routes/orgs/mod.rs
+++ b/crates/gateway/src/routes/orgs/mod.rs
@@ -36,7 +36,6 @@ use crate::orgs::models::{
     AddMemberRequest, AssignWalletRequest, CreateApiKeyRequest, CreateOrgRequest, CreateTeamRequest,
 };
 use crate::orgs::queries;
-use crate::security;
 use crate::AppState;
 
 /// Query parameters for the audit log endpoint.
@@ -98,7 +97,7 @@ fn require_admin(state: &AppState, headers: &HeaderMap) -> Result<(), Response> 
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .is_some_and(|token| security::constant_time_eq(token.as_bytes(), admin_token.as_bytes()));
+        .is_some_and(|token| admin_token.verify(token.as_bytes()));
 
     if !authorized {
         return Err((
@@ -149,9 +148,7 @@ pub(crate) fn require_auth(
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
-            .is_some_and(|token| {
-                security::constant_time_eq(token.as_bytes(), admin_token.as_bytes())
-            });
+            .is_some_and(|token| admin_token.verify(token.as_bytes()));
         if is_admin {
             return Ok(AuthContext::Admin);
         }
@@ -328,7 +325,7 @@ supports_vision = true
             http_client: reqwest::Client::new(),
             slot_cache: crate::routes::escrow::new_slot_cache(),
             escrow_metrics: None,
-            admin_token: admin_token.map(String::from),
+            admin_token: admin_token.map(|t| crate::secret::AdminToken::new(t.to_string())),
             prometheus_handle: None,
             dev_bypass_payment: false,
         });
@@ -488,7 +485,7 @@ mod tests {
             http_client: reqwest::Client::new(),
             slot_cache: crate::routes::escrow::new_slot_cache(),
             escrow_metrics: None,
-            admin_token: Some("admin-secret".to_string()),
+            admin_token: Some(crate::secret::AdminToken::new("admin-secret".to_string())),
             prometheus_handle: None,
             dev_bypass_payment: false,
         };
@@ -531,7 +528,7 @@ mod tests {
             http_client: reqwest::Client::new(),
             slot_cache: crate::routes::escrow::new_slot_cache(),
             escrow_metrics: None,
-            admin_token: Some("admin-secret".to_string()),
+            admin_token: Some(crate::secret::AdminToken::new("admin-secret".to_string())),
             prometheus_handle: None,
             dev_bypass_payment: false,
         };
@@ -577,7 +574,7 @@ mod tests {
             http_client: reqwest::Client::new(),
             slot_cache: crate::routes::escrow::new_slot_cache(),
             escrow_metrics: None,
-            admin_token: Some("admin-secret".to_string()),
+            admin_token: Some(crate::secret::AdminToken::new("admin-secret".to_string())),
             prometheus_handle: None,
             dev_bypass_payment: false,
         };

--- a/crates/gateway/src/routes/services.rs
+++ b/crates/gateway/src/routes/services.rs
@@ -128,7 +128,7 @@ pub async fn register_service(
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .is_some_and(|token| security::constant_time_eq(token.as_bytes(), admin_token.as_bytes()));
+        .is_some_and(|token| admin_token.verify(token.as_bytes()));
 
     if !authorized {
         return (

--- a/crates/gateway/src/secret.rs
+++ b/crates/gateway/src/secret.rs
@@ -1,0 +1,119 @@
+//! Secret-bearing types for the gateway.
+//!
+//! Wraps secrets like the admin token in newtypes that:
+//! - Redact the value in `Debug` output
+//! - Zeroize the underlying bytes on drop
+//! - Force callers through a constant-time comparison helper
+//!
+//! These are belt-and-braces defenses against accidental log leakage,
+//! heap dumps, and timing side-channels. See issue #173 (L4 GW).
+
+use std::fmt;
+
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::security::constant_time_eq;
+
+/// The admin token used to gate operator-only endpoints (`/v1/escrow/admin`,
+/// `/metrics`, sensitive health subroutes).
+///
+/// Stored as `Vec<u8>` rather than `String` so the bytes can be zeroized
+/// deterministically on drop without relying on `String`'s capacity. The
+/// `Debug` impl redacts the value so the token never appears in panic
+/// output, structured-log dumps, or accidental `dbg!` calls. Equality is
+/// only exposed via the constant-time `verify` method — `PartialEq` is
+/// intentionally omitted to make the timing-safe path the only path.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct AdminToken(Vec<u8>);
+
+impl AdminToken {
+    /// Wrap a string token. The original `String` is consumed; the only
+    /// remaining copy of the bytes lives inside the `AdminToken`.
+    #[must_use]
+    pub fn new(token: String) -> Self {
+        Self(token.into_bytes())
+    }
+
+    /// Constant-time comparison against a candidate byte slice. Returns
+    /// `true` iff the candidate equals the wrapped token. The compare always
+    /// iterates `max(self.len(), candidate.len())` bytes, so an attacker
+    /// cannot infer prefix matches or correct length from response timing.
+    #[must_use]
+    pub fn verify(&self, candidate: &[u8]) -> bool {
+        constant_time_eq(&self.0, candidate)
+    }
+
+    /// True if the wrapped token is empty. Operators who set
+    /// `SOLVELA_ADMIN_TOKEN=` (no value) almost certainly mean "not
+    /// configured" — callers should normalize that case to `None` rather
+    /// than accept an empty-string match.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Debug for AdminToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("AdminToken").field(&"[REDACTED]").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_matches_exact_token() {
+        let token = AdminToken::new("hunter2".to_string());
+        assert!(token.verify(b"hunter2"));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_token() {
+        let token = AdminToken::new("hunter2".to_string());
+        assert!(!token.verify(b"hunter3"));
+    }
+
+    #[test]
+    fn verify_rejects_prefix() {
+        // The wrapped token is longer than the candidate.
+        let token = AdminToken::new("hunter2-extra".to_string());
+        assert!(!token.verify(b"hunter2"));
+    }
+
+    #[test]
+    fn verify_rejects_suffix() {
+        // The candidate is longer than the wrapped token.
+        let token = AdminToken::new("hunter2".to_string());
+        assert!(!token.verify(b"hunter2-extra"));
+    }
+
+    #[test]
+    fn verify_empty_matches_empty() {
+        let token = AdminToken::new(String::new());
+        assert!(token.verify(b""));
+    }
+
+    #[test]
+    fn debug_redacts_value() {
+        let token = AdminToken::new("topsecret123".to_string());
+        let debug_output = format!("{token:?}");
+        assert!(
+            !debug_output.contains("topsecret123"),
+            "Debug must not leak the token: got {debug_output}"
+        );
+        assert!(
+            debug_output.contains("REDACTED"),
+            "Debug must mark value as REDACTED: got {debug_output}"
+        );
+    }
+
+    #[test]
+    fn is_empty_reflects_inner_length() {
+        let empty = AdminToken::new(String::new());
+        let non_empty = AdminToken::new("x".to_string());
+        assert!(empty.is_empty());
+        assert!(!non_empty.is_empty());
+    }
+}

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -250,7 +250,9 @@ fn test_app_with_state() -> (axum::Router, Arc<AppState>) {
         replay_set: AppState::new_replay_set(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: None,
-        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -396,7 +398,9 @@ fn test_app_with_mock_provider_and_state() -> (axum::Router, Arc<AppState>) {
         replay_set: AppState::new_replay_set(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: None,
-        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -463,7 +467,9 @@ fn test_app_with_mock_provider_and_escrow() -> axum::Router {
         replay_set: AppState::new_replay_set(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: None,
-        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -529,7 +535,9 @@ fn test_app_with_escrow() -> axum::Router {
         replay_set: AppState::new_replay_set(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: None,
-        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -1824,7 +1832,9 @@ fn test_app_with_nonce_pool() -> axum::Router {
         replay_set: AppState::new_replay_set(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: None,
-        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -3385,7 +3395,9 @@ fn test_app_with_escrow_metrics() -> axum::Router {
         replay_set: AppState::new_replay_set(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: Some(metrics),
-        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -3544,7 +3556,9 @@ async fn test_escrow_health_reflects_incremented_metrics() {
         replay_set: AppState::new_replay_set(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: Some(Arc::clone(&metrics)),
-        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -3773,7 +3787,9 @@ async fn test_escrow_health_status_down_without_claimer() {
         replay_set: AppState::new_replay_set(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: None,
-        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -71,7 +71,7 @@ fn router_with_pool(pool: PgPool) -> Router {
         http_client: reqwest::Client::new(),
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: None,
-        admin_token: Some(ADMIN_TOKEN.to_string()),
+        admin_token: Some(gateway::secret::AdminToken::new(ADMIN_TOKEN.to_string())),
         prometheus_handle: None,
         dev_bypass_payment: false,
     });


### PR DESCRIPTION
## Summary

- New `secret::AdminToken` newtype wraps `Vec<u8>` with `Zeroize` + `ZeroizeOnDrop`, a redacting `Debug` impl, and a `verify(&[u8])` method that delegates to the existing `security::constant_time_eq`.
- All six gateway call sites that compared the admin token (`routes/{health,escrow,metrics,services,admin_stats}.rs` + `routes/orgs/mod.rs` × 2) switch to `admin_token.verify(token.as_bytes())`. `security` imports are removed from files where they become unused.
- Test fixtures in unit tests (`health.rs`, `orgs/mod.rs`) and integration tests (`tests/integration.rs`, `tests/orgs_routes.rs`) updated to construct the newtype.

## Why

From #173 L4 GW — surfaced in the 2026-05-08 security review. The admin token was stored as `Option<String>` with correct constant-time comparison, but plaintext String storage left:

- A heap-dump exposure window (bytes linger until reallocation).
- An accidental-logging surface (a future `tracing::info!(?state.admin_token)` or `dbg!` would print the value).

`AdminToken` closes both: zeroize-on-drop wipes the bytes deterministically; `Debug` redacts to `AdminToken("[REDACTED]")`. `PartialEq` is deliberately omitted so the timing-safe path is the only path.

## What I considered and rejected

- **`secrecy::SecretString`** (already used in `crates/cli/`): adds a dep that's not yet in the gateway, and `expose_secret().as_bytes()` is easy to misuse. The narrow `verify` API on a small inline newtype gives stronger compile-time guarantees about correct usage.
- **Leave as `String`, audit logs**: doesn't address the heap-dump exposure; only addresses the (currently absent) logging hazard.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test -p gateway --lib\` — 515 pass (was 508; +7 new in \`secret::tests\`)
- [x] \`cargo test -p gateway --test integration\` — 129 pass
- [ ] \`cargo test -p gateway --test escrow_queue\` — DB-backed, not exercised locally (env missing the legacy \`rcr\` Postgres user). CI will run with a configured DB; the diff doesn't touch any sqlx queries.

### New test coverage (in \`crates/gateway/src/secret.rs\`)

| Test | Asserts |
| --- | --- |
| \`verify_matches_exact_token\` | Correct token returns true |
| \`verify_rejects_wrong_token\` | Wrong content returns false |
| \`verify_rejects_prefix\` | Shorter candidate (stored is longer) returns false |
| \`verify_rejects_suffix\` | Longer candidate (stored is shorter) returns false |
| \`verify_empty_matches_empty\` | Empty-vs-empty matches (sanity check) |
| \`debug_redacts_value\` | Debug output never contains the raw bytes; contains "REDACTED" |
| \`is_empty_reflects_inner_length\` | Helper for env-var normalization |

## Risk

Pure behavior-preserving refactor at the auth boundary. The 644 existing gateway tests pass unchanged — the same constant-time comparison runs, just through the newtype's `verify` method. No public API on `AppState` changes shape externally; only the storage type of `admin_token` field is tightened.

## Out of scope (other #173 items)

- **L1 GW** (API-key HMAC salt): non-trivial migration story (existing key rehash) — separate PR.
- **L2 GW** (`validate_*` re-check): inspection task.
- **L3 SDK** (`dangerouslySetInnerHTML` annotation): dashboard side, separate PR.
- See the hygiene comment on #173 for the full remaining roster.

Refs: #173 (L4 GW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)