### PR TITLE
docs(audit): batch 7 — landing model count + debug headers + Redis key prefix

### DIFF
--- a/dashboard/content/docs/operations/security.mdx
+++ b/dashboard/content/docs/operations/security.mdx
@@ -87,7 +87,7 @@ CORS is configured restrictively:
 - **Development** (`SOLVELA_ENV != "production"`): allows `localhost:3000`, `localhost:8080`, `127.0.0.1:3000`
 - **Production** (`SOLVELA_ENV=production`): only origins listed in `SOLVELA_CORS_ORIGINS`
 - **Allowed methods**: GET, POST, OPTIONS only
-- **Allowed headers**: `Content-Type`, `Authorization`, `PAYMENT-SIGNATURE`, `X-Request-Id`, `X-RCR-Debug`, `X-Session-Id`
+- **Allowed headers**: `Content-Type`, `Authorization`, `PAYMENT-SIGNATURE`, `X-Request-Id`, `X-Session-Id`, `X-Solvela-Debug` (canonical) plus legacy `X-RCR-Debug` for pre-rebrand clients
 
 SDK and agent clients are unaffected by CORS since they do not run in browsers.
 
@@ -118,7 +118,7 @@ Every response includes:
 | `X-Content-Type-Options` | `nosniff` | Prevents MIME type sniffing |
 | `X-Frame-Options` | `DENY` | Prevents clickjacking |
 | `Referrer-Policy` | `no-referrer` | Prevents referrer leakage |
-| `X-RCR-Request-Id` | UUID | Request correlation (always present) |
+| `X-Solvela-Request-Id` | UUID | Request correlation (always present). The legacy `X-RCR-Request-Id` mirror is also emitted for pre-rebrand clients. |
 
 ## Prompt Guard
 

--- a/dashboard/content/docs/operations/troubleshooting.mdx
+++ b/dashboard/content/docs/operations/troubleshooting.mdx
@@ -31,7 +31,7 @@ Enable debug headers to diagnose routing and payment issues:
 ```bash
 curl -X POST http://localhost:8402/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "X-RCR-Debug: true" \
+  -H "X-Solvela-Debug: true" \
   -H "PAYMENT-SIGNATURE: <payment>" \
   -d '{"model": "auto", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
@@ -39,20 +39,20 @@ curl -X POST http://localhost:8402/v1/chat/completions \
 The response includes:
 
 ```
-X-RCR-Request-Id: 550e8400-e29b-41d4-a716-446655440000
-X-RCR-Model-Requested: auto
-X-RCR-Model-Resolved: google/gemini-2.5-flash
-X-RCR-Route-Profile: auto
-X-RCR-Route-Tier: simple
-X-RCR-Route-Score: -0.3500
-X-RCR-Provider: google
-X-RCR-Cache-Status: miss
-X-RCR-Payment-Status: verified
-X-RCR-Token-Estimate: 10
-X-RCR-Duration-Ms: 1247
+X-Solvela-Request-Id: 550e8400-e29b-41d4-a716-446655440000
+X-Solvela-Model-Requested: auto
+X-Solvela-Model-Resolved: google/gemini-2.5-flash
+X-Solvela-Route-Profile: auto
+X-Solvela-Route-Tier: simple
+X-Solvela-Route-Score: -0.3500
+X-Solvela-Provider: google
+X-Solvela-Cache-Status: miss
+X-Solvela-Payment-Status: verified
+X-Solvela-Token-Estimate: 10
+X-Solvela-Duration-Ms: 1247
 ```
 
-`X-RCR-Request-Id` is always returned (not gated by the debug flag).
+The legacy `X-RCR-*` header set (request flag + every response header) is still emitted for backward compatibility with pre-rebrand clients. `X-Solvela-Request-Id` (and its `X-RCR-Request-Id` mirror) is always returned, not gated by the debug flag.
 
 ## Health Check Interpretation
 
@@ -159,8 +159,8 @@ docker compose ps redis
 # Check connectivity
 redis-cli -h localhost ping
 
-# Check cache keys
-redis-cli -h localhost keys "rcr:*" | head -20
+# Check cache keys (prefixes: solvela:cache: for response cache, solvela:txn: for replay protection)
+redis-cli -h localhost keys "solvela:*" | head -20
 
 # Check memory usage
 redis-cli -h localhost info memory | grep used_memory_human

--- a/dashboard/src/components/landing/provider-row.tsx
+++ b/dashboard/src/components/landing/provider-row.tsx
@@ -12,7 +12,7 @@ export function ProviderRow() {
               className="font-display leading-[1.05] text-foreground"
               style={{ fontSize: 'clamp(1.5rem, 2.4vw, 2rem)', fontWeight: 600 }}
             >
-              One endpoint. Five providers. Twenty-six models.
+              One endpoint. Five providers. Twenty-five+ models.
             </h2>
           </div>
           <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-faint">


### PR DESCRIPTION
## Summary

Three more fixes, each verified against current source. **No bot review requested.**

### Landing — \`provider-row.tsx\`

The site simultaneously claims 25, 25+, and 26 models on a single page:

- \`inline-metrics\` (hero area): \`METRICS.value = 25, suffix = '+'\` → reads "25+"
- \`landing-ticker\`: \`'25+ models · 5 providers'\`
- \`provider-row\` (this PR): \`Twenty-six models\`

The provider-row was the outlier. Aligned to \`Twenty-five+\` so all three surfaces match.

> The actual count is bounded between 25 and 26 because \`config/models.toml\` has two entries (\`anthropic-claude-sonnet-4-5\` and \`-4-6\`) collapsing to the same canonical ID. Flagged in PR #342's description; still needs a config decision.

### Docs — \`operations/troubleshooting.mdx\` debug headers

Documented \`X-RCR-Debug: true\` and an \`X-RCR-*\` response header set as the canonical debug interface. Per \`crates/gateway/src/routes/debug_headers.rs\`, \`X-Solvela-*\` is canonical and \`X-RCR-*\` is only kept as a backward-compat mirror. Rewrote to show \`X-Solvela-*\` first, with a single sentence noting the legacy \`X-RCR-*\` mirror.

### Docs — \`operations/troubleshooting.mdx\` Redis check

\`redis-cli keys "rcr:*"\` returns nothing today. Real prefixes (\`crates/gateway/src/cache.rs:34,37\`):

- \`solvela:cache:\` — response cache
- \`solvela:txn:\` — replay protection

Updated the example to \`keys "solvela:*"\` with both prefixes documented inline.

## Test plan

- [ ] Landing renders with consistent "25+" everywhere.
- [ ] \`X-Solvela-Debug: true\` returns the debug headers (verify against running gateway).
- [ ] \`redis-cli keys "solvela:*"\` returns cache + replay keys after any 200 response.