### PR TITLE
docs(concepts): fix stale model IDs, wrong routing table, binary name

### DIFF
--- a/dashboard/content/docs/concepts/architecture.mdx
+++ b/dashboard/content/docs/concepts/architecture.mdx
@@ -9,7 +9,7 @@ Solvela is a Rust workspace composed of five focused crates, an on-chain Anchor 
 
 <CardGroup cols={2}>
   <Card title="gateway" icon="server">
-    The **only binary** in the workspace (`solvela`). Axum HTTP server with routes, middleware, provider proxies, usage tracking, Redis caching, and Prometheus metrics.
+    The **only binary** in the workspace (`solvela-gateway`). Axum HTTP server with routes, middleware, provider proxies, usage tracking, Redis caching, and Prometheus metrics.
   </Card>
   <Card title="x402" icon="lock">
     Pure protocol library — **no Axum dependency**. Solana verification, escrow integration, fee payer pool, nonce pool, and the chain-agnostic `PaymentVerifier` trait.

--- a/dashboard/content/docs/concepts/pricing.mdx
+++ b/dashboard/content/docs/concepts/pricing.mdx
@@ -51,14 +51,10 @@ All prices are USDC per million tokens (provider cost before the 5% fee).
 
 | Model | Model ID | Input ($/M) | Output ($/M) | Context |
 |-------|----------|-------------|--------------|---------|
-| Claude Opus 4.6 | `anthropic/claude-opus-4-20250514` | $5.00 | $25.00 | 200K |
-| Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-20250514` | $3.00 | $15.00 | 200K |
-| Claude Sonnet 4.5 | `anthropic-claude-sonnet-4-5` | $3.00 | $15.00 | 200K |
+| Claude Opus 4.6 | `anthropic/claude-opus-4-6` | $5.00 | $25.00 | 200K |
+| Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-6` | $3.00 | $15.00 | 200K |
+| Claude Sonnet 4.5 | `anthropic/claude-sonnet-4-5-20250929` | $3.00 | $15.00 | 200K |
 | Claude Haiku 4.5 | `anthropic/claude-haiku-4-5-20251001` | $1.00 | $5.00 | 200K |
-
-<Note>
-  Sonnet 4.5 shares its upstream `model_id` with Sonnet 4.6 (`claude-sonnet-4-20250514`). The registry-key form `anthropic-claude-sonnet-4-5` is the unambiguous identifier; the `provider/model_id` slash form resolves to whichever entry is loaded last and is best avoided for Sonnet specifically.
-</Note>
 
 ### Google
 

--- a/dashboard/content/docs/concepts/request-flow.mdx
+++ b/dashboard/content/docs/concepts/request-flow.mdx
@@ -11,7 +11,7 @@ Every request enters the system through the `gateway` binary. The path it takes 
 
 <Steps>
   <Step title="Parse and resolve the model">
-    The gateway parses the request body and resolves the `model` field. This accepts short aliases (`sonnet`, `gpt4o`), routing profile names (`auto`, `eco`, `premium`, `free`), or full model IDs (`claude-sonnet-4-20250514`). Profile names are handed to the smart router for tier classification.
+    The gateway parses the request body and resolves the `model` field. This accepts short aliases (`sonnet`, `gpt5`), routing profile names (`auto`, `eco`, `premium`, `free`), or full model IDs (`anthropic/claude-sonnet-4-6`). Profile names are handed to the smart router for tier classification.
   </Step>
   <Step title="Prompt guard checks">
     The request content is scanned for prompt injection attempts, jailbreak patterns, and PII. Requests that fail these checks are rejected before any payment logic runs.
@@ -104,10 +104,12 @@ Each routing profile then maps tiers to specific models:
 
 | Profile | Simple | Medium | Complex | Reasoning |
 |---------|--------|--------|---------|-----------|
-| `eco` | Gemini Flash | Gemini Flash | DeepSeek-V3 | DeepSeek-R1 |
-| `auto` | Gemini Flash | GPT-4o mini | Claude Sonnet | o3 |
-| `premium` | GPT-4o | GPT-4o | Claude Opus | o3 |
-| `free` | Free-tier only | Free-tier only | Free-tier only | Free-tier only |
+| `eco` | DeepSeek Chat | Gemini Flash Lite | DeepSeek Chat | DeepSeek Reasoner |
+| `auto` | Gemini Flash | Grok Code Fast | Gemini 3.1 Pro | Grok 4 Fast |
+| `premium` | GPT-4o | Claude Sonnet 4.6 | Claude Opus 4.6 | o3 |
+| `free` | gpt-oss-120b | gpt-oss-120b | gpt-oss-120b | gpt-oss-120b |
+
+See [Smart Router](/docs/concepts/smart-router#routing-table) for the authoritative `(profile, tier) → model ID` table.
 
 <Note>
 Scoring is pure rule-based and runs in under **1 microsecond** with zero external calls. There is no ML model involved — the scorer is a deterministic weighted sum over the 15 dimensions.
@@ -128,5 +130,5 @@ Every verified `PAYMENT-SIGNATURE` is written to Redis with a TTL that matches t
 </Accordion>
 
 <Warning>
-Replay protection requires Redis. Without it, the gateway skips the Redis check and relies solely on Facilitator-side nonce validation, which is slower and less reliable under high concurrency.
+Redis is the primary store for replay protection. Without it, the gateway falls back to an in-memory LRU set with per-entry TTL — bounded to ~10,000 signatures. Recent-blockhash transactions (≈90-second validity) are safe under this fallback; durable-nonce transactions carry a 24-hour replay window the LRU cannot reliably cover, so they are rejected outright when Redis is unavailable (GHSA-fq3f-c8p7-873f).
 </Warning>

--- a/dashboard/content/docs/concepts/smart-router.mdx
+++ b/dashboard/content/docs/concepts/smart-router.mdx
@@ -31,8 +31,8 @@ You can also use model aliases as shortcuts to specific models:
 | Alias | Resolves to |
 |-------|-------------|
 | `gpt5` | `openai/gpt-5.2` |
-| `sonnet` | `anthropic/claude-sonnet-4-20250514` |
-| `opus` | `anthropic/claude-opus-4-20250514` |
+| `sonnet` | `anthropic/claude-sonnet-4-6` |
+| `opus` | `anthropic/claude-opus-4-6` |
 | `gemini` | `google/gemini-3.1-pro` |
 | `flash` | `google/gemini-2.5-flash` |
 | `grok` | `xai/grok-4-fast-reasoning` |
@@ -80,8 +80,8 @@ Each (Profile, Tier) pair maps to a specific model:
 | Tier | eco | auto | premium | free |
 |------|-----|------|---------|------|
 | Simple | `deepseek/deepseek-chat` | `google/gemini-2.5-flash` | `openai/gpt-4o` | `openai/gpt-oss-120b` |
-| Medium | `google/gemini-2.5-flash-lite` | `xai/grok-code-fast-1` | `anthropic/claude-sonnet-4-20250514` | `openai/gpt-oss-120b` |
-| Complex | `deepseek/deepseek-chat` | `google/gemini-3.1-pro` | `anthropic/claude-opus-4-20250514` | `openai/gpt-oss-120b` |
+| Medium | `google/gemini-2.5-flash-lite` | `xai/grok-code-fast-1` | `anthropic/claude-sonnet-4-6` | `openai/gpt-oss-120b` |
+| Complex | `deepseek/deepseek-chat` | `google/gemini-3.1-pro` | `anthropic/claude-opus-4-6` | `openai/gpt-oss-120b` |
 | Reasoning | `deepseek/deepseek-reasoner` | `xai/grok-4-fast-reasoning` | `openai/o3` | `openai/gpt-oss-120b` |
 
 ## Example: same prompt, different profiles
@@ -115,7 +115,7 @@ To use a specific model, pass its full ID directly:
 
 ```json
 {
-  "model": "anthropic/claude-opus-4-20250514",
+  "model": "anthropic/claude-opus-4-6",
   "messages": [...]
 }
 ```


### PR DESCRIPTION
## Summary

Walked all six `concepts/` docs against source. **escrow.mdx and x402.mdx are accurate** (program ID `9neDHouX…`, PDA seeds `[b"escrow", agent, service_id]`, 402 `PaymentRequired` wire structure, payment schemes, and replay description all match). **smart-router.mdx's 15-dimension weight table matches `scorer.rs:7-22` exactly and sums to 1.0.** Four files had errors. **No bot review requested.**

### architecture.mdx
- Gateway binary is `solvela-gateway`, not `solvela` (that's the CLI, `solvela-cli`).

### pricing.mdx
- Stale Anthropic IDs → `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929` (per #358).
- Removed the Note describing the old Sonnet 4.5/4.6 `model_id` **collision** — #358 gave them distinct IDs, so the collision and its "resolves to whichever loaded last" caveat no longer exist.

### smart-router.mdx
- Same stale Anthropic IDs in the alias table, routing table, and bypass example (5 spots). Tier ranges + routing table otherwise verified against `profiles.rs`.

### request-flow.mdx
- Stale full-model-ID example; `gpt4o` isn't a registered alias (→ `gpt5`).
- **The (profile, tier) routing table contradicted `profiles.rs`** — it claimed `auto/Medium`→GPT-4o mini and `auto/Complex`→Claude Sonnet, but `resolve_model()` returns `grok-code-fast-1` and `gemini-3.1-pro`. Corrected, and linked smart-router.mdx as the single source of truth to stop the duplicate table from re-drifting.
- Replay-fallback note claimed "relies solely on Facilitator-side nonce validation" without Redis. Reality (`cache.rs`): in-memory LRU + TTL, and durable-nonce txs are rejected outright (GHSA-fq3f-c8p7-873f). x402.mdx already described this correctly.

## Test plan
- [ ] `npm --prefix dashboard run build` succeeds (MDX renders)
- [x] All concept model IDs reconciled with `config/models.toml`; routing tables reconciled with `profiles.rs`; scorer weights reconciled with `scorer.rs`

## Audit position
concepts/ directory walk. 2/6 clean (escrow, x402); 4 fixed. Completes the high-value architectural-claims docs.