### PR TITLE
docs(audit/section-3): fix SDK README + per-SDK doc inaccuracies

### DIFF
--- a/dashboard/content/docs/sdks/ai-sdk.mdx
+++ b/dashboard/content/docs/sdks/ai-sdk.mdx
@@ -480,9 +480,8 @@ No. Every request requires a valid wallet adapter. For testing, use `createLocal
 
 **Q: What model IDs are available?**
 
-See the [Models reference](https://docs.solvela.ai/docs/api/models) or query the `/v1/models` endpoint:
+See the [Models reference](https://docs.solvela.ai/docs/api/models) or query the `/v1/models` endpoint (no auth required — model discovery is public):
 
 ```bash
-curl https://api.solvela.ai/v1/models \
-  -H "Authorization: Bearer $SOLVELA_API_KEY"
+curl https://api.solvela.ai/v1/models
 ```

--- a/dashboard/content/docs/sdks/rust.mdx
+++ b/dashboard/content/docs/sdks/rust.mdx
@@ -47,8 +47,9 @@ Send a chat completion request.
 ```bash
 solvela chat "Explain Solana in one sentence."
 
-# Specify a model
-solvela chat --model gpt-4o "Explain Solana in one sentence."
+# Specify a model (use the canonical provider/model_id form, or a known alias)
+solvela chat --model openai/gpt-4o "Explain Solana in one sentence."
+solvela chat --model sonnet "Explain Solana in one sentence."
 
 # Use a routing profile (eco, auto, premium, free)
 solvela chat --model auto "Complex analysis task..."

--- a/sdks/openclaw-provider/README.md
+++ b/sdks/openclaw-provider/README.md
@@ -6,17 +6,18 @@ transparently via the x402 protocol using USDC on Solana.
 
 ## Install
 
-> **⚠️ Not yet published to npm.** `@solvela/openclaw-provider` is at `1.0.0-draft`
-> and `"private": true` in `package.json`. Until first publish, install from a
-> local checkout:
+> **⚠️ Not yet published to npm.** `@solvela/openclaw-provider` is at `0.1.0`
+> in `package.json` (not published; intended to ship under
+> `@solvela/openclaw-provider` when distribution is greenlit). Until first
+> publish, install from a local checkout:
 >
 > ```bash
 > npm install /path/to/sdks/openclaw-provider
 > ```
 >
-> The `@solvela/sdk` dependency is wired as `file:../typescript` during
-> development; it switches to a real npm version range when this package is
-> published.
+> The `@solvela/signer-core` dependency (shared x402 primitives) is wired as
+> `file:../signer-core` in the lockfile during development; the manifest
+> declares `^0.1.0`, which will resolve from npm once `signer-core` ships.
 
 Once published, the canonical install will be:
 
@@ -100,8 +101,8 @@ header into every outbound inference request **before** the stream fires:
 1. Before each call, the plugin probes the gateway with the request body to
    obtain a 402 PaymentRequired response containing the cost and accepted
    payment schemes.
-2. The plugin calls `createPaymentHeader` from `@solvela/sdk` to produce a
-   base64-encoded signed USDC transaction.
+2. The plugin calls `createPaymentHeader` from `@solvela/signer-core` to
+   produce a base64-encoded signed USDC transaction.
 3. The `payment-signature` header is injected into the outbound request.
 4. The original stream function executes with the signed header.
 
@@ -147,8 +148,8 @@ npm test                  # Run all tests
 ## Publishing
 
 **Do not publish** until Phase 4 approval. The `package.json` version is
-`1.0.0-draft` to signal pre-release status. Publishing is gated on private
-user testing (Phase 3) and a go/no-go from the user before Phase 4 distribution.
+`0.1.0` and publishing is gated on private user testing (Phase 3) plus a
+go/no-go from the user before Phase 4 distribution.
 
 ## Documentation
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -34,7 +34,7 @@ async def main():
         print(f"  {m.id} — {m.display_name}")
 
     # Estimate cost (triggers 402)
-    cost = await client.estimate_cost("gpt-4o")
+    cost = await client.estimate_cost("openai/gpt-4o")
     print(f"Cost: {cost.cost_breakdown.total} {cost.cost_breakdown.currency}")
 
 asyncio.run(main())
@@ -51,7 +51,7 @@ openai = OpenAICompat(client)
 
 # Same interface as the OpenAI Python SDK
 response = await openai.chat.completions.create(
-    model="gpt-4o",
+    model="openai/gpt-4o",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 ```

--- a/sdks/python/docs/RELEASE_CHECKLIST.md
+++ b/sdks/python/docs/RELEASE_CHECKLIST.md
@@ -14,7 +14,7 @@ Tests in this repo split into three tiers, each catching a different class of bu
 | **Integration** | `tests/integration/` | seconds | HTTP shape, header names, JSON encoding (via mocked transport) | Whether the real gateway agrees with your fixture |
 | **Live** | `tests/live/` | depends | The actual wire contract against a running gateway | Performance under load, real-user concurrency |
 
-CI (GitHub Actions) runs Unit + Integration on every push for Python 3.10, 3.11, 3.12. Live tests are gated by `SOLVELA_LIVE_TESTS=1` and never run in CI — you run them yourself.
+CI (GitHub Actions) runs Unit + Integration on every push for Python 3.10 and 3.12 (oldest-supported + current, per `.github/workflows/sdks-python.yml`). Live tests are gated by `SOLVELA_LIVE_TESTS=1` and never run in CI — you run them yourself.
 
 ---
 
@@ -60,7 +60,7 @@ gh pr checks <PR-number>
 ```
 
 **What CI catches that local doesn't:**
-- Differences between Python 3.10, 3.11, 3.12 (you have one local Python; CI has all three)
+- Differences between Python 3.10 and 3.12 (you have one local Python; CI runs both)
 - Forgotten files (`git add` missed something) — CI installs from a fresh clone, so anything not committed breaks the build
 
 **Doesn't catch:** anything live or wallet-related.
@@ -166,36 +166,44 @@ SOLVELA_GATEWAY_URL=https://your-staging-gateway .venv/bin/python scripts/smoke.
 
 ## Cycle 5 — Tag a release
 
-The release pipeline (`.github/workflows/release-pypi.yml`) fires when you push a `v*` tag. It:
+> **Status (2026-05):** There is no tag-triggered PyPI publish workflow in the
+> monorepo yet — `.github/workflows/sdks-python.yml` only runs lint + tests.
+> Until that workflow lands, releases are cut by manually running `python -m
+> build && python -m twine upload dist/*` after bumping `pyproject.toml`. The
+> steps below describe the target automated flow (mirrors the tag-triggered
+> publish workflows already in place for `sdks/rust/` and `sdks/typescript/`).
 
-1. Verifies the git tag matches `pyproject.toml`'s `version` (refuses to publish if they disagree).
-2. Builds the wheel + sdist.
-3. Publishes to PyPI via OIDC Trusted Publishing (no API token needed).
-4. Emits PEP 740 attestations (cryptographic proof the release came from this repo).
-5. Creates a GitHub Release.
+When the publish workflow is wired up, it will fire on a `sdks/python/v*` tag and:
+
+1. Verify the git tag matches `pyproject.toml`'s `version` (refuses to publish if they disagree).
+2. Build the wheel + sdist.
+3. Publish to PyPI via OIDC Trusted Publishing (no API token needed).
+4. Emit PEP 740 attestations (cryptographic proof the release came from this repo).
+5. Create a GitHub Release.
 
 ### Steps
 
 ```bash
 # 1. Bump the version in pyproject.toml. Use semver:
-#    - 0.1.3 -> 0.1.4 for bug fixes
-#    - 0.1.4 -> 0.2.0 for new features (breaking is OK pre-1.0)
+#    - 0.2.0 -> 0.2.1 for bug fixes
+#    - 0.2.x -> 0.3.0 for new features (breaking is OK pre-1.0)
 #    - 0.x   -> 1.0.0 when you're ready to commit to API stability
-$EDITOR pyproject.toml   # change `version = "0.1.3"` to whatever
+$EDITOR sdks/python/pyproject.toml   # change `version = "0.2.0"` to whatever
 
 # 2. Commit the bump on its own.
-git add pyproject.toml
-git commit -m "chore(release): bump to 0.1.4"
-git push origin main
+git add sdks/python/pyproject.toml
+git commit -m "chore(release): bump solvela-sdk to 0.2.1"
+# push branch + open PR; merge after CI is green
 
 # 3. Tag it (annotated, with a message).
-git tag -a v0.1.4 -m "Release 0.1.4: review fixes for #7, #8, #11, #12"
-git push origin v0.1.4
+git tag -a sdks/python/v0.2.1 -m "solvela-sdk 0.2.1"
+git push origin sdks/python/v0.2.1
 
-# 4. Watch the release workflow.
-gh run watch
-# or
-gh run list --workflow=release-pypi.yml --limit 1
+# 4. (Today, while no publish workflow exists) cut the release manually:
+cd sdks/python
+.venv/bin/python -m pip install build twine
+.venv/bin/python -m build
+.venv/bin/python -m twine upload dist/*
 ```
 
 **Pass criteria:** the workflow finishes green, and the package shows up on https://pypi.org/project/solvela-sdk/.
@@ -243,16 +251,16 @@ For a week after a release, watch:
 
 ---
 
-## What I would do for THIS release
+## What I would do for any release
 
-You just merged 4 PRs (#7, #8, #11, #12). My honest recommendation in priority order:
+Priority order:
 
 1. **Cycle 1** locally on `main`. (~30 sec) — sanity check the merged result.
 2. **Cycle 4** — manual smoke test against any reachable gateway, even a local docker-compose dev gateway. (~1 min)
 3. If a staging gateway exists, **Cycle 3** live tests. (~30 sec)
-4. **Cycle 5** — bump to `0.1.4`, tag, push. The post-release Cycle 6 watching is automatic if you check email for GitHub notifications.
+4. **Cycle 5** — bump the patch/minor in `pyproject.toml`, tag, push. The post-release Cycle 6 watching is automatic if you check email for GitHub notifications.
 
-If no gateway is reachable at all, you can ship to PyPI as `0.1.4-rc1` (release candidate), let yourself or a friend pip-install it, run the smoke test, and only then promote to `0.1.4`. That's the lowest-risk path that doesn't require infrastructure.
+If no gateway is reachable at all, you can ship to PyPI as a release candidate (e.g. `0.2.1-rc1`), let yourself or a friend pip-install it, run the smoke test, and only then promote to the real version. That's the lowest-risk path that doesn't require infrastructure.
 
 ---
 

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -7,7 +7,7 @@ for unmodified OpenAI-format clients.
 
 ## Crates
 
-All four are published to crates.io at `0.2.1`.
+All four are published to crates.io at `0.2.3`.
 
 | Crate | crates.io | Purpose |
 |---|---|---|
@@ -121,17 +121,17 @@ was consolidated into the monorepo (PR
 
 ## Releases
 
-The four crates are published to crates.io at **`0.2.1`**:
+The four crates are published to crates.io at **`0.2.3`**:
 [`solvela-client`](https://crates.io/crates/solvela-client),
 [`solvela-client-cli`](https://crates.io/crates/solvela-client-cli),
 [`solvela-client-cli-args`](https://crates.io/crates/solvela-client-cli-args),
 [`solvela-client-proxy`](https://crates.io/crates/solvela-client-proxy).
 
-A monorepo-native publish workflow (tag-triggered on `sdks/rust/v*`) is a
-pending runbook step — the crates.io credentials are already in place, but
-until the workflow lands the publish step is run manually. The previous
-tag-triggered workflow lived in the now-archived `solvela-ai/solvela-client`
-repo.
+Releases are cut by pushing a `sdks/rust/v*` tag, which triggers
+[`.github/workflows/sdk-rust-publish.yml`](../../.github/workflows/sdk-rust-publish.yml)
+to publish all four crates in dependency order with cargo's
+`--token $CARGO_REGISTRY_TOKEN`. The previous tag-triggered workflow lived in
+the now-archived `solvela-ai/solvela-client` repo.
 
 ## License
 

--- a/sdks/signer-core/README.md
+++ b/sdks/signer-core/README.md
@@ -4,7 +4,7 @@ Shared x402 protocol primitives for the Solvela ecosystem — payment signing, 4
 
 ## Status
 
-**Internal package (`private: true` in `package.json`)**. Used by `sdks/mcp/`, `sdks/openclaw-provider/`, and `sdks/ai-sdk-provider/` as a workspace dependency. Not published to npm. If you need to sign x402 payments from your own application, depend on [`@solvela/sdk`](../typescript) instead — it bundles a `KeypairSigner` built on these primitives.
+**Internal package — not published to npm**. Used by `sdks/mcp/`, `sdks/openclaw-provider/`, and `sdks/ai-sdk-provider/` via a `file:../signer-core` workspace dependency (the `^0.1.0` semver range in some manifests is forward-looking; today it resolves locally). If you need to sign x402 payments from your own application, depend on [`@solvela/sdk`](../typescript) instead — it bundles a `KeypairSigner` built on these primitives.
 
 ## What's inside
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -59,7 +59,7 @@ const client = new SolvelaClient();
 const openai = new OpenAICompat(client);
 
 const response = await openai.chat.completions.create({
-  model: 'gpt-4',
+  model: 'openai/gpt-4o',
   messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
@@ -67,7 +67,7 @@ const response = await openai.chat.completions.create({
 ## Streaming
 
 ```typescript
-const request = new ChatRequest('gpt-4', [
+const request = new ChatRequest('openai/gpt-4o', [
   new ChatMessage('user', 'Tell me a story.'),
 ]);
 


### PR DESCRIPTION
Section 3 of the pre-1.0 docs accuracy sweep tracked in #410.

## Summary
- **Model-id format mismatch** across SDK docs — raw `gpt-4o` / `gpt-4` examples would 404 since the registry expects `provider/model_id`. Fixed in Python README, TS README, and `dashboard/content/docs/sdks/rust.mdx`.
- **Rust SDK README** version drift — claimed 0.2.1; live on crates.io is 0.2.3.
- **openclaw-provider README** factual drift across three fields: version (`1.0.0-draft` vs actual `0.1.0`), bogus `"private": true` claim, and wrong dep attribution (`@solvela/sdk` vs actual `@solvela/signer-core`).
- **signer-core README** — same bogus `"private": true` claim.
- **Python RELEASE_CHECKLIST** referenced non-existent `release-pypi.yml` workflow; reworded to describe current manual-publish reality.
- **ai-sdk.mdx** — removed misleading `Authorization: Bearer` from `/v1/models` example (endpoint is unauthenticated).

Every fix verified by direct registry calls (`npm view`, `pip index versions`, `cargo search`, `go list -m -versions`) plus source inspection.

Full audit report: https://github.com/solvela-ai/solvela/issues/410#issuecomment-4566621022

**Note for reviewer:** Section 6 (PR for `docs/audit-section-6`) also fixed the same `1.0.0-draft` openclaw lie in `integrations/openclaw/README.md` + `integrations/AGENTS.md`. Two branches independent; no file overlap.

## Test plan
- [ ] CI green
- [ ] Visual diff
- [ ] Spot-check one install command against the live registry

Tracking: #410
