### PR TITLE
docs(dashboard): annotate Shiki dangerouslySetInnerHTML safety boundary (#173 L3 SDK)

### DIFF
--- a/dashboard/src/components/landing/sdk-cta-panel.tsx
+++ b/dashboard/src/components/landing/sdk-cta-panel.tsx
@@ -167,6 +167,16 @@ export function SdkCtaPanel({ preHighlighted }: SdkCtaPanelProps) {
                 <CopyButton text={active.code} label="copy" />
               </div>
               {activeHtml ? (
+                // Safe: `activeHtml` is server-rendered Shiki output for
+                // entries in the hardcoded `SAMPLES` constant (see
+                // `./sdk-samples.ts`). No runtime data flows into `code` or
+                // `lang`, and Shiki only emits its own typed <span>/<code>
+                // tree. If you ever wire SAMPLES (or `preHighlighted` from
+                // page.tsx) to runtime input, switch to the plain-text
+                // fallback branch below or pipe through a sanitizer first.
+                // The repo's `react/no-danger` lint rule is not currently
+                // enabled by `eslint-config-next`'s default presets; treat
+                // this comment as the policy gate. See issue #173 (L3 SDK).
                 <pre
                   key={active.id}
                   role="tabpanel"

--- a/dashboard/src/components/landing/sdk-samples.ts
+++ b/dashboard/src/components/landing/sdk-samples.ts
@@ -1,3 +1,11 @@
+// SAFETY: `SAMPLES` below feeds `app/page.tsx`'s server-side Shiki pipeline,
+// whose HTML output is rendered via `dangerouslySetInnerHTML` in
+// `./sdk-cta-panel.tsx`. The injection is only safe because every `code`
+// string here is a build-time literal in this file. Do NOT source `code`
+// (or any other field) from runtime input — CMS, query params, fetch
+// responses, user submissions, etc. — without first routing through a
+// sanitizer. See issue #173 (L3 SDK).
+
 import type { SupportedLang } from '@/lib/shiki/highlighter'
 
 export type SampleStatus = 'live' | 'alpha' | 'soon'


### PR DESCRIPTION
## Summary

- Adds a multi-line safety comment above the `<pre dangerouslySetInnerHTML>` site in `dashboard/src/components/landing/sdk-cta-panel.tsx`.
- Adds a module-level SAFETY block at the top of `dashboard/src/components/landing/sdk-samples.ts` warning contributors not to source any `Sample` field — especially `code` — from runtime input without first sanitizing.
- No behavior change. `npm run build` clean; `npx eslint` on touched files clean.

## Why

From #173 L3 SDK — surfaced in the 2026-05-08 security review. The landing page injects pre-rendered Shiki HTML via `dangerouslySetInnerHTML`. **Safe today** because:

1. The HTML comes from a server-only `highlight()` helper.
2. Input is the hardcoded `SAMPLES: Sample[]` constant — every `code` string is a literal in `sdk-samples.ts`.
3. Shiki's `codeToHtml` for known languages only emits its own typed `<span>` / `<code>` tree.

The risk is architectural: a future refactor could pipe runtime data (CMS, query params, fetch responses) into SAMPLES and re-introduce an XSS vector. The Shiki pipeline would happily highlight attacker-controlled tokens that include valid HTML escape sequences, and nothing downstream sanitizes. The annotations make the invariant explicit at both ends of the pipeline.

## Why not enable `react/no-danger` lint rule

That would be the stronger fix — turning the disable comment into a load-bearing exception that fails-closed on any new `dangerouslySetInnerHTML`. I attempted it (\`eslint.config.mjs\` rules entry + matching `eslint-disable-next-line` directive) but the repo's `config-protection` hook blocks edits to `eslint.config.mjs`. The hook's heuristic doesn't distinguish tightening from loosening, and bypassing it for this case felt out of scope. Tracked as a separate consideration; the in-code annotations are the policy gate in the meantime.

## Test plan

- [x] \`npx eslint src/components/landing/sdk-cta-panel.tsx src/components/landing/sdk-samples.ts\` — clean
- [x] \`npm run build\` — clean (landing page route built without errors)
- [ ] Manual: load \`/\` in Vercel preview, confirm the SDK quickstart panel still renders highlighted code on the typescript / python / go / vercel-ai-sdk tabs

## Risk

Zero behavior change — comment-only edit. No diff in runtime, build output, or rendered HTML.

## Out of scope (other #173 items)

- L1 GW (API-key HMAC salt) — non-trivial migration story
- L2 GW (validate_* re-check) — inspection task
- L3 GW (nonce_pool warn elevation) — partially mitigated by existing `tracing::warn!`
- Tier-B design-sensitive items (M5/M6 GW, M3 SDK, M1 SDK) — need product/operator call
- Enabling `react/no-danger` globally — blocked by config-protection hook

Refs: #173 (L3 SDK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)