### PR TITLE
ci(openclaw-provider): enforce generated models fresh vs config/models.toml

### DIFF
--- a/.github/workflows/openclaw-provider.yml
+++ b/.github/workflows/openclaw-provider.yml
@@ -11,12 +11,17 @@ on:
       # side?". Proper end-to-end wire-compat verification needs SDK
       # tests against a live gateway — tracked separately.
       - 'crates/protocol/**'
+      # The generated model registry (src/models.generated.ts) is derived
+      # from config/models.toml. Trigger here so the models-fresh job catches
+      # a TOML change that wasn't followed by `npm run generate:models`.
+      - 'config/models.toml'
       - '.github/workflows/openclaw-provider.yml'
   pull_request:
     paths:
       - 'sdks/openclaw-provider/**'
       - 'sdks/signer-core/**'
       - 'crates/protocol/**'
+      - 'config/models.toml'
       - '.github/workflows/openclaw-provider.yml'
 
 defaults:
@@ -171,6 +176,33 @@ jobs:
       # ecosystem. Dependabot security alerts cover the high-severity gap on
       # the repo level; this job catches CRITICAL regressions in CI.
       - run: npm audit --production --audit-level=critical
+
+  models-fresh:
+    name: Generated models up to date
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: sdks/openclaw-provider/package-lock.json
+      - run: npm ci
+      # src/models.generated.ts is generated from config/models.toml. If the
+      # TOML changed but the generated file wasn't regenerated, the provider
+      # ships stale model_ids. Regenerate and fail if the committed file
+      # differs. Mirrors the ai-sdk-provider models-fresh job (#358 → #366
+      # drift class).
+      - run: npm run generate:models
+      - name: Fail if src/models.generated.ts is stale vs config/models.toml
+        run: |
+          if ! git diff --quiet src/models.generated.ts; then
+            echo "::error::src/models.generated.ts is out of date with config/models.toml. Run 'npm run generate:models' in sdks/openclaw-provider and commit the result."
+            git --no-pager diff src/models.generated.ts
+            exit 1
+          fi
+          echo "OK: generated models are up to date with config/models.toml"
 
   guard-deprecated-openclaw-imports:
     # OpenClaw is mid-refactor ("slim core, expand plugins" — 2026-05-13 audit).


### PR DESCRIPTION
## Summary

- Adds a `models-fresh` CI job to `.github/workflows/openclaw-provider.yml` that runs `npm run generate:models` and fails on diff against the committed `src/models.generated.ts`. Mirrors the equivalent ai-sdk-provider job.
- Adds `config/models.toml` to this workflow's `push`/`pull_request` path triggers so the job runs when the source-of-truth TOML changes.

## Why

`src/models.generated.ts` is derived from `config/models.toml` via `npm run generate:models`. Without CI enforcement, a TOML change without regen silently ships stale `model_id`s in the OpenClaw provider plugin — the same drift class as the #358 → #366 incident on the ai-sdk-provider side.

## Cascade enforcement state after this PR

| Target | Enforcement |
|---|---|
| `ai-sdk-provider/src/generated/models.ts` | `models-fresh` CI job |
| `openclaw-provider/src/models.generated.ts` | `models-fresh` CI job *(new)* |
| `crates/gateway/.../fallback.rs::model_fallback_chain` | `every_fallback_chain_id_is_registered` unit test |

## Test plan

- [x] Local: `npm run generate:models` produces zero diff against committed file (clean state would pass CI)
- [ ] CI: `models-fresh` job appears in this PR's check list and is green
- [ ] CI: the openclaw-provider workflow triggers on this PR (`.github/workflows/openclaw-provider.yml` path matches)