### PR TITLE
feat(openclaw-provider): wire F4 settle into the streamFn body

### DIFF
--- a/sdks/openclaw-provider/README.md
+++ b/sdks/openclaw-provider/README.md
@@ -62,23 +62,22 @@ completes. There are two ways the claim can be triggered:
 1. **Gateway auto-claim after `max_timeout_seconds`** — works today; the
    deposit is reconciled on a timer, so refunds for over-deposits arrive
    asynchronously.
-2. **Client-side `wrapStreamForF4`** — the plugin exports a `wrapStreamForF4`
-   helper that observes the stream's `result()` Promise and POSTs the actual
-   token usage to the gateway's `/v1/escrow/settle` endpoint as soon as the
-   stream finishes. Reduces reconciliation latency from minutes to
-   milliseconds.
+2. **Client-side `wrapStreamForF4` (the default in escrow mode)** — the
+   plugin's wrapped `streamFn` observes the inner stream's `result()`
+   Promise and fire-and-forget POSTs the actual token usage to the
+   gateway's `/v1/escrow/settle` endpoint as soon as the stream finishes.
+   Reduces reconciliation latency from `max_timeout_seconds` (minutes) to
+   milliseconds. Settle failures are logged to stderr but never block the
+   stream consumer; auto-claim remains the fallback.
 
-The `wrapStreamForF4` wrapper is fully implemented and unit-tested
-(`tests/f4-wrapper.test.ts`). The matching gateway endpoint at
-`/v1/escrow/settle` is planned but not yet deployed — until it lands, settle
-POSTs return 404 and the wrapper logs a warning (the stream consumer is
-unaffected). Until the endpoint is live, you can still safely use escrow mode
-and rely on the auto-claim timer.
+The helper is also exported (`wrapStreamForF4`) for advanced wiring
+outside the bundled `wrapStreamFn` path. Both the client side and the
+gateway-side endpoint (`POST /v1/escrow/settle`) are live in production
+as of 2026-05-26.
 
 **Security note on `direct` mode:** Direct-transfer payments are
 non-refundable if the stream fails mid-response. If recovery from
-partial-stream failures matters for your workload, prefer escrow mode (with
-F4 once the gateway endpoint ships, or auto-claim today).
+partial-stream failures matters for your workload, prefer escrow mode.
 
 ## Dev bypass
 

--- a/sdks/openclaw-provider/src/index.ts
+++ b/sdks/openclaw-provider/src/index.ts
@@ -54,8 +54,9 @@ import type {
   CatalogContext,
   DynamicModelContext,
 } from './openclaw-types.js';
-import { parse402, sanitizeGatewayError } from '@solvela/signer-core';
+import { decodePaymentHeader, parse402, sanitizeGatewayError } from '@solvela/signer-core';
 import type { PaymentRequired } from '@solvela/signer-core';
+import { wrapStreamForF4, type ResultableStream } from './f4-wrapper.js';
 
 export { SOLVELA_MODELS } from './models.generated.js';
 export { ROUTING_PROFILES } from './registry.js';
@@ -493,8 +494,44 @@ export default function register(api: OpenClawApi, opts: RegisterOptions = {}): 
           },
         };
 
+        // F4 — extract escrow metadata from the just-built header. Best-effort:
+        // if the signer chose a non-escrow scheme (direct/exact), there's no
+        // escrow PDA to settle and `escrowMeta` stays null. Any decode failure
+        // is treated as "no F4 this call" rather than blocking the request;
+        // F4 is a fire-and-forget reconciliation hook, never on the hot path.
+        let escrowMeta: { serviceId: string; agentPubkey: string } | null = null;
         try {
-          return await inner(model, context, wrappedOptions);
+          const decoded = decodePaymentHeader(paymentHeader) as {
+            accepted?: { scheme?: string };
+            payload?: { service_id?: string; agent_pubkey?: string };
+          };
+          if (
+            decoded?.accepted?.scheme === 'escrow' &&
+            typeof decoded?.payload?.service_id === 'string' &&
+            typeof decoded?.payload?.agent_pubkey === 'string'
+          ) {
+            escrowMeta = {
+              serviceId: decoded.payload.service_id,
+              agentPubkey: decoded.payload.agent_pubkey,
+            };
+          }
+        } catch {
+          // Decode failure is a signer-core defect, not a user-facing error.
+          // Skip F4 for this call; the gateway's on-chain auto-timeout refund
+          // remains the fallback reconciliation path.
+        }
+
+        try {
+          const stream = await inner(model, context, wrappedOptions);
+          if (escrowMeta) {
+            wrapStreamForF4(stream as unknown as ResultableStream, {
+              serviceId: escrowMeta.serviceId,
+              agentPubkey: escrowMeta.agentPubkey,
+              modelId: model.id,
+              gatewayUrl: apiUrl,
+            });
+          }
+          return stream;
         } catch (err) {
           await signer.refundBudget(cost);
           throw err;

--- a/sdks/openclaw-provider/src/signer.ts
+++ b/sdks/openclaw-provider/src/signer.ts
@@ -53,16 +53,16 @@ export interface SignerOptions {
  * Create one instance per plugin registration; reuse across calls.
  * The budget mutex serialises concurrent access to sessionSpent.
  *
- * Default signing mode is 'direct'. Escrow mode works but relies on gateway
- * auto-claim after max_timeout_seconds; direct mode is recommended until
- * the F4 escrow-claim hook lands.
+ * Default signing mode is 'direct'. Escrow mode is now fully wired: when
+ * the gateway offers an escrow scheme and signing succeeds, the wrapped
+ * streamFn schedules a fire-and-forget F4 settle POST to /v1/escrow/settle
+ * on stream completion. The gateway claims the actual usage-priced amount
+ * instead of waiting for the auto-timeout refund.
  */
 export class SolvelaSigner {
   private readonly sessionBudget?: number;
   private readonly signingMode: 'auto' | 'escrow' | 'direct';
   private sessionSpent = 0;
-  /** Count of escrow/auto deposits — emits a WARN every 10 (HF-P3-H6). */
-  private escrowDepositCount = 0;
   /** Mutex ensures budget check + increment is atomic across parallel calls. */
   private readonly budgetMutex = new Mutex();
   /** DI override for createPaymentHeader — tests only (HF-P3-H3). */
@@ -165,21 +165,6 @@ export class SolvelaSigner {
         'Payment signing returned a stub transaction. Reinstall @solvela/openclaw-provider ' +
           'and ensure @solana/web3.js peer deps are resolvable at runtime.',
       );
-    }
-
-    // Step 7 — Escrow deposit counter WARN (HF-P3-H6)
-    // Emit a warning every 10 escrow/auto deposits to remind users that the
-    // claim path relies on gateway auto-claim until both halves of F4 ship
-    // (client wrapper landed; gateway /v1/escrow/settle endpoint pending).
-    if (this.signingMode === 'escrow' || this.signingMode === 'auto') {
-      this.escrowDepositCount++;
-      if (this.escrowDepositCount % 10 === 0) {
-        process.stderr.write(
-          `[solvela-openclaw] WARN: ${this.escrowDepositCount} escrow deposits made; ` +
-            'gateway auto-claim still handles reconciliation (F4 settle endpoint not yet deployed). ' +
-            'See README.md "Escrow accounting (F4)".\n',
-        );
-      }
     }
 
     return paymentHeader;

--- a/sdks/openclaw-provider/tests/index.test.ts
+++ b/sdks/openclaw-provider/tests/index.test.ts
@@ -39,6 +39,22 @@ const REAL_LOOKING_HEADER = Buffer.from(
   'utf-8',
 ).toString('base64');
 
+// Escrow-scheme variant — used by the F4 wire-up test below. Carries the
+// service_id + agent_pubkey that index.ts decodes to schedule the settle POST.
+const REAL_LOOKING_ESCROW_HEADER = Buffer.from(
+  JSON.stringify({
+    x402_version: 2,
+    resource: { url: 'https://api.solvela.ai/v1/chat/completions', method: 'POST' },
+    accepted: { scheme: 'escrow', network: 'solana' },
+    payload: {
+      deposit_tx: 'REAL_ESCROW_TX_NOT_STUB_xABCDEF1234567890',
+      service_id: 'svc-abc-base64-test-fixture',
+      agent_pubkey: 'AgentPubkey11111111111111111111111111111111',
+    },
+  }),
+  'utf-8',
+).toString('base64');
+
 /** Create a SolvelaSigner with DI that returns a non-stub header. */
 function makeDISigner(opts: ConstructorParameters<typeof SolvelaSigner>[0] = {}): SolvelaSigner {
   return new SolvelaSigner({
@@ -102,6 +118,47 @@ async function startMock200Server(): Promise<{ server: Server; port: number }> {
   return startMockServer((res) => {
     res.writeHead(200, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ id: 'test', object: 'chat.completion', created: 0, model: 'auto', choices: [] }));
+  });
+}
+
+const mock402Escrow = JSON.parse(
+  readFileSync(resolve(__dirname, 'fixtures/mock-402-escrow.json'), 'utf-8'),
+);
+
+/**
+ * Mock server that serves a 402-escrow envelope on `/v1/chat/completions`
+ * AND a capturing 200 on `/v1/escrow/settle`. Used by the F4 wire-up test.
+ */
+async function startMock402EscrowPlusSettleServer(): Promise<{
+  server: Server;
+  port: number;
+  settleCalls: () => Array<{ body: string }>;
+}> {
+  const settleCalls: Array<{ body: string }> = [];
+  return new Promise((resolveReady, reject) => {
+    const server = createServer((req, res) => {
+      if (req.url === '/v1/escrow/settle' && req.method === 'POST') {
+        let body = '';
+        req.on('data', (chunk: Buffer) => (body += chunk.toString('utf-8')));
+        req.on('end', () => {
+          settleCalls.push({ body });
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end('{"ok":true}');
+        });
+        return;
+      }
+      res.writeHead(402, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(mock402Escrow));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('could not get server port'));
+        return;
+      }
+      resolveReady({ server, port: addr.port, settleCalls: () => settleCalls });
+    });
+    server.on('error', reject);
   });
 }
 
@@ -509,6 +566,91 @@ describe('wrapStreamFn', () => {
       !opts?.headers || !('payment-signature' in opts.headers),
       'payment-signature must NOT be injected in dev_bypass mode',
     );
+  });
+
+  it('schedules F4 settle POST when signer chose an escrow scheme', async () => {
+    const { server, port, settleCalls } = await startMock402EscrowPlusSettleServer();
+    process.env['SOLVELA_API_URL'] = `http://127.0.0.1:${port}`;
+    process.env['SOLANA_WALLET_KEY'] = 'fake_wallet_key_for_test';
+    process.env['SOLVELA_SIGNING_MODE'] = 'escrow';
+
+    const { api, config } = makeMockApi();
+    register(api, {
+      _signer: new SolvelaSigner({
+        signingMode: 'escrow',
+        _createPaymentHeaderFn: async () => REAL_LOOKING_ESCROW_HEADER,
+      } as ConstructorParameters<typeof SolvelaSigner>[0] & {
+        _createPaymentHeaderFn: () => Promise<string>;
+      }),
+    });
+    const cfg = (config as unknown as { config: ProviderConfig }).config;
+
+    // Inner streamFn returns a ResultableStream whose .result() resolves with
+    // a mock AssistantMessage. F4 awaits .result() before firing the settle.
+    const innerFn = (() => ({
+      result: async () => ({
+        stopReason: 'stop' as const,
+        usage: { input: 42, output: 17 },
+      }),
+    })) as unknown as NonNullable<StreamFnContext['streamFn']>;
+    const ctx: StreamFnContext = { streamFn: innerFn };
+    const wrapped = cfg.wrapStreamFn!(ctx)!;
+
+    try {
+      await callWrapped(wrapped);
+      // F4 is fire-and-forget — give scheduleSettle a tick to await result()
+      // and post to the mock server.
+      for (let i = 0; i < 50 && settleCalls().length === 0; i++) {
+        await new Promise((r) => setTimeout(r, 10));
+      }
+    } finally {
+      server.close();
+    }
+
+    const calls = settleCalls();
+    assert.strictEqual(calls.length, 1, 'F4 must POST exactly once to /v1/escrow/settle');
+    const body = JSON.parse(calls[0].body) as Record<string, unknown>;
+    assert.strictEqual(body.service_id, 'svc-abc-base64-test-fixture');
+    assert.strictEqual(body.agent_pubkey, 'AgentPubkey11111111111111111111111111111111');
+    assert.strictEqual(body.status, 'completed');
+    assert.strictEqual(body.actual_prompt_tokens, 42);
+    assert.strictEqual(body.actual_completion_tokens, 17);
+  });
+
+  it('does NOT schedule F4 when signer chose a direct (exact) scheme', async () => {
+    const { server, port } = await startMockServer((res) => {
+      res.writeHead(402, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(mock402));
+    });
+    process.env['SOLVELA_API_URL'] = `http://127.0.0.1:${port}`;
+    process.env['SOLANA_WALLET_KEY'] = 'fake_wallet_key_for_test';
+
+    const { api, config } = makeMockApi();
+    register(api, { _signer: makeDISigner() });
+    const cfg = (config as unknown as { config: ProviderConfig }).config;
+
+    // Track whether the stream's result() ever gets called — F4 only calls it
+    // when escrow scheme is detected. With the direct REAL_LOOKING_HEADER
+    // fixture, F4 must not fire.
+    let resultCalled = false;
+    const innerFn = (() => ({
+      result: async () => {
+        resultCalled = true;
+        return { stopReason: 'stop' as const };
+      },
+    })) as unknown as NonNullable<StreamFnContext['streamFn']>;
+    const ctx: StreamFnContext = { streamFn: innerFn };
+    const wrapped = cfg.wrapStreamFn!(ctx)!;
+
+    try {
+      await callWrapped(wrapped);
+      // Give any background work a tick to run.
+      await new Promise((r) => setTimeout(r, 50));
+    } finally {
+      server.close();
+    }
+
+    assert.strictEqual(resultCalled, false, 'F4 must not invoke .result() on direct-scheme calls');
   });
 });
 

--- a/sdks/openclaw-provider/tests/signer.test.ts
+++ b/sdks/openclaw-provider/tests/signer.test.ts
@@ -99,12 +99,10 @@ describe('SolvelaSigner', () => {
   });
 
   it('default signingMode is direct (HF-P3-H6)', () => {
-    // Constructed with no options — signingMode defaults to direct
+    // Constructed with no options — signingMode defaults to direct.
+    // The canonical assertion is in index.test.ts via getSigningMode().
     const signer = new SolvelaSigner();
     assert.strictEqual(signer.getSessionSpent(), 0, 'initial spend should be 0');
-    // Verify via escrow-mode check: auto and escrow would increment escrowDepositCount
-    // We can only observe the default indirectly via no WARN on direct mode builds.
-    // The canonical assertion is in index.test.ts via getSigningMode() which defaults 'direct'.
   });
 
   it('stub-header guard: rejects STUB_BASE64_TX (HF-P3-H3 — direct stub check)', async () => {
@@ -326,39 +324,6 @@ describe('SolvelaSigner', () => {
       spentBefore,
       'budget must not be reserved when filterAccepts throws',
     );
-  });
-
-  it('escrow deposit counter: WARN emitted at every 10th deposit (HF-P3-H6)', async () => {
-    // Use an escrow-scheme mock402 fixture so filterAccepts passes in escrow mode.
-    const mock402Escrow = JSON.parse(
-      readFileSync(resolve(__dirname, 'fixtures/mock-402-escrow.json'), 'utf-8'),
-    ) as PaymentRequired;
-
-    const warnings: string[] = [];
-    const origWrite = process.stderr.write.bind(process.stderr);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (process.stderr as any).write = (chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean => {
-      if (typeof chunk === 'string') warnings.push(chunk);
-      return origWrite(chunk, cb as (err?: Error | null) => void);
-    };
-
-    try {
-      const signer = new SolvelaSigner({
-        signingMode: 'escrow',
-        _createPaymentHeaderFn: async () => REAL_LOOKING_HEADER,
-      } as ConstructorParameters<typeof SolvelaSigner>[0] & { _createPaymentHeaderFn: () => Promise<string> });
-
-      // Make 10 calls — WARN should fire on the 10th
-      for (let i = 0; i < 10; i++) {
-        await signer.buildHeader(mock402Escrow, 'https://api.solvela.ai/v1/chat/completions', '{}');
-      }
-    } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (process.stderr as any).write = origWrite;
-    }
-
-    const warnLine = warnings.find((l) => l.includes('10 escrow deposits made'));
-    assert.ok(warnLine, `expected escrow deposit WARN at 10th deposit, got: ${warnings.join('')}`);
   });
 
   it('filterAccepts: direct mode filters escrow accepts', async () => {


### PR DESCRIPTION
## Why

The F4 helper (\`wrapStreamForF4\`) has shipped, exported, and unit-tested for weeks, but the bundled \`wrapStreamFn\` hot path never invoked it. That meant escrow accounting fell back to the gateway's \`max_timeout_seconds\` auto-claim timer — minutes of reconciliation latency for sub-second LLM calls. All three deps F4 needs are now in place:

- \`@solvela/signer-core\` exposes \`service_id\` in the encoded payment header (\`sdks/signer-core/src/sign.ts:217\`).
- The gateway-side \`POST /v1/escrow/settle\` endpoint shipped in #267.
- \`decodePaymentHeader\` from signer-core unwraps the base64 payload after \`signer.buildHeader\` returns.

This closes the \`Known follow-ups\` bullet in STATUS.md "End-to-end F4 wire-up in \`@solvela/openclaw-provider\`'s \`wrapStreamFn\` body."

## What

### \`sdks/openclaw-provider/src/index.ts\`
- After \`signer.buildHeader(...)\`, best-effort-decode the just-built header. If the chosen scheme is \`escrow\` and the payload carries both \`service_id\` and \`agent_pubkey\`, capture them into \`escrowMeta\`. Decode failures fall through silently.
- After \`inner(model, context, wrappedOptions)\` returns, call \`wrapStreamForF4(stream, { serviceId, agentPubkey, modelId, gatewayUrl })\` when \`escrowMeta\` is set. The helper schedules a fire-and-forget POST to \`/v1/escrow/settle\` when \`stream.result()\` resolves; on failure it logs and continues.

### \`sdks/openclaw-provider/src/signer.ts\`
- Removed the periodic "auto-claim only" WARN that fired every 10 escrow deposits — the message claimed the settle endpoint wasn't deployed, which is no longer true.
- Removed the now-dead \`escrowDepositCount\` field and its tick.
- Class docstring updated: escrow mode is fully wired.

### Tests
- **New** \`schedules F4 settle POST when signer chose an escrow scheme\` — mock server accepts 402 on chat + captures the settle POST body. Verifies that \`service_id\`, \`agent_pubkey\`, \`status=completed\`, and the actual token counts from \`AssistantMessage.usage\` all reach the settle endpoint.
- **New** \`does NOT schedule F4 when signer chose a direct scheme\` — uses the existing direct-scheme \`REAL_LOOKING_HEADER\` fixture and asserts the stream's \`.result()\` is never called.
- **Removed** the obsolete WARN test in \`signer.test.ts\` and a lingering stale comment in the default-signing-mode test.

### Docs
\`README.md\` "Escrow accounting (F4)" section rewritten: the client-side helper IS the default in escrow mode now; gateway endpoint is explicitly noted as live in production.

## Test plan
- [x] \`npm run build\` (tsc) clean
- [x] \`npm test\` — 71/71 pass (was 70/70 before; +2 new F4 wire-up tests, -1 obsolete WARN test)