### PR TITLE
docs(concepts): fix escrow claim excess-handling (refunded, not retained)

### DIFF
--- a/dashboard/content/docs/concepts/escrow.mdx
+++ b/dashboard/content/docs/concepts/escrow.mdx
@@ -49,7 +49,7 @@ The escrow system provides trustless payment guarantees via a deployed Anchor pr
   <Step>
     **Gateway claims the actual cost**
 
-    After the response is sent, the gateway fires a fire-and-forget claim transaction to collect the actual token cost from the PDA vault. Any excess remains in the vault.
+    After the response is sent, the gateway fires a fire-and-forget claim transaction. In one transaction the escrow program pays the provider the actual token cost, refunds the remainder (`deposit − actual`) to the agent, and closes the vault and escrow accounts (rent returned to the agent). The agent's `refund` instruction is only needed for the fallback case where the gateway never claims before expiry.
   </Step>
 </Steps>
 


### PR DESCRIPTION
## Summary

Audited the landing-page components for factual claims. **They're clean** — model count "25+", "5% flat fee", 5 providers, the truncated escrow program ID (`9neDHouXgEgHZDde5Sp…`), and the hero copy all verified against source. But cross-checking the hero's escrow claim surfaced a real error in **escrow.mdx**. **No bot review requested.**

### The bug
escrow.mdx step 6 said the claim "collect[s] the actual token cost from the PDA vault. **Any excess remains in the vault.**" That's wrong. The on-chain claim instruction (`programs/escrow/src/instructions/claim.rs:10-13`) does three things in **one** transaction:
1. transfers `actual_amount` → provider ATA
2. transfers the remainder (`deposit − actual`) → **agent ATA (refund)**
3. closes the vault + escrow accounts (rent back to the agent)

So the excess is refunded to the agent atomically with the claim — it does not linger. The separate `refund` instruction is only the fallback for when the gateway never claims before expiry.

The landing hero's "the rest refunds on-chain, in the same transaction" is **correct**; escrow.mdx was the one out of step (I marked escrow.mdx clean in the concepts pass #363 and missed this — the claim step's excess wording).

## Test plan
- [ ] `npm --prefix dashboard run build` succeeds (MDX renders)
- [x] Verified against `programs/escrow/src/instructions/claim.rs`

## Audit position
Landing-components audit (all clean) + the escrow.mdx correction it exposed. This closes the landing surface.