### PR TITLE
docs(audit): batch 6 — fix stale postgres dev credentials (rcr → solvela)

### DIFF
--- a/dashboard/content/docs/operations/deployment.mdx
+++ b/dashboard/content/docs/operations/deployment.mdx
@@ -21,7 +21,7 @@ Services:
 | `redis` | `redis:7-alpine` | `127.0.0.1:6379` | Response cache, replay protection |
 
 <Warning>
-Default credentials (`rcr` / `rcr_dev_password`) are for local development only. Never use in production.
+Default credentials (`solvela` / `solvela_dev_password`) are for local development only. Never use in production.
 </Warning>
 
 Ports are bound to `127.0.0.1` only -- not accessible from the network.

--- a/dashboard/content/docs/operations/troubleshooting.mdx
+++ b/dashboard/content/docs/operations/troubleshooting.mdx
@@ -137,14 +137,14 @@ If PostgreSQL-dependent features (stats, spend logging) are not working:
 docker compose ps postgres
 
 # Check connectivity
-psql postgres://rcr:rcr_dev_password@localhost:5432/solvela -c "SELECT 1"
+psql postgres://solvela:solvela_dev_password@localhost:5432/solvela -c "SELECT 1"
 
 # Check migrations ran
-psql postgres://rcr:rcr_dev_password@localhost:5432/solvela \
+psql postgres://solvela:solvela_dev_password@localhost:5432/solvela \
   -c "\dt"
 
 # Check spend logs
-psql postgres://rcr:rcr_dev_password@localhost:5432/solvela \
+psql postgres://solvela:solvela_dev_password@localhost:5432/solvela \
   -c "SELECT COUNT(*) FROM spend_log"
 ```
 


### PR DESCRIPTION
## Summary

Operations docs still cited the pre-rebrand RCR postgres credentials. Fixed against the actual `docker-compose.yml`. **No bot review requested.**

| Doc reference | Was | Now (matches `docker-compose.yml`) |
|---|---|---|
| \`operations/deployment.mdx:24\` | \`rcr\` / \`rcr_dev_password\` | \`solvela\` / \`solvela_dev_password\` |
| \`operations/troubleshooting.mdx:140,143,147\` | \`postgres://rcr:rcr_dev_password@...\` | \`postgres://solvela:solvela_dev_password@...\` |

Anyone copy-pasting the psql command from the troubleshooting doc against a real local-dev container would hit "password authentication failed."

## Test plan

- [ ] \`docker compose up -d\` and run \`psql postgres://solvela:solvela_dev_password@localhost:5432/solvela -c "SELECT 1"\` — succeeds.
- [ ] No remaining \`rcr_dev_password\` literal in the docs site.

## Audit progress note

PR #338 / #339 / #340 / #341 / #342 / this is Batch 6. Coverage on user-facing surfaces is substantial. Known remaining issues that need a product decision (NOT doc fixes):

1. **Polar.sh + GitHub Sponsors profiles not set up** — both `sponsor/page.tsx` (PR #341) and `enterprise/sponsorship.mdx` (docs L54-55) link to URLs that 404 or redirect.
2. **Config duplicate** — `config/models.toml` has two entries (`anthropic-claude-sonnet-4-5` and `anthropic-claude-sonnet-4-6`) both pointing at `model_id = "claude-sonnet-4-20250514"`. Docs claim "26 models"; `/v1/models` returns 25. Either fix config or adjust docs.