### PR TITLE
docs(audit): batch 3 — SDK README fixes (TS quickstart model, MCP install, ai-sdk-provider not-yet-published)

### DIFF
--- a/sdks/ai-sdk-provider/README.md
+++ b/sdks/ai-sdk-provider/README.md
@@ -4,6 +4,18 @@ Vercel AI SDK provider for Solvela — AI agent payments with USDC on Solana via
 
 ## Install
 
+> **⚠️ Not yet published to npm.** `@solvela/ai-sdk-provider` is at `0.2.1` in
+> `package.json` (`private: false`) but has not been published. The npm install
+> command below will fail today. To use the provider now, clone the monorepo
+> and depend on this directory via a `file:` path or workspace link:
+>
+> ```bash
+> git clone https://github.com/solvela-ai/solvela
+> cd solvela/sdks/ai-sdk-provider && npm install && npm run build
+> ```
+
+Once published, the canonical install will be:
+
 ```bash
 npm install @solvela/ai-sdk-provider ai @ai-sdk/provider-utils @ai-sdk/openai-compatible
 ```

--- a/sdks/mcp/README.md
+++ b/sdks/mcp/README.md
@@ -10,7 +10,7 @@ Install the `solvela` CLI, then run the one-line installer for your host:
 
 ```bash
 # Install the Solvela CLI (once)
-cargo install --path crates/cli
+cargo install solvela-cli
 
 # Install into your preferred host
 solvela mcp install --host=claude-code

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -21,7 +21,7 @@ const client = new SolvelaClient({
   config: { gatewayUrl: 'http://localhost:8402' },
 });
 
-const request = new ChatRequest('gpt-4', [
+const request = new ChatRequest('auto', [
   new ChatMessage('user', 'Hello!'),
 ]);
 


### PR DESCRIPTION
## Summary

Three copy-paste failures fixed in user-facing SDK READMEs. **No bot review requested.**

| File:line | Severity | Was | Now | Why |
|---|---|---|---|---|
| `sdks/typescript/README.md:24` | BROKEN | `new ChatRequest('gpt-4', [...])` | `new ChatRequest('auto', [...])` | `'gpt-4'` is not in `config/models.toml` (real entries: `gpt-4o`, `gpt-5.2`, `gpt-4-1`, ...) and not in `resolve_alias` (`crates/router/src/profiles.rs`). Returns "model not found". `'auto'` is a smart-router profile that always resolves. |
| `sdks/mcp/README.md:13` | BROKEN | `cargo install --path crates/cli` | `cargo install solvela-cli` | The `--path` form only works from inside the monorepo. External users have no `crates/cli` to point at. The published crate `solvela-cli` is the same binary. |
| `sdks/ai-sdk-provider/README.md:7-8` | MISLEADING | `npm install @solvela/ai-sdk-provider ...` (only) | Added leading "not yet published" warning + git-clone install for current use; kept npm command labeled as the post-publish canonical path. | `registry.npmjs.org/@solvela/ai-sdk-provider` returns 404 — package.json has `private: false` but never published. |

Each fix is one or a few lines; the diff is small and surgical.

## Test plan

- [ ] TS quickstart compiles + runs as shown.
- [ ] MCP quickstart works for a fresh-install user (not the monorepo developer).
- [ ] AI SDK provider README's install instructions are achievable today.

## Audit progress

This is the third PR in a multi-batch documentation audit. PR #338 = Batch 1 (4 small fixes). PR #339 = Batch 2 (landing samples + enterprise endpoints + stale archived-repo refs). PR #339 has the highest-impact landing-page fixes.

**Still to come:** `sdks/rust/README.md` (full rewrite — documents 4 legacy crates), `STATUS.md:42` perf claim verification, ~30 docs MDX files not yet line-audited, remaining 2 SDK READMEs (`signer-core` is internal-only, already disclosed; `cli-npm` and `openclaw-provider` already handled in Batch 1).