### PR TITLE
docs(readme): add canonical Solvela definition + etymology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Solvela
 
-Solana-native AI agent payment gateway. No API keys, no accounts -- just wallets.
+> **Solvela** *(n.)* — the place where settlement happens. From Latin *solvere* (to settle, to pay) + Romance *-ela*. A Solana-native settlement layer for AI agents.
+
+No API keys, no accounts -- just wallets.
 
 ![Rust](https://img.shields.io/badge/rust-stable-F97316?style=flat&logo=rust&logoColor=white)
 ![Gateway License](https://img.shields.io/badge/gateway-BUSL--1.1-F97316?style=flat)


### PR DESCRIPTION
## Summary

- Adds an italicized epigraph at the top of the README with the canonical one-line definition: *"Solvela (n.) — the place where settlement happens. From Latin solvere (to settle, to pay) + Romance -ela. A Solana-native settlement layer for AI agents."*
- Drops the now-redundant "Solana-native AI agent payment gateway" half of the prior tagline; keeps the "no API keys, no accounts -- just wallets" hook below the epigraph.
- Reframes the README's lead from "payment gateway" → "settlement layer" to match external positioning.

## Render

> **Solvela** *(n.)* — the place where settlement happens. From Latin *solvere* (to settle, to pay) + Romance *-ela*. A Solana-native settlement layer for AI agents.
>
> No API keys, no accounts -- just wallets.

## Test plan

- [ ] Confirm the blockquote renders as intended on github.com (em-dash + italics)
- [ ] No other surfaces drift — this PR touches only the top three lines of README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)