### PR TITLE
docs(api): fix stale Anthropic model IDs + example id format in models.mdx

### DIFF
--- a/dashboard/content/docs/api/models.mdx
+++ b/dashboard/content/docs/api/models.mdx
@@ -19,7 +19,7 @@ curl https://api.solvela.ai/v1/models
   "object": "list",
   "data": [
     {
-      "id": "gpt-4o",
+      "id": "openai/gpt-4o",
       "object": "model",
       "provider": "openai",
       "display_name": "GPT-4o",
@@ -75,9 +75,9 @@ For a full pricing table, see [Pricing](/docs/concepts/pricing).
 | `openai/gpt-4.1-mini` | OpenAI | $0.40 | $1.60 |
 | `openai/gpt-4.1-nano` | OpenAI | $0.10 | $0.40 |
 | `openai/gpt-oss-120b` | OpenAI | $0.00 | $0.00 |
-| `anthropic/claude-opus-4-20250514` | Anthropic | $5.00 | $25.00 |
-| `anthropic/claude-sonnet-4-20250514` | Anthropic | $3.00 | $15.00 |
-| `anthropic-claude-sonnet-4-5` | Anthropic | $3.00 | $15.00 |
+| `anthropic/claude-opus-4-6` | Anthropic | $5.00 | $25.00 |
+| `anthropic/claude-sonnet-4-6` | Anthropic | $3.00 | $15.00 |
+| `anthropic/claude-sonnet-4-5-20250929` | Anthropic | $3.00 | $15.00 |
 | `anthropic/claude-haiku-4-5-20251001` | Anthropic | $1.00 | $5.00 |
 | `google/gemini-3.1-pro` | Google | $2.00 | $12.00 |
 | `google/gemini-2.5-flash` | Google | $0.30 | $2.50 |


### PR DESCRIPTION
## Summary

`api/models.mdx` carried three Anthropic model IDs that no longer match the registry after #358 corrected them, plus an example-response `id` in the wrong format. **No bot review requested.**

| Location | Was | Now |
|---|---|---|
| Table L78 | `anthropic/claude-opus-4-20250514` | `anthropic/claude-opus-4-6` |
| Table L79 | `anthropic/claude-sonnet-4-20250514` | `anthropic/claude-sonnet-4-6` |
| Table L80 | `anthropic-claude-sonnet-4-5` (also malformed — no provider slash) | `anthropic/claude-sonnet-4-5-20250929` |
| Example response | `"id": "gpt-4o"` | `"id": "openai/gpt-4o"` |

The example fix reflects what `GET /v1/models` actually emits: `routes/models.rs` serializes `ModelInfo.id`, which is the canonical `"{provider}/{model_id}"` (`crates/router/src/models.rs:105`), so the real response id is `openai/gpt-4o`, not `gpt-4o`.

Cross-checked **all 26 rows** against `config/models.toml`: every price matches and every model is present (`deepseek-coder` is real, config L269). Only the three Anthropic IDs and the example id were wrong.

## Test plan

- [ ] `npm --prefix dashboard run build` succeeds (MDX renders)
- [x] All 26 model IDs + prices reconciled against `config/models.toml`

## Audit position

First file of the API-docs batch. Follows #358 (which changed the canonical Anthropic IDs). `rate-limits.mdx` documents a fictional enterprise API (`client.sessions.create`, `denied_models`, wrong budget JSON) and is deferred to a separate focused PR; `chat-completions.mdx` not yet walked.