### PR TITLE
docs(audit): batch 5 — fix wrong cache claim in pre-auth doc + ai-sdk install warning

### DIFF
--- a/dashboard/content/docs/concepts/payment-pre-auth.mdx
+++ b/dashboard/content/docs/concepts/payment-pre-auth.mdx
@@ -133,20 +133,21 @@ The receipt model maps cleanly:
 
 So the same opt-in client header set works for EVM with no protocol change beyond the chain-aware enablement gate.
 
-## Replay protection — the failsafe
+## Response cache — adjacent failsafe
 
-Even with pre-auth disabled on Solana and constrained on EVM, the gateway carries a defense-in-depth layer against accidentally-replayed pre-signed payments:
+Even with pre-auth disabled on Solana and constrained on EVM, the gateway carries a related layer that limits the blast radius of accidentally-replayed requests:
 
-The existing **request-dedup cache** at `crates/gateway/src/cache.rs::request_dedup` computes a SHA-256 of the canonicalized request body (sorted keys, agent timestamp prefixes stripped) and caches the response for 30 seconds keyed on that hash. A client that retries the same request within 30s — pre-auth header or not — gets the cached response, NOT a fresh charge.
+The existing **response cache** (`ResponseCache` in [`crates/gateway/src/cache.rs`](https://github.com/solvela-ai/solvela/blob/main/crates/gateway/src/cache.rs)) keys on `SHA-256(model ‖ serialised_messages ‖ temperature)` and stores the upstream completion for the configured TTL (default 10 minutes). A client that issues the same prompt twice within the TTL window — pre-auth header or not — gets the cached response and the upstream LLM is only charged once.
 
-This means: even if a client mishandles its receipt cache and replays a request with both `X-Solvela-PreAuth-Receipt` and a fresh `payment-signature`, the gateway returns the cached response and does not double-charge.
+This is **not** a payment-replay guard. Payment-replay protection is handled separately: the gateway tracks transaction signatures and rejects duplicate `payment-signature` headers with `402 Invalid Payment`. The response cache is a cost-control / latency optimization, not a correctness safeguard against double-charging.
 
-Pre-auth and request-dedup are independent layers:
+The two layers are deliberately independent:
 
-- **Pre-auth** is a *latency* optimization (skip the 402 round-trip).
-- **Request-dedup** is a *correctness* guard (don't charge twice for the same logical request).
+- **Pre-auth** is a *latency* optimization on the gateway's HTTP boundary (skip the 402 round-trip).
+- **Response cache** is a *cost* optimization on the upstream LLM hop (don't call the provider twice for the same prompt).
+- **Payment-signature replay protection** is a *correctness* guard at the verifier (don't accept the same signed transaction twice).
 
-Both ship.
+The pre-auth design only interacts with the first two; it cannot weaken the third.
 
 ## Sequence diagram
 

--- a/dashboard/content/docs/sdks/ai-sdk.mdx
+++ b/dashboard/content/docs/sdks/ai-sdk.mdx
@@ -7,6 +7,18 @@ This page will be picked up by the docs.solvela.ai migration when it runs.
 
 ## Installation
 
+> **⚠️ Not yet published to npm.** `@solvela/ai-sdk-provider` is at `0.2.1` in
+> `package.json` but has not been published to the registry. The npm install
+> below will fail today. To use the provider now, install from a local
+> checkout of the monorepo:
+>
+> ```bash
+> git clone https://github.com/solvela-ai/solvela
+> cd solvela/sdks/ai-sdk-provider && npm install && npm run build
+> ```
+
+Once published, the canonical install will be:
+
 ```bash
 npm install @solvela/ai-sdk-provider ai @ai-sdk/provider-utils @ai-sdk/openai-compatible
 ```


### PR DESCRIPTION
## Summary

Two more factual fixes. **No bot review requested.**

### \`dashboard/content/docs/concepts/payment-pre-auth.mdx\` (lines 138–149)

The "Replay protection — the failsafe" section described a non-existent function and got the cache's mechanism, key shape, AND TTL wrong. Verified against \`crates/gateway/src/cache.rs\`:

| Claim | Reality |
|---|---|
| \`crates/gateway/src/cache.rs::request_dedup\` function | \`ResponseCache\` (cache.rs:66). No \`request_dedup\` exists anywhere. |
| Key: "canonicalized request body, sorted keys, agent timestamp prefixes stripped" | \`SHA-256(model + serialised_messages + temperature)\` (cache.rs:3, 8) |
| TTL: 30 seconds | Default 10 minutes, configurable per model (cache.rs:4) |
| Framing: "correctness guard against double-charging" | Cost / latency optimization. Payment-replay protection is a **separate** mechanism (signature dedup at the verifier). |

Rewrote the section to describe what the cache actually does and to be honest about what it is and isn't. Three layers — pre-auth, response cache, payment-signature replay protection — are now distinguished cleanly.

### \`dashboard/content/docs/sdks/ai-sdk.mdx\` (lines 8–14)

Same fix as PR #340 applied to \`sdks/ai-sdk-provider/README.md\`: \`npm install @solvela/ai-sdk-provider ...\` would fail today (404 on npm). Added a leading warning + git-clone install. The original npm command is preserved as the post-publish canonical path.

## Test plan

- [ ] \`npm --prefix dashboard run build\` succeeds, MDX renders.
- [ ] \`payment-pre-auth.mdx\` no longer claims a non-existent function or a wrong TTL.
- [ ] \`sdks/ai-sdk.mdx\` install instructions are achievable today.

## Audit position

PR #338 / #339 / #340 / #341 are open. This is Batch 5. Coverage on user-facing surfaces is now substantial. **Remaining for a future pass:** deep-walk on api/{authentication,errors,rate-limits}.mdx, enterprise/{commercial-license,sponsorship,index,orgs,api-keys,teams,budgets,audit,analytics}.mdx, operations/* (deployment, monitoring, security, troubleshooting), concepts/* (architecture, escrow, payment-flow, pricing, request-flow, smart-router, x402) and remaining landing components.

## One bug discovered NOT a doc fix

`config/models.toml` has two entries (`anthropic-claude-sonnet-4-5` and `anthropic-claude-sonnet-4-6`) both pointing at `model_id = "claude-sonnet-4-20250514"`. The registry tolerates equal-pricing duplicates but collapses them in `HashMap::collect`, so `/v1/models` shows 25 unique IDs while docs (`index.mdx`, `pricing.mdx`, `README.md`) all say "26 models." Either fix the config (split the model_ids or drop the duplicate) or adjust the docs to "25." Reported here; not fixed in this batch.