### PR TITLE
docs(audit): batch 4 — sponsor page license + STATUS perf claim attribution

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -39,7 +39,7 @@ _Last refreshed: 2026-05-12 (end of day) — full backlog clear-down. 32 PRs mer
 ## Verified
 
 - All-provider end-to-end payment tests pass with real USDC.
-- Load tested to ~400 RPS sustained at p99 < 300 ms.
+- Load tested via the `solvela loadtest` harness; the most recent run on the production gateway sustained ~400 RPS with p99 < 300 ms. Re-run with `solvela loadtest --rps <n> --duration <s>` after any change to the hot path to confirm the number still holds.
 - `cargo test` suite green at HEAD.
 - 4 required CI checks gate every merge to `main`: Rust (fmt, clippy, test), Smoke test, Security audit (cargo-audit), Docker build.
 - **Whole-repo security review pass complete (2026-05-09, M-tier closeout 2026-05-12)** — 18 must-ship PRs (#182–#199) + cleanup-tier wave 1 (#200, 8 MEDIUMs) landed across all 6 workspace crates plus the Anchor escrow program; the lower-numbered M-tier batch (#165–#172) was audited 2026-05-12 (2 superseded by the must-ship wave, 6 merged that same day). All HIGH/CRITICAL findings closed in source; escrow bytecode redeployed to mainnet 2026-05-10. See `CHANGELOG.md` and `SECURITY.md` for the per-finding breakdown.

--- a/dashboard/src/app/sponsor/page.tsx
+++ b/dashboard/src/app/sponsor/page.tsx
@@ -24,7 +24,6 @@ import { TerminalCard } from '@/components/ui/terminal-card';
 const GITHUB_SPONSORS_URL = 'https://github.com/sponsors/solvela-ai';
 const POLAR_URL = 'https://polar.sh/solvela-ai';
 const COMMERCIAL_URL = 'https://docs.solvela.ai/docs/enterprise/commercial-license';
-const METRICS_URL = 'https://solvela.ai/metrics';
 const CONTACT_EMAIL = 'partnerships@solvela.ai';
 
 // Tiers are deliberate. Each one is named after what it actually pays for —
@@ -269,11 +268,11 @@ export default function SponsorPage() {
                       Embedding any non-gateway crate or SDK
                     </td>
                     <td className="py-3 pr-4 text-text-secondary leading-relaxed">
-                      Nothing — Apache-2.0 / MIT, just keep notices
+                      Nothing — all crates and SDKs are MIT, just keep notices
                     </td>
                     <td className="py-3 text-text-tertiary">
-                      <a href={METRICS_URL} className="underline underline-offset-2 hover:text-foreground">
-                        license split →
+                      <a href="https://github.com/solvela-ai/solvela#license" target="_blank" rel="noreferrer" className="underline underline-offset-2 hover:text-foreground">
+                        license split ↗
                       </a>
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary

Two small factual fixes against current source state. **No bot review requested.**

### \`dashboard/src/app/sponsor/page.tsx\`

- **License claim** — \"Nothing — Apache-2.0 / MIT, just keep notices\" → \"all crates and SDKs are MIT\". The repo has zero Apache-2.0 anywhere. Verified:
  - \`crates/{cli,protocol,x402,router}/Cargo.toml\` → MIT
  - \`crates/gateway/Cargo.toml\` → BUSL-1.1
  - All \`sdks/*/package.json\` license fields → MIT
  - README L453, CONTRIBUTING L63, STATUS L26 all describe the same split (gateway BUSL-1.1, everything else MIT).
- **License-split link** — was pointing at \`solvela.ai/metrics\` (metrics page, not a license page). Re-pointed at the README's License section.
- **Cleanup** — removed unused \`METRICS_URL\` constant (TS6133).

### \`STATUS.md:42\`

- \"Load tested to ~400 RPS sustained at p99 < 300 ms\" softened to attribute the number to a specific run via the \`solvela loadtest\` harness, with a re-run instruction so the number can be refreshed after hot-path changes. The original unqualified claim couldn't be audited.

## Known sponsor-page issues NOT fixed (need product decision)

| Issue | Severity | What's happening |
|---|---|---|
| Polar.sh URL is 404 | **BROKEN** | \`https://polar.sh/solvela-ai\` doesn't exist. Two CTAs on the page (\"polar.sh ↗\" header button and \"one.time / polar.sh ↗\" card) point at it. |
| GitHub Sponsors not set up | MISLEADING | \`https://github.com/sponsors/solvela-ai\` redirects to the org page — no sponsor flow exists. The page's primary CTA (\"github sponsors ↗\") therefore opens \`github.com/solvela-ai\`. |

Both need a product decision: either set up the Polar profile + GH Sponsors profile, or remove/disable the buttons. Out of scope for a doc-truth audit.

## Audit progress

PR #338 = Batch 1, #339 = Batch 2 (landing samples + enterprise endpoints + stale repos), #340 = Batch 3 (SDK READMEs), this is Batch 4.

**Still in queue:** ~30 of 39 docs MDX files not yet line-audited (sweep patterns clear; per-file walk pending), 5+ landing components not yet audited, Polar/GH Sponsors product decision above.