### PR TITLE
fix(x402,gateway): fail closed on durable-nonce tx when pool unconfigured (#173 L3 GW)

### DIFF
--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -161,6 +161,30 @@ async fn main() -> anyhow::Result<()> {
         Ok("production") | Ok("prod")
     );
 
+    // ── Durable nonce pool ────────────────────────────────────────────────────
+    //
+    // Build a NoncePool from environment variables. Returns an empty pool
+    // (not an error) if no nonce accounts are configured. When unconfigured
+    // the SolanaVerifier rejects all client-submitted durable-nonce
+    // transactions (see #173 L3 GW) — clients must use a recent blockhash
+    // instead. Constructed before SolanaVerifier so we can plumb it in via
+    // `with_nonce_pool` below; also reused by EscrowClaimer.
+    let nonce_pool = {
+        let pool = solvela_x402::nonce_pool::NoncePool::from_env();
+        if pool.is_empty() {
+            warn!(
+                "nonce_pool not configured — client durable-nonce transactions \
+                 will be REJECTED. Set SOLVELA_SOLANA__NONCE_ACCOUNT[_N] to \
+                 allowlist nonce accounts, or instruct clients to use a recent \
+                 blockhash."
+            );
+            None
+        } else {
+            info!(accounts = pool.len(), "durable nonce pool initialized");
+            Some(Arc::new(pool))
+        }
+    };
+
     let solana_verifier = match solvela_x402::solana::SolanaVerifier::new(
         &app_config.solana.rpc_url,
         &app_config.solana.recipient_wallet,
@@ -204,6 +228,15 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
+    // Attach the durable-nonce allowlist to the verifier so client-submitted
+    // nonce transactions can be checked against operator-approved accounts.
+    // Without this, the verifier rejects every nonce-based payment (#173 L3 GW).
+    let solana_verifier = if let Some(pool) = &nonce_pool {
+        solana_verifier.with_nonce_pool(Arc::clone(pool))
+    } else {
+        solana_verifier
+    };
+
     // Build verifiers list — always include the direct SolanaVerifier
     let mut verifiers: Vec<Arc<dyn solvela_x402::traits::PaymentVerifier>> =
         vec![Arc::new(solana_verifier)];
@@ -245,23 +278,6 @@ async fn main() -> anyhow::Result<()> {
                     None
                 }
             }
-        }
-    };
-
-    // ── Durable nonce pool ────────────────────────────────────────────────────
-    //
-    // Build a NoncePool from environment variables. Returns an empty pool
-    // (not an error) if no nonce accounts are configured — clients fall back
-    // to using a recent blockhash in that case.
-    // Constructed before EscrowClaimer because the claimer now uses the pool.
-    let nonce_pool = {
-        let pool = solvela_x402::nonce_pool::NoncePool::from_env();
-        if pool.is_empty() {
-            info!("nonce pool empty — clients will use recent blockhash (set SOLVELA_SOLANA__NONCE_ACCOUNT to enable)");
-            None
-        } else {
-            info!(accounts = pool.len(), "durable nonce pool initialized");
-            Some(Arc::new(pool))
         }
     };
 

--- a/crates/x402/src/solana.rs
+++ b/crates/x402/src/solana.rs
@@ -370,25 +370,7 @@ impl PaymentVerifier for SolanaVerifier {
                 "detected durable nonce transaction — skipping blockhash recency check"
             );
 
-            // If a nonce pool is configured, verify the nonce account is registered.
-            // If not configured, warn operators and accept any client-supplied nonce account.
-            if let Some(pool) = &self.nonce_pool {
-                let nonce_account_b58 = nonce_account.to_string();
-                let is_known = pool
-                    .entries_iter()
-                    .any(|e| e.nonce_account == nonce_account_b58);
-                if !is_known {
-                    return Err(Error::InvalidTransaction(format!(
-                        "nonce account {nonce_account_b58} is not registered in the gateway nonce pool"
-                    )));
-                }
-            } else {
-                tracing::warn!(
-                    nonce_account = %nonce_account,
-                    "nonce_pool not configured — skipping nonce-account validation; \
-                     any client-supplied nonce account is accepted"
-                );
-            }
+            validate_nonce_account(self.nonce_pool.as_deref(), &nonce_account)?;
 
             // Simulate WITHOUT replacing the blockhash (nonce tx must keep its nonce value)
             self.simulate_transaction(&solana_payload.transaction, false)
@@ -480,6 +462,36 @@ impl PaymentVerifier for SolanaVerifier {
             }
         }
     }
+}
+
+/// Validate that a client-submitted durable-nonce transaction's nonce account
+/// is in the operator's allowlist. Fail closed when no pool is configured —
+/// accepting any client-supplied nonce account would let a stale signed
+/// transaction be replayed against any nonce account on chain, bypassing the
+/// blockhash-recency check that protects non-nonce transactions. See issue
+/// #173 (L3 GW).
+fn validate_nonce_account(
+    nonce_pool: Option<&NoncePool>,
+    nonce_account: &Pubkey,
+) -> Result<(), Error> {
+    let Some(pool) = nonce_pool else {
+        return Err(Error::InvalidTransaction(
+            "nonce_pool not configured on the gateway — durable-nonce \
+             transactions require an operator-allowlisted nonce account. \
+             Resubmit with a recent blockhash."
+                .to_string(),
+        ));
+    };
+    let nonce_account_b58 = nonce_account.to_string();
+    let is_known = pool
+        .entries_iter()
+        .any(|e| e.nonce_account == nonce_account_b58);
+    if !is_known {
+        return Err(Error::InvalidTransaction(format!(
+            "nonce account {nonce_account_b58} is not registered in the gateway nonce pool"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -943,5 +955,78 @@ mod tests {
         assert_eq!(transfer.destination, recipient);
         assert_eq!(transfer.amount, 25000);
         assert_eq!(transfer.mint, Some(usdc_mint));
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_nonce_account (#173 L3 GW)
+    // -----------------------------------------------------------------------
+
+    /// A well-known valid 32-byte base58 nonce account pubkey for tests.
+    const TEST_NONCE_ACCOUNT: &str = "9noXzpXnkyEcKF3AeXqUHTdR59V5uvrRBUo9bwsHaByz";
+    const TEST_AUTHORITY: &str = "So11111111111111111111111111111111111111112";
+
+    fn test_nonce_pool_with(account: &str) -> NoncePool {
+        use crate::nonce_pool::NonceEntry;
+        NoncePool::from_entries(vec![NonceEntry {
+            nonce_account: account.to_string(),
+            authority: TEST_AUTHORITY.to_string(),
+        }])
+        .expect("valid entries")
+    }
+
+    #[test]
+    fn test_validate_nonce_account_no_pool_returns_err() {
+        let nonce_account = Pubkey::from_str(TEST_NONCE_ACCOUNT).unwrap();
+        let result = validate_nonce_account(None, &nonce_account);
+        assert!(result.is_err(), "no pool must fail closed");
+        match result.unwrap_err() {
+            Error::InvalidTransaction(msg) => {
+                assert!(
+                    msg.contains("nonce_pool not configured"),
+                    "error must name the missing configuration: {msg}"
+                );
+                assert!(
+                    msg.contains("Resubmit with a recent blockhash"),
+                    "error should direct clients to the safe alternative: {msg}"
+                );
+            }
+            other => panic!("expected InvalidTransaction, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_nonce_account_in_pool_returns_ok() {
+        let pool = test_nonce_pool_with(TEST_NONCE_ACCOUNT);
+        let nonce_account = Pubkey::from_str(TEST_NONCE_ACCOUNT).unwrap();
+        let result = validate_nonce_account(Some(&pool), &nonce_account);
+        assert!(
+            result.is_ok(),
+            "allowlisted nonce account must verify: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_nonce_account_not_in_pool_returns_err() {
+        // Pool contains a different account.
+        let pool = test_nonce_pool_with("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+        let nonce_account = Pubkey::from_str(TEST_NONCE_ACCOUNT).unwrap();
+        let result = validate_nonce_account(Some(&pool), &nonce_account);
+        assert!(
+            result.is_err(),
+            "non-allowlisted nonce account must be rejected"
+        );
+        match result.unwrap_err() {
+            Error::InvalidTransaction(msg) => {
+                assert!(
+                    msg.contains("not registered in the gateway nonce pool"),
+                    "error must explain the mismatch: {msg}"
+                );
+                assert!(
+                    msg.contains(TEST_NONCE_ACCOUNT),
+                    "error should name the rejected account: {msg}"
+                );
+            }
+            other => panic!("expected InvalidTransaction, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **`x402::solana`** — `SolanaVerifier::verify` now rejects client-submitted durable-nonce transactions when `nonce_pool` is `None` (was: `warn!` + accept).
- **`gateway::main`** — wires the `NoncePool` into the verifier via `.with_nonce_pool(...)`. Without this, fail-closed would have broken every legitimate nonce-based payment because the verifier was never receiving the pool.
- Startup `nonce_pool` empty log upgraded from `info!` to `warn!` with a message that names the new fail-closed behavior.

## Why

The 2026-05-08 review (#173 L3 GW) flagged the `warn!` + accept path as "documented in code, but operationally easy to miss." Audit during this fix surfaced a deeper bug: **the gateway never plumbed the pool into the verifier at all** — `with_nonce_pool` exists in the type but no caller invokes it. So in production today, every client-submitted durable-nonce transaction takes the fail-open branch, regardless of whether the operator configured nonce accounts.

Fail-open here is a real security gap: a client can submit a stale signed transaction (replayable for as long as the nonce account hasn't been advanced) against any nonce account, bypassing the blockhash-recency check that protects regular transactions. The fix is unambiguous — reject every durable-nonce payment that doesn't come through an operator-allowlisted nonce account.

## Operator-visible behavior

| Pool state | Client account | Before | After |
| --- | --- | --- | --- |
| Configured | Allowlisted | ✅ verifies | ✅ verifies |
| Configured | Not in pool | ❌ rejected | ❌ rejected (unchanged) |
| Unconfigured | Any | ⚠️ silently accepted via `warn!` | ❌ rejected with clear error |

The new client-visible error names the missing configuration and points at the safe alternative:

> nonce_pool not configured on the gateway — durable-nonce transactions require an operator-allowlisted nonce account. Resubmit with a recent blockhash.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test -p solvela-x402 --lib\` — 135 pass (was 132; +3 new \`validate_nonce_account\` tests)
- [x] \`cargo test -p gateway --lib\` — 528 pass
- [x] \`cargo test -p gateway --test integration\` — 129 pass

### New test coverage

| Test | Asserts |
| --- | --- |
| \`solana::tests::test_validate_nonce_account_no_pool_returns_err\` | Fail-closed path returns \`Error::InvalidTransaction\` with a message that names both the missing config AND the safe alternative |
| \`solana::tests::test_validate_nonce_account_in_pool_returns_ok\` | Allowlisted account verifies |
| \`solana::tests::test_validate_nonce_account_not_in_pool_returns_err\` | Non-allowlisted account is rejected with an error naming the exact pubkey |

## Implementation notes

- Extracted `validate_nonce_account(pool, account)` as a private free function in `x402::solana` so the fail-closed branch is testable without spinning up the full verifier + Solana RPC mock. Inlined version was a 14-line block inside `SolanaVerifier::verify`.
- The `main.rs` reorganization moves `nonce_pool` ahead of `solana_verifier`. `nonce_pool` only depends on env vars, so no other ordering constraint is violated. `EscrowClaimer` (which also uses `nonce_pool`) continues to bind it at the same place.
- The startup log message at `main.rs` switches from `info!` ("nonce pool empty — clients will use recent blockhash") to `warn!` ("client durable-nonce transactions will be REJECTED"). The old message was also incorrect: clients choose blockhash vs. nonce themselves; the gateway doesn't redirect them.

## Risk

This is a behavior change. Before this PR, any operator running without `SOLVELA_SOLANA__NONCE_ACCOUNT` configured would silently accept client durable-nonce transactions. After this PR, those clients receive a 4xx with a clear error. Mitigation: error message explicitly names the safe alternative (recent-blockhash submission), so clients can recover without operator action.

## Out of scope

- A startup-time validation that nonce pool consistency matches the rest of the Solana config. Not asked for in the original finding.
- Per-tenant nonce account allowlists. The current pool is gateway-wide. Future enhancement, not required for this fix.

Refs: #173 (L3 GW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)