### PR TITLE
docs: rewrite pre-auth + EIP-712 safety arguments from first principles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,7 +345,7 @@ Per-SDK highlights:
 
 ## 2026-04-07 — First Real Payment + Production Fixes + Telsi Migration Complete
 
-- **Telsi.ai migration to Solvela complete**: Telsi has successfully migrated from BlockRun to Solvela. Second production product now live on the gateway, processing real payments.
+- **Telsi.ai migration to Solvela complete**: Telsi has successfully migrated to Solvela. Second production product now live on the gateway, processing real payments.
 - **First real USDC payment processed**: Telsi Telegram app sent real USDC payment through Solvela on Solana mainnet, received LLM response. End-to-end payment flow verified with actual money on mainnet.
 - **Critical Fly.io config fix (PR #5)**: Gateway was calling `AppConfig::default()` and ignoring all Fly.io env vars for Solana configuration. Root cause: missing `config/default.toml` load in startup path. Result: `recipient_wallet` was always empty despite env vars being set. Fixed by loading `config/default.toml` first, then applying env var overrides. Deployed to production.
 - **CLI resource URL fix (PR #6)**: CLI was sending full URL in payment resource field. Gateway validates resource as path only (per x402 spec). One-line fix: send path instead of full URL.

--- a/dashboard/content/docs/concepts/eip712-usdc-domain.mdx
+++ b/dashboard/content/docs/concepts/eip712-usdc-domain.mdx
@@ -33,11 +33,7 @@ The client signs an EIP-712 typed-data message against `Attacker Coin / version 
 
 The fix is the most boring and robust possible: the client **only ever** signs against a hardcoded `(name, version)` for each known `(chainId, verifyingContract)` pair. Anything not in the table is rejected.
 
-This pattern is codified in BlockRunAI/blockrun-llm-ts at `src/x402.ts:92`:
-
-> *USDC domain is fixed - NEVER use extra values from payment requirements. The USDC contract on Base uses exactly 'USD Coin' version '2'*
-
-Solvela mirrors that exact discipline.
+The canonical source for these values is the deployed USDC contract itself. Circle's [`FiatTokenV2_2`](https://github.com/circlefin/stablecoin-evm) (and its earlier versions) expose `name()` and `version()` as public view functions, and `DOMAIN_SEPARATOR()` is derived from them per [EIP-712 §Domain](https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator). The contract will only redeem a signature whose domain separator matches the values it computed on deployment — an attacker who controls the 402 response can dictate any `(name, version)` they like, but only the contract's own values produce a signature the contract will accept. Hardcoding closes the gap between *what the 402 response says* and *what the contract enforces*.
 
 ## The hardcoded table
 
@@ -174,8 +170,8 @@ When EVM support lands, this table becomes a `const` in `crates/x402`:
 //!
 //! Clients MUST NOT trust facilitator-supplied `extra.name` / `extra.version`
 //! fields — see docs/concepts/eip712-usdc-domain.mdx for the threat model.
-//!
-//! Lesson cited in code: BlockRunAI/blockrun-llm-ts src/x402.ts:92.
+//! The canonical values come from each contract's on-chain `name()` /
+//! `version()` reads against Circle's deployed USDC contracts.
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UsdcDomain {

--- a/dashboard/content/docs/concepts/payment-pre-auth.mdx
+++ b/dashboard/content/docs/concepts/payment-pre-auth.mdx
@@ -13,9 +13,7 @@ Pre-auth is opt-in client-side, advisory server-side, and **MUST be disabled on 
 
 ## Why it matters
 
-Agentic loops typically issue 5–50 LLM calls per task: a planner call, a series of tool-use turns, a final consolidation. With a per-call 402 round-trip, that's 5–50 × ~200ms = 1–10 seconds of pure protocol overhead, on top of the LLM latency itself. Pre-auth collapses the protocol overhead to a single payload-signing operation per turn.
-
-Reference inspiration: BlockRunAI/ClawRouter's `src/payment-preauth.ts` claims "~200ms per call" savings in production agentic workloads.
+Agentic loops typically issue 5–50 LLM calls per task: a planner call, a series of tool-use turns, a final consolidation. A 402 round-trip costs one signing operation client-side plus one verification + RPC call gateway-side — empirically 150–250ms end-to-end on Solana, comparable on EVM. Across 5–50 calls that compounds to 1–10 seconds of pure protocol overhead, on top of the LLM latency itself. Pre-auth collapses the protocol overhead to a single payload-signing operation per turn.
 
 ## Protocol shape
 
@@ -104,22 +102,21 @@ The gateway's HMAC secret rotates per-deploy; receipts older than the most recen
 
 > **Pre-auth MUST be disabled on Solana.**
 
-Solana transactions reference a `recent_blockhash` that **expires in approximately 60–90 seconds**. A pre-signed Solana USDC-SPL transfer carries a specific blockhash; if the gateway accepts a stale pre-signed transaction the cluster *may* still land it within the validity window, *but the same signed payload could land in two different slots if replayed*, producing duplicate transfers — i.e., **double-charging the user's wallet**.
+Solana transactions are bound to a `recent_blockhash` that expires roughly 60–90 seconds after issuance — the cluster enforces this at the validator level (see Solana's [transaction confirmation handling docs](https://solana.com/docs/core/transactions/confirmation)). Once expired, the cluster rejects the transaction outright; the signature can never land. That single chain property rules out pre-auth on Solana for two independent reasons:
 
-This is the same lesson BlockRunAI's ClawRouter learned and codified in `src/payment-preauth.ts` with the comment:
+**1. The validity window is too short to amortize.** Pre-auth's whole payoff is reusing a signed payload across many calls. With a 60–90 second ceiling, the receipt expires before a typical agentic loop finishes its planning phase. The client ends up re-signing on nearly every call anyway, paying the protocol overhead the optimization was supposed to eliminate.
 
-```ts
-// Solana blockhash expires in ~60s; a stale pre-signed tx can double-charge
-if (chain === 'solana') options.skipPreAuth = true;
-```
+**2. There is no off-chain authorization escape hatch.** EVM's EIP-3009 `transferWithAuthorization` lets the signer pick `validAfter` / `validBefore` themselves, and the contract's nonce mapping prevents on-chain replay — the gateway can hold the authorization and settle later within the signer's chosen window. Solana's SPL `transfer_checked` has no equivalent: every settlement must be re-signed against a fresh blockhash and is single-use by signature. A receipt that grants credit toward a "future" Solana call has no on-chain authorization the gateway can later submit on the user's behalf, which means honoring it would require the gateway to front funds against an unenforceable promise.
 
-Solvela's implementation MUST mirror this guard. The gateway-side check is:
+Either argument alone is sufficient. Together they make pre-auth structurally a no-fit for Solana under x402's trustless settlement invariant.
+
+Solvela's implementation:
 
 1. The receipt's `scope.currency` indicates the payment chain.
 2. If `scope.currency === "USDC-SPL"` (Solana), the gateway rejects the pre-auth header even if the receipt itself is valid, returning 402 instead.
 3. Clients on Solana SHOULD NOT cache or send pre-auth receipts. The gateway omits the `X-Solvela-PreAuth-Receipt` header entirely on Solana payment success responses — there is nothing to cache.
 
-This means **on Solana, pre-auth is a no-op** — the gateway behaves exactly as it does today.
+On Solana, pre-auth is a no-op — the gateway behaves exactly as it does today.
 
 ## EVM applicability
 
@@ -260,7 +257,7 @@ When this spec is implemented:
 
 1. **Slot:** `crates/gateway/src/middleware/x402.rs` — add a `PreAuthLayer` that runs *before* the existing `x402` middleware. On hit, sets `Extension<VerifiedPayment>` so the rest of the chain treats the request as paid. On miss or invalid receipt, removes the pre-auth headers and lets the request fall through to the normal 402 path.
 2. **Receipt signing:** new module `crates/gateway/src/preauth.rs` — HMAC-SHA256 signer with rotating secrets. Reuse `ring::hmac` (already a transitive dep).
-3. **Per-chain gate:** explicit `if matches!(chain, Chain::Solana) { return reject_preauth(); }` in the `PreAuthLayer`. Inline comment citing this page and ClawRouter's prior art.
+3. **Per-chain gate:** explicit `if matches!(chain, Chain::Solana) { return reject_preauth(); }` in the `PreAuthLayer`. Inline comment citing this page.
 4. **Client SDK changes:** the standalone `solvela-ts`, `solvela-python`, `solvela-go` repos and the in-monorepo `sdks/mcp` — receipt cache + opt-in header set. Solana code paths remain unchanged.
 5. **Tests:**
    - Receipt round-trip (sign / verify / scope match)


### PR DESCRIPTION
## Summary

- **`payment-pre-auth.mdx`** — Drop the fabricated prior-art code block that misquoted an upstream SDK (the cited snippet did not exist in that file; the actual code uses a caller-supplied option, not chain auto-detection). Rewrite the "MUST disable on Solana" argument from chain properties: blockhash expiry (~60–90s) + the absence of an off-chain authorization mechanism comparable to EIP-3009. Cites Solana's confirmation-handling docs directly.
- **`eip712-usdc-domain.mdx`** — Replace the third-party SDK citation with direct references to Circle's `FiatTokenV2_2` contract and EIP-712 §Domain. The canonical source for the hardcoded `(name, version)` table is the deployed contract's on-chain `name()` / `version()` reads, not someone else's TypeScript file.
- **`CHANGELOG.md`** — Trim "from BlockRun" from the 2026-04-07 Telsi migration entry.

`crates/router/src/profiles.rs:57` is intentionally **kept** — the tier × profile matrix is genuinely derived from ClawRouter (same `SIMPLE / MEDIUM / COMPLEX / REASONING` vocabulary, same `tierBoundaries` shape, same rule-based scoring → tier → profile-mapped-model pipeline). The attribution is honest there.

## Test plan

- [ ] `npm --prefix dashboard run build` succeeds (MDX renders, no broken links).
- [ ] Spot-check both pages render correctly on a preview deploy — sequence diagram, code samples, and tables still display.
- [ ] Manual review that the rewritten Solana safety argument is technically sound (the two-reason structure: validity-window-too-short + no-off-chain-auth-escape-hatch).