### PR TITLE
docs(audit): batch 8 — sponsor CTAs go to mailto until GH Sponsors + Polar profiles are live

### DIFF
--- a/dashboard/content/docs/enterprise/sponsorship.mdx
+++ b/dashboard/content/docs/enterprise/sponsorship.mdx
@@ -51,8 +51,11 @@ Use this table to figure out which one applies to you.
 
 ## How to sponsor
 
-- **GitHub Sponsors** — [github.com/sponsors/solvela-ai](https://github.com/sponsors/solvela-ai). Recurring billing, corporate-card-friendly, receipts handled by GitHub.
-- **Polar.sh** — [polar.sh/solvela-ai](https://polar.sh/solvela-ai). One-time payments, crypto, alternative billing.
+> **Profiles in setup.** GitHub Sponsors and Polar profiles for the `solvela-ai` org are not live yet. Until they are, email **partnerships@solvela.ai** with the tier you want to support and we'll send back payment instructions.
+
+- **GitHub Sponsors** (coming soon) — recurring billing, corporate-card-friendly, receipts handled by GitHub. Profile will live at `github.com/sponsors/solvela-ai` once enabled.
+- **Polar.sh** (coming soon) — one-time payments, crypto, alternative billing. Profile will live at `polar.sh/solvela-ai` once enabled.
+- **Direct sponsorship** (available today) — email **partnerships@solvela.ai** to wire / ACH / crypto-pay any of the listed tiers.
 - **In-kind sponsorship** (RPC credits, infra credits, security audit time) — email **partnerships@solvela.ai** with what you'd like to contribute.
 
 ## Transparency

--- a/dashboard/src/app/sponsor/page.tsx
+++ b/dashboard/src/app/sponsor/page.tsx
@@ -21,10 +21,17 @@ import { LandingTopStrip } from '@/components/landing/landing-chrome';
 import { LandingFooter } from '@/components/landing/landing-footer';
 import { TerminalCard } from '@/components/ui/terminal-card';
 
-const GITHUB_SPONSORS_URL = 'https://github.com/sponsors/solvela-ai';
-const POLAR_URL = 'https://polar.sh/solvela-ai';
-const COMMERCIAL_URL = 'https://docs.solvela.ai/docs/enterprise/commercial-license';
+// GitHub Sponsors and Polar profiles are not yet enabled for solvela-ai;
+// both URLs currently 404 or redirect to the org page. Until the profiles
+// are set up, every CTA on this page funnels to a working mailto:.
+// When the profiles go live, restore the real URLs:
+//   const GITHUB_SPONSORS_URL = 'https://github.com/sponsors/solvela-ai';
+//   const POLAR_URL = 'https://polar.sh/solvela-ai';
 const CONTACT_EMAIL = 'partnerships@solvela.ai';
+const SPONSOR_MAILTO = `mailto:${CONTACT_EMAIL}?subject=Solvela%20Sponsorship`;
+const GITHUB_SPONSORS_URL = SPONSOR_MAILTO;
+const POLAR_URL = SPONSOR_MAILTO;
+const COMMERCIAL_URL = 'https://docs.solvela.ai/docs/enterprise/commercial-license';
 
 // Tiers are deliberate. Each one is named after what it actually pays for —
 // not a vanity ladder. If a sponsor asks "what does $X cover?" we want the


### PR DESCRIPTION
## Summary

Last batch addresses one of the three open product issues (the broken sponsor URLs) with a non-product code change. **No bot review requested.**

Two URLs that don't work today:

| URL | Status |
|---|---|
| \`https://github.com/sponsors/solvela-ai\` | Redirects to org page — GitHub Sponsors not enabled |
| \`https://polar.sh/solvela-ai\` | 404 — no Polar profile exists |

Both were rendered as primary CTAs on the sponsor page and as bullet links in \`enterprise/sponsorship.mdx\`. Any click landed on a dead end.

## Fix

| File | Change |
|---|---|
| \`dashboard/src/app/sponsor/page.tsx\` | \`GITHUB_SPONSORS_URL\` and \`POLAR_URL\` now both resolve to \`mailto:partnerships@solvela.ai?subject=Solvela%20Sponsorship\`. Original URL constants preserved as a comment for verbatim restoration once profiles are live. |
| \`dashboard/content/docs/enterprise/sponsorship.mdx\` | Two dead links replaced with: a "Profiles in setup" note, two "(coming soon)" bullets that mention but don't link the future URLs, and a "Direct sponsorship (available today)" mailto: row. |

No product decision involved: the doc now reflects what's true (profiles aren't ready) and routes sponsorship interest to a working contact (\`partnerships@solvela.ai\`). When the profiles go live, restore the original URLs by uncommenting the lines and reverting the doc bullets.

## Test plan

- [ ] Click "github sponsors ↗" or "polar.sh ↗" on /sponsor — opens mailto with prefilled subject.
- [ ] /docs/enterprise/sponsorship renders the "Profiles in setup" note and the mailto: link works.

## Remaining open issues

- **`config/models.toml` duplicate** — \`anthropic-claude-sonnet-4-5\` and \`-4-6\` collapse to the same canonical ID. Docs claim "25+" everywhere now (per #344) but the underlying entry-vs-unique-ID mismatch is a config decision: split the model_ids, drop a duplicate, or accept the silent collapse. Not addressed here.

This is the eighth and likely final batch in the audit sweep. The remaining surface (visual landing components without factual claims, internal AGENTS.md files, older CHANGELOG entries) is truly low-yield for further verification.