### PR TITLE
fix(gateway): harden org validators against malformed input (#173 L2 GW)

### DIFF
--- a/crates/gateway/src/routes/orgs/mod.rs
+++ b/crates/gateway/src/routes/orgs/mod.rs
@@ -244,6 +244,12 @@ fn validate_slug(slug: &str) -> Result<(), (StatusCode, Json<serde_json::Value>)
             Json(json!({"error": "slug must not start or end with a hyphen"})),
         ));
     }
+    if slug.contains("--") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "slug must not contain consecutive hyphens"})),
+        ));
+    }
     Ok(())
 }
 
@@ -255,14 +261,78 @@ fn validate_name(name: &str, field: &str) -> Result<(), (StatusCode, Json<serde_
             Json(json!({"error": format!("{} must be 1-256 characters", field)})),
         ));
     }
+    // Reject characters that enable log injection, display spoofing, or
+    // bidirectional-text attacks. Names flow into structured logs (tracing!),
+    // JSON audit entries, and dashboard rendering — each surface has a
+    // different escape model and the safest contract is "no control chars,
+    // no bidi overrides, no zero-width spoofing chars". See #173 (L2 GW).
+    if trimmed.chars().any(is_disallowed_display_char) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "{} must not contain control characters, bidirectional overrides, or zero-width characters",
+                    field
+                )
+            })),
+        ));
+    }
     Ok(())
 }
 
+/// Returns true for characters that should be rejected from human-display
+/// fields (names, labels) because they enable log injection, Trojan-Source
+/// style bidi spoofing, or zero-width-character display impersonation.
+fn is_disallowed_display_char(c: char) -> bool {
+    // C0 controls + DEL: includes \r \n \t \0 etc. Newlines in particular
+    // can fake log lines or split structured-log entries.
+    if c.is_control() {
+        return true;
+    }
+    matches!(c,
+        // Bidi formatting / override (Trojan Source — CVE-2021-42574).
+        '\u{202A}'..='\u{202E}'
+        | '\u{2066}'..='\u{2069}'
+        // Zero-width characters used for display spoofing of identifiers.
+        | '\u{200B}'..='\u{200D}'
+        | '\u{2060}'
+        | '\u{FEFF}'
+    )
+}
+
 fn validate_wallet_address(addr: &str) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    // Solana base58-encoded Ed25519 pubkeys are typically 32-44 characters.
+    // The cheap length-only check was accepting arbitrary 1-64-character
+    // strings, including text that wasn't even base58. Decode the input as
+    // base58 and verify it is exactly 32 bytes (the canonical Solana pubkey
+    // size). This catches typos, copy-paste truncation, and obviously-wrong
+    // values at the API boundary instead of letting them propagate to the
+    // database. See #173 (L2 GW).
+    //
+    // 32 bytes encodes to 43-44 base58 characters depending on the leading
+    // byte; clamp the input length below that ceiling first to short-circuit
+    // pathological inputs before bs58 decoding.
     if addr.is_empty() || addr.len() > 64 {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "wallet address must be 1-64 characters"})),
+        ));
+    }
+    let decoded = match bs58::decode(addr).into_vec() {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "wallet address must be a valid base58 string"})),
+            ));
+        }
+    };
+    if decoded.len() != 32 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "wallet address must decode to a 32-byte Solana pubkey"
+            })),
         ));
     }
     Ok(())
@@ -727,6 +797,14 @@ mod tests {
     }
 
     #[test]
+    fn validate_slug_consecutive_hyphens_returns_err() {
+        use super::validate_slug;
+        assert!(validate_slug("my--org").is_err());
+        assert!(validate_slug("my---org").is_err());
+        assert!(validate_slug("a--b").is_err());
+    }
+
+    #[test]
     fn validate_slug_valid() {
         use super::validate_slug;
         assert!(validate_slug("my-org").is_ok());
@@ -764,6 +842,48 @@ mod tests {
         assert!(validate_name("Acme Corp", "name").is_ok());
         assert!(validate_name("a", "name").is_ok());
         assert!(validate_name(&"a".repeat(256), "name").is_ok());
+        // Unicode letters and punctuation are allowed (only display-class
+        // attack chars are rejected).
+        assert!(validate_name("Café del Mar", "name").is_ok());
+        assert!(validate_name("北京", "name").is_ok());
+        assert!(validate_name("ACME Inc. — flagship", "name").is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_control_chars() {
+        use super::validate_name;
+        // Newline (log injection): a real attacker would inject something
+        // like "Acme\nFAKE INFO[2026-01-01] auth bypass detected" to forge
+        // log entries.
+        assert!(validate_name("Acme\nFAKE", "name").is_err());
+        assert!(validate_name("Acme\r\nFAKE", "name").is_err());
+        assert!(validate_name("Acme\tco", "name").is_err());
+        assert!(validate_name("Acme\0co", "name").is_err());
+        // DEL
+        assert!(validate_name("Acme\u{007F}co", "name").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_bidi_overrides() {
+        use super::validate_name;
+        // Trojan Source — CVE-2021-42574. RLO (U+202E) and friends can
+        // make "evil.exe" render as "exe.live" or similar.
+        assert!(validate_name("admin\u{202E}eltt", "name").is_err());
+        assert!(validate_name("acme\u{202A}corp", "name").is_err());
+        assert!(validate_name("acme\u{2066}corp", "name").is_err());
+        assert!(validate_name("acme\u{2069}corp", "name").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_zero_width_chars() {
+        use super::validate_name;
+        // Zero-width chars enable display spoofing — "acme" and
+        // "ac\u{200B}me" look identical but compare unequal.
+        assert!(validate_name("ac\u{200B}me", "name").is_err());
+        assert!(validate_name("ac\u{200C}me", "name").is_err());
+        assert!(validate_name("ac\u{200D}me", "name").is_err());
+        assert!(validate_name("ac\u{FEFF}me", "name").is_err());
+        assert!(validate_name("ac\u{2060}me", "name").is_err());
     }
 
     // -----------------------------------------------------------------------
@@ -784,9 +904,31 @@ mod tests {
     }
 
     #[test]
+    fn validate_wallet_address_invalid_base58_returns_err() {
+        use super::validate_wallet_address;
+        // '0', 'O', 'I', 'l' are excluded from the base58 alphabet — using
+        // them must fail decoding rather than slip through.
+        assert!(validate_wallet_address("0OIl1234567890123456789012345678901234567890").is_err());
+        // Plain ASCII text without base58 noise.
+        assert!(validate_wallet_address("not-a-valid-address!!").is_err());
+    }
+
+    #[test]
+    fn validate_wallet_address_wrong_byte_length_returns_err() {
+        use super::validate_wallet_address;
+        // 64 chars of 'a' decodes to ~46 bytes, well over the 32-byte
+        // pubkey size. The old length-only check let this through.
+        assert!(validate_wallet_address(&"a".repeat(64)).is_err());
+        // Short input that decodes to fewer than 32 bytes.
+        assert!(validate_wallet_address("abc").is_err());
+    }
+
+    #[test]
     fn validate_wallet_address_valid() {
         use super::validate_wallet_address;
+        // Wrapped-SOL mint — canonical 32-byte Solana pubkey.
         assert!(validate_wallet_address("So11111111111111111111111111111111111111112").is_ok());
-        assert!(validate_wallet_address(&"a".repeat(64)).is_ok());
+        // USDC-SPL mint.
+        assert!(validate_wallet_address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").is_ok());
     }
 }

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -33,6 +33,15 @@ use gateway::AppState;
 use solvela_router::models::ModelRegistry;
 
 const ADMIN_TOKEN: &str = "test-admin-token";
+
+// Valid 32-byte Solana base58 pubkeys for happy-path fixtures. The wrapped-SOL
+// mint and the USDC-SPL mint are used as visually-distinct placeholders so the
+// org owner and added-member rows are easy to tell apart in test output. The
+// tightened `validate_wallet_address` in `src/routes/orgs/mod.rs` rejects
+// anything that doesn't bs58-decode to exactly 32 bytes, so these constants
+// have to be real pubkeys (see #173 L2 GW).
+const TEST_OWNER_WALLET: &str = "So11111111111111111111111111111111111111112";
+const TEST_MEMBER_WALLET: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const TEST_MODELS_TOML: &str = r#"
 [models.openai-gpt-4o]
 provider = "openai"
@@ -135,7 +144,8 @@ async fn body_to_json(resp: axum::response::Response) -> Value {
 }
 
 async fn create_test_org(app: &Router, slug: &str) -> Uuid {
-    let body = format!(r#"{{"name":"Org {slug}","slug":"{slug}","owner_wallet":"owner-{slug}"}}"#);
+    let body =
+        format!(r#"{{"name":"Org {slug}","slug":"{slug}","owner_wallet":"{TEST_OWNER_WALLET}"}}"#,);
     let resp = app
         .clone()
         .oneshot(json_request("POST", "/v1/orgs", &body))
@@ -163,7 +173,7 @@ async fn create_org_returns_201_with_id(pool: PgPool) {
         .oneshot(json_request(
             "POST",
             "/v1/orgs",
-            r#"{"name":"Acme","slug":"acme","owner_wallet":"acmewallet"}"#,
+            &format!(r#"{{"name":"Acme","slug":"acme","owner_wallet":"{TEST_OWNER_WALLET}"}}"#,),
         ))
         .await
         .expect("call");
@@ -172,7 +182,7 @@ async fn create_org_returns_201_with_id(pool: PgPool) {
     let json = body_to_json(resp).await;
     assert_eq!(json["name"], "Acme");
     assert_eq!(json["slug"], "acme");
-    assert_eq!(json["owner_wallet"], "acmewallet");
+    assert_eq!(json["owner_wallet"], TEST_OWNER_WALLET);
     assert!(Uuid::parse_str(json["id"].as_str().unwrap()).is_ok());
 }
 
@@ -323,13 +333,13 @@ async fn add_and_list_members_via_http(pool: PgPool) {
         .oneshot(json_request(
             "POST",
             &format!("/v1/orgs/{org_id}/members"),
-            r#"{"wallet_address":"alice","role":"admin"}"#,
+            &format!(r#"{{"wallet_address":"{TEST_MEMBER_WALLET}","role":"admin"}}"#),
         ))
         .await
         .expect("add member");
     assert_eq!(resp.status(), StatusCode::CREATED);
     let json = body_to_json(resp).await;
-    assert_eq!(json["wallet_address"], "alice");
+    assert_eq!(json["wallet_address"], TEST_MEMBER_WALLET);
     assert_eq!(json["role"], "admin");
 
     let resp = app
@@ -353,7 +363,7 @@ async fn assign_wallet_404s_when_team_not_in_org(pool: PgPool) {
         .oneshot(json_request(
             "POST",
             &format!("/v1/orgs/{org_id}/teams/{bogus_team}/wallets"),
-            r#"{"wallet_address":"alice"}"#,
+            &format!(r#"{{"wallet_address":"{TEST_MEMBER_WALLET}"}}"#),
         ))
         .await
         .expect("call");
@@ -382,7 +392,7 @@ async fn assign_and_list_team_wallets_via_http(pool: PgPool) {
         .oneshot(json_request(
             "POST",
             &format!("/v1/orgs/{org_id}/teams/{team_id}/wallets"),
-            r#"{"wallet_address":"alice"}"#,
+            &format!(r#"{{"wallet_address":"{TEST_MEMBER_WALLET}"}}"#),
         ))
         .await
         .expect("assign wallet");
@@ -399,7 +409,7 @@ async fn assign_and_list_team_wallets_via_http(pool: PgPool) {
     let json = body_to_json(resp).await;
     let arr = json.as_array().unwrap();
     assert_eq!(arr.len(), 1);
-    assert_eq!(arr[0]["wallet_address"], "alice");
+    assert_eq!(arr[0]["wallet_address"], TEST_MEMBER_WALLET);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Audit of the three org-route input validators (\`validate_name\`, \`validate_wallet_address\`, \`validate_slug\`) — the explicit re-check task from #173 (L2 GW). Found three real gaps, fixed all three in this PR.

## Findings + fixes

| Validator | Before | After |
| --- | --- | --- |
| `validate_name` | Length-only — accepted any Unicode | Rejects control chars (incl. newlines/tabs/NUL/DEL), bidi formatting/overrides (Trojan Source — CVE-2021-42574), zero-width chars (display spoofing) |
| `validate_wallet_address` | Length-only — `"a".repeat(64)` and ASCII text passed | Base58 decode + verify exactly 32 bytes (canonical Solana pubkey) |
| `validate_slug` | Allowed `my--org` | Rejects consecutive hyphens |

### Why each matters

- **`validate_name`** flows into structured logs (\`tracing!\`), JSON audit entries (\`audit_log.action\`, \`details\`), and dashboard rendering. Each surface has a different escape model — the safest contract is "no display-class attack chars at the API boundary". A real attacker case: \`"Acme\\nFAKE INFO[2026-01-01] auth bypass detected"\` injected into a tracing log line.
- **`validate_wallet_address`** previously let typos / copy-paste truncation / outright text reach the database. A Solana pubkey is 32 bytes base58-encoded; anything else can't be used to send funds and shouldn't be stored as a wallet identifier.
- **`validate_slug`** is the lowest-severity find — slug never flows into URL paths (paths use \`{id}\` UUIDs) so the issue body's URL-traversal concern is moot. Consecutive hyphens are mostly cosmetic; included for completeness.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test -p gateway --lib\` — 521 pass (was 515; +6 net new validator tests)
- [x] \`cargo test -p gateway --test integration\` — 129 pass
- [ ] \`cargo test -p gateway --test orgs_routes\` — DB-backed, not exercised locally (env missing legacy \`rcr\` Postgres user; CI runs it)

### New test coverage

| Test | What it asserts |
| --- | --- |
| \`validate_slug_consecutive_hyphens_returns_err\` | \`my--org\`, \`my---org\`, \`a--b\` all rejected |
| \`validate_name_rejects_control_chars\` | \`\\n\`, \`\\r\\n\`, \`\\t\`, \`\\0\`, DEL all rejected |
| \`validate_name_rejects_bidi_overrides\` | RLO, LRO, isolate marks rejected (Trojan Source) |
| \`validate_name_rejects_zero_width_chars\` | ZWSP/ZWNJ/ZWJ/BOM/word-joiner rejected |
| \`validate_name_valid\` (extended) | Real Unicode names still pass — \`Café del Mar\`, \`北京\`, em-dash punctuation |
| \`validate_wallet_address_invalid_base58_returns_err\` | Chars outside the base58 alphabet (\`0\`, \`O\`, \`I\`, \`l\`) rejected |
| \`validate_wallet_address_wrong_byte_length_returns_err\` | Replaces the old \`"a".repeat(64).is_ok()\` assertion that was the canonical example of the loose contract |
| \`validate_wallet_address_valid\` (updated) | Wrapped-SOL mint + USDC-SPL mint accepted; loose 64-\`a\` example removed |

## Risk

Tightening at the API boundary. All callers (\`routes/orgs/{crud,api_keys,teams}.rs\`) already \`match\` on the \`Result\` and surface the 400 directly, so no call-site changes are required. Any existing rows in the DB with names/wallet-addresses that violate the new rules continue to exist unchanged — this PR only gates **new writes**.

There's one possible behavior change for clients sending names with mostly-harmless control characters (e.g. a stray tab) that previously slipped through. They now get a 400 with a clear error message. That seems strictly desirable.

## Out of scope

- Backfill / migration of existing DB rows that contain newlines or non-pubkey "wallet addresses" — separate concern; the original review didn't ask for it and forced cleanup of stored data is a riskier operation than gating new writes.
- Length tightening (the 64-char cap on wallet_address is now redundant once base58 decoding enforces 32 bytes → ~44 chars max; kept as a cheap pre-check to short-circuit pathological inputs).

Refs: #173 (L2 GW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)