### PR TITLE
fix(python-sdk): clear 8 strict-mypy errors + gate mypy in CI

### DIFF
--- a/.github/workflows/sdks-python.yml
+++ b/.github/workflows/sdks-python.yml
@@ -34,4 +34,5 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
+      - run: mypy src/
       - run: pytest tests/unit/ tests/integration/ -v --tb=short

--- a/sdks/python/src/solvela/openai_compat.py
+++ b/sdks/python/src/solvela/openai_compat.py
@@ -9,6 +9,7 @@ from solvela.types import ChatMessage, ChatRequest, Role
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
+    from solvela.client import SolvelaClient
     from solvela.types import ChatChunk, ChatResponse
 
 
@@ -20,17 +21,17 @@ class OpenAICompat:
         resp = await openai.chat.completions.create(model="gpt-4o", messages=[...])
     """
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: SolvelaClient) -> None:
         self.chat = _ChatNamespace(client)
 
 
 class _ChatNamespace:
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: SolvelaClient) -> None:
         self.completions = _CompletionsNamespace(client)
 
 
 class _CompletionsNamespace:
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: SolvelaClient) -> None:
         self._client = client
 
     async def create(

--- a/sdks/python/src/solvela/quality.py
+++ b/sdks/python/src/solvela/quality.py
@@ -34,8 +34,13 @@ _ERROR_PHRASES = [
 _TRUNCATION_MIN_LEN = 250
 
 
-def check_degraded(content: str) -> DegradedReason | None:
-    """Check if response content is degraded. Returns reason or None if OK."""
+def check_degraded(content: str | None) -> DegradedReason | None:
+    """Check if response content is degraded. Returns reason or None if OK.
+
+    A ``None`` content (an absent assistant message) is treated as
+    ``EMPTY_CONTENT`` — the empty/whitespace guard below short-circuits before
+    any string method runs.
+    """
     # 1. Empty/whitespace
     if not content or not content.strip():
         return DegradedReason.EMPTY_CONTENT

--- a/sdks/python/src/solvela/signer.py
+++ b/sdks/python/src/solvela/signer.py
@@ -16,7 +16,7 @@ from solvela.types import (
 )
 
 if TYPE_CHECKING:
-    from solders.pubkey import Pubkey  # type: ignore[import-untyped]
+    from solders.pubkey import Pubkey
 
     from solvela.wallet import Wallet
 

--- a/sdks/python/src/solvela/transport.py
+++ b/sdks/python/src/solvela/transport.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 
@@ -116,14 +116,14 @@ class Transport:
                         break
                     yield ChatChunk.from_dict(json.loads(data_str))
 
-    async def fetch_models(self) -> list[dict]:
+    async def fetch_models(self) -> list[dict[str, Any]]:
         """Fetch model list from gateway."""
         url = self._build_url("/v1/models")
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             resp = await client.get(url)
             if resp.status_code != 200:
                 raise GatewayError(status=resp.status_code, message=resp.text)
-            return _decode_json(resp).get("data", [])
+            return cast("list[dict[str, Any]]", _decode_json(resp).get("data", []))
 
 
 # --- Module-level decode helpers ---------------------------------------------

--- a/sdks/python/src/solvela/wallet.py
+++ b/sdks/python/src/solvela/wallet.py
@@ -6,12 +6,12 @@ import os
 from typing import TYPE_CHECKING
 
 from mnemonic import Mnemonic
-from solders.keypair import Keypair  # type: ignore[import-untyped]
+from solders.keypair import Keypair
 
 from solvela.errors import WalletError
 
 if TYPE_CHECKING:
-    from solders.pubkey import Pubkey  # type: ignore[import-untyped]
+    from solders.pubkey import Pubkey
 
 _BIP39 = Mnemonic("english")
 


### PR DESCRIPTION
## Summary

`sdks/python/pyproject.toml` declares `[tool.mypy] strict = true`, but **`sdks-python.yml` never ran mypy** — so 8 strict errors had accumulated on main undetected. Surfaced while type-checking the doc code examples (#369). **No bot review requested.**

All fixes are type-only — **181 unit tests still pass**, `mypy src/` now reports **0 issues across 14 files** (was 8).

| File | Error(s) | Fix |
|---|---|---|
| `quality.py` | `check_degraded` got `str\|None`, expected `str` (`client.py:121`) | Widened param to `str \| None` — the function already treats None as `EMPTY_CONTENT` (the `not content` guard short-circuits before `.strip()`) |
| `openai_compat.py` (×2) | `no-any-return` on the `ChatResponse \| AsyncIterator` return | Namespace classes held `client: Any`; typed them `SolvelaClient` (TYPE_CHECKING import — no runtime cycle) |
| `transport.py` (×2) | bare `dict`, `Any` return | `fetch_models -> list[dict[str, Any]]` + `cast` on `_decode_json(...).get("data")` |
| `wallet.py` (×2), `signer.py` (×1) | unused `# type: ignore[import-untyped]` | Removed — `solders` ships type info; strict's `warn_unused_ignores` flagged them |

### CI gate
Added `- run: mypy src/` to `sdks-python.yml` (after the ruff steps) so the strict gate the project already declared is actually enforced. **Lands green** — verified locally.

## Test plan
- [x] `mypy src/` → Success, 0 issues (14 files)
- [x] `pytest tests/unit/` → 181 passed
- [ ] sdks-python CI green (now includes the mypy step) on both 3.10 and 3.12

## Origin
Started as "fix the `client.py:121` bug" flagged in #369's verification; the SDK's own `mypy src/` revealed it was 8 errors + a missing CI gate, so this clears all of them and wires the gate.