### PR TITLE
docs(audit/section-1): fix wrong crate names, model IDs, deploy path, toolchain refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@ cargo build --release             # release build
 # Test — run `cargo test` for current counts (don't trust hardcoded numbers)
 cargo test                        # all workspace tests
 cargo test -p gateway             # gateway (unit + integration)
-cargo test -p x402                # x402 protocol
-cargo test -p router              # smart router
+cargo test -p solvela-x402        # x402 protocol
+cargo test -p solvela-router      # smart router
 cargo test -p solvela-protocol    # wire-format types
 cargo test -p solvela-cli         # CLI
 
@@ -34,7 +34,7 @@ cargo test scorer                 # all tests matching "scorer"
 # Scoped test runs
 cargo test -p gateway --test integration  # integration tests only
 cargo test -p gateway --lib               # unit tests only
-cargo test -p x402 -- --nocapture         # show stdout/tracing output
+cargo test -p solvela-x402 -- --nocapture # show stdout/tracing output
 
 # Escrow program (standalone — NOT in workspace)
 # Default: runs only unit tests in tests/unit.rs (no on-chain artifact required).
@@ -255,7 +255,7 @@ These skills contain patterns, checklists, and constraints specific to this proj
 
 ## Deployment
 
-- Dockerfile: 2-stage build with dummy-source dependency caching (`rust:1.88-slim-bookworm` builder → `debian:bookworm-slim` runtime, non-root `solvela` user)
+- Dockerfile: 2-stage build with dummy-source dependency caching (`rust:1.88-slim-trixie` builder → `debian:trixie-slim` runtime, non-root `solvela` user)
 - Fly.io config in `fly.toml` (app: `solvela-gateway`, port 8402, region ord)
 - Docker Compose for local dev: PostgreSQL 16 + Redis 7
 - Dashboard: Next.js on Vercel (`solvela.vercel.app`)

--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ The 402 response includes a `cost_breakdown` with per-token pricing, estimated t
 | OpenAI | `o3-mini` | $1.10 | $4.40 | 200K |
 | OpenAI | `o4-mini` | $1.10 | $4.40 | 200K |
 | OpenAI | `gpt-oss-120b` | Free | Free | 128K |
-| Anthropic | `claude-opus-4.6` | $5.00 | $25.00 | 200K |
-| Anthropic | `claude-sonnet-4.6` | $3.00 | $15.00 | 200K |
-| Anthropic | `claude-sonnet-4.5` | $3.00 | $15.00 | 200K |
-| Anthropic | `claude-haiku-4.5` | $1.00 | $5.00 | 200K |
+| Anthropic | `claude-opus-4-6` | $5.00 | $25.00 | 200K |
+| Anthropic | `claude-sonnet-4-6` | $3.00 | $15.00 | 200K |
+| Anthropic | `claude-sonnet-4-5-20250929` | $3.00 | $15.00 | 200K |
+| Anthropic | `claude-haiku-4-5-20251001` | $1.00 | $5.00 | 200K |
 | Google | `gemini-3.1-pro` | $2.00 | $12.00 | 1M |
 | Google | `gemini-2.5-flash` | $0.30 | $2.50 | 1M |
 | Google | `gemini-2.5-flash-lite` | $0.10 | $0.40 | 1M |
@@ -275,9 +275,24 @@ go get github.com/solvela-ai/solvela/sdks/go
 ```
 
 ```go
-client, _ := solvela.NewClient()
-response, _ := client.Chat(ctx, "openai/gpt-4o", "Hello!")
+import (
+    "context"
+    solvela "github.com/solvela-ai/solvela/sdks/go"
+)
+
+wallet, _, _ := solvela.CreateWallet()
+client, _ := solvela.NewClient(wallet, nil,
+    solvela.WithGatewayURL("https://api.solvela.ai"),
+)
+resp, _ := client.Chat(context.Background(), &solvela.ChatRequest{
+    Model: "openai/gpt-4o",
+    Messages: []solvela.ChatMessage{
+        {Role: solvela.RoleUser, Content: "Hello!"},
+    },
+})
 ```
+
+The bundled `UnimplementedSigner` is a placeholder — supply a custom `Signer` (or use the Python / TypeScript SDK) to actually settle payments. See [`sdks/go/README.md`](./sdks/go/README.md).
 
 ### MCP (Claude Code)
 
@@ -323,8 +338,8 @@ cargo build --release                 # Release build
 # Rust workspace — run `cargo test` for current counts; suites are growing
 cargo test                            # All workspace tests
 cargo test -p gateway                 # gateway unit + integration
-cargo test -p x402                    # x402 protocol
-cargo test -p router                  # smart router
+cargo test -p solvela-x402            # x402 protocol
+cargo test -p solvela-router          # smart router
 cargo test -p solvela-protocol        # wire-format types
 
 # Single test
@@ -431,8 +446,8 @@ Solvela is deployed on Fly.io:
 | Redis | `solvela-cache` (Upstash, ord + iad) |
 
 ```bash
-# Deploy
-cd crates/gateway && fly deploy -a solvela-gateway
+# Deploy (fly.toml lives at the repo root)
+fly deploy -a solvela-gateway
 
 # Set provider keys
 fly secrets set -a solvela-gateway OPENAI_API_KEY=... ANTHROPIC_API_KEY=...

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,22 +28,22 @@ A small set of advisories cannot be cleared without a major ecosystem migration.
 
 ### Rust (escrow program — `programs/escrow/Cargo.lock`)
 
-The escrow program is built against the Solana 1.18 / Anchor 0.30 toolchain (matches the deployed mainnet bytecode). Solana 1.x pins a number of legacy transitive dependencies that cannot be upgraded individually:
+The escrow program is built against the Anchor 0.31.1 / Solana SDK 2.2 toolchain (matches the deployed mainnet bytecode). A number of legacy transitive dependencies are still pulled in by the Anchor 0.31 / `solana-sdk` 2.x graph and cannot be upgraded individually:
 
 | Crate | Advisory | Status |
 |---|---|---|
-| `curve25519-dalek` 3.2.0 | RUSTSEC-2024-0344 | Pinned by Solana 1.18 SDK. Resolves on Solana 2.x migration. |
-| `ed25519-dalek` 1.0.1 | RUSTSEC-2022-0093 | Pinned by Solana 1.18 SDK. Resolves on Solana 2.x migration. |
-| `rustls-webpki` 0.101.7 | RUSTSEC-2026-0098, 0099, 0104 | Pinned via legacy `rustls` major in Solana 1.x dep tree. |
-| `bincode` 1.3.3 | RUSTSEC-2025-0141 | Pinned by Solana 1.x; bincode 2.x is a major-API break. |
-| `rand` 0.7.3 | RUSTSEC-2026-0097 | Transitive via `solana-sdk` 1.x. |
-| `libsecp256k1` 0.6.0 | RUSTSEC-2025-0161 | Anchor 0.30 transitive. |
-| `rustls-pemfile` 1.0.4 | RUSTSEC-2025-0134 | Solana 1.x transitive. |
-| `ansi_term`, `atty`, `derivative`, `paste` | various unmaintained | All Solana 1.x build-time transitives. |
+| `curve25519-dalek` 3.2.0 | RUSTSEC-2024-0344 | Pulled in by `ed25519-dalek` 1.0.1 via `solana-keypair` 2.2.1. Resolves on the broader Solana 3.x / `@solana/kit` migration. |
+| `ed25519-dalek` 1.0.1 | RUSTSEC-2022-0093 | Pulled in by `solana-keypair` 2.2.1 (Solana SDK 2.x). Resolves on the Solana 3.x / `@solana/kit` migration. |
+| `rustls-webpki` 0.101.7 | RUSTSEC-2026-0098, 0099, 0104 | Pulled in via the legacy `rustls` major still in the Solana 2.x dep tree. |
+| `bincode` 1.3.3 | RUSTSEC-2025-0141 | Pulled in by the Solana SDK; bincode 2.x is a major-API break. |
+| `rand` 0.7.3 | RUSTSEC-2026-0097 | Transitive via `solana-sdk` 2.x. |
+| `libsecp256k1` 0.6.0 | RUSTSEC-2025-0161 | Anchor 0.31 transitive. |
+| `rustls-pemfile` 1.0.4 | RUSTSEC-2025-0134 | Solana 2.x transitive. |
+| `ansi_term`, `atty`, `derivative`, `paste` | various unmaintained | Anchor 0.31 / Solana SDK 2.x build-time transitives. |
 
-**Risk evaluation:** The deployed program bytecode is fixed at deploy time and is not affected by these advisories at runtime — the vulnerable code paths live in build-time transitives, not in the on-chain bytecode. The 2026-05-08 redeploy (slot 418438627) used the same Anchor 0.31.1 / Solana 1.x toolchain, so the transitive-advisory profile is unchanged.
+**Risk evaluation:** The deployed program bytecode is fixed at deploy time and is not affected by these advisories at runtime — the vulnerable code paths live in build-time transitives, not in the on-chain bytecode. The 2026-05-10 redeploy (slot 418832804) used the same Anchor 0.31.1 / Solana SDK 2.2 toolchain, so the transitive-advisory profile is unchanged.
 
-**Resolution path:** Solana 2.x / `@solana/kit` migration is the next planned escrow redeploy. Tracking issues [#155](https://github.com/solvela-ai/solvela/issues/155) and [#156](https://github.com/solvela-ai/solvela/issues/156); no fixed target date — the deployed program is stable on mainnet and the migration will be coordinated with the broader ecosystem move.
+**Resolution path:** Solana 3.x / `@solana/kit` migration is the next planned escrow redeploy. Tracking issues [#155](https://github.com/solvela-ai/solvela/issues/155) and [#156](https://github.com/solvela-ai/solvela/issues/156) are closed-as-blocked (see [`STATUS.md`](./STATUS.md) — Anchor 1.0 drags Solana 3.x back in but still leaves cfg-hygiene warnings unfixed); revisit once the broader Solana 2.x → `@solana/kit` ecosystem migration is unblocked.
 
 ### npm (Solana web3.js 1.x ecosystem — `sdks/mcp`, `sdks/openclaw-provider`, `integrations/openclaw`)
 


### PR DESCRIPTION
Section 1 of the pre-1.0 docs accuracy sweep tracked in #410.

## Summary
- README and CLAUDE.md `cargo test -p x402` / `-p router` commands didn't match actual crate names; fixed.
- README Anthropic model IDs were in dotted form (`claude-sonnet-4.5`); registry expects dashed (`claude-sonnet-4-5`).
- README `cd crates/gateway && fly deploy` example fails because `fly.toml` is at repo root; corrected.
- README Go SDK example didn't compile against current signatures; replaced.
- CLAUDE.md Dockerfile base claimed `bookworm`; actual is `trixie`.
- SECURITY.md attributed escrow program to Solana 1.18 + Anchor 0.30; real per `Cargo.lock` is Anchor 0.31.1 + Solana SDK 2.2.1.

Full audit report: https://github.com/solvela-ai/solvela/issues/410#issuecomment-4566634037

## Test plan
- [ ] CI green (lints + builds)
- [ ] Visual review of the diff
- [ ] Spot-check one fixed command in a clean shell

Tracking: #410
