### PR TITLE
docs: make doc code examples type-clean (verified by compile pass)

### DIFF
--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -194,7 +194,7 @@ data: [DONE]
     ```python
     import asyncio
     from solvela import SolvelaClient, ClientConfig, Wallet, KeypairSigner
-    from solvela.types import ChatRequest, ChatMessage, Role
+    from solvela.types import AtomicUsdc, ChatRequest, ChatMessage, Role
 
     async def main():
         wallet = Wallet.from_env('SOLANA_PRIVATE_KEY')
@@ -202,7 +202,7 @@ data: [DONE]
         client = SolvelaClient(
             config=ClientConfig(
                 gateway_url='https://api.solvela.ai',
-                max_payment_amount=100_000,  # per-call cap: 0.10 USDC (atomic units)
+                max_payment_amount=AtomicUsdc(100_000),  # per-call cap: 0.10 USDC (atomic units)
             ),
             wallet=wallet,
             signer=signer,

--- a/dashboard/content/docs/sdks/python.mdx
+++ b/dashboard/content/docs/sdks/python.mdx
@@ -46,13 +46,14 @@ Without a `Signer`, paid endpoints raise `PaymentRequiredError` on the first cal
   <Tab value="Dataclass">
     ```python
     from solvela import ClientConfig
+    from solvela.types import AtomicUsdc
 
     config = ClientConfig(
         gateway_url="http://localhost:8402",    # default: https://api.solvela.ai
         rpc_url="https://api.mainnet-beta.solana.com",
         prefer_escrow=False,                    # "exact" first, "escrow" fallback
         timeout=180.0,
-        max_payment_amount=10_000_000,          # cap per call (10 USDC = 10_000_000 atomic)
+        max_payment_amount=AtomicUsdc(10_000_000),  # cap per call (10 USDC = 10_000_000 atomic)
         expected_recipient=None,                # if set, gateway must pay-to this address
         enable_cache=False,                     # opt-in response caching
         enable_sessions=False,                  # opt-in three-strike session escalation
@@ -66,6 +67,7 @@ Without a `Signer`, paid endpoints raise `PaymentRequiredError` on the first cal
   <Tab value="Builder">
     ```python
     from solvela import ClientBuilder
+    from solvela.types import AtomicUsdc
 
     config = (
         ClientBuilder()
@@ -73,7 +75,7 @@ Without a `Signer`, paid endpoints raise `PaymentRequiredError` on the first cal
         .enable_cache(True)
         .enable_sessions(True)
         .free_fallback_model("openai/gpt-4o-mini")
-        .max_payment_amount(100_000)            # 0.10 USDC cap
+        .max_payment_amount(AtomicUsdc(100_000))  # 0.10 USDC cap
         .build()
     )
     ```

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -44,7 +44,7 @@ const client = new SolvelaClient({
 });
 
 const response = await client.chat(
-  new ChatRequest('claude-sonnet-4-20250514', [
+  new ChatRequest('claude-sonnet-4-6', [
     new ChatMessage('user', 'Explain the x402 protocol.'),
   ]),
 );


### PR DESCRIPTION
## Summary

Compile/type-checked **every language SDK code example** in the docs against the real in-repo SDKs. All examples already *run*; this fixes the two that weren't strictly type-clean. **No bot review requested.**

### Verification matrix (no live gateway / funded wallet needed)
| Language | Examples | Result |
|---|---|---|
| TypeScript | chat-completions.mdx + README "With Wallet" | `tsc --noEmit` clean vs built `@solvela/sdk` |
| Go | go.mdx unsigned + chat-completions signed (stub signer) | `go build` clean vs local SDK |
| Rust | rust SDK README library quickstart | `cargo build` clean vs `solvela-client` |
| Python | chat-completions.mdx + python.mdx config/builder | `mypy` clean **after this change** |

### Fixes
1. **Python `max_payment_amount`** — typed `AtomicUsdc | None` (`config.py:62`/`103`). A bare `int` runs (NewType is a runtime no-op) but trips `mypy --strict`, and the SDK's own docs say to wrap with `AtomicUsdc(...)`. Wrapped + imported in `api/chat-completions.mdx` (Python tab) and `sdks/python.mdx` (dataclass + builder). Re-ran mypy: example files clean (the lone remaining `client.py:121` error is SDK-internal, not the example).
2. **TS README "With Wallet"** — stale `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (per #358). Compiled fine and still resolves (deprecated model), just stale.

## Test plan
- [x] tsc / go build / cargo build / mypy all green for the examples
- [ ] `npm --prefix dashboard run build` (MDX renders)

## Note (out of scope)
`sdks/python/src/solvela/client.py:121` has a pre-existing SDK-internal mypy error (`check_degraded` arg type `str | None` vs `str`) — surfaced during this pass, unrelated to the doc examples. Worth a separate code fix.