### PR TITLE
chore(sdks-rust): bump workspace to 0.2.2

### DIFF
--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "base64",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "futures",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli-args"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bs58",
  "clap",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-proxy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "axum",
  "clap",

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT"


### PR DESCRIPTION
First version published via the new sdk-rust-publish.yml workflow (PR #404, cargo 1.90 overlay-publish). Bumps all four member crates via version.workspace = true. solvela-protocol stays at 0.2.2 (already on crates.io). Tag sdks/rust/v0.2.2 after merge to fire the publish workflow.