### PR TITLE
ci(sdk-rust): fix manifest-version extraction and bump to 0.2.3

### DIFF
--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -149,15 +149,30 @@ jobs:
           # populated on both tag-push and workflow_dispatch invocations —
           # downstream jobs can rely on it for symmetry / future use even
           # though the publish job is skipped on dry-run dispatch.
+          # Extract the value between the first pair of double quotes
+          # on the `version = "..."` line inside [workspace.package].
+          #
+          # NB: the previous form used `gsub(/.*"|".*/, "")` which
+          # produced the empty string — the greedy `.*"` matched the
+          # whole line through the LAST quote, leaving nothing. POSIX
+          # `match()` + `substr()` is portable across gawk and mawk
+          # (ubuntu-latest ships mawk) and gives the exact substring.
           MANIFEST_VERSION=$(awk '
             /^\[workspace\.package\]/ { in_section = 1; next }
             /^\[/ { in_section = 0 }
             in_section && /^version[[:space:]]*=/ {
-              gsub(/.*"|".*/, "")
-              print
-              exit
+              if (match($0, /"[^"]*"/) > 0) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
             }
           ' sdks/rust/Cargo.toml)
+
+          if [ -z "$MANIFEST_VERSION" ]; then
+            echo "ERROR: failed to extract version from sdks/rust/Cargo.toml [workspace.package]"
+            echo "Halting — refusing to compare a tag against an empty manifest version."
+            exit 1
+          fi
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             # Manual rehearsal path: there is no tag to compare against,

--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ahash",
  "base64",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "futures",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli-args"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bs58",
  "clap",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-proxy"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "axum",
  "clap",

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT"


### PR DESCRIPTION
The verify job's awk used `gsub(/.*"|".*/, "")` which produces the empty string (greedy `.*"` eats through the last quote). The sdks/rust/v0.2.2 tag fired against this broken workflow and the verify job failed before any publish attempt — 0.2.2 was never published to crates.io.

Fix: POSIX `match()` + `substr()` to capture the content between the first pair of double-quotes, plus an empty-string guard that halts with a clear error if extraction fails.

Bump skips 0.2.2 because retagging a published tag is forbidden by the publisher charter (tags are immutable history). Next tag will be sdks/rust/v0.2.3.