### PR TITLE
docs(sdks): fix MCP tool list + stale stub warning, rust CLI model ID

### DIFF
--- a/dashboard/content/docs/sdks/mcp.mdx
+++ b/dashboard/content/docs/sdks/mcp.mdx
@@ -82,10 +82,12 @@ The MCP server exposes the following tools to connected agents:
 
 | Tool | Description |
 |------|-------------|
-| `chat` | Send a chat completion request to a specified model |
+| `chat` | Send a prompt to a specific LLM model |
+| `smart_chat` | Send a prompt via the smart router — it auto-selects the model |
+| `wallet_status` | Check the configured Solana wallet's status and gateway connectivity |
 | `list_models` | List available models with pricing |
-| `health` | Check gateway health |
-| `get_cost` | Estimate cost for a model and token count |
+| `spending` | Show USDC spending statistics for the current session |
+| `deposit_escrow` | Deposit USDC into a trustless escrow PDA for a future call |
 
 ## Example usage in Claude Desktop
 
@@ -97,7 +99,7 @@ Claude: [calls solvela.chat with model="openai/gpt-4o"]
 ```
 
 <Warning>
-  The MCP server signing is currently a stub — it uses placeholder payment signatures. For production use, implement proper Solana transaction signing in the MCP server or use the TypeScript or Python SDK directly.
+  The MCP server performs real Solana USDC-SPL signing via `@solvela/signer-core` when `SOLANA_WALLET_KEY` is set. If signing degrades to stub mode (for example, when `@solana/web3.js` peer dependencies cannot be resolved), the server **rejects** the call rather than sending a placeholder signature — a misconfigured build fails loudly instead of burning budget.
 </Warning>
 
 <Note>

--- a/dashboard/content/docs/sdks/rust.mdx
+++ b/dashboard/content/docs/sdks/rust.mdx
@@ -115,7 +115,7 @@ $ solvela health
 $ solvela models
 ID                                    Provider    Input $/M   Output $/M
 openai/gpt-4o                         openai      2.50        10.00
-anthropic/claude-opus-4-20250514      anthropic   5.00        25.00
+anthropic/claude-opus-4-6             anthropic   5.00        25.00
 google/gemini-2.5-flash               google      0.30        2.50
 ...
 


### PR DESCRIPTION
## Summary

Walked all seven `sdks/` docs. **typescript, python, ai-sdk, go, and index are accurate** — verified the Python `OpenAICompat`/`.chat.completions.create` shim (`openai_compat.py:15`), `Signer` ABC, `AtomicUsdc` NewType; the Go `NewClient`/`UnimplementedSigner` surface; the `createSolvelaProvider` factory; and that ai-sdk.mdx's `anthropic-claude-sonnet-4-5` is **valid** (the provider uses a hyphenated `provider-key` id scheme, `generated/models.ts`). Two files had errors. **No bot review requested.**

### mcp.mdx
- **Tool list was wrong.** The server exposes `chat`, `smart_chat`, `wallet_status`, `list_models`, `spending`, `deposit_escrow` (`sdks/mcp/src/tools.ts`). The doc listed `health` and `get_cost` (neither exists) and omitted four real tools.
- **"Signing is currently a stub" warning is stale.** The server does real USDC-SPL signing via `@solvela/signer-core`; `client.ts:379` actively *rejects* stub payment headers. Reworded to describe real signing + the stub-rejection guard.

### rust.mdx
- `solvela models` output example: `anthropic/claude-opus-4-20250514` → `anthropic/claude-opus-4-6` (per #358). Operator CLI commands (incl. `solvela recover`, `wallet init/status/export`) verified against `crates/cli/src/main.rs`.

## Test plan
- [ ] `npm --prefix dashboard run build` succeeds (MDX renders)

## Audit position
sdks/ directory walk — completes it, and with it **every MDX directory** (api, concepts, enterprise, operations, sdks) is now walked.

### Out-of-scope code follow-up
`sdks/ai-sdk-provider/src/generated/models.ts` still has stale `modelId: "claude-sonnet-4-20250514"` / `"claude-opus-4-20250514"` — #358 updated `config/models.toml` but the generated provider file wasn't regenerated (`npm run generate-models`). The hyphenated `id`s are correct; only the embedded upstream `modelId`s drifted. Worth a follow-up regen (the old IDs still resolve until 2026-06-15).