### PR TITLE
docs(audit): batch 1 truth fixes — routing profile, response shape, pre-publish warnings

### DIFF
--- a/dashboard/content/docs/index.mdx
+++ b/dashboard/content/docs/index.mdx
@@ -40,7 +40,7 @@ The gateway is OpenAI-compatible, so any existing code that targets the OpenAI A
 
 <CardGroup>
   <Card title="26 models across 5 providers" description="OpenAI, Anthropic, Google, xAI, and DeepSeek — all behind one endpoint with unified USDC pricing." href="/docs/api/models" />
-  <Card title="Smart routing" description="Set model to 'auto', 'eco', or 'premium' and the gateway picks the right model for your prompt's complexity." href="/docs/concepts/smart-router" />
+  <Card title="Smart routing" description="Set model to 'auto', 'eco', 'premium', or 'free' and the gateway picks the right model for your prompt's complexity." href="/docs/concepts/smart-router" />
   <Card title="Escrow payments" description="Trustless on-chain escrow with deposit/claim/refund — no upfront full payment required." href="/docs/concepts/escrow" />
   <Card title="OpenAI-compatible" description="Drop-in replacement for the OpenAI API. Change the base URL and add payment handling." href="/docs/api/chat-completions" />
   <Card title="Transparent pricing" description="5% platform fee on top of provider cost. All pricing exposed at GET /pricing." href="/docs/concepts/pricing" />

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -293,7 +293,7 @@ curl https://api.solvela.ai/v1/chat/completions \
   }'
 ```
 
-A successful response is standard OpenAI format plus a `x_solvela` cost field.
+A successful response is standard OpenAI format. Gateway-specific metadata (request ID, model fallback used, session token) is returned in `x-solvela-*` response headers; the JSON body itself is unmodified for drop-in OpenAI compatibility.
 
 </Step>
 

--- a/sdks/cli-npm/README.md
+++ b/sdks/cli-npm/README.md
@@ -2,7 +2,14 @@
 
 Solvela CLI — MCP installer and wallet management for Solana x402 payments.
 
-## Installation
+> **⚠️ Not yet published to npm.** `@solvela/cli` is at `1.0.0-draft` and the package
+> is marked `"private": true`. The install commands below will fail until first
+> publish lands. For now, build from source: clone `solvela-ai/solvela` and run
+> `npm install && npm run build` in `sdks/cli-npm/`. The Rust CLI (same surface,
+> different language) is already published as `solvela-cli` on crates.io —
+> `cargo install solvela-cli` is the supported install today.
+
+## Installation (once published)
 
 ```bash
 npm install -g @solvela/cli

--- a/sdks/openclaw-provider/README.md
+++ b/sdks/openclaw-provider/README.md
@@ -6,16 +6,23 @@ transparently via the x402 protocol using USDC on Solana.
 
 ## Install
 
-```bash
-npm install @solvela/openclaw-provider
-```
-
-> **Note:** During private testing, install from the local path:
+> **⚠️ Not yet published to npm.** `@solvela/openclaw-provider` is at `1.0.0-draft`
+> and `"private": true` in `package.json`. Until first publish, install from a
+> local checkout:
+>
 > ```bash
 > npm install /path/to/sdks/openclaw-provider
 > ```
-> The `@solvela/sdk` dependency switches to a real npm version range at publish
-> time (Phase 4). During development it references `file:../typescript`.
+>
+> The `@solvela/sdk` dependency is wired as `file:../typescript` during
+> development; it switches to a real npm version range when this package is
+> published.
+
+Once published, the canonical install will be:
+
+```bash
+npm install @solvela/openclaw-provider
+```
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary

First batch of fixes from a sweep against current monorepo source. Each issue verified before edit; no changes deferred without a note.

| File | Severity | What was wrong | Source-of-truth check |
|---|---|---|---|
| `dashboard/content/docs/index.mdx` | STALE | Smart-routing card listed `'auto', 'eco', or 'premium'`. The `free` profile was missing. | `crates/cli/src/main.rs` (CLI help text) and `crates/router/src/profiles.rs:42-52` (`Profile::from_alias`) both expose `free` as a routing profile. |
| `dashboard/content/docs/quickstart.mdx` | BROKEN | Claimed *"A successful response is standard OpenAI format plus a `x_solvela` cost field."* | No such body field in `crates/gateway/src/routes/chat/`. Gateway adds `x-solvela-*` **response headers** only (`x-solvela-session`, `x-solvela-fallback`, `x-solvela-request-id`); body is unmodified OpenAI format. Rewrote to describe the actual shape. |
| `sdks/cli-npm/README.md` | MISLEADING | `npm install -g @solvela/cli` shown as the install command. | `package.json` has `"version": "1.0.0-draft"` and `"private": true`; `https://registry.npmjs.org/@solvela/cli` returns 404. Added a leading warning and pointed at the published Rust CLI (`cargo install solvela-cli`) as the supported install today. |
| `sdks/openclaw-provider/README.md` | MISLEADING | Same private/draft state as cli-npm; npm install was shown first with the local-path workaround in a follow-up Note. | Restructured so the local-path install (the actually-working method) comes first, and the npm command is labeled as the canonical install for after first publish. |

## Deferred to a separate batch

- `sdks/rust/README.md` still documents the old 4-crate split (`solvela-client`, `solvela-client-cli`, `solvela-client-cli-args`, `solvela-client-proxy`) from the now-archived `solvela-ai/solvela-client` repo. Needs a full rewrite to reflect the current published structure (`solvela-cli` + the three workspace library crates), not a one-line patch.
- 36 of 39 docs MDX files have not yet been verified end-to-end. Same for the landing page components and the remaining SDK READMEs.

## Test plan

- [ ] `npm --prefix dashboard run build` succeeds (MDX renders).
- [ ] Spot-check that the updated card in `index.mdx` mentions all four routing profiles.
- [ ] Spot-check that the quickstart's "Resend with the payment signature" step no longer claims a `x_solvela` body field.