### PR TITLE
fix(ai-sdk-provider): regenerate models.ts after #358 model-ID change

### DIFF
--- a/sdks/ai-sdk-provider/src/generated/models.ts
+++ b/sdks/ai-sdk-provider/src/generated/models.ts
@@ -48,7 +48,7 @@ export const MODELS = [
   {
     id: "anthropic-claude-opus-4-6",
     provider: "anthropic",
-    modelId: "claude-opus-4-20250514",
+    modelId: "claude-opus-4-6",
     displayName: "Claude Opus 4.6",
     inputCostPerMillion: 5,
     outputCostPerMillion: 25,
@@ -62,7 +62,7 @@ export const MODELS = [
   {
     id: "anthropic-claude-sonnet-4-5",
     provider: "anthropic",
-    modelId: "claude-sonnet-4-20250514",
+    modelId: "claude-sonnet-4-5-20250929",
     displayName: "Claude Sonnet 4.5",
     inputCostPerMillion: 3,
     outputCostPerMillion: 15,
@@ -77,7 +77,7 @@ export const MODELS = [
   {
     id: "anthropic-claude-sonnet-4-6",
     provider: "anthropic",
-    modelId: "claude-sonnet-4-20250514",
+    modelId: "claude-sonnet-4-6",
     displayName: "Claude Sonnet 4.6",
     inputCostPerMillion: 3,
     outputCostPerMillion: 15,


### PR DESCRIPTION
## Summary

#358 corrected the Anthropic `model_id`s in `config/models.toml`, but the ai-sdk-provider's **generated** model registry (`src/generated/models.ts`) was never regenerated — so its embedded upstream `modelId` values still pointed at the deprecated `claude-{opus,sonnet}-4-20250514` snapshots. Flagged during the sdks/ docs audit (#365). **No bot review requested.**

Ran `npm run generate-models` (reads `config/models.toml`). Only the three drifted Anthropic `modelId`s change; the hyphenated `id` keys the provider exposes are unchanged:

| `id` (unchanged) | `modelId` was | `modelId` now |
|---|---|---|
| `anthropic-claude-opus-4-6` | `claude-opus-4-20250514` | `claude-opus-4-6` |
| `anthropic-claude-sonnet-4-5` | `claude-sonnet-4-20250514` | `claude-sonnet-4-5-20250929` |
| `anthropic-claude-sonnet-4-6` | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |

(Haiku was already correct.)

## Test plan
- [x] `npm run typecheck` (tsc --noEmit) clean
- [x] `npm run test:unit` — 261 pass
- [x] No test referenced the old `modelId`s
- [ ] ai-sdk-provider CI (typecheck + unit + integration) green

## Why it matters
The provider sends `modelId` to the gateway. The old snapshots still resolve (deprecated, not retired until 2026-06-15), so nothing was broken — but the provider now sends the correctly-labelled IDs matching the registry.