### PR TITLE
docs(audit/section-2): correct 402 wire shape, headers, encoding, status codes in docs site

### DIFF
--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -50,17 +50,7 @@ See [Smart Router](/docs/concepts/smart-router) for how profiles work.
 
 ### 402 Payment Required — no payment header
 
-When no `payment-signature` header is present, the gateway returns `402`. Parse `error.message` as JSON to get cost and payment instructions.
-
-```json
-{
-  "error": {
-    "message": "{\"x402_version\":2,\"resource\":{\"url\":\"/v1/chat/completions\",\"method\":\"POST\"},\"accepts\":[{\"scheme\":\"exact\",\"network\":\"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\",\"amount\":\"2625\",\"asset\":\"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\"pay_to\":\"<gateway-wallet>\",\"max_timeout_seconds\":300},{\"scheme\":\"escrow\",\"network\":\"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\",\"amount\":\"2625\",\"asset\":\"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\"pay_to\":\"<gateway-wallet>\",\"max_timeout_seconds\":300,\"escrow_program_id\":\"9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU\"}],\"cost_breakdown\":{\"provider_cost\":\"0.002500\",\"platform_fee\":\"0.000125\",\"total\":\"0.002625\",\"currency\":\"USDC\",\"fee_percent\":5},\"error\":\"Payment required\"}"
-  }
-}
-```
-
-The decoded `PaymentRequired` object has this structure:
+When no `payment-signature` header is present, the gateway returns `402` with the `PaymentRequired` object at the **top level** of the response body (x402-spec compliant — not wrapped in the OpenAI `{ "error": { ... } }` envelope). Parse the body as JSON directly:
 
 ```json
 {
@@ -74,6 +64,15 @@ The decoded `PaymentRequired` object has this structure:
       "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "pay_to": "<gateway-recipient-wallet>",
       "max_timeout_seconds": 300
+    },
+    {
+      "scheme": "escrow",
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "amount": "2625",
+      "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "pay_to": "<gateway-recipient-wallet>",
+      "max_timeout_seconds": 300,
+      "escrow_program_id": "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
     }
   ],
   "cost_breakdown": {
@@ -86,6 +85,23 @@ The decoded `PaymentRequired` object has this structure:
   "error": "Payment required"
 }
 ```
+
+The trailing `error` field is a plain string banner. The second `accepts` entry (`escrow_program_id` present) is only included when the gateway has an escrow program configured.
+
+### 402 Payment Required — invalid payment header
+
+A `payment-signature` header that fails to decode, replays a previous transaction, or fails on-chain verification returns `402` with the **OpenAI error envelope** (distinct from the no-payment shape above):
+
+```json
+{
+  "error": {
+    "type": "invalid_payment",
+    "message": "transaction has already been used; each payment signature may only be submitted once"
+  }
+}
+```
+
+`error.type` for this 402 is always `"invalid_payment"`; `error.message` is a plain-text reason string, never a JSON-encoded payload.
 
 ### 200 OK — successful completion
 

--- a/dashboard/content/docs/api/errors.mdx
+++ b/dashboard/content/docs/api/errors.mdx
@@ -6,47 +6,62 @@ description: HTTP status codes, error shapes, and how to handle common failures
 
 ## Error format
 
-All errors use the OpenAI error envelope. The `message` field contains a human-readable description.
+Most errors use the OpenAI-style envelope with `type` and `message`:
 
 ```json
 {
   "error": {
+    "type": "bad_request",
     "message": "description of what went wrong"
   }
 }
 ```
 
-For `402` responses specifically, `error.message` is a **JSON-encoded string** containing the full `PaymentRequired` object. You must parse it twice:
+**Exception: 402 without a payment header.** When the client has not supplied a `payment-signature` header, the gateway emits the x402-spec `PaymentRequired` object at the **top level** of the response body — not wrapped in `error.message`. Parse the body as JSON directly:
 
 ```typescript
 const body = await response.json();
-const paymentRequired = JSON.parse(body.error.message);
+if (response.status === 402 && body.x402_version) {
+  // Cost-quote 402 — body IS the PaymentRequired object
+  const cost = body.cost_breakdown;
+  const accepts = body.accepts;
+}
 ```
+
+**Other 402 cases** — invalid signature, replay, expired transaction, amount mismatch — use the OpenAI envelope with `type: "invalid_payment"` and a plain-text `message`. Distinguish the two shapes by checking for the top-level `x402_version` field.
 
 ## HTTP status codes
 
 | Code | Name | When it occurs |
 |------|------|----------------|
 | `200` | OK | Request succeeded |
-| `400` | Bad Request | Invalid parameters, unsupported model, message limit exceeded |
+| `400` | Bad Request | Invalid parameters, message limit exceeded, payment field validation (amount, network, asset, pay_to mismatch) |
+| `401` | Unauthorized | Missing or invalid admin token / API key on enterprise endpoints |
 | `402` | Payment Required | No `payment-signature` header, or payment verification failed |
-| `404` | Not Found | Unknown endpoint |
+| `403` | Forbidden | Authenticated but lacking permission (e.g. member role calling admin-only org endpoints) |
+| `404` | Not Found | Unknown endpoint, or `model` ID not in the registry (`type: model_not_found`) |
 | `429` | Too Many Requests | Rate limit exceeded |
-| `500` | Internal Server Error | Gateway error (bug or misconfiguration) |
-| `502` | Bad Gateway | Upstream provider returned an error |
-| `503` | Service Unavailable | Gateway temporarily unavailable |
+| `500` | Internal Server Error | Gateway error (bug or misconfiguration), or all configured providers failed |
+| `502` | Bad Gateway | Upstream provider returned an error (`type: provider_error`) |
+| `503` | Service Unavailable | Required dependency unavailable (e.g. Prometheus recorder, database, or marketplace target marked unhealthy) |
 
 ## Common errors and fixes
 
 ### 402 — No payment
 
 ```json
-{ "error": { "message": "<json-encoded PaymentRequired>" } }
+{
+  "x402_version": 2,
+  "resource": { "url": "/v1/chat/completions", "method": "POST" },
+  "accepts": [ { "scheme": "exact", "amount": "...", "pay_to": "...", "...": "..." } ],
+  "cost_breakdown": { "total": "...", "currency": "USDC", "fee_percent": 5, "...": "..." },
+  "error": "Payment required"
+}
 ```
 
 **Cause:** No `payment-signature` header was included.
 
-**Fix:** Parse the `PaymentRequired` from `error.message`, build and sign a Solana USDC-SPL transaction for the `amount` to the `pay_to` address, encode it as a `PaymentPayload`, base64-encode, and resend with the `payment-signature` header.
+**Fix:** The body **is** the `PaymentRequired` object (top-level fields, no OpenAI envelope). Read `accepts[0].amount` and `accepts[0].pay_to`, build and sign a Solana USDC-SPL transaction, wrap the signed bytes in a `PaymentPayload`, base64-encode the JSON, and resend with the `payment-signature` header.
 
 See [x402 Protocol](/docs/concepts/x402) for the full flow.
 
@@ -55,17 +70,22 @@ See [x402 Protocol](/docs/concepts/x402) for the full flow.
 ### 402 — Payment verification failed
 
 ```json
-{ "error": { "message": "payment verification failed: ..." } }
+{
+  "error": {
+    "type": "invalid_payment",
+    "message": "Payment verification failed. Check your transaction and retry."
+  }
+}
 ```
 
-**Cause:** The `payment-signature` header was present but the transaction could not be verified on Solana.
+**Cause:** The `payment-signature` header was present but the transaction could not be verified on Solana. The gateway intentionally returns a generic message — server-side detail (RPC errors, signer mismatch) is in the gateway logs, not the response.
 
 **Common reasons:**
 - Transaction not yet confirmed — retry after a few seconds
-- Wrong recipient address (`pay_to` mismatch)
-- Wrong asset (not USDC-SPL mint)
-- Wrong network (not Solana mainnet)
-- Amount below the required minimum
+- Wrong recipient address (`pay_to` mismatch) — separate error: `"Payment recipient does not match. Use the pay_to advertised in the 402 response."` (returned as 400 Bad Request)
+- Wrong asset (not USDC-SPL mint) — separate 400: `"Payment asset is unsupported. Use the asset advertised in the 402 response."`
+- Wrong network (not Solana mainnet) — separate 400: `"Payment network is unsupported. Use the network advertised in the 402 response."`
+- Settlement not confirmed: `"Payment transaction could not be confirmed. Please retry."`
 
 ---
 
@@ -81,11 +101,18 @@ See [x402 Protocol](/docs/concepts/x402) for the full flow.
 
 ---
 
-### 400 — Model not found
+### 404 — Model not found
 
 ```json
-{ "error": { "message": "model not found: 'my-custom-model'" } }
+{
+  "error": {
+    "type": "model_not_found",
+    "message": "model not found: my-custom-model"
+  }
+}
 ```
+
+**Status code:** `404 Not Found` (the model-not-found path returns 404, not 400 — see `GatewayError::ModelNotFound` in `crates/gateway/src/error.rs`).
 
 **Cause:** The `model` field contains an ID that isn't in the registry.
 
@@ -148,9 +175,14 @@ See [x402 Protocol](/docs/concepts/x402) for the full flow.
 ### 429 — Rate limited
 
 ```json
-{ "error": { "message": "rate limit exceeded" } }
+{
+  "error": {
+    "type": "rate_limit_exceeded",
+    "message": "Too many requests. Please slow down."
+  }
+}
 ```
 
-**Cause:** Too many requests from this IP or wallet within the rate limit window.
+**Cause:** Too many requests from this client (payer wallet, falling back to source IP) within the rate-limit window.
 
-**Fix:** Back off and retry. The default ceiling is **60 requests per 60-second sliding window** per wallet/IP — use the `X-RateLimit-Reset` header to time retries rather than a fixed backoff. See [Rate Limits](/docs/api/rate-limits).
+**Fix:** Back off and retry. The default ceiling is **60 requests per 60-second fixed window** per identified client (10 for the shared "unknown" bucket when neither a wallet nor a source IP can be derived) — use the `X-RateLimit-Reset` header or the `Retry-After` header to time retries rather than a fixed backoff. See [Rate Limits](/docs/api/rate-limits).

--- a/dashboard/content/docs/api/index.mdx
+++ b/dashboard/content/docs/api/index.mdx
@@ -38,7 +38,7 @@ All endpoints accept and return `application/json`. Streaming responses use SSE 
 | `payment-signature: <value>` | Required for paid endpoints (chat completions) |
 | `X-Request-Id: <uuid>` | Optional — tracked in usage logs |
 | `X-Session-Id: <string>` | Optional — correlates requests in a session |
-| `X-Debug-Payment: true` | Optional — returns cost breakdown in response headers |
+| `X-Solvela-Debug: true` | Optional — attaches routing diagnostics (`X-Solvela-Model`, `-Tier`, `-Score`, `-Provider`, `-Cache`, `-Payment-Status`, etc.) to the response. Legacy `X-RCR-Debug` is also accepted. |
 
 ## Endpoints
 
@@ -64,21 +64,22 @@ All endpoints accept and return `application/json`. Streaming responses use SSE 
 
 ## Rate limiting
 
-The gateway enforces per-IP and per-wallet rate limits. The default is **60 requests per 60-second sliding window** per wallet (and the same per IP, before wallet identity is established). Always read `X-RateLimit-Limit` and `X-RateLimit-Reset` from response headers rather than hardcoding expected values. Exceeding the limit returns `429 Too Many Requests`. Enterprise API keys can override these limits — see [Rate Limits](/docs/api/rate-limits).
+The gateway enforces a per-client rate limit, identifying the client as the payer wallet derived from the signed transaction first, then falling back to the TCP peer IP, then to a stricter shared "unknown" bucket. The default is **60 requests per 60-second fixed window** per identified client (10 for the shared unknown bucket). Always read `X-RateLimit-Limit` and `X-RateLimit-Reset` from response headers rather than hardcoding expected values. Exceeding the limit returns `429 Too Many Requests`. See [Rate Limits](/docs/api/rate-limits).
 
 ## Error format
 
-All errors use the OpenAI error envelope:
+Most errors use the OpenAI-style envelope with `type` and `message`:
 
 ```json
 {
   "error": {
+    "type": "bad_request",
     "message": "human-readable description"
   }
 }
 ```
 
-For `402` responses, `error.message` contains a JSON-encoded `PaymentRequired` object. See [Error Reference](/docs/api/errors) for the full list of status codes.
+**Exception:** a 402 returned because no `payment-signature` header was supplied emits the `PaymentRequired` object at the **top level** of the response body — not wrapped in an envelope. See [Error Reference](/docs/api/errors) for the full list of status codes and shapes.
 
 <Note>
   The gateway degrades gracefully when Redis or PostgreSQL are unavailable. Redis absence disables response caching and falls back to in-memory replay protection. PostgreSQL absence disables spend logging and budget enforcement.

--- a/dashboard/content/docs/concepts/payment-flow.mdx
+++ b/dashboard/content/docs/concepts/payment-flow.mdx
@@ -272,7 +272,7 @@ The official SDKs expose a **per-call** payment cap (the maximum amount they wil
 <Accordion title="Payment invalid — signature cannot be verified">
   **HTTP status:** `402 Payment Required` (new 402, not 200)
 
-  The gateway could not verify the signature. Common causes: wrong `pay_to` address, wrong `amount`, or a malformed base58 encoding in the header. Parse the new 402 response and re-sign with the updated parameters.
+  The gateway could not verify the signature. Common causes: wrong `pay_to` address, wrong `amount`, or a malformed `payment-signature` header (the header itself must be base64-encoded JSON, and the inner `payload` field must be the base64-encoded signed Solana versioned transaction). Parse the new 402 response and re-sign with the updated parameters.
 </Accordion>
 
 <Accordion title="Payment insufficient — amount too low">

--- a/dashboard/content/docs/concepts/payment-flow.mdx
+++ b/dashboard/content/docs/concepts/payment-flow.mdx
@@ -28,20 +28,9 @@ If you are using the TypeScript, Python, Rust, or Go SDK, you never need to impl
   </Step>
 
   <Step title="Parse the 402 response">
-    The 402 body wraps the `PaymentRequired` object inside an OpenAI-style `error.message` field as a JSON string. Parse `error.message` as JSON to access the fields.
+    The 402 body **is** the `PaymentRequired` object at the top level — not wrapped in the OpenAI `{ "error": { ... } }` envelope. Parse the response body directly as JSON.
 
     ```json title="402 response body (wire shape)"
-    {
-      "error": {
-        "type": "invalid_payment",
-        "message": "{\"x402_version\":2,\"resource\":{\"url\":\"/v1/chat/completions\",\"method\":\"POST\"},\"accepts\":[{\"scheme\":\"exact\",\"network\":\"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\",\"amount\":\"2625\",\"asset\":\"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\"pay_to\":\"<gateway-recipient-wallet>\",\"max_timeout_seconds\":300},{\"scheme\":\"escrow\",\"network\":\"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\",\"amount\":\"2625\",\"asset\":\"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\"pay_to\":\"<gateway-recipient-wallet>\",\"max_timeout_seconds\":300,\"escrow_program_id\":\"9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU\"}],\"cost_breakdown\":{\"provider_cost\":\"0.002500\",\"platform_fee\":\"0.000125\",\"total\":\"0.002625\",\"currency\":\"USDC\",\"fee_percent\":5},\"error\":\"Payment required\"}"
-      }
-    }
-    ```
-
-    Once you `JSON.parse(error.message)`, the inner `PaymentRequired` looks like:
-
-    ```json title="Parsed PaymentRequired"
     {
       "x402_version": 2,
       "resource": { "url": "/v1/chat/completions", "method": "POST" },
@@ -75,6 +64,21 @@ If you are using the TypeScript, Python, Rust, or Go SDK, you never need to impl
     }
     ```
 
+    The trailing `error` field is a plain string banner, not an OpenAI error object. A second `accepts` entry (with `escrow_program_id`) only appears when the gateway has an escrow program configured.
+
+    A 402 returned for an **invalid** payment header (malformed, replayed, expired, amount-insufficient, etc.) uses the conventional OpenAI envelope instead:
+
+    ```json title="Invalid-payment 402 (distinct shape)"
+    {
+      "error": {
+        "type": "invalid_payment",
+        "message": "transaction has already been used; each payment signature may only be submitted once"
+      }
+    }
+    ```
+
+    Distinguish the two shapes by checking for the top-level `x402_version` field.
+
     <Warning>
     The `asset` field is the **SPL mint address** of the token being requested, not a symbolic name. For mainnet USDC this is always `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Verify this byte-for-byte in your client before signing — older drafts of the protocol used the literal string `"USDC-SPL"` and clients hardcoded against that will silently skip mint validation. The `network` field uses CAIP-2 form (`solana:<cluster-genesis-hash>`); the trailing identifier is the mainnet cluster genesis hash.
     </Warning>
@@ -105,7 +109,7 @@ If you are using the TypeScript, Python, Rust, or Go SDK, you never need to impl
       }'
     ```
 
-    The `PaymentPayload` envelope itself contains `scheme`, `network`, and a `payload` field with the base58-encoded signed transaction bytes. The outer header value is base64-encoded JSON; the inner signed transaction is base58. See [x402 Protocol](/docs/concepts/x402) for the exact shape.
+    The `PaymentPayload` envelope itself contains `x402_version`, `resource`, an `accepted` block (one entry from the 402 `accepts` array), and a `payload` field with the **base64**-encoded signed Solana versioned transaction bytes. The outer header value is base64-encoded JSON; the inner signed transaction is also base64 (Solana versioned-tx wire bytes). See [x402 Protocol](/docs/concepts/x402) for the exact shape.
   </Step>
 
   <Step title="Receive the LLM response">
@@ -259,9 +263,9 @@ All official SDKs support a `sessionBudget` option that caps total spending for 
 </Accordion>
 
 <Accordion title="Payment insufficient — amount too low">
-  **HTTP status:** `402 Payment Required` (new 402)
+  **HTTP status:** `400 Bad Request` with `error.type = "bad_request"` and message `"payment amount insufficient: paid {N} but cost is {M} atomic USDC"`.
 
-  The signed amount is less than the required `amount` in the accepts object. This can happen if prices change between your first 402 and your retry. The new 402 will contain the current required amount — re-sign and retry.
+  The signed amount is less than the required `amount` in the accepts object. This can happen if prices change between your first 402 and your retry. Resend the request without `payment-signature` to fetch a fresh quote, then re-sign for the new amount and retry.
 </Accordion>
 
 <Accordion title="Payment expired — max_timeout_seconds exceeded">
@@ -277,9 +281,7 @@ All official SDKs support a `sessionBudget` option that caps total spending for 
 </Accordion>
 
 <Accordion title="Wallet balance too low">
-  **HTTP status:** `402 Payment Required` (new 402, with an additional `error` field)
-
-  The gateway detected that your wallet does not hold enough USDC-SPL to cover the payment. Top up your wallet and retry. The 402 payload will include `"error": "insufficient_balance"` to distinguish this from other 402 reasons.
+  The gateway does not pre-check your wallet balance — it submits the signed transaction and surfaces the on-chain failure. If your wallet is short of USDC-SPL (or short of SOL for the signature fee), the transfer fails at the cluster, the gateway's facilitator reports settlement failure, and you receive a generic `402 invalid_payment` with `message: "Payment verification failed. Check your transaction and retry."`. Top up the wallet and re-sign with a fresh blockhash.
 </Accordion>
 
 <Warning>

--- a/dashboard/content/docs/concepts/payment-flow.mdx
+++ b/dashboard/content/docs/concepts/payment-flow.mdx
@@ -193,17 +193,26 @@ The `accepts` array may contain one or both payment schemes. Choose based on you
 
 ---
 
-## Session Budgets
+## Spend Caps
 
-All official SDKs support a `sessionBudget` option that caps total spending for the lifetime of a client instance. Once the budget is reached, the SDK throws rather than signing another payment.
+The official SDKs expose a **per-call** payment cap (the maximum amount they will sign for in one chat call) rather than a session-wide budget. The cap rejects the payment client-side before signing if the gateway's quoted amount exceeds it, preventing a misconfigured or attacker-controlled 402 from charging more than expected.
 
 <Tabs items={["TypeScript", "Python", "Rust", "Go"]}>
   <Tab value="TypeScript">
     ```typescript
+    import { SolvelaClient, Wallet, KeypairSigner } from '@solvela/sdk';
+
+    // @solvela/sdk caps spend per call, not per session.
+    // Track lifetime spend yourself if you need a session-wide budget.
+    const wallet = Wallet.fromEnv('SOLANA_PRIVATE_KEY');
+    const signer = new KeypairSigner(wallet);
     const client = new SolvelaClient({
-      endpoint: "https://api.solvela.ai",
-      walletKey: process.env.SOLANA_PRIVATE_KEY,
-      sessionBudget: "0.10", // max $0.10 USDC this session
+      wallet,
+      signer,
+      config: {
+        gatewayUrl: 'https://api.solvela.ai',
+        // No per-session budget knob — see the Warning below.
+      },
     });
     ```
   </Tab>
@@ -226,11 +235,15 @@ All official SDKs support a `sessionBudget` option that caps total spending for 
   </Tab>
   <Tab value="Rust">
     ```rust
-    let client = SolvelaClient::builder()
-        .endpoint("https://api.solvela.ai")
-        .wallet_key(&env::var("SOLANA_PRIVATE_KEY")?)
-        .session_budget("0.10")
-        .build()?;
+    use solvela_client::{ClientConfig, SolvelaClient, Wallet};
+
+    // solvela-client caps spend per call, not per session.
+    // Track lifetime spend yourself if you need a session-wide budget.
+    let wallet = Wallet::from_env("SOLANA_PRIVATE_KEY")?;
+    let config = ClientConfig::new()
+        .gateway_url("https://api.solvela.ai")
+        .max_payment_amount(100_000); // per-call cap: 0.10 USDC atomic
+    let client = SolvelaClient::new(wallet, config)?;
     ```
   </Tab>
   <Tab value="Go">
@@ -249,7 +262,7 @@ All official SDKs support a `sessionBudget` option that caps total spending for 
 </Tabs>
 
 <Warning>
-**Important:** `sessionBudget` is a client-side guard only and does not communicate a limit to the server. For server-enforced limits, use enterprise team budgets. The SDK accumulates `cost_breakdown.total` values across all signed payments and stops signing once the sum exceeds the budget.
+**Important:** `max_payment_amount` / `maxPaymentAmount` is a client-side per-call guard only and does not communicate a limit to the server. For session-wide caps, track lifetime spend in your own code; for server-enforced spend ceilings, use enterprise team or wallet budgets (see [Budgets](/docs/enterprise/budgets)).
 </Warning>
 
 ---

--- a/dashboard/content/docs/concepts/x402.mdx
+++ b/dashboard/content/docs/concepts/x402.mdx
@@ -45,17 +45,7 @@ Solvela uses x402 to enable AI agents to pay for LLM API calls with USDC-SPL on 
 
 ## The 402 response
 
-When no `payment-signature` header is present, the gateway responds with `HTTP 402`. The body uses OpenAI error envelope format — the `PaymentRequired` JSON is inside `error.message` as a string.
-
-```json
-{
-  "error": {
-    "message": "<JSON-encoded PaymentRequired>"
-  }
-}
-```
-
-The decoded `PaymentRequired` object looks like:
+When no `payment-signature` header is present, the gateway responds with `HTTP 402` and emits the `PaymentRequired` body **at the top level** of the response — not wrapped in the OpenAI `{ "error": { ... } }` envelope. (Gateway behavior locked by `GatewayError::PaymentChallenge`; see issue #217.)
 
 ```json
 {
@@ -93,6 +83,8 @@ The decoded `PaymentRequired` object looks like:
   "error": "Payment required"
 }
 ```
+
+The trailing `error` field is a plain string banner, not the OpenAI error object. A 402 returned for an **invalid** payment header (malformed, replayed, expired) does use the OpenAI envelope with `error.type = "invalid_payment"` and a plain-text `error.message`. Distinguish the two shapes by checking for the top-level `x402_version` field.
 
 ### Fields
 

--- a/dashboard/content/docs/operations/deployment.mdx
+++ b/dashboard/content/docs/operations/deployment.mdx
@@ -100,10 +100,12 @@ Run:
 ```bash
 docker run -p 8402:8402 \
   -e OPENAI_API_KEY=sk-... \
-  -e SOLVELA_SOLANA_RPC_URL=https://api.devnet.solana.com \
-  -e SOLVELA_SOLANA_RECIPIENT_WALLET=your-wallet \
+  -e SOLVELA_SOLANA__RPC_URL=https://api.devnet.solana.com \
+  -e SOLVELA_SOLANA__RECIPIENT_WALLET=your-wallet \
   solvela
 ```
+
+The canonical env-var separator is **double underscore** (Fly.io convention; see `crates/gateway/src/main.rs:70`). The legacy single-underscore form (`SOLVELA_SOLANA_RPC_URL`) is also accepted as a fallback so existing deployments keep working.
 
 ## Fly.io Deployment
 
@@ -155,9 +157,9 @@ fly deploy
 ```bash
 fly secrets set OPENAI_API_KEY=sk-...
 fly secrets set ANTHROPIC_API_KEY=sk-ant-...
-fly secrets set SOLVELA_SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
-fly secrets set SOLVELA_SOLANA_RECIPIENT_WALLET=your-wallet-pubkey
-fly secrets set SOLVELA_SOLANA_FEE_PAYER_KEY=your-fee-payer-key
+fly secrets set SOLVELA_SOLANA__RPC_URL=https://api.mainnet-beta.solana.com
+fly secrets set SOLVELA_SOLANA__RECIPIENT_WALLET=your-wallet-pubkey
+fly secrets set SOLVELA_SOLANA__FEE_PAYER_KEY=your-fee-payer-key
 fly secrets set SOLVELA_ADMIN_TOKEN=your-admin-token
 fly secrets set DATABASE_URL=postgres://...
 fly secrets set REDIS_URL=redis://...
@@ -173,14 +175,14 @@ Fly.io probes `GET /health` every 15 seconds with a 5-second timeout and 10-seco
 Before deploying to production:
 
 - [ ] Set `SOLVELA_ENV=production` (disables localhost CORS origins)
-- [ ] Set `SOLVELA_ADMIN_TOKEN` (protects `/metrics` and `/v1/escrow/health`)
+- [ ] Set `SOLVELA_ADMIN_TOKEN` (protects `/metrics`, `/v1/escrow/health`, and the org-management endpoints)
 - [ ] Set `SOLVELA_SESSION_SECRET` to a stable value (auto-generated secret changes on restart)
-- [ ] Set `SOLVELA_SOLANA_RPC_URL` to a mainnet-beta endpoint
+- [ ] Set `SOLVELA_SOLANA__RPC_URL` to a mainnet-beta endpoint
 - [ ] Configure `DATABASE_URL` with production PostgreSQL credentials
 - [ ] Configure `REDIS_URL` with production Redis
 - [ ] Set `SOLVELA_CORS_ORIGINS` to your dashboard domain
 - [ ] Verify all provider API keys are set
-- [ ] Set `SOLVELA_SOLANA_RECIPIENT_WALLET` to your production wallet
-- [ ] Configure fee payer keys if using escrow
+- [ ] Set `SOLVELA_SOLANA__RECIPIENT_WALLET` to your production wallet
+- [ ] Configure fee payer keys if using escrow (`SOLVELA_SOLANA__FEE_PAYER_KEY` plus optional `_2` through `_8` for rotation)
 - [ ] Run `cargo test` and `cargo clippy` before deploying
 - [ ] Review `RUST_LOG` level (avoid `debug` in production)

--- a/dashboard/content/docs/operations/security.mdx
+++ b/dashboard/content/docs/operations/security.mdx
@@ -104,7 +104,7 @@ SDK and agent clients are unaffected by CORS since they do not run in browsers.
 
 Fee payer keys support rotation:
 
-- Primary key: `SOLVELA_SOLANA_FEE_PAYER_KEY`
+- Primary key: `SOLVELA_SOLANA__FEE_PAYER_KEY`
 - Additional keys: `SOLVELA_SOLANA__FEE_PAYER_KEY_2` through `_8`
 - The `FeePayerPool` rotates across healthy keys automatically
 - Failed keys enter a 60-second cooldown before reuse

--- a/dashboard/content/docs/operations/security.mdx
+++ b/dashboard/content/docs/operations/security.mdx
@@ -78,7 +78,7 @@ The following endpoints require `Authorization: Bearer <SOLVELA_ADMIN_TOKEN>`:
 
 Token comparison uses constant-time equality (`subtle::ConstantTimeEq` equivalent) to prevent timing attacks.
 
-If `SOLVELA_ADMIN_TOKEN` is not set, admin endpoints return 403.
+When `SOLVELA_ADMIN_TOKEN` is not set, the metrics endpoint is hidden and returns **404 Not Found** (rather than advertising its existence). Org-management endpoints that need an admin token return **503 Service Unavailable** with `"admin endpoint not configured"`. A request that supplies a wrong/missing token to a configured admin endpoint returns **401 Unauthorized**.
 
 ## CORS
 

--- a/dashboard/content/docs/operations/troubleshooting.mdx
+++ b/dashboard/content/docs/operations/troubleshooting.mdx
@@ -7,18 +7,19 @@ description: Common issues, debug headers, and diagnostics
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Gateway returns 503 for all chat requests | No provider API key configured | Set at least one provider key in `.env` (e.g., `OPENAI_API_KEY`) |
-| 402 response but SDK does not auto-pay | Wallet key not configured | Set `SOLANA_WALLET_KEY` environment variable |
+| Paid chat requests return 500 with `error.type = "internal_error"` and `"all providers failed"` | No upstream provider API key configured for the resolved model's provider | Set at least one matching provider key in `.env` (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `DEEPSEEK_API_KEY`) and restart the gateway |
+| 402 response but SDK does not auto-pay | Wallet key env var not set, or read under the wrong name (the CLI reads `SOLANA_WALLET_KEY`; the TypeScript/Python SDK examples read `SOLANA_PRIVATE_KEY` — the env var name is whatever you pass to `Wallet.fromEnv()` / `Wallet.from_env()`) | Set the env var your code reads and verify the value is a base58-encoded Solana keypair |
 | 402 returned with `accepts[0].amount: "0"` | Using a free model (`gpt-oss-120b`) | Free models do not require payment; remove the `PAYMENT-SIGNATURE` header |
 | Redis connection refused | Redis not running | Run `docker compose up -d redis` |
-| "replay detected" error | Same transaction signature sent twice | Generate a new transaction for each request |
-| "insufficient amount" error | Payment amount less than quoted price | Use `accepts[0].amount` from the 402 response (atomic units: 1 USDC = 1,000,000) |
-| "recipient mismatch" error | Payment sent to wrong wallet | Send to `accepts[0].pay_to` from the 402 response |
-| 429 Too Many Requests | Per-wallet rate limit exceeded | Wait for the `Retry-After` period, then retry |
-| 500 Internal Server Error on chat | Provider returned unexpected response | Check `RUST_LOG=gateway=debug` for details |
-| "unknown model" error | Model ID not in registry | Use `GET /v1/models` to list valid model IDs |
+| 402 `"transaction has already been used; each payment signature may only be submitted once"` | Same transaction signature submitted twice | Generate a new transaction for each request |
+| 400 `"payment amount insufficient: paid N but cost is M atomic USDC"` | Signed amount less than the quoted price | Fetch a fresh 402, use `accepts[0].amount` exactly (atomic units: 1 USDC = 1,000,000) |
+| 400 `"Payment recipient does not match. Use the pay_to advertised in the 402 response."` | Payment sent to wrong wallet | Send to `accepts[0].pay_to` from the 402 response |
+| 429 Too Many Requests | Per-client rate limit exceeded (payer wallet → IP fallback) | Wait until `X-RateLimit-Reset` (also surfaced as `Retry-After`), then retry |
+| 502 Bad Gateway with `error.type = "provider_error"` | Upstream LLM provider returned an error | Check `RUST_LOG=gateway=debug` for sanitised details (raw provider errors are redacted from the response) |
+| 404 `model not found: …` (`error.type = "model_not_found"`) | Model ID not in registry | Use `GET /v1/models` to list valid model IDs |
 | Escrow claim failures | Fee payer SOL balance too low | Fund fee payer wallets; check `GET /v1/escrow/health` |
-| Metrics endpoint returns 403 | `SOLVELA_ADMIN_TOKEN` not set or wrong token | Set `SOLVELA_ADMIN_TOKEN` (or `RCR_ADMIN_TOKEN` for backward compat) and use `Authorization: Bearer <token>` |
+| Metrics endpoint returns 404 | `SOLVELA_ADMIN_TOKEN` not set — endpoint is hidden when no token is configured | Set `SOLVELA_ADMIN_TOKEN` (or `RCR_ADMIN_TOKEN` for backward compat) and use `Authorization: Bearer <token>` |
+| Metrics endpoint returns 401 | Token configured but request omitted/sent wrong `Authorization: Bearer …` header | Send `Authorization: Bearer $SOLVELA_ADMIN_TOKEN` |
 | Wallet stats returns 503 | PostgreSQL not configured | Set `DATABASE_URL` in `.env` |
 | CORS errors in browser | Origin not in allowlist | Add your domain to `SOLVELA_CORS_ORIGINS` (or `RCR_CORS_ORIGINS` for backward compat) |
 | Slow responses (>10s) | Provider latency or network issues | Check `solvela_provider_request_duration_seconds` metric; try a different provider |

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -138,13 +138,30 @@ First, send a request without any payment header. The gateway will respond with 
       }'
     ```
 
-    You will get a `402` response. The body looks like:
+    You will get a `402` response. The body is the `PaymentRequired` object at the top level (x402-spec compliant — not wrapped in an OpenAI error envelope):
 
     ```json
     {
-      "error": {
-        "message": "{\"x402_version\":2,\"resource\":{\"url\":\"/v1/chat/completions\",\"method\":\"POST\"},\"accepts\":[{\"scheme\":\"exact\",\"network\":\"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\",\"amount\":\"315\",\"asset\":\"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\"pay_to\":\"<gateway-wallet>\",\"max_timeout_seconds\":300}],\"cost_breakdown\":{\"provider_cost\":\"0.000300\",\"platform_fee\":\"0.000015\",\"total\":\"0.000315\",\"currency\":\"USDC\",\"fee_percent\":5},\"error\":\"Payment required\"}"
-      }
+      "x402_version": 2,
+      "resource": { "url": "/v1/chat/completions", "method": "POST" },
+      "accepts": [
+        {
+          "scheme": "exact",
+          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "amount": "315",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "pay_to": "<gateway-wallet>",
+          "max_timeout_seconds": 300
+        }
+      ],
+      "cost_breakdown": {
+        "provider_cost": "0.000300",
+        "platform_fee": "0.000015",
+        "total": "0.000315",
+        "currency": "USDC",
+        "fee_percent": 5
+      },
+      "error": "Payment required"
     }
     ```
   </Tab>
@@ -156,7 +173,7 @@ First, send a request without any payment header. The gateway will respond with 
 
 ## Parse the 402 response
 
-The `error.message` field contains a JSON-encoded `PaymentRequired` object. Parse it to get the cost and the accepted payment schemes.
+The body **is** the `PaymentRequired` object — parse it directly to get the cost and the accepted payment schemes:
 
 ```json
 {
@@ -183,7 +200,7 @@ The `error.message` field contains a JSON-encoded `PaymentRequired` object. Pars
 }
 ```
 
-The `amount` field is in **atomic USDC units** (6 decimal places). `315` means `$0.000315 USDC`.
+The `amount` field is in **atomic USDC units** (6 decimal places). `315` means `$0.000315 USDC`. The trailing `error` field is a plain string banner — not the OpenAI `{ error: { ... } }` envelope.
 
 </Step>
 


### PR DESCRIPTION
Section 2 of the pre-1.0 docs accuracy sweep tracked in #410.

## Summary
**Highest-impact bug in the whole audit.** The 402 response wire shape was documented incorrectly in six separate docs (`quickstart`, `api/chat-completions`, `api/errors`, `api/index`, `concepts/x402`, `concepts/payment-flow`). Docs described `PaymentRequired` wrapped in `{"error":{"message":"<json-string>"}}`; gateway has emitted it at the top level since #217, locked by `test_payment_challenge_emits_top_level_payment_required`. Clients built against the old docs would have shipped broken 402 parsers.

Other fixes:
- Debug header is `X-Solvela-Debug`, not `X-Debug-Payment`.
- Inner signed Solana transaction is base64, not base58.
- `ModelNotFound` returns 404 (not 400); metrics-unauthorized returns 404/401 (not 403); paid-no-provider returns 500 (not 503).
- Fabricated `insufficient_balance` 402 variant removed (no such code path).
- Fabricated `SolvelaClient.builder()...` API replaced with real constructor signatures.
- `SOLVELA_SOLANA_*` env-var examples switched to canonical double-underscore form per CLAUDE.md.

Full audit report: https://github.com/solvela-ai/solvela/issues/410#issuecomment-4566639263

Verification: `npm --prefix dashboard run build` passes after both commits — all 38 docs paths compile.

## Test plan
- [ ] CI green
- [ ] `npm --prefix dashboard run build` reproduces locally
- [ ] Visual diff review for prose drift

Tracking: #410
