### PR TITLE
chore(dashboard): declare shiki as a direct dependency

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -18,6 +18,7 @@
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "recharts": "^3.8.1",
+        "shiki": "^4.0.2",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -20,6 +20,7 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "recharts": "^3.8.1",
+    "shiki": "^4.0.2",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

`src/lib/shiki/highlighter.ts` imports `shiki` directly, but the package was only present **transitively** via `fumadocs-core` — i.e. it worked purely by npm hoisting and would break if fumadocs dropped or bumped it. `knip` flagged it as an unlisted dependency in PR #375's audit.

Declares `shiki@^4.0.2`, matching the already-resolved version so it dedupes to the single existing install (`npm ls shiki` shows fumadocs-core's copy as `deduped` — no duplicate added).

## Verification
- `npm ls shiki` — single 4.0.2 install, deduped
- `knip` — no longer reports any unlisted dependency
- `npx tsc --noEmit` — clean
- `npm test` — 100/100 pass
- `npm run build` — succeeds