### PR TITLE
docs(api,operations): align /v1/models + 402 references with real wire shape (#218)

### DIFF
--- a/dashboard/content/docs/api/models.mdx
+++ b/dashboard/content/docs/api/models.mdx
@@ -20,17 +20,21 @@ curl https://api.solvela.ai/v1/models
   "data": [
     {
       "id": "gpt-4o",
-      "display_name": "GPT-4o",
+      "object": "model",
       "provider": "openai",
+      "display_name": "GPT-4o",
       "context_window": 128000,
-      "supports_streaming": true,
-      "supports_tools": true,
-      "supports_vision": true,
-      "reasoning": false,
       "pricing": {
-        "input_per_million_usdc": 2.50,
-        "output_per_million_usdc": 10.00,
-        "platform_fee_percent": 5
+        "input_per_million": 2.50,
+        "output_per_million": 10.00,
+        "currency": "USDC",
+        "fee_percent": 5
+      },
+      "capabilities": {
+        "streaming": true,
+        "tools": true,
+        "vision": true,
+        "reasoning": false
       }
     }
   ]
@@ -41,17 +45,19 @@ curl https://api.solvela.ai/v1/models
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | The model ID to pass in `model` field of requests |
-| `display_name` | string | Human-readable model name |
+| `id` | string | The model ID to pass in the `model` field of requests |
+| `object` | string | Always `"model"` (OpenAI-compatible discriminator) |
 | `provider` | string | Upstream provider: `openai`, `anthropic`, `google`, `xai`, `deepseek` |
+| `display_name` | string | Human-readable model name |
 | `context_window` | integer | Maximum tokens in the combined input + output |
-| `supports_streaming` | boolean | Whether SSE streaming is available |
-| `supports_tools` | boolean | Whether function calling / tools are supported |
-| `supports_vision` | boolean | Whether image inputs are accepted |
-| `reasoning` | boolean | Whether the model performs multi-step reasoning (o3, Grok, etc.) |
-| `pricing.input_per_million_usdc` | float | Provider cost per million input tokens in USDC |
-| `pricing.output_per_million_usdc` | float | Provider cost per million output tokens in USDC |
-| `pricing.platform_fee_percent` | integer | Platform fee percentage (always `5`) |
+| `pricing.input_per_million` | float | Provider cost per million input tokens, in `pricing.currency` |
+| `pricing.output_per_million` | float | Provider cost per million output tokens, in `pricing.currency` |
+| `pricing.currency` | string | Always `"USDC"` today |
+| `pricing.fee_percent` | integer | Platform fee percentage (always `5`) |
+| `capabilities.streaming` | boolean | Whether SSE streaming is available |
+| `capabilities.tools` | boolean | Whether function calling / tools are supported |
+| `capabilities.vision` | boolean | Whether image inputs are accepted |
+| `capabilities.reasoning` | boolean | Whether the model performs multi-step reasoning (o3, Grok, etc.) |
 
 ## Available models
 

--- a/dashboard/content/docs/operations/troubleshooting.mdx
+++ b/dashboard/content/docs/operations/troubleshooting.mdx
@@ -9,11 +9,11 @@ description: Common issues, debug headers, and diagnostics
 |---------|-------|-----|
 | Gateway returns 503 for all chat requests | No provider API key configured | Set at least one provider key in `.env` (e.g., `OPENAI_API_KEY`) |
 | 402 response but SDK does not auto-pay | Wallet key not configured | Set `SOLANA_WALLET_KEY` environment variable |
-| "payment_required" with `amount_usdc: "0.000000"` | Using a free model (`gpt-oss-120b`) | Free models do not require payment; remove the `PAYMENT-SIGNATURE` header |
+| 402 returned with `accepts[0].amount: "0"` | Using a free model (`gpt-oss-120b`) | Free models do not require payment; remove the `PAYMENT-SIGNATURE` header |
 | Redis connection refused | Redis not running | Run `docker compose up -d redis` |
 | "replay detected" error | Same transaction signature sent twice | Generate a new transaction for each request |
-| "insufficient amount" error | Payment amount less than quoted price | Use the `amount_usdc` from the 402 response |
-| "recipient mismatch" error | Payment sent to wrong wallet | Send to the `recipient_wallet` from the 402 response |
+| "insufficient amount" error | Payment amount less than quoted price | Use `accepts[0].amount` from the 402 response (atomic units: 1 USDC = 1,000,000) |
+| "recipient mismatch" error | Payment sent to wrong wallet | Send to `accepts[0].pay_to` from the 402 response |
 | 429 Too Many Requests | Per-wallet rate limit exceeded | Wait for the `Retry-After` period, then retry |
 | 500 Internal Server Error on chat | Provider returned unexpected response | Check `RUST_LOG=gateway=debug` for details |
 | "unknown model" error | Model ID not in registry | Use `GET /v1/models` to list valid model IDs |


### PR DESCRIPTION
Closes #218.

## Summary

Sweeps the two final wire-shape drift items from #218 that survived the earlier doc reshuffles. The original `docs/book/` mdBook handbook (which #218 catalogued) was retired by #225, and `sdks/python.md` was rewritten by #219, but two leftover inaccuracies in the live Fumadocs content at **docs.solvela.ai** still misnamed fields a client would read off the wire.

## Why the scope is small

#218 catalogued seven drifts. Before editing, I verified each Fumadocs counterpart against the actual gateway/SDK code:

| #218 drift | File today | Status |
|---|---|---|
| #1 `/v1/models` shape | `api/models.mdx` | **Fixed in this PR** |
| #2 402 envelope (chat-completions) | `api/chat-completions.mdx` | Already correct (PR #303 closed #217) |
| #3 PaymentRequired in x402 concepts | `concepts/x402.mdx`, `concepts/payment-flow.mdx` | Already correct |
| #4 Quickstart selectors + 402 | `quickstart.mdx` | Already correct |
| #5 Troubleshooting field names | `operations/troubleshooting.mdx` | **Fixed in this PR** |
| #6 python.md fictional SDK | `sdks/python.mdx` | Already correct (PR #219) |
| #7 `/v1/supported` shape | `api/models.mdx` (only navigation reference today) | Not documented in detail; nothing to drift |

The "wrapped `{\"error\":{\"message\":\"...\"}}`" envelope shape that #218 cites as the actual 402 body is itself stale — PR #303 ("emit PaymentRequired at top level on 402") moved the gateway to the top-level x402 spec shape. Current docs already reflect that.

## Verified against code

`api/models.mdx` aligned against:
- `crates/gateway/src/routes/models.rs` (top-level `{"object":"list","data":[...]}` wrapper, per-item `object: "model"` + `pricing.currency: "USDC"`)
- `crates/protocol/src/model.rs` (`ModelInfoWire` Serialize impl — nested `capabilities` + `pricing`, field names `input_per_million` / `output_per_million` / `fee_percent`)

`operations/troubleshooting.mdx` aligned against the x402 spec body emitted by `GatewayError::PaymentChallenge` in `crates/gateway/src/error.rs:80` — clients should read `accepts[0].amount` and `accepts[0].pay_to`, not the fictional `amount_usdc` / `recipient_wallet`.

## Test plan

- [x] Targeted grep across `dashboard/content/docs/` for all drift markers from #218 catalogue — only the two files in this PR matched.
- [x] Re-grep after edits: no drift markers remain (the `solvela_payment_amount_usdc` hits in `operations/monitoring.mdx` are real Prometheus metric names, not wire fields — confirmed in `crates/gateway/src/routes/{chat/mod.rs:499, proxy.rs:420}`).
- [ ] CI: dashboard build + lint (will run on the PR).
- [ ] Reviewer spot-check the rendered MDX at the Vercel preview deployment.

## Out of scope

- Field renames on the gateway side (e.g. picking `input_usdc_per_million` vs `input_per_million` to match the SDK). The Python SDK exposes `input_usdc_per_million` on its dataclass and the wire is `input_per_million` — the SDK already handles that translation. Aligning them is a separate API decision; this PR only documents what the gateway emits today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)