### PR TITLE
docs(audit/section-4): fix stale rcr_k_ API key prefix in orgs route docs

### DIFF
--- a/crates/gateway/src/routes/orgs/mod.rs
+++ b/crates/gateway/src/routes/orgs/mod.rs
@@ -1,7 +1,8 @@
 //! Organization and team management REST API.
 //!
 //! Endpoints accept **either** a global admin token (`Authorization: Bearer <admin_token>`)
-//! or an org-scoped API key (`Authorization: Bearer rcr_k_...`).
+//! or an org-scoped API key (`Authorization: Bearer solvela_k_...`; legacy
+//! `rcr_k_...` keys are still accepted for backward compatibility).
 //! Database (`db_pool`) must be configured — returns 503 otherwise.
 
 mod analytics;


### PR DESCRIPTION
Section 4 of the pre-1.0 docs accuracy sweep tracked in #410.

## Summary
Single fix: `crates/gateway/src/routes/orgs/mod.rs:4` claimed org-scoped API keys look like `Bearer rcr_k_...`, but `generate_api_key()` in `crates/gateway/src/orgs/queries.rs:32-34` has emitted `solvela_k_`-prefixed keys since the rebrand. Verified the middleware still accepts both prefixes for backward compatibility.

The Rust crate doc-comment surface was otherwise very accurate. `cargo test --doc --workspace` reports 0 doctests in scope (the only ` ```rust` block lives inside a `[[bin]]` target which rustdoc skips). No `examples/` directories exist inside any workspace crate.

Full audit report: https://github.com/solvela-ai/solvela/issues/410#issuecomment-4566627052

## Test plan
- [ ] CI green
- [ ] `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings` pass

Tracking: #410
