### PR TITLE
docs: switch public contact email to partnerships@solvela.ai

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -6,7 +6,7 @@
 #
 # Looking for a *commercial* license (you're hosting the gateway as a managed
 # service for third parties, or your annual revenue from the Licensed Work
-# exceeds USD $1M)? Email kd@sky64.io — see /docs/enterprise/commercial-license.
+# exceeds USD $1M)? Email partnerships@solvela.ai — see /docs/enterprise/commercial-license.
 github: [solvela-ai]
 custom:
   - "https://solvela.ai/sponsor"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -29,7 +29,7 @@ contact_links:
     about: |
       If you're hosting the gateway as a managed service to third parties, your
       annual revenue derived from the gateway exceeds USD $1M, or you need a
-      support SLA — see the commercial license page or email kd@sky64.io.
+      support SLA — see the commercial license page or email partnerships@solvela.ai.
 
   - name: Become a sponsor of a specific feature
     url: https://github.com/solvela-ai/solvela/discussions/categories/sponsored-features

--- a/BACKERS.md
+++ b/BACKERS.md
@@ -30,7 +30,7 @@ _Be the first sponsor at this tier: [github.com/sponsors/solvela-ai](https://git
 
 Organizations contributing infrastructure credits, RPC quota, security audit time, or other in-kind support that keeps the public gateway online.
 
-_No in-kind sponsors yet. If your organization can contribute Solana RPC credits (Helius, Triton, QuickNode), Fly.io credits, Vercel credits, Upstash credits, or external security audit time, email **kd@sky64.io**._
+_No in-kind sponsors yet. If your organization can contribute Solana RPC credits (Helius, Triton, QuickNode), Fly.io credits, Vercel credits, Upstash credits, or external security audit time, email **partnerships@solvela.ai**._
 
 ## Past backers
 
@@ -42,7 +42,7 @@ _None yet._
 
 - **GitHub Sponsors** — [github.com/sponsors/solvela-ai](https://github.com/sponsors/solvela-ai). Recurring billing; receipts handled by GitHub. Best for individuals and corporate cards.
 - **Polar.sh** — [polar.sh/solvela-ai](https://polar.sh/solvela-ai). One-time payments and crypto-native sponsorship.
-- **In-kind** — email **kd@sky64.io** with what you can contribute.
+- **In-kind** — email **partnerships@solvela.ai** with what you can contribute.
 - **Commercial license** — if the [BSL Additional Use Grant](./LICENSE) doesn't cover your use case, sponsorship isn't the right vehicle. See [`commercial-license.mdx`](./dashboard/content/docs/enterprise/commercial-license.mdx).
 
 ## Transparency

--- a/README.md
+++ b/README.md
@@ -461,8 +461,8 @@ Solvela uses a **per-component license split**. Pick the license of the piece yo
 
 - **You're a developer using Solvela's hosted gateway at `api.solvela.ai`** → no license obligations on you, just use it.
 - **You're self-hosting the gateway internally for your own product** → free under the Additional Use Grant if your gross annual revenue attributable to the gateway is under USD $1M.
-- **You're building a competing managed gateway service from this code** → you need a commercial license. Contact `kd@sky64.io`.
-- **Your annual revenue derived from the gateway will exceed USD $1M** → you need a commercial license. Contact `kd@sky64.io`.
+- **You're building a competing managed gateway service from this code** → you need a commercial license. Contact `partnerships@solvela.ai`.
+- **Your annual revenue derived from the gateway will exceed USD $1M** → you need a commercial license. Contact `partnerships@solvela.ai`.
 - **You're embedding the SDK or building on top of the protocol/router crates** → standard MIT obligations apply (preserve the copyright notice, no warranty). No payment to Solvela required.
 
 ### Trademark

--- a/brand/README.md
+++ b/brand/README.md
@@ -64,7 +64,7 @@ When seeding the GitHub org for the first time, or refreshing branding:
 - [ ] **Avatar**: upload `avatars/png/solvela-500.png` at https://github.com/organizations/solvela-ai/settings/profile
 - [ ] **Description**: `Solana-native x402 LLM gateway. Stablecoin payments for AI agents.`
 - [ ] **URL**: `https://solvela.ai`
-- [ ] **Email**: `partnerships@solvela.ai` (or `kd@sky64.io` until that alias is set up)
+- [ ] **Email**: `partnerships@solvela.ai`
 - [ ] **Location**: city/country (helps Superteam regional grant gating)
 - [ ] **Twitter/X**: org handle if/when one exists
 - [ ] **Pinned repos** in this order: `solvela`, `solvela-python`, `solvela-ts`, `solvela-go`, `solvela-client`

--- a/dashboard/content/docs/enterprise/commercial-license.mdx
+++ b/dashboard/content/docs/enterprise/commercial-license.mdx
@@ -54,7 +54,7 @@ All tiers include security advisories, named contact for issues, and a perpetual
 
 ## How to get one
 
-Email **kd@sky64.io** with:
+Email **partnerships@solvela.ai** with:
 
 1. Your company / project name and URL
 2. How you intend to use the gateway (internal? hosted-service? embedded in product?)

--- a/dashboard/content/docs/enterprise/sponsorship.mdx
+++ b/dashboard/content/docs/enterprise/sponsorship.mdx
@@ -35,7 +35,7 @@ If sponsorship ever exceeds these line items, the surplus funds an external secu
 | **Infrastructure** | $250 | A month of paid-tier RPC + monitoring + spare capacity for traffic bursts. | All Operator perks; logo on the homepage sponsors strip; direct Slack/Discord with the maintainer. |
 | **Underwriter** | $1,000 | Audit prep, contributor honoraria, and the kind of headroom that keeps the lights on without rent-seeking from users. | All Infrastructure perks; quarterly roadmap call; pre-publication notice on security advisories. |
 
-Custom tiers (annual prepay, multi-tier sponsorship, in-kind RPC credits) are welcome — email **kd@sky64.io**.
+Custom tiers (annual prepay, multi-tier sponsorship, in-kind RPC credits) are welcome — email **partnerships@solvela.ai**.
 
 ## Sponsorship versus commercial license
 
@@ -53,7 +53,7 @@ Use this table to figure out which one applies to you.
 
 - **GitHub Sponsors** — [github.com/sponsors/solvela-ai](https://github.com/sponsors/solvela-ai). Recurring billing, corporate-card-friendly, receipts handled by GitHub.
 - **Polar.sh** — [polar.sh/solvela-ai](https://polar.sh/solvela-ai). One-time payments, crypto, alternative billing.
-- **In-kind sponsorship** (RPC credits, infra credits, security audit time) — email **kd@sky64.io** with what you'd like to contribute.
+- **In-kind sponsorship** (RPC credits, infra credits, security audit time) — email **partnerships@solvela.ai** with what you'd like to contribute.
 
 ## Transparency
 

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -475,10 +475,10 @@ export default async function MetricsPage() {
                 Grants, acquihire, integrations, RPC partnerships.
               </p>
               <a
-                href="mailto:kd@sky64.io"
+                href="mailto:partnerships@solvela.ai"
                 className="mt-3 inline-flex h-9 items-center rounded border border-border px-3 font-mono text-xs uppercase tracking-[0.14em] text-text-secondary transition-colors hover:text-foreground"
               >
-                kd@sky64.io ↗
+                partnerships@solvela.ai ↗
               </a>
             </TerminalCard>
           </div>

--- a/dashboard/src/app/sponsor/page.tsx
+++ b/dashboard/src/app/sponsor/page.tsx
@@ -25,7 +25,7 @@ const GITHUB_SPONSORS_URL = 'https://github.com/sponsors/solvela-ai';
 const POLAR_URL = 'https://polar.sh/solvela-ai';
 const COMMERCIAL_URL = 'https://docs.solvela.ai/docs/enterprise/commercial-license';
 const METRICS_URL = 'https://solvela.ai/metrics';
-const CONTACT_EMAIL = 'kd@sky64.io';
+const CONTACT_EMAIL = 'partnerships@solvela.ai';
 
 // Tiers are deliberate. Each one is named after what it actually pays for —
 // not a vanity ladder. If a sponsor asks "what does $X cover?" we want the

--- a/docs/runbooks/sdk-consolidation.md
+++ b/docs/runbooks/sdk-consolidation.md
@@ -147,7 +147,7 @@ cd /home/kennethdixon/projects/solvela-ts
 git add README.md
 git commit -m "docs: redirect to monorepo at solvela-ai/solvela/sdks/typescript
 
-Signed-off-by: sky4 <kd@sky64.io>"
+Signed-off-by: sky4 <15861617+sky64@users.noreply.github.com>"
 git push origin main
 gh repo archive solvela-ai/solvela-ts --yes
 ```


### PR DESCRIPTION
## Summary
- Replaces 14 references to `kd@sky64.io` across docs, dashboard pages, and an example signoff with `partnerships@solvela.ai`
- Drops the now-stale "(or `kd@sky64.io` until that alias is set up)" caveat in `brand/README.md` since the alias is live
- Personal email stays out of newly-public surfaces; licensing/sponsor inquiries now route through an alias that can be delegated later

## Files touched (10)
- `README.md` — commercial-license contact bullets
- `BACKERS.md` — in-kind sponsor contact
- `.github/FUNDING.yml`, `.github/ISSUE_TEMPLATE/config.yml`
- `brand/README.md` — org checklist
- `dashboard/content/docs/enterprise/commercial-license.mdx`
- `dashboard/content/docs/enterprise/sponsorship.mdx`
- `dashboard/src/app/metrics/page.tsx` — partnerships card on `/metrics`
- `dashboard/src/app/sponsor/page.tsx` — `CONTACT_EMAIL` constant on `/sponsor`
- `docs/runbooks/sdk-consolidation.md` — example `Signed-off-by` template

## Out of scope
- Past commits keeping their original author emails (cannot be rewritten without breaking refs)
- Global git config separately switched to GitHub's noreply form so future commits no longer leak `sky64.io`

## Test plan
- [ ] CI green
- [ ] Verify `solvela.vercel.app/metrics` and `/sponsor` render the new email after preview deploy
- [ ] `mailto:partnerships@solvela.ai` link on `/metrics` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)