### PR TITLE
docs(operations): fix payment-status metric values, CORS methods, token cap

### DIFF
--- a/dashboard/content/docs/operations/monitoring.mdx
+++ b/dashboard/content/docs/operations/monitoring.mdx
@@ -47,9 +47,10 @@ scrape_configs:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `solvela_payments_total` | Counter | `status` | Payment outcomes. Status values: `verified` (valid payment), `cached` (cached response), `free` (free model), `none` (402 returned), `failed` (verification failed). |
+| `solvela_payments_total` | Counter | `status` | Payment outcomes. Status values: `verified` (valid payment), `dev_bypass` (payment bypass enabled in dev), `none` (402 returned, no payment header), `failed` (verification failed). |
 | `solvela_payment_amount_usdc` | Histogram | -- | Distribution of payment amounts in USDC. |
 | `solvela_replay_rejections_total` | Counter | -- | Number of rejected replay attacks. |
+| `solvela_paid_stub_rejections_total` | Counter | -- | Paid requests that reached the fallback-stub path because every provider failed. The gateway returns an error instead of a stub so a paying caller never receives a fabricated response. |
 
 ### Provider Metrics
 

--- a/dashboard/content/docs/operations/security.mdx
+++ b/dashboard/content/docs/operations/security.mdx
@@ -86,7 +86,7 @@ CORS is configured restrictively:
 
 - **Development** (`SOLVELA_ENV != "production"`): allows `localhost:3000`, `localhost:8080`, `127.0.0.1:3000`
 - **Production** (`SOLVELA_ENV=production`): only origins listed in `SOLVELA_CORS_ORIGINS`
-- **Allowed methods**: GET, POST, OPTIONS only
+- **Allowed methods**: GET, POST, PUT, PATCH, DELETE, OPTIONS (the enterprise org/team/budget endpoints use PUT and DELETE)
 - **Allowed headers**: `Content-Type`, `Authorization`, `PAYMENT-SIGNATURE`, `X-Request-Id`, `X-Session-Id`, `X-Solvela-Debug` (canonical) plus legacy `X-RCR-Debug` for pre-rebrand clients
 
 SDK and agent clients are unaffected by CORS since they do not run in browsers.
@@ -132,7 +132,7 @@ Flagged requests are rejected with 400 before any payment is processed.
 
 ## Input Validation
 
-- `max_tokens` capped at 128,000 (prevents unbounded cost)
+- Billed completion tokens are capped at `min(max_tokens, model max-output, 8192)` — the 8192 default ceiling prevents unbounded cost when a request omits `max_tokens`
 - Session IDs: max 128 characters, `[a-zA-Z0-9\-_]` only
 - Wallet addresses: base58 character set, 32-44 characters
 - Service IDs: alphanumeric + hyphens only


### PR DESCRIPTION
## Summary

Walked all five `operations/` docs against source. **deployment.mdx is fully accurate** — its embedded Dockerfile + fly.toml match the real files (2-stage dummy-source build, `rust:1.88-slim-bookworm`, non-root `solvela` UID 1001, app/region/health-check/VM size). **troubleshooting.mdx and index.mdx are accurate.** monitoring.mdx and security.mdx each had errors. **No bot review requested.**

### monitoring.mdx
- `solvela_payments_total` status values `cached` and `free` are **never emitted**. The real values (grep of `counter!("solvela_payments_total" …)` in `routes/proxy.rs` + `routes/chat/mod.rs`) are `verified`, `none`, `failed`, `dev_bypass`. Corrected.
- Added the real-but-undocumented `solvela_paid_stub_rejections_total` counter (`routes/chat/mod.rs:709`). *(The escrow metrics in the doc are real — they live in `crates/x402/src/escrow/claim_processor.rs`, which my first grep didn't cover.)*

### security.mdx
- CORS "Allowed methods" listed "GET, POST, OPTIONS only", but `build_cors()` (`lib.rs`) allows GET/POST/PUT/PATCH/DELETE/OPTIONS — the enterprise PUT/DELETE endpoints require them.
- "max_tokens capped at 128,000" → the billed completion-token cap is `min(max_tokens, model max-output, DEFAULT_COMPLETION_TOKENS_CAP)` and the constant is **8192** (`routes/chat/cost.rs:14`), not 128,000.

### Verified accurate (unchanged)
50KB payment-header limit (`x402.rs:70`), 120s replay TTL (`cache.rs:234`), `Retry-After` on 429 (`rate_limit.rs:221`), 10MB body limit (`lib.rs:306`), all 12 documented metric names, SSRF ranges, secret-redaction rules.

## Test plan
- [ ] `npm --prefix dashboard run build` succeeds (MDX renders)

## Audit position
operations/ directory walk — completes it. 3/5 docs needed no changes.

### Out-of-scope side finding
`CLAUDE.md` says the Dockerfile is a "3-stage build with cargo-chef" — the real Dockerfile is a 2-stage dummy-source build (deployment.mdx is correct). That's a repo file, not a dashboard doc; flagging for a separate fix.