### PR TITLE
docs(audit): fix debug-header names to match debug_headers.rs

### DIFF
--- a/dashboard/content/docs/operations/troubleshooting.mdx
+++ b/dashboard/content/docs/operations/troubleshooting.mdx
@@ -40,19 +40,21 @@ The response includes:
 
 ```
 X-Solvela-Request-Id: 550e8400-e29b-41d4-a716-446655440000
-X-Solvela-Model-Requested: auto
-X-Solvela-Model-Resolved: google/gemini-2.5-flash
-X-Solvela-Route-Profile: auto
-X-Solvela-Route-Tier: simple
-X-Solvela-Route-Score: -0.3500
+X-Solvela-Model: google/gemini-2.5-flash
+X-Solvela-Profile: auto
+X-Solvela-Tier: simple
+X-Solvela-Score: -0.3500
 X-Solvela-Provider: google
-X-Solvela-Cache-Status: miss
+X-Solvela-Cache: miss
 X-Solvela-Payment-Status: verified
-X-Solvela-Token-Estimate: 10
-X-Solvela-Duration-Ms: 1247
+X-Solvela-Token-Estimate-In: 10
+X-Solvela-Token-Estimate-Out: 1000
+X-Solvela-Latency-Ms: 1247
 ```
 
-The legacy `X-RCR-*` header set (request flag + every response header) is still emitted for backward compatibility with pre-rebrand clients. `X-Solvela-Request-Id` (and its `X-RCR-Request-Id` mirror) is always returned, not gated by the debug flag.
+`X-Solvela-Model` is the model the request actually routed to (already resolved from an alias or a profile like `auto`); the routing decision is broken out across `X-Solvela-Profile`, `X-Solvela-Tier`, and `X-Solvela-Score`. Input and output token estimates are separate headers (`-In` / `-Out`).
+
+The legacy `X-RCR-*` header set (the `X-RCR-Debug` request flag plus an `X-RCR-` mirror of every response header above) is still emitted for backward compatibility with pre-rebrand clients. `X-Solvela-Request-Id` (and its `X-RCR-Request-Id` mirror) is always returned, not gated by the debug flag.
 
 ## Health Check Interpretation
 


### PR DESCRIPTION
## Summary

The "Debug Headers" example in `operations/troubleshooting.mdx` listed header names the gateway **never emits**. The names predate the implementation and survived the `X-RCR-` → `X-Solvela-` rebrand (#344) unchanged. I flagged this during the #344 review; this is the fix. **No bot review requested.**

Verified against `crates/gateway/src/routes/debug_headers.rs` (`attach_debug_headers` pair table, lines 119-146) and `middleware/request_id.rs`:

| Doc said | Gateway actually emits |
|---|---|
| `X-Solvela-Model-Requested` + `X-Solvela-Model-Resolved` (2) | `X-Solvela-Model` (1) |
| `X-Solvela-Route-Profile` / `-Route-Tier` / `-Route-Score` | `X-Solvela-Profile` / `-Tier` / `-Score` |
| `X-Solvela-Cache-Status` | `X-Solvela-Cache` |
| `X-Solvela-Duration-Ms` | `X-Solvela-Latency-Ms` |
| `X-Solvela-Token-Estimate` (1) | `X-Solvela-Token-Estimate-In` + `-Out` (2) |
| `X-Solvela-Provider`, `X-Solvela-Payment-Status`, `X-Solvela-Request-Id` | (already correct) |

The single `X-Solvela-Model` header carries the **resolved** model id: the handler does `req.model = resolved_model` (`routes/chat/mod.rs:93`) before `build_debug_info` is called (`routes/chat/provider.rs:139`). Added a sentence noting the routing decision is broken out across the profile/tier/score headers.

A reader testing the documented `curl` against a live gateway would have seen a different header set than the docs promised.

## Test plan

- [ ] `npm --prefix dashboard run build` succeeds (MDX renders)
- [ ] Run the documented curl with `X-Solvela-Debug: true` against a gateway and confirm the emitted headers match the doc exactly

## Audit position

Follow-up to the doc-audit sweep (#337–#345, #355). Closes the debug-header-name accuracy item flagged in the #344 review.