### PR TITLE
docs(claude.md): correct Dockerfile description (2-stage, not 3-stage cargo-chef)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,7 @@ These skills contain patterns, checklists, and constraints specific to this proj
 
 ## Deployment
 
-- Dockerfile: 3-stage build with cargo-chef for dependency caching
+- Dockerfile: 2-stage build with dummy-source dependency caching (`rust:1.88-slim-bookworm` builder → `debian:bookworm-slim` runtime, non-root `solvela` user)
 - Fly.io config in `fly.toml` (app: `solvela-gateway`, port 8402, region ord)
 - Docker Compose for local dev: PostgreSQL 16 + Redis 7
 - Dashboard: Next.js on Vercel (`solvela.vercel.app`)


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s Deployment section claimed the Dockerfile is a "3-stage build with cargo-chef for dependency caching". The real Dockerfile is a **2-stage** build that caches dependencies by compiling against dummy source files (no cargo-chef) — a `rust:1.88-slim-bookworm` builder stage and a `debian:bookworm-slim` runtime stage running as the non-root `solvela` user. **No bot review requested.**

Surfaced during the operations/ docs audit (#364): `dashboard/content/docs/operations/deployment.mdx` already describes the real 2-stage build correctly; this just aligns CLAUDE.md.

## Test plan
- [x] Verified against the actual `Dockerfile` (FROM at lines 2 + 41, dummy-source caching, non-root user)
- N/A — docs-only, no build impact

## Audit position
Final cleanup item from the docs/website audit sweep. Closes the last flagged inaccuracy.