### PR TITLE
fix(models): correct Anthropic model IDs; resolve sonnet duplicate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,6 +411,45 @@ jobs:
               echo "$headers" | grep -qi "x-ratelimit-limit"
             ' "$BASE"
 
+          # 8. GET /v1/models exposes every corrected Anthropic model ID.
+          #    Catches registry collapses (two entries sharing a canonical
+          #    provider/model_id dedupe to one in /v1/models) and model_id
+          #    typos. See PR #358 — the prior duplicate sonnet entries would
+          #    have made one of these IDs absent here.
+          check "GET /v1/models exposes all Anthropic model IDs" \
+            bash -c '
+              body=$(curl -sf "$0/v1/models")
+              for id in \
+                "anthropic/claude-opus-4-6" \
+                "anthropic/claude-sonnet-4-6" \
+                "anthropic/claude-sonnet-4-5-20250929" \
+                "anthropic/claude-haiku-4-5-20251001"; do
+                if ! echo "$body" | grep -q "\"$id\""; then
+                  echo "  missing from /v1/models: $id"
+                  exit 1
+                fi
+              done
+            ' "$BASE"
+
+          # 9. Anthropic aliases resolve through the full HTTP path. A 404
+          #    (model_not_found) means the alias points at a model the
+          #    registry does not contain — the alias↔registry drift class.
+          #    Any non-404 (200 stub, 402, 429) means resolution succeeded.
+          check "Anthropic aliases resolve (not 404)" \
+            bash -c '
+              for alias in opus sonnet sonnet4.5 haiku; do
+                status=$(curl -s -o /dev/null -w "%{http_code}" \
+                  -X POST "$0/v1/chat/completions" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"model\":\"$alias\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}")
+                echo "  $alias -> $status"
+                if [ "$status" = "404" ]; then
+                  echo "  alias $alias did not resolve (model_not_found)"
+                  exit 1
+                fi
+              done
+            ' "$BASE"
+
           echo ""
           echo "Results: $PASS passed, $FAIL failed"
           [ "$FAIL" -eq 0 ]

--- a/config/models.toml
+++ b/config/models.toml
@@ -59,7 +59,7 @@ supports_streaming = true
 
 [models.anthropic-claude-opus-4-6]
 provider = "anthropic"
-model_id = "claude-opus-4-20250514"
+model_id = "claude-opus-4-6"
 display_name = "Claude Opus 4.6"
 input_cost_per_million = 5.00
 output_cost_per_million = 25.00
@@ -71,7 +71,7 @@ reasoning = true
 
 [models.anthropic-claude-sonnet-4-6]
 provider = "anthropic"
-model_id = "claude-sonnet-4-20250514"
+model_id = "claude-sonnet-4-6"
 display_name = "Claude Sonnet 4.6"
 input_cost_per_million = 3.00
 output_cost_per_million = 15.00
@@ -232,7 +232,7 @@ max_output_tokens = 32768
 
 [models.anthropic-claude-sonnet-4-5]
 provider = "anthropic"
-model_id = "claude-sonnet-4-20250514"
+model_id = "claude-sonnet-4-5-20250929"
 display_name = "Claude Sonnet 4.5"
 input_cost_per_million = 3.00
 output_cost_per_million = 15.00

--- a/crates/gateway/src/providers/fallback.rs
+++ b/crates/gateway/src/providers/fallback.rs
@@ -431,57 +431,57 @@ pub fn fallback_chain(primary: &str) -> Vec<String> {
 pub fn model_fallback_chain<'a>(provider: &'a str, model: &'a str) -> Vec<(&'a str, &'a str)> {
     let chain: Vec<(&str, &str)> = match (provider, model) {
         // --- Premium tier (reasoning, high capability) ---
-        ("anthropic", "claude-opus-4-20250514") => vec![
-            ("anthropic", "claude-opus-4-20250514"),
+        ("anthropic", "claude-opus-4-6") => vec![
+            ("anthropic", "claude-opus-4-6"),
             ("openai", "gpt-5.2"),
             ("google", "gemini-3.1-pro"),
             ("openai", "o3"),
         ],
         ("openai", "gpt-5.2") => vec![
             ("openai", "gpt-5.2"),
-            ("anthropic", "claude-opus-4-20250514"),
+            ("anthropic", "claude-opus-4-6"),
             ("google", "gemini-3.1-pro"),
         ],
         ("google", "gemini-3.1-pro") => vec![
             ("google", "gemini-3.1-pro"),
-            ("anthropic", "claude-opus-4-20250514"),
+            ("anthropic", "claude-opus-4-6"),
             ("openai", "gpt-5.2"),
         ],
 
         // --- Mid tier (strong general purpose) ---
-        ("anthropic", "claude-sonnet-4-20250514") => vec![
-            ("anthropic", "claude-sonnet-4-20250514"),
+        ("anthropic", "claude-sonnet-4-6") => vec![
+            ("anthropic", "claude-sonnet-4-6"),
             ("openai", "gpt-4.1"),
             ("google", "gemini-3.1-pro"),
             ("xai", "grok-3"),
         ],
         ("openai", "gpt-4o") => vec![
             ("openai", "gpt-4o"),
-            ("anthropic", "claude-sonnet-4-20250514"),
+            ("anthropic", "claude-sonnet-4-6"),
             ("google", "gemini-3.1-pro"),
             ("xai", "grok-3"),
         ],
         ("openai", "gpt-4.1") => vec![
             ("openai", "gpt-4.1"),
-            ("anthropic", "claude-sonnet-4-20250514"),
+            ("anthropic", "claude-sonnet-4-6"),
             ("google", "gemini-3.1-pro"),
         ],
         ("xai", "grok-3") => vec![
             ("xai", "grok-3"),
-            ("anthropic", "claude-sonnet-4-20250514"),
+            ("anthropic", "claude-sonnet-4-6"),
             ("openai", "gpt-4o"),
         ],
 
         // --- Budget tier (fast, cheap) ---
         ("openai", "gpt-4o-mini") => vec![
             ("openai", "gpt-4o-mini"),
-            ("anthropic", "claude-3-5-haiku-20241022"),
+            ("anthropic", "claude-haiku-4-5-20251001"),
             ("google", "gemini-2.5-flash"),
             ("deepseek", "deepseek-chat"),
         ],
         ("openai", "gpt-4.1-mini") => vec![
             ("openai", "gpt-4.1-mini"),
-            ("anthropic", "claude-3-5-haiku-20241022"),
+            ("anthropic", "claude-haiku-4-5-20251001"),
             ("google", "gemini-2.5-flash"),
         ],
         ("openai", "gpt-4.1-nano") => vec![
@@ -489,8 +489,8 @@ pub fn model_fallback_chain<'a>(provider: &'a str, model: &'a str) -> Vec<(&'a s
             ("google", "gemini-2.5-flash-lite"),
             ("google", "gemini-2.0-flash-lite"),
         ],
-        ("anthropic", "claude-3-5-haiku-20241022") => vec![
-            ("anthropic", "claude-3-5-haiku-20241022"),
+        ("anthropic", "claude-haiku-4-5-20251001") => vec![
+            ("anthropic", "claude-haiku-4-5-20251001"),
             ("openai", "gpt-4o-mini"),
             ("google", "gemini-2.5-flash"),
             ("deepseek", "deepseek-chat"),
@@ -498,7 +498,7 @@ pub fn model_fallback_chain<'a>(provider: &'a str, model: &'a str) -> Vec<(&'a s
         ("google", "gemini-2.5-flash") => vec![
             ("google", "gemini-2.5-flash"),
             ("openai", "gpt-4o-mini"),
-            ("anthropic", "claude-3-5-haiku-20241022"),
+            ("anthropic", "claude-haiku-4-5-20251001"),
             ("deepseek", "deepseek-chat"),
         ],
         ("deepseek", "deepseek-chat") => vec![
@@ -510,7 +510,7 @@ pub fn model_fallback_chain<'a>(provider: &'a str, model: &'a str) -> Vec<(&'a s
         // --- Reasoning tier ---
         ("openai", "o3") => vec![
             ("openai", "o3"),
-            ("anthropic", "claude-opus-4-20250514"),
+            ("anthropic", "claude-opus-4-6"),
             ("deepseek", "deepseek-reasoner"),
         ],
         ("openai", "o3-mini") | ("openai", "o4-mini") => vec![
@@ -580,8 +580,8 @@ mod tests {
 
     #[test]
     fn test_model_fallback_chain_opus() {
-        let chain = model_fallback_chain("anthropic", "claude-opus-4-20250514");
-        assert_eq!(chain[0], ("anthropic", "claude-opus-4-20250514"));
+        let chain = model_fallback_chain("anthropic", "claude-opus-4-6");
+        assert_eq!(chain[0], ("anthropic", "claude-opus-4-6"));
         assert!(chain.len() > 1);
         // Must have cross-provider fallbacks
         assert!(chain.iter().any(|(p, _)| *p != "anthropic"));
@@ -618,7 +618,7 @@ mod tests {
     fn test_fallback_result_indicates_fallback() {
         let result: FallbackResult<String> = FallbackResult {
             data: "test".to_string(),
-            original_model: "claude-opus-4-20250514".to_string(),
+            original_model: "claude-opus-4-6".to_string(),
             actual_model: "gpt-5.2".to_string(),
             actual_provider: "openai".to_string(),
             was_fallback: true,
@@ -630,17 +630,17 @@ mod tests {
     #[test]
     fn test_model_fallback_chain_no_self_duplicates() {
         let known_models: Vec<(&str, &str)> = vec![
-            ("anthropic", "claude-opus-4-20250514"),
+            ("anthropic", "claude-opus-4-6"),
             ("openai", "gpt-5.2"),
             ("google", "gemini-3.1-pro"),
-            ("anthropic", "claude-sonnet-4-20250514"),
+            ("anthropic", "claude-sonnet-4-6"),
             ("openai", "gpt-4o"),
             ("openai", "gpt-4.1"),
             ("xai", "grok-3"),
             ("openai", "gpt-4o-mini"),
             ("openai", "gpt-4.1-mini"),
             ("openai", "gpt-4.1-nano"),
-            ("anthropic", "claude-3-5-haiku-20241022"),
+            ("anthropic", "claude-haiku-4-5-20251001"),
             ("google", "gemini-2.5-flash"),
             ("deepseek", "deepseek-chat"),
             ("openai", "o3"),

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -197,8 +197,8 @@ supports_streaming = true
 
 [models.anthropic-claude-sonnet]
 provider = "anthropic"
-model_id = "claude-sonnet-4-20250514"
-display_name = "Claude Sonnet 4"
+model_id = "claude-sonnet-4-6"
+display_name = "Claude Sonnet 4.6"
 input_cost_per_million = 3.00
 output_cost_per_million = 15.00
 context_window = 200000

--- a/crates/router/src/profiles.rs
+++ b/crates/router/src/profiles.rs
@@ -72,8 +72,8 @@ pub fn resolve_model(profile: Profile, tier: Tier) -> &'static str {
 
         // PREMIUM: best quality regardless of cost
         (Profile::Premium, Tier::Simple) => "openai/gpt-4o",
-        (Profile::Premium, Tier::Medium) => "anthropic/claude-sonnet-4-20250514",
-        (Profile::Premium, Tier::Complex) => "anthropic/claude-opus-4-20250514",
+        (Profile::Premium, Tier::Medium) => "anthropic/claude-sonnet-4-6",
+        (Profile::Premium, Tier::Complex) => "anthropic/claude-opus-4-6",
         (Profile::Premium, Tier::Reasoning) => "openai/o3",
 
         // FREE: only free-tier models
@@ -88,8 +88,8 @@ pub fn resolve_model(profile: Profile, tier: Tier) -> &'static str {
 pub fn resolve_alias(alias: &str) -> Option<&'static str> {
     match alias.to_lowercase().as_str() {
         "gpt5" | "gpt-5" => Some("openai/gpt-5.2"),
-        "sonnet" | "claude-sonnet" => Some("anthropic/claude-sonnet-4-20250514"),
-        "opus" | "claude-opus" => Some("anthropic/claude-opus-4-20250514"),
+        "sonnet" | "claude-sonnet" => Some("anthropic/claude-sonnet-4-6"),
+        "opus" | "claude-opus" => Some("anthropic/claude-opus-4-6"),
         // The canonical key here MUST match one registered by `from_toml`
         // — see the cross-check test below. Previously this pointed at
         // `claude-3-5-haiku-20241022`, which has never been in
@@ -107,7 +107,7 @@ pub fn resolve_alias(alias: &str) -> Option<&'static str> {
         "gpt4.1" | "gpt-4.1" | "gpt41" => Some("openai/gpt-4.1"),
         "gpt4.1-mini" | "gpt-4.1-mini" => Some("openai/gpt-4.1-mini"),
         "gpt4.1-nano" | "gpt-4.1-nano" => Some("openai/gpt-4.1-nano"),
-        "sonnet4.5" | "sonnet-4.5" => Some("anthropic/claude-sonnet-4-20250514"),
+        "sonnet4.5" | "sonnet-4.5" => Some("anthropic/claude-sonnet-4-5-20250929"),
         "grok3" | "grok-3" => Some("xai/grok-3"),
         "grok3-mini" | "grok-3-mini" => Some("xai/grok-3-mini"),
         _ => None,
@@ -158,10 +158,7 @@ mod tests {
     #[test]
     fn test_resolve_alias() {
         assert_eq!(resolve_alias("gpt5"), Some("openai/gpt-5.2"));
-        assert_eq!(
-            resolve_alias("sonnet"),
-            Some("anthropic/claude-sonnet-4-20250514")
-        );
+        assert_eq!(resolve_alias("sonnet"), Some("anthropic/claude-sonnet-4-6"));
         // R1 regression: this used to point at the unregistered
         // `claude-3-5-haiku-20241022`. The canonical key MUST match a
         // model registered in `config/models.toml`.


### PR DESCRIPTION
## Summary

The model registry had two entries (`anthropic-claude-sonnet-4-5` and `-4-6`) both pointing at `model_id = "claude-sonnet-4-20250514"` — the deprecated **Sonnet 4.0** snapshot, not the 4.5/4.6 their display names claimed. They collapsed to one canonical key in `ModelRegistry::from_toml`, so `/v1/models` returned **25** unique IDs while the registry has 26 entries and the docs say "26 models". The Opus entry was mislabeled the same way. **No bot review requested.**

Corrected each to its real Claude API ID (source: [platform.claude.com models overview](https://platform.claude.com/docs/en/docs/about-claude/models/overview)):

| Entry (display name) | Was | Now |
|---|---|---|
| `anthropic-claude-opus-4-6` ("Opus 4.6") | `claude-opus-4-20250514` (Opus 4.0) | `claude-opus-4-6` |
| `anthropic-claude-sonnet-4-6` ("Sonnet 4.6") | `claude-sonnet-4-20250514` (Sonnet 4.0) | `claude-sonnet-4-6` |
| `anthropic-claude-sonnet-4-5` ("Sonnet 4.5") | `claude-sonnet-4-20250514` (Sonnet 4.0) | `claude-sonnet-4-5-20250929` |
| `anthropic-claude-haiku-4-5` | `claude-haiku-4-5-20251001` | ✓ already correct |

All four Anthropic entries now have distinct canonical IDs → collision gone → `/v1/models` returns **26 unique**, matching the docs.

## Lockstep changes (kept the alias↔registry regression guard green)

- **`crates/router/src/profiles.rs`** — `Premium/Medium` + `Premium/Complex` routing targets, the `sonnet`/`opus`/`sonnet4.5` aliases, and the `test_resolve_alias` assertion.
- **`crates/gateway/src/providers/fallback.rs`** (hot path) — re-keyed the opus and sonnet fallback chains (as primary keys *and* as cross-provider fallback targets). Without this, opus/sonnet requests would fall through to `vec![primary]` after the routing change and **silently lose cross-provider failover**. Also fixed a separate stale ID in the same table: the budget-tier chains pointed at `claude-3-5-haiku-20241022`, which was **never registered** in models.toml (the dangling ID the profiles.rs comment already calls out) — re-keyed to `claude-haiku-4-5-20251001`.

Test-only sample strings using the deprecated `-20250514` IDs in unrelated suites (stats, admin_stats, session, debug_headers, anthropic adapter) are left as-is — they exercise generic behavior, not registry membership, and remain valid (Sonnet/Opus 4.0 are deprecated, not retired until 2026-06-15).

## Test plan

- [x] `cargo test -p solvela-router` — 19 pass, incl. `every_alias_and_profile_tier_resolves_to_a_registered_model` + `test_resolve_alias`
- [x] `cargo test -p gateway --lib` — 528 pass
- [x] `cargo fmt --all -- --check` clean, `cargo clippy -p solvela-router -p gateway --all-targets -- -D warnings` clean
- [ ] Live: `solvela chat "hi" --model opus` (and `sonnet`, `sonnet4.5`) resolves and pays against a real gateway

## Origin

Closes the `config/models.toml` duplicate flagged across the doc-audit sweep (#342/#344/#345). Surfaced a second stale-ID bug (the never-registered haiku in fallback.rs), fixed in the same PR.