### PR TITLE
docs(enterprise): fix api-keys.mdx + broken README #license anchors

### DIFF
--- a/dashboard/content/docs/enterprise/api-keys.mdx
+++ b/dashboard/content/docs/enterprise/api-keys.mdx
@@ -10,7 +10,7 @@ description: Create and manage org-scoped bearer tokens for programmatic access 
 Org-scoped API keys let programs authenticate without the admin token. Keys are prefixed `solvela_k_` and sent as a standard Bearer token.
 
 ```http
-Authorization: Bearer solvela_k_live_...
+Authorization: Bearer solvela_k_...
 ```
 
 Each key carries a role (`owner`, `admin`, or `member`) that gates what the key can do within the org.
@@ -48,8 +48,8 @@ The full key value is returned **once** at creation time and never shown again. 
 ```json
 {
   "id": "01a4b5c6-...",
-  "key": "solvela_k_live_xxxxxxxxxxxxxxxx",
-  "key_prefix": "solvela_k_live_xxxx",
+  "key": "solvela_k_3f9a1c7e2b8d4f06a5e1c9b7d2f8a4e6c0b3d5f7a9e1c2b4d6f8a0c2e4b6d8f0",
+  "key_prefix": "solvela_k_01a4b5c6",
   "name": "ci-deploy",
   "role": "admin",
   "expires_at": "2025-12-01T00:00:00Z"
@@ -74,7 +74,7 @@ Authorization: Bearer <admin-token | solvela_k_...>
   {
     "id": "01a4b5c6-...",
     "org_id": "018f1a2b-...",
-    "key_prefix": "solvela_k_live_xxxx",
+    "key_prefix": "solvela_k_01a4b5c6",
     "name": "ci-deploy",
     "role": "admin",
     "last_used_at": "2025-09-10T14:22:00Z",
@@ -94,8 +94,12 @@ DELETE /v1/orgs/018f1a2b-.../api-keys/01a4b5c6-...
 Authorization: Bearer <admin-token | solvela_k_...>
 ```
 
-**Response** — `204 No Content`
+**Response** — `200 OK`
 
-Revoked keys are rejected immediately on the next request. There is no grace period.
+```json
+{ "revoked": true }
+```
+
+Revoked keys are rejected immediately on the next request. There is no grace period. Revoking a key that does not exist (or is already revoked) returns `404 Not Found`.
 
 <UpgradeCta />

--- a/dashboard/src/app/sponsor/page.tsx
+++ b/dashboard/src/app/sponsor/page.tsx
@@ -278,7 +278,7 @@ export default function SponsorPage() {
                       Nothing — all crates and SDKs are MIT, just keep notices
                     </td>
                     <td className="py-3 text-text-tertiary">
-                      <a href="https://github.com/solvela-ai/solvela#license" target="_blank" rel="noreferrer" className="underline underline-offset-2 hover:text-foreground">
+                      <a href="https://github.com/solvela-ai/solvela#licensing" target="_blank" rel="noreferrer" className="underline underline-offset-2 hover:text-foreground">
                         license split ↗
                       </a>
                     </td>

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -140,4 +140,4 @@ published to crates.io. The Solvela monorepo uses a per-component license
 split: the gateway crate (`crates/gateway`) is BUSL-1.1; every other crate,
 the SDKs, and the dashboard are MIT. Client-side SDKs are kept MIT-only so
 agent authors can freely embed them. See the
-[root README License section](../../README.md#license) for the full table.
+[root README Licensing section](../../README.md#licensing) for the full table.


### PR DESCRIPTION
## Summary

Enterprise-docs audit pass. I verified all six endpoint docs against `crates/gateway/src/routes/orgs/*`: **orgs, teams, budgets, audit, and analytics are accurate** (paths, methods, request/response shapes, auth, and the `$100/day` default + `days` 1–90 clamp all match source). `api-keys.mdx` had two errors, and the pass surfaced two broken anchor links I introduced in earlier PRs. **No bot review requested.**

### `api-keys.mdx`
| Issue | Was | Now |
|---|---|---|
| Key format | `solvela_k_live_...` | No `_live_` infix exists. `generate_api_key()` (`orgs/queries.rs:34`) returns `solvela_k_` + 64 hex; display prefix (`queries.rs:46`) is `solvela_k_` + 8 UUID chars. Replaced the Stripe-style placeholders with real-shaped values. |
| Revoke response | `204 No Content` | `200 OK` `{"revoked": true}` (`routes/orgs/api_keys.rs:142`); `404` for missing/already-revoked (L144). |

### Broken anchors (README heading is `## Licensing` → `#licensing`, not `#license`)
- `dashboard/src/app/sponsor/page.tsx` — "license split" link (from #341) → `#licensing`
- `sdks/rust/README.md` — License section link (from #355) → `#licensing`

Verified `README.md:447` is `## Licensing`; `commercial-license.mdx` already links `#licensing`/`#trademark` correctly (both headings exist), and `index.mdx` is accurate.

## Test plan
- [ ] `npm --prefix dashboard run build` succeeds (MDX + sponsor page render)

## Audit position
Enterprise directory walk. 5/6 endpoint docs needed no changes; `commercial-license.mdx`, `index.mdx` clean; `sponsorship.mdx` handled in #345. Bundles the two `#license`→`#licensing` anchor regressions from #341/#355.