### PR TITLE
fix(gateway): HMAC-keyed API key hashing with dual-lookup migration (#173 L1 GW)

### DIFF
--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -113,6 +113,7 @@ supports_vision = false
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: None,
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         })

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -730,6 +730,7 @@ supports_vision = false
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: None,
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         })
@@ -1026,6 +1027,7 @@ supports_vision = false
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: None,
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         })

--- a/crates/gateway/src/a2a/jsonrpc.rs
+++ b/crates/gateway/src/a2a/jsonrpc.rs
@@ -119,6 +119,7 @@ supports_vision = false
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: None,
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         });

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -86,6 +86,13 @@ pub struct AppState {
     /// output, zeroized on drop, and only comparable via the constant-time
     /// `verify` method. See issue #173 (L4 GW).
     pub admin_token: Option<secret::AdminToken>,
+    /// HMAC keying secret for API-key hashing at rest. When `Some`, new API
+    /// keys are stored under HMAC-SHA256(secret, key) instead of plain
+    /// SHA-256(key). Verification accepts both forms during the migration
+    /// window — see [`secret::HmacSecret`] and [`crate::orgs::queries`].
+    /// `None` falls back to legacy plain-SHA-256 behavior with a startup
+    /// warning. See issue #173 (L1 GW).
+    pub api_key_hmac_secret: Option<Arc<secret::HmacSecret>>,
     /// Prometheus metrics handle for rendering the `/metrics` endpoint.
     /// `None` when the recorder failed to install (metrics unavailable).
     pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -443,6 +443,26 @@ async fn main() -> anyhow::Result<()> {
         .filter(|t| !t.is_empty())
         .map(gateway::secret::AdminToken::new);
 
+    // Read the API-key HMAC keying secret. When set, new API keys are stored
+    // under HMAC-SHA256(secret, key) instead of plain SHA-256(key). Defense
+    // against database-dump offline brute-force — without the secret, an
+    // attacker holding `api_keys.key_hash` cannot verify candidate keys
+    // (see #173 L1 GW). Optional for back-compat; gateway emits a startup
+    // warn when unset.
+    let api_key_hmac_secret =
+        env_with_fallback("SOLVELA_API_KEY_HMAC_SECRET", "RCR_API_KEY_HMAC_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|s| Arc::new(gateway::secret::HmacSecret::new(s.into_bytes())));
+    if api_key_hmac_secret.is_none() {
+        warn!(
+            "SOLVELA_API_KEY_HMAC_SECRET is not set — API keys are hashed with \
+             plain SHA-256 (no keying secret). Set this env var to a long, \
+             random value to harden the api_keys.key_hash column against \
+             offline brute-force from a database dump. See #173 L1 GW."
+        );
+    }
+
     // Dev-mode payment bypass — only when SOLVELA_DEV_BYPASS_PAYMENT=true AND not production
     let dev_bypass_payment = if is_production {
         if env_with_fallback("SOLVELA_DEV_BYPASS_PAYMENT", "RCR_DEV_BYPASS_PAYMENT").as_deref()
@@ -477,6 +497,7 @@ async fn main() -> anyhow::Result<()> {
         db_pool,
         escrow_metrics: escrow_metrics.clone(),
         admin_token,
+        api_key_hmac_secret,
         session_secret: {
             let secret = match env_with_fallback("SOLVELA_SESSION_SECRET", "RCR_SESSION_SECRET") {
                 Ok(b64) => {

--- a/crates/gateway/src/middleware/api_key.rs
+++ b/crates/gateway/src/middleware/api_key.rs
@@ -38,7 +38,13 @@ pub async fn extract_api_key(
     {
         if auth.starts_with("solvela_k_") || auth.starts_with("rcr_k_") {
             if let Some(pool) = &state.db_pool {
-                match crate::orgs::queries::verify_api_key(pool, auth).await {
+                match crate::orgs::queries::verify_api_key(
+                    pool,
+                    auth,
+                    state.api_key_hmac_secret.as_deref(),
+                )
+                .await
+                {
                     Ok(Some((api_key, org_id))) => {
                         request.extensions_mut().insert(OrgContext {
                             org_id,
@@ -217,6 +223,7 @@ supports_vision = false
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: None,
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         })

--- a/crates/gateway/src/orgs/queries.rs
+++ b/crates/gateway/src/orgs/queries.rs
@@ -7,6 +7,7 @@ use crate::orgs::models::{
     AddMemberRequest, ApiKey, ApiKeyCreated, AssignWalletRequest, CreateApiKeyRequest,
     CreateOrgRequest, CreateTeamRequest, OrgMember, OrgRole, Organization, Team, TeamWallet,
 };
+use crate::secret::HmacSecret;
 
 /// Number of UUID hex chars (no hyphens) included after `"solvela_k_"` in the
 /// stored display prefix. The prefix derives from the API-key row's UUID `id`
@@ -45,11 +46,24 @@ fn key_prefix_for_display(row_id: Uuid) -> String {
     format!("solvela_k_{}", &id_simple[..len])
 }
 
-/// Compute the SHA-256 hex digest of an API key.
-pub fn hash_api_key(key: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(key.as_bytes());
-    hex::encode(hasher.finalize())
+/// Compute the hash of an API key for storage / lookup in `api_keys.key_hash`.
+///
+/// When `hmac_secret` is `Some`, returns `HMAC-SHA256(secret, key)` as a hex
+/// digest. When `None`, returns plain `SHA-256(key)` as a hex digest. Both
+/// forms are 64 lowercase hex chars and share the same column. Verification
+/// in `verify_api_key` checks against both candidate hashes so legacy rows
+/// (written before the operator configured the secret) keep working. See
+/// issue #173 (L1 GW).
+#[must_use]
+pub fn hash_api_key(key: &str, hmac_secret: Option<&HmacSecret>) -> String {
+    match hmac_secret {
+        Some(secret) => secret.hmac_sha256_hex(key.as_bytes()),
+        None => {
+            let mut hasher = Sha256::new();
+            hasher.update(key.as_bytes());
+            hex::encode(hasher.finalize())
+        }
+    }
 }
 
 /// Create a new organization and auto-enroll the owner as a member with role "owner".
@@ -274,19 +288,21 @@ pub async fn list_team_wallets(
 
 /// Create a new API key for an organization.
 ///
-/// Generates a plaintext key, stores only its SHA-256 hash, and returns the
+/// Generates a plaintext key, stores only its hash (HMAC-SHA256 if
+/// `hmac_secret` is `Some`, plain SHA-256 otherwise), and returns the
 /// plaintext key once. The plaintext is never persisted.
 pub async fn create_api_key(
     pool: &PgPool,
     org_id: Uuid,
     req: CreateApiKeyRequest,
+    hmac_secret: Option<&HmacSecret>,
 ) -> Result<ApiKeyCreated, sqlx::Error> {
     let id = Uuid::new_v4();
     let now = Utc::now();
     let role = req.role.unwrap_or(OrgRole::Member);
 
     let key = generate_api_key();
-    let key_hash = hash_api_key(&key);
+    let key_hash = hash_api_key(&key, hmac_secret);
     // Display prefix is derived from the row UUID, not the key bytes — see
     // `key_prefix_for_display` for why. This is the H3 fix.
     let key_prefix = key_prefix_for_display(id);
@@ -324,44 +340,112 @@ pub async fn create_api_key(
 
 /// Verify an API key by hashing it and looking up the hash.
 ///
+/// Computes the candidate hash under the current `hmac_secret` (HMAC-SHA256
+/// if `Some`, plain SHA-256 if `None`) AND a legacy plain-SHA-256 hash, then
+/// looks up `WHERE key_hash IN (primary, legacy)`. This lets the gateway
+/// keep verifying keys that were stored before the operator configured
+/// `SOLVELA_API_KEY_HMAC_SECRET`. When a row matches via the legacy hash and
+/// HMAC is now configured, an opportunistic background task rewrites the
+/// row's `key_hash` to the HMAC form — so active keys self-migrate without
+/// requiring operator rotation. See issue #173 (L1 GW).
+///
 /// Returns `Some((api_key_row, org_id))` when valid, `None` when not found,
 /// expired, or revoked. Updates `last_used_at` fire-and-forget.
 pub async fn verify_api_key(
     pool: &PgPool,
     key: &str,
+    hmac_secret: Option<&HmacSecret>,
 ) -> Result<Option<(ApiKey, Uuid)>, sqlx::Error> {
-    let key_hash = hash_api_key(key);
+    let primary_hash = hash_api_key(key, hmac_secret);
+    // Legacy fallback: always also accept a row stored under plain SHA-256.
+    // When `hmac_secret` is `None`, `primary == legacy` and the `IN` clause
+    // degenerates to a single value (Postgres optimizes this away).
+    let legacy_hash = hash_api_key(key, None);
     let now = Utc::now();
 
-    let row = sqlx::query_as::<_, ApiKey>(
+    // Internal row type that mirrors ApiKey + the stored hash. Needed because
+    // verify_api_key has to know which form (HMAC vs. legacy SHA-256) the row
+    // is stored under to decide whether to opportunistically rehash.
+    #[derive(sqlx::FromRow)]
+    struct ApiKeyRow {
+        id: Uuid,
+        org_id: Uuid,
+        key_prefix: String,
+        name: String,
+        role: OrgRole,
+        last_used_at: Option<chrono::DateTime<Utc>>,
+        expires_at: Option<chrono::DateTime<Utc>>,
+        revoked_at: Option<chrono::DateTime<Utc>>,
+        created_at: chrono::DateTime<Utc>,
+        key_hash: String,
+    }
+
+    let row = sqlx::query_as::<_, ApiKeyRow>(
         r#"
-        SELECT id, org_id, key_prefix, name, role, last_used_at, expires_at, revoked_at, created_at
+        SELECT id, org_id, key_prefix, name, role, last_used_at, expires_at, revoked_at, created_at, key_hash
         FROM api_keys
-        WHERE key_hash = $1
+        WHERE key_hash IN ($1, $2)
           AND revoked_at IS NULL
-          AND (expires_at IS NULL OR expires_at > $2)
+          AND (expires_at IS NULL OR expires_at > $3)
         "#,
     )
-    .bind(&key_hash)
+    .bind(&primary_hash)
+    .bind(&legacy_hash)
     .bind(now)
     .fetch_optional(pool)
     .await?;
 
-    if let Some(api_key) = row {
+    if let Some(row) = row {
+        let stored_hash = row.key_hash;
+        let api_key = ApiKey {
+            id: row.id,
+            org_id: row.org_id,
+            key_prefix: row.key_prefix,
+            name: row.name,
+            role: row.role,
+            last_used_at: row.last_used_at,
+            expires_at: row.expires_at,
+            revoked_at: row.revoked_at,
+            created_at: row.created_at,
+        };
         let org_id = api_key.org_id;
         let key_id = api_key.id;
+        let matched_via_legacy = stored_hash != primary_hash;
 
-        // Fire-and-forget last_used_at update — never block the caller.
+        // Fire-and-forget last_used_at update — never block the caller. When
+        // the row matched via the legacy hash and the operator has now
+        // configured HMAC, also rewrite the key_hash to the HMAC form so the
+        // migration self-completes for active keys.
         let pool_clone = pool.clone();
+        let primary_for_rehash = primary_hash;
         tokio::spawn(async move {
-            let result = sqlx::query(r#"UPDATE api_keys SET last_used_at = $1 WHERE id = $2"#)
-                .bind(Utc::now())
-                .bind(key_id)
-                .execute(&pool_clone)
-                .await;
+            let update_result = if matched_via_legacy {
+                sqlx::query(r#"UPDATE api_keys SET last_used_at = $1, key_hash = $2 WHERE id = $3"#)
+                    .bind(Utc::now())
+                    .bind(&primary_for_rehash)
+                    .bind(key_id)
+                    .execute(&pool_clone)
+                    .await
+            } else {
+                sqlx::query(r#"UPDATE api_keys SET last_used_at = $1 WHERE id = $2"#)
+                    .bind(Utc::now())
+                    .bind(key_id)
+                    .execute(&pool_clone)
+                    .await
+            };
 
-            if let Err(e) = result {
-                tracing::warn!(key_id = %key_id, error = %e, "failed to update api key last_used_at");
+            if let Err(e) = update_result {
+                tracing::warn!(
+                    key_id = %key_id,
+                    rehashed = matched_via_legacy,
+                    error = %e,
+                    "failed to update api key last_used_at",
+                );
+            } else if matched_via_legacy {
+                tracing::info!(
+                    key_id = %key_id,
+                    "rehashed api key from legacy SHA-256 to HMAC-SHA256 on verify (#173 L1 GW)"
+                );
             }
         });
 
@@ -467,8 +551,8 @@ mod tests {
     #[test]
     fn hash_api_key_is_deterministic_and_64_chars() {
         let key = "solvela_k_abc123testkey";
-        let hash1 = hash_api_key(key);
-        let hash2 = hash_api_key(key);
+        let hash1 = hash_api_key(key, None);
+        let hash2 = hash_api_key(key, None);
 
         assert_eq!(hash1, hash2, "hash_api_key must be deterministic");
         assert_eq!(
@@ -479,7 +563,35 @@ mod tests {
         );
 
         // Different inputs must produce different hashes
-        let hash_other = hash_api_key("solvela_k_different");
+        let hash_other = hash_api_key("solvela_k_different", None);
         assert_ne!(hash1, hash_other, "different keys must hash differently");
+    }
+
+    #[test]
+    fn hash_api_key_hmac_mode_differs_from_plain() {
+        let key = "solvela_k_abc123testkey";
+        let secret = HmacSecret::new(b"server-side-secret".to_vec());
+
+        let plain = hash_api_key(key, None);
+        let hmac = hash_api_key(key, Some(&secret));
+
+        assert_ne!(plain, hmac, "HMAC mode must differ from plain SHA-256");
+        assert_eq!(plain.len(), 64);
+        assert_eq!(hmac.len(), 64);
+    }
+
+    #[test]
+    fn hash_api_key_hmac_mode_is_secret_dependent() {
+        let key = "solvela_k_abc123testkey";
+        let s1 = HmacSecret::new(b"secret-one".to_vec());
+        let s2 = HmacSecret::new(b"secret-two".to_vec());
+
+        let h1 = hash_api_key(key, Some(&s1));
+        let h2 = hash_api_key(key, Some(&s2));
+
+        // The defining security property: with different keying secrets, the
+        // same input key produces different stored hashes. A database dump
+        // without the secret cannot be brute-forced against candidate keys.
+        assert_ne!(h1, h2);
     }
 }

--- a/crates/gateway/src/routes/health.rs
+++ b/crates/gateway/src/routes/health.rs
@@ -158,6 +158,7 @@ supports_vision = false
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: None,
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         })
@@ -229,6 +230,7 @@ supports_vision = false
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: Some(AdminToken::new("test-admin-token".to_string())),
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         })

--- a/crates/gateway/src/routes/orgs/api_keys.rs
+++ b/crates/gateway/src/routes/orgs/api_keys.rs
@@ -47,7 +47,7 @@ pub async fn create_api_key(
 
     let (actor_api_key, actor_admin) = auth.audit_actor();
 
-    match queries::create_api_key(pool, org_id, body).await {
+    match queries::create_api_key(pool, org_id, body, state.api_key_hmac_secret.as_deref()).await {
         Ok(created) => {
             log_audit(
                 pool,
@@ -248,6 +248,7 @@ mod tests {
             escrow_metrics: None,
             admin_token: None, // no admin token — forces API key auth path
             prometheus_handle: None,
+            api_key_hmac_secret: None,
             dev_bypass_payment: false,
         });
 

--- a/crates/gateway/src/routes/orgs/mod.rs
+++ b/crates/gateway/src/routes/orgs/mod.rs
@@ -396,6 +396,7 @@ supports_vision = true
             slot_cache: crate::routes::escrow::new_slot_cache(),
             escrow_metrics: None,
             admin_token: admin_token.map(|t| crate::secret::AdminToken::new(t.to_string())),
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         });
@@ -556,6 +557,7 @@ mod tests {
             slot_cache: crate::routes::escrow::new_slot_cache(),
             escrow_metrics: None,
             admin_token: Some(crate::secret::AdminToken::new("admin-secret".to_string())),
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         };
@@ -599,6 +601,7 @@ mod tests {
             slot_cache: crate::routes::escrow::new_slot_cache(),
             escrow_metrics: None,
             admin_token: Some(crate::secret::AdminToken::new("admin-secret".to_string())),
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         };
@@ -645,6 +648,7 @@ mod tests {
             slot_cache: crate::routes::escrow::new_slot_cache(),
             escrow_metrics: None,
             admin_token: Some(crate::secret::AdminToken::new("admin-secret".to_string())),
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         };

--- a/crates/gateway/src/routes/orgs/teams.rs
+++ b/crates/gateway/src/routes/orgs/teams.rs
@@ -426,6 +426,7 @@ mod tests {
             escrow_metrics: None,
             admin_token: None, // no admin token — forces API key auth path
             prometheus_handle: None,
+            api_key_hmac_secret: None,
             dev_bypass_payment: false,
         });
 

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -917,6 +917,7 @@ mod tests {
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: None,
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         });
@@ -1046,6 +1047,7 @@ mod tests {
             slot_cache: new_slot_cache(),
             escrow_metrics: None,
             admin_token: None,
+            api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
         })

--- a/crates/gateway/src/secret.rs
+++ b/crates/gateway/src/secret.rs
@@ -1,15 +1,18 @@
 //! Secret-bearing types for the gateway.
 //!
-//! Wraps secrets like the admin token in newtypes that:
+//! Wraps secrets in newtypes that:
 //! - Redact the value in `Debug` output
 //! - Zeroize the underlying bytes on drop
-//! - Force callers through a constant-time comparison helper
+//! - Expose only the narrow operation the secret is meant for (constant-time
+//!   compare for bearer tokens, HMAC computation for keying secrets)
 //!
 //! These are belt-and-braces defenses against accidental log leakage,
-//! heap dumps, and timing side-channels. See issue #173 (L4 GW).
+//! heap dumps, and timing side-channels. See issue #173 (L1 GW, L4 GW).
 
 use std::fmt;
 
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::security::constant_time_eq;
@@ -56,6 +59,52 @@ impl AdminToken {
 impl fmt::Debug for AdminToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("AdminToken").field(&"[REDACTED]").finish()
+    }
+}
+
+/// Server-side keying secret for `HMAC-SHA256(secret, message)`.
+///
+/// Used to keying-hash API keys at rest so a stolen `api_keys.key_hash`
+/// column dump alone is not sufficient to brute-force a candidate key — the
+/// attacker also needs the server secret. See issue #173 (L1 GW).
+///
+/// Like [`AdminToken`], stored as `Vec<u8>` with `ZeroizeOnDrop` and a
+/// redacting `Debug` impl. The only exposed operation is `hmac_sha256_hex`,
+/// which computes the hex digest of the HMAC-SHA256 of a message under this
+/// secret. `PartialEq` is intentionally omitted — there's no caller use case
+/// for comparing two secrets, and adding the impl would invite misuse.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct HmacSecret(Vec<u8>);
+
+impl HmacSecret {
+    /// Wrap raw secret bytes. The caller is responsible for ensuring the
+    /// bytes have at least 128 bits of entropy — NIST SP 800-107 recommends
+    /// at least 16 bytes for HMAC keys. Any length is accepted, but a
+    /// too-short secret defeats the purpose.
+    #[must_use]
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Compute `HMAC-SHA256(self, message)` and return the hex-encoded digest
+    /// (64 chars, lowercase). The output shape matches the existing plain
+    /// `SHA-256` hex digest stored in `api_keys.key_hash`, so the same column
+    /// holds either form during the migration period.
+    #[must_use]
+    pub fn hmac_sha256_hex(&self, message: &[u8]) -> String {
+        // `Hmac::new_from_slice` accepts any key length; per the type's
+        // documentation it never returns Err for `Hmac<Sha256>` (the bound
+        // is `KeyInit`, which is infallible for fixed-output MACs).
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(&self.0).expect("HMAC-SHA256 accepts any key length");
+        mac.update(message);
+        hex::encode(mac.finalize().into_bytes())
+    }
+}
+
+impl fmt::Debug for HmacSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("HmacSecret").field(&"[REDACTED]").finish()
     }
 }
 
@@ -115,5 +164,69 @@ mod tests {
         let non_empty = AdminToken::new("x".to_string());
         assert!(empty.is_empty());
         assert!(!non_empty.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // HmacSecret
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn hmac_secret_is_deterministic_for_same_input() {
+        let secret = HmacSecret::new(b"server-side-secret".to_vec());
+        let h1 = secret.hmac_sha256_hex(b"solvela_k_abc123");
+        let h2 = secret.hmac_sha256_hex(b"solvela_k_abc123");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64, "SHA-256 hex digest must be 64 chars");
+        // Lowercase hex only — matches the existing `hex::encode` output.
+        assert!(h1
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn hmac_secret_differs_per_message() {
+        let secret = HmacSecret::new(b"server-side-secret".to_vec());
+        let a = secret.hmac_sha256_hex(b"solvela_k_one");
+        let b = secret.hmac_sha256_hex(b"solvela_k_two");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hmac_secret_differs_per_key() {
+        let s1 = HmacSecret::new(b"secret-one".to_vec());
+        let s2 = HmacSecret::new(b"secret-two".to_vec());
+        let msg = b"solvela_k_abc";
+        // Different keys must produce different MACs for the same message —
+        // this is the load-bearing property: a stolen DB dump alone is not
+        // enough to verify candidate keys without the secret.
+        assert_ne!(s1.hmac_sha256_hex(msg), s2.hmac_sha256_hex(msg));
+    }
+
+    #[test]
+    fn hmac_secret_known_test_vector() {
+        // RFC 4231 § 4.2 — HMAC-SHA-256 test vector 1:
+        //   Key:  20 bytes of 0x0b
+        //   Data: "Hi There"
+        //   HMAC: b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
+        let secret = HmacSecret::new(vec![0x0b; 20]);
+        let got = secret.hmac_sha256_hex(b"Hi There");
+        assert_eq!(
+            got,
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+    }
+
+    #[test]
+    fn hmac_secret_debug_redacts_value() {
+        let secret = HmacSecret::new(b"correct-horse-battery-staple".to_vec());
+        let debug_output = format!("{secret:?}");
+        assert!(
+            !debug_output.contains("correct-horse"),
+            "Debug must not leak the secret: got {debug_output}"
+        );
+        assert!(
+            debug_output.contains("REDACTED"),
+            "Debug must mark value as REDACTED: got {debug_output}"
+        );
     }
 }

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -253,6 +253,7 @@ fn test_app_with_state() -> (axum::Router, Arc<AppState>) {
         admin_token: Some(gateway::secret::AdminToken::new(
             TEST_ADMIN_TOKEN.to_string(),
         )),
+        api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -401,6 +402,7 @@ fn test_app_with_mock_provider_and_state() -> (axum::Router, Arc<AppState>) {
         admin_token: Some(gateway::secret::AdminToken::new(
             TEST_ADMIN_TOKEN.to_string(),
         )),
+        api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -470,6 +472,7 @@ fn test_app_with_mock_provider_and_escrow() -> axum::Router {
         admin_token: Some(gateway::secret::AdminToken::new(
             TEST_ADMIN_TOKEN.to_string(),
         )),
+        api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -538,6 +541,7 @@ fn test_app_with_escrow() -> axum::Router {
         admin_token: Some(gateway::secret::AdminToken::new(
             TEST_ADMIN_TOKEN.to_string(),
         )),
+        api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -1835,6 +1839,7 @@ fn test_app_with_nonce_pool() -> axum::Router {
         admin_token: Some(gateway::secret::AdminToken::new(
             TEST_ADMIN_TOKEN.to_string(),
         )),
+        api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -3398,6 +3403,7 @@ fn test_app_with_escrow_metrics() -> axum::Router {
         admin_token: Some(gateway::secret::AdminToken::new(
             TEST_ADMIN_TOKEN.to_string(),
         )),
+        api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -3559,6 +3565,7 @@ async fn test_escrow_health_reflects_incremented_metrics() {
         admin_token: Some(gateway::secret::AdminToken::new(
             TEST_ADMIN_TOKEN.to_string(),
         )),
+        api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -3790,6 +3797,7 @@ async fn test_escrow_health_status_down_without_claimer() {
         admin_token: Some(gateway::secret::AdminToken::new(
             TEST_ADMIN_TOKEN.to_string(),
         )),
+        api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
     });
@@ -4923,6 +4931,7 @@ async fn test_admin_stats_returns_404_when_admin_token_not_configured() {
         escrow_metrics: None,
         admin_token: None, // <-- no admin token configured
         prometheus_handle: Some(test_prometheus_handle()),
+        api_key_hmac_secret: None,
         dev_bypass_payment: false,
     });
     let app = build_router(

--- a/crates/gateway/tests/orgs_queries.rs
+++ b/crates/gateway/tests/orgs_queries.rs
@@ -253,6 +253,7 @@ async fn create_api_key_returns_plaintext_once_and_persists_hash(pool: PgPool) {
             role: Some(OrgRole::Admin),
             expires_in_days: Some(30),
         },
+        None,
     )
     .await
     .expect("create_api_key");
@@ -273,7 +274,7 @@ async fn create_api_key_returns_plaintext_once_and_persists_hash(pool: PgPool) {
             .fetch_optional(&pool)
             .await
             .expect("query hash");
-    assert_eq!(stored_hash, Some(hash_api_key(&created.key)));
+    assert_eq!(stored_hash, Some(hash_api_key(&created.key, None)));
 
     // The plaintext itself does not appear anywhere in the api_keys row.
     let any_plaintext: i64 = sqlx::query_scalar(
@@ -303,6 +304,7 @@ async fn create_api_key_without_expiry_leaves_expires_at_null(pool: PgPool) {
             role: None,
             expires_in_days: None,
         },
+        None,
     )
     .await
     .expect("create_api_key");
@@ -324,11 +326,12 @@ async fn verify_api_key_returns_some_for_valid_key(pool: PgPool) {
             role: None,
             expires_in_days: None,
         },
+        None,
     )
     .await
     .expect("create");
 
-    let verified = verify_api_key(&pool, &created.key)
+    let verified = verify_api_key(&pool, &created.key, None)
         .await
         .expect("verify")
         .expect("must verify a freshly-created key");
@@ -339,7 +342,7 @@ async fn verify_api_key_returns_some_for_valid_key(pool: PgPool) {
 #[sqlx::test(migrations = "../../migrations")]
 async fn verify_api_key_returns_none_for_unknown_key(pool: PgPool) {
     let unknown = generate_api_key();
-    let result = verify_api_key(&pool, &unknown).await.expect("verify");
+    let result = verify_api_key(&pool, &unknown, None).await.expect("verify");
     assert!(result.is_none(), "unknown key returns None");
 }
 
@@ -356,6 +359,7 @@ async fn verify_api_key_returns_none_for_revoked_key(pool: PgPool) {
             role: None,
             expires_in_days: None,
         },
+        None,
     )
     .await
     .expect("create");
@@ -365,7 +369,9 @@ async fn verify_api_key_returns_none_for_revoked_key(pool: PgPool) {
         .expect("revoke");
     assert!(updated, "first revoke returns true");
 
-    let result = verify_api_key(&pool, &created.key).await.expect("verify");
+    let result = verify_api_key(&pool, &created.key, None)
+        .await
+        .expect("verify");
     assert!(result.is_none(), "revoked key must not verify");
 
     let second = revoke_api_key(&pool, created.id, org.id)
@@ -382,7 +388,7 @@ async fn verify_api_key_returns_none_for_expired_key(pool: PgPool) {
 
     // Insert an expired key directly so we don't have to wait.
     let key = generate_api_key();
-    let key_hash = hash_api_key(&key);
+    let key_hash = hash_api_key(&key, None);
     sqlx::query(
         r#"INSERT INTO api_keys (id, org_id, key_prefix, key_hash, name, role, expires_at, created_at)
            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"#,
@@ -399,7 +405,7 @@ async fn verify_api_key_returns_none_for_expired_key(pool: PgPool) {
     .await
     .expect("insert expired key");
 
-    let result = verify_api_key(&pool, &key).await.expect("verify");
+    let result = verify_api_key(&pool, &key, None).await.expect("verify");
     assert!(result.is_none(), "expired key must not verify");
 }
 
@@ -417,6 +423,7 @@ async fn list_api_keys_filters_revoked(pool: PgPool) {
             role: None,
             expires_in_days: None,
         },
+        None,
     )
     .await
     .expect("create active");
@@ -429,6 +436,7 @@ async fn list_api_keys_filters_revoked(pool: PgPool) {
             role: None,
             expires_in_days: None,
         },
+        None,
     )
     .await
     .expect("create to-revoke");
@@ -471,6 +479,7 @@ async fn revoke_api_key_scopes_to_org(pool: PgPool) {
             role: None,
             expires_in_days: None,
         },
+        None,
     )
     .await
     .expect("create");
@@ -485,7 +494,9 @@ async fn revoke_api_key_scopes_to_org(pool: PgPool) {
     );
 
     // The key still verifies.
-    let verified = verify_api_key(&pool, &created.key).await.expect("verify");
+    let verified = verify_api_key(&pool, &created.key, None)
+        .await
+        .expect("verify");
     assert!(
         verified.is_some(),
         "key targeted by a cross-org revoke must remain valid"

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -81,6 +81,7 @@ fn router_with_pool(pool: PgPool) -> Router {
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         escrow_metrics: None,
         admin_token: Some(gateway::secret::AdminToken::new(ADMIN_TOKEN.to_string())),
+        api_key_hmac_secret: None,
         prometheus_handle: None,
         dev_bypass_payment: false,
     });


### PR DESCRIPTION
## Summary

- Replaces unsalted SHA-256 of `api_keys.key_hash` with HMAC-SHA256 keyed by a server secret. A stolen DB dump alone can no longer verify candidate keys offline — the attacker also needs `SOLVELA_API_KEY_HMAC_SECRET`.
- **Optional + back-compat**: when the secret is unset, gateway falls back to plain SHA-256 and emits a startup `warn!` recommending operators configure it. No breaking change.
- **Self-completing migration**: `verify_api_key` does a single `WHERE key_hash IN (primary, legacy)` lookup, then if the row matched via the legacy SHA-256 path AND HMAC is configured, a fire-and-forget background task rewrites the row to the HMAC form. Active keys rehash on first use.

## Design

New `secret::HmacSecret` newtype alongside `AdminToken`: `Vec<u8>` + `Zeroize` + `ZeroizeOnDrop` + redacting `Debug`. Exposes only `hmac_sha256_hex(message) -> String`. `PartialEq` deliberately omitted.

`hash_api_key(key, hmac_secret: Option<&HmacSecret>) -> String` produces HMAC-SHA256 hex when `Some`, plain SHA-256 hex when `None`. Both forms are 64 lowercase hex chars so the existing column shape is unchanged.

`verify_api_key` computes both candidate hashes and looks up `WHERE key_hash IN ($primary, $legacy)`. When `hmac_secret` is `None`, primary == legacy and the IN degenerates to a single value (PostgreSQL optimizes this away). When `Some`, rows stored before the operator configured the secret keep verifying via the legacy hash — and self-rehash on first use.

`AppState.api_key_hmac_secret: Option<Arc<HmacSecret>>` is loaded once at startup from `SOLVELA_API_KEY_HMAC_SECRET` (or the legacy `RCR_API_KEY_HMAC_SECRET` for consistency with the project's dual-prefix env-var convention).

## Migration (operator-facing)

1. Set `SOLVELA_API_KEY_HMAC_SECRET` to a long random value on Fly.io secrets.
2. Restart the gateway. The startup warn disappears.
3. New keys store under HMAC. Existing keys keep working unchanged.
4. As keys are used, each one rehashes on first verify. Operator sees `tracing::info!` per rehash.
5. Once all active keys have rehashed, the legacy SHA-256 fallback can be removed in a follow-up.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test -p gateway --lib\` — 528 pass (was 521; +7 new HMAC-related tests, +1 existing test updated for new arg)
- [x] \`cargo test -p gateway --test integration\` — 129 pass
- [ ] \`cargo test -p gateway --test orgs_queries\` — DB-backed under \`#[sqlx::test]\`, not exercised locally (env missing legacy \`rcr\` Postgres user; CI runs it)

### New test coverage

| Test | What it asserts |
| --- | --- |
| \`secret::tests::hmac_secret_is_deterministic_for_same_input\` | Deterministic 64-char lowercase hex output |
| \`secret::tests::hmac_secret_differs_per_message\` | Same key + different inputs → different MACs |
| \`secret::tests::hmac_secret_differs_per_key\` | **Defining security property** — same input + different keys → different MACs (a DB dump alone is insufficient) |
| \`secret::tests::hmac_secret_known_test_vector\` | RFC 4231 § 4.2 vector 1 (20 × \`0x0b\` key, "Hi There" → known digest) |
| \`secret::tests::hmac_secret_debug_redacts_value\` | \`Debug\` redacts |
| \`orgs::queries::tests::hash_api_key_is_deterministic_and_64_chars\` | Updated for new \`None\` arg; back-compat path verified |
| \`orgs::queries::tests::hash_api_key_hmac_mode_differs_from_plain\` | HMAC mode ≠ plain SHA-256 for same input |
| \`orgs::queries::tests::hash_api_key_hmac_mode_is_secret_dependent\` | Same input + different secrets → different hashes |

## Risk

- **Behavior change at API boundary**: none. The HTTP contract for `POST /v1/orgs/{id}/api-keys` and `GET /v1/orgs/{id}/api-keys` is unchanged.
- **Behavior change for existing keys**: none in default config (secret unset, plain SHA-256, warn at startup). After operator configures the secret: existing keys keep verifying via legacy lookup, and self-rehash on first use.
- **`WHERE key_hash IN ($1, $2)`**: PostgreSQL handles the case where $1 == $2 efficiently; benchmarked equivalent to `=` for single-value matches.

## Out of scope

- Removing the legacy SHA-256 fallback path. Defer until operator has confirmed all active keys have rehashed (visible via the per-rehash `tracing::info!`).
- Migrating Redis-cached auth lookups — there's no current Redis caching layer on `api_keys`.

Refs: #173 (L1 GW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)