### PR TITLE
docs(audit/section-5): fix factual errors in CODEMAPS, product docs, and SDK runbook

### DIFF
--- a/docs/CODEMAPS/INDEX.md
+++ b/docs/CODEMAPS/INDEX.md
@@ -35,9 +35,9 @@ solvela/
 │   └── escrow/           (Anchor program, USDC-SPL escrow)
 │
 ├── dashboard/            (Next.js 16 frontend)
-├── sdks/                 (TypeScript, Python, Go, MCP, providers)
+├── sdks/                 (typescript, python, go, rust, ai-sdk-provider, openclaw-provider, signer-core, mcp, cli-npm)
 ├── config/               (models.toml, services.toml, default.toml)
-├── migrations/           (PostgreSQL schema, 7 files)
+├── migrations/           (PostgreSQL schema, 9 files)
 └── docs/CODEMAPS/        (This documentation)
 ```
 
@@ -133,7 +133,7 @@ See [dependencies.md](dependencies.md)
 ### Add Database Schema
 1. Create migration SQL file in `migrations/`
 2. Use idempotent `CREATE TABLE IF NOT EXISTS`
-3. Run `cargo sqlx prepare --database-url=$DATABASE_URL`
+3. (sqlx is used in runtime-checked mode — no offline `sqlx prepare` step is required)
 4. Add queries to `crates/gateway/src/` (sqlx checked)
 See [data.md](data.md)
 
@@ -163,14 +163,15 @@ See [architecture.md](architecture.md) + [dependencies.md](dependencies.md)
 | router | Yes (scorer, profiles) | Yes (routing decisions) | N/A |
 | protocol | Yes (serialization, types) | Yes (wire format) | N/A |
 | cli | Yes (commands, parsing) | Yes (integration) | No |
-| dashboard | Yes (Vitest) | Yes (RTL) | Yes (Playwright) |
+| dashboard | Yes (Vitest) | N/A | No |
 
 Run tests:
 ```bash
 cargo test                              # All Rust tests
-npm --prefix dashboard test             # Frontend unit tests
-npm --prefix dashboard run e2e          # E2E tests (Playwright)
+npm --prefix dashboard test             # Frontend unit tests (vitest)
 ```
+
+The dashboard has no `e2e` npm script — Playwright is pulled in only as a transitive `@vitest/browser-playwright` dep. End-to-end testing is not yet wired up.
 
 ---
 
@@ -183,7 +184,7 @@ npm --prefix dashboard run e2e          # E2E tests (Playwright)
 
 ### Environment Variables
 - Provider API keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.
-- Solana: `SOLVELA_SOLANA_RPC_URL`, `SOLVELA_SOLANA_RECIPIENT_WALLET`
+- Solana: `SOLVELA_SOLANA__RPC_URL`, `SOLVELA_SOLANA__RECIPIENT_WALLET` (Fly.io double-underscore is canonical; legacy single-underscore form is also accepted as a fallback)
 - Database (optional): `DATABASE_URL`, `REDIS_URL`
 - Admin: `SOLVELA_ADMIN_TOKEN`, `SOLVELA_DEV_BYPASS_PAYMENT`
 
@@ -207,8 +208,8 @@ See [dependencies.md](dependencies.md) for full env var list.
 
 ### Resource Usage
 - **In-memory replay protection** — 10k entries max (120s TTL, LRU eviction)
-- **Response cache** — 24-hour TTL per response
-- **Binary size** — ~15MB (release build, 3-stage Docker)
+- **Response cache** — 10-minute TTL per response (default; see `cache::ResponseCacheConfig::default_ttl_secs = 600`)
+- **Binary size** — ~15MB (release build, 2-stage Docker)
 
 ---
 

--- a/docs/CODEMAPS/architecture.md
+++ b/docs/CODEMAPS/architecture.md
@@ -95,18 +95,20 @@ Return Task (completed) with artifacts + receipt
 
 ### routes/
 - **chat/** — Chat completions; handlers in mod.rs, cost.rs, payment.rs, provider.rs, response.rs
-- **orgs/** — Org CRUD, teams, API keys, audit logs, budget enforcement, analytics
+- **orgs/** — Org CRUD, teams, API keys, audit logs, budget enforcement, analytics, stats
 - **models.rs** — List available models
-- **services.rs** — Service marketplace registry
-- **escrow.rs** — Escrow config, claim status
+- **services.rs** — Service marketplace registry (loads `config/services.toml`)
+- **escrow.rs** — Escrow config + health
+- **escrow_settle.rs** — Escrow claim/settle endpoint
 - **health.rs** — Health check (returns 200 OK)
-- **metrics.rs** — Prometheus `/metrics` endpoint (if configured)
-- **pricing.rs** — Model pricing endpoint
+- **metrics.rs** — Prometheus `/metrics` endpoint
+- **pricing.rs** — Model pricing endpoint (served at `/pricing`)
 - **nonce.rs** — Nonce account status
 - **images.rs** — Image proxy (for vision models)
 - **admin_stats.rs** — Admin-only system statistics
-- **proxy.rs** — Generic provider proxy helper
+- **proxy.rs** — Generic per-service x402 proxy
 - **debug_headers.rs** — Debug request headers
+- **stats.rs** — Wallet-scoped usage stats
 - **supported.rs** — List supported models/providers
 
 ### middleware/
@@ -143,11 +145,12 @@ Return Task (completed) with artifacts + receipt
 - **config.rs** — `AppConfig` (Solana RPC, recipient wallet, USDC mint, server port)
 - **error.rs** — `GatewayError` enum with HTTP status mapping
 - **payment_util.rs** — Cost calculation helpers
+- **secret.rs** — Redacted secret-string wrapper
 - **usage.rs** — `UsageTracker` (PostgreSQL spend logs, budget checks)
-- **cache.rs** — `ResponseCache` (Redis); wallet-agnostic by model+messages+temp
+- **cache/** — `ResponseCache` (Redis + LRU fallback); wallet-agnostic by model+messages+temp; submodules `exact`, `semantic`, `embedder`
 - **audit.rs** — Fire-and-forget audit log writer (async, no .await on hot path)
 - **security.rs** — Secret redaction, API key verification
-- **balance_monitor.rs** — Background task: monitor fee payer USDC balance
+- **balance_monitor.rs** — Background task: monitor fee-payer SOL balance (not USDC)
 - **services.rs** — `ServiceRegistry` (loads config/services.toml)
 - **service_health.rs** — Health tracking for external services
 - **session.rs** — Session token generation/verification (HMAC)
@@ -156,18 +159,18 @@ Return Task (completed) with artifacts + receipt
 
 | Table | Purpose | Key Fields |
 |-------|---------|-----------|
-| `spend_logs` | One row per LLM request | wallet_address, model, cost_usdc, input/output_tokens, tx_signature, created_at |
-| `wallet_budgets` | Per-wallet spend limits | wallet_address (PK), daily_limit_usdc, monthly_limit_usdc, total_spent_usdc |
+| `spend_logs` | One row per LLM request | wallet_address, model, provider, input_tokens, output_tokens, cost_usdc, tx_signature, request_id, session_id, created_at |
+| `wallet_budgets` | Per-wallet spend limits | wallet_address (PK), hourly/daily/monthly_limit_usdc, total_spent_usdc |
 | `organizations` | Billing entity | id (UUID), name, slug (unique), owner_wallet |
 | `teams` | Org sub-division | id, org_id (FK), name |
 | `org_members` | Wallet→Org mapping | id, org_id (FK), wallet_address, role (owner/admin/member) |
 | `team_wallets` | Team→Wallet mapping | id, team_id (FK), wallet_address |
-| `api_keys` | Org-scoped API credentials | id, org_id (FK), key_hash (unique), key_prefix, expires_at, revoked_at |
-| `audit_logs` | Action tracking | id, org_id (FK), wallet_address, action, details, created_at |
-| `escrow_claim_queue` | Pending USDC claims | id, agent_address, service_id, amount_usdc, tx_signature, status, next_retry_at |
-| `hourly_spend_limits` | Per-org hourly caps | org_id (FK), hour_start, spent_usdc |
+| `team_budgets` | Per-team spend caps | team_id (PK/FK), hourly/daily/monthly_limit_usdc |
+| `api_keys` | Org-scoped API credentials | id, org_id (FK), key_hash (unique), key_prefix, role, expires_at, revoked_at |
+| `audit_logs` | Action tracking | id, org_id (FK), actor_wallet, actor_api_key (FK), action, resource_type, resource_id, details, ip_address, created_at |
+| `escrow_claim_queue` | Pending USDC claims | id, agent_pubkey, service_id (BYTEA), claim_amount (BIGINT atomic), deposited_amount, status, attempts, tx_signature, next_retry_at, updated_at |
 
-Migrations in `migrations/`: 001 (spend_logs, budgets) → 007 (hourly limits).
+Migrations in `migrations/`: 001 (spend_logs, budgets) → 009 (audit actor admin); see [data.md](data.md) for the per-migration breakdown.
 
 ## x402 Crate (Protocol)
 
@@ -211,20 +214,23 @@ Migrations in `migrations/`: 001 (spend_logs, budgets) → 007 (hourly limits).
 | Route | Component | Purpose |
 |-------|-----------|---------|
 | `/` | `page.tsx` | Public landing page |
-| `/dashboard` | `dashboard/page.tsx` | Overview (connected wallet, recent requests) |
+| `/dashboard` | `dashboard/page.tsx` | Dashboard root |
+| `/dashboard/overview` | `dashboard/overview/page.tsx` | Overview (recent requests) |
 | `/dashboard/usage` | `dashboard/usage/page.tsx` | Spend analytics, charts |
 | `/dashboard/models` | `dashboard/models/page.tsx` | Available models, pricing, info |
 | `/dashboard/wallet` | `dashboard/wallet/page.tsx` | Wallet balances, transaction history |
 | `/dashboard/settings` | `dashboard/settings/page.tsx` | Org/team settings, API keys, budget limits |
 | `/metrics` | `metrics/page.tsx` | Public metrics, system stats |
-| `/docs/*` | `docs/layout.tsx` | Markdown documentation (via Source) |
+| `/sponsor` | `sponsor/page.tsx` | Sponsors / backers page |
+| `/docs/[[...slug]]` | `docs/[[...slug]]/page.tsx` | Markdown documentation (Fumadocs) |
 
 Key files:
-- `lib/api.ts` — API client wrapper (gateway proxy)
-- `lib/auth.ts` — Wallet connection, session tokens
+- `lib/api.ts` — Flat async helpers (`fetchHealth`, `fetchModels`, `fetchOrgs`, `createApiKey`, etc.)
+- `lib/auth.ts` — API-key getter/setter helpers backed by `localStorage`
 - `lib/mock-data.ts` — Mock data for dev (when API unavailable)
 - `lib/theme-config.ts` — Design tokens
 - `lib/metrics-aggregator.ts` — Aggregates usage data (hourly, daily, monthly)
+- `src/proxy.ts` — Server-side gateway proxy helper
 
 ## SDKs
 
@@ -259,26 +265,32 @@ Key files:
 | `redis` | 1.2 | Cache layer (optional) |
 | `reqwest` | 0.12 | HTTP client |
 | `tracing` | 0.1 | Structured logging |
-| `metrics` + `prometheus` | 0.24/0.18 | Metrics export |
+| `metrics` + `metrics-exporter-prometheus` | 0.24/0.18 | Metrics export |
 | `ed25519-dalek` + `curve25519-dalek` | 2/4 | Solana sig verification |
 | `thiserror` | 2 | Error macro (libraries) |
 | `anyhow` | 1 | Error context (binaries) |
-| `tower-http` | 0.6 | Middleware layers |
+| `tower` + `tower-http` | 0.5/0.6 | Middleware layers |
 
 ## Environment Variables (SOLVELA_ prefix, RCR_ deprecated fallback)
+
+Double-underscore (Fly.io convention) is the canonical separator; single-underscore form is also accepted as a fallback. Legacy `RCR_` prefix still works with a deprecation warning.
 
 | Variable | Required | Purpose | Example |
 |----------|----------|---------|---------|
 | `SOLVELA_HOST` | No (default 0.0.0.0) | Listen address | 127.0.0.1 |
 | `SOLVELA_PORT` | No (default 8402) | Listen port | 8080 |
-| `SOLVELA_SOLANA_RPC_URL` | Yes | Solana RPC endpoint | https://api.mainnet-beta.solana.com |
-| `SOLVELA_SOLANA_RECIPIENT_WALLET` | Yes | USDC recipient | Hpq... (wallet addr) |
-| `SOLVELA_SOLANA_USDC_MINT` | No (default) | USDC mint | EPjFWaJY... |
+| `SOLVELA_SOLANA__RPC_URL` | Yes | Solana RPC endpoint | https://api.mainnet-beta.solana.com |
+| `SOLVELA_SOLANA__RECIPIENT_WALLET` | Yes | USDC recipient | Hpq... (wallet addr) |
+| `SOLVELA_SOLANA__USDC_MINT` | No (defaults to mainnet USDC) | USDC mint | EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v |
+| `SOLVELA_SOLANA__FEE_PAYER_KEY` | No | Fee payer hot wallet | base64/JSON private key |
+| `SOLVELA_SOLANA__ESCROW_PROGRAM_ID` | No | Escrow program ID | 9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU |
 | `DATABASE_URL` | No | PostgreSQL conn (optional) | postgres://user:pass@localhost/solvela |
 | `REDIS_URL` | No | Redis conn (optional) | redis://localhost:6379 |
 | `OPENAI_API_KEY` | No | OpenAI API key | sk-... |
 | `ANTHROPIC_API_KEY` | No | Anthropic API key | sk-ant-... |
 | `GOOGLE_API_KEY` | No | Google Gemini key | ... |
+| `XAI_API_KEY` | No | xAI Grok key | xai-... |
+| `DEEPSEEK_API_KEY` | No | DeepSeek key | sk-... |
 | `SOLVELA_DEV_BYPASS_PAYMENT` | No | Skip payment (dev only) | true |
 | `SOLVELA_ADMIN_TOKEN` | No | Admin endpoints access token | secret |
 | `RUST_LOG` | No (default gateway=info) | Log level filter | debug,tower_http=debug |
@@ -301,7 +313,7 @@ No need for a running server; all tests are isolated and fast.
 
 ## Deployment
 
-- **Dockerfile** — 3-stage Cargo build; binary at `/app/solvela-gateway`
+- **Dockerfile** — 2-stage build (`rust:1.88-slim-trixie` builder → `debian:trixie-slim` runtime, non-root `solvela` user); binary at `/app/solvela-gateway`
 - **fly.toml** — Fly.io config; port 8402, region ord (Chicago)
 - **docker-compose.yml** — Local dev: PostgreSQL 16, Redis 7
 - **Dashboard** — Next.js on Vercel (`solvela.vercel.app`)

--- a/docs/CODEMAPS/backend.md
+++ b/docs/CODEMAPS/backend.md
@@ -8,59 +8,60 @@
 
 ## Route Tree
 
+Routes as registered in `crates/gateway/src/lib.rs::build_router`.
+
 ```
-GET  /
 GET  /.well-known/agent.json
 GET  /health
 POST /a2a
 
 GET  /v1/models
-GET  /v1/models/{model_id}
+GET  /v1/supported
 POST /v1/chat/completions         [x402 payment required]
 POST /v1/images/generations       [x402 payment required]
 
-GET  /v1/pricing
+GET  /pricing
 GET  /v1/services
+POST /v1/services/register
+POST /v1/services/{service_id}/proxy
+
 GET  /v1/escrow/config
-GET  /v1/escrow/claim/{tx_sig}
+GET  /v1/escrow/health
+POST /v1/escrow/settle
 
 GET  /v1/nonce
-POST /v1/nonce/reserve
-
-GET  /debug/headers
+GET  /v1/wallet/{address}/stats
 
 GET  /metrics
-GET  /admin/stats
+GET  /v1/admin/stats
 
-POST /orgs
-GET  /orgs/{org_id}
-PATCH /orgs/{org_id}
-DELETE /orgs/{org_id}                                    [RequireOrgAdmin]
+POST /v1/orgs                                           [requires OrgContext or admin token]
+GET  /v1/orgs                                           [list]
+GET  /v1/orgs/{id}
 
-POST /orgs/{org_id}/teams
-GET  /orgs/{org_id}/teams
-POST /orgs/{org_id}/teams/{team_id}/wallets             [RequireOrgAdmin]
+POST /v1/orgs/{id}/teams
+GET  /v1/orgs/{id}/teams
+POST /v1/orgs/{id}/teams/{tid}/wallets
+GET  /v1/orgs/{id}/teams/{tid}/wallets
 
-POST /orgs/{org_id}/members
-GET  /orgs/{org_id}/members
-DELETE /orgs/{org_id}/members/{member_id}               [RequireOrgAdmin]
+POST /v1/orgs/{id}/members
+GET  /v1/orgs/{id}/members
 
-POST /orgs/{org_id}/api-keys                            [RequireOrgAdmin]
-GET  /orgs/{org_id}/api-keys
-DELETE /orgs/{org_id}/api-keys/{key_id}                 [RequireOrgAdmin]
+POST /v1/orgs/{id}/api-keys
+GET  /v1/orgs/{id}/api-keys
+DELETE /v1/orgs/{id}/api-keys/{kid}
 
-POST /orgs/{org_id}/budgets
-GET  /orgs/{org_id}/budgets
-PUT  /orgs/{org_id}/budgets/{wallet}                    [RequireOrgAdmin]
+PUT  /v1/orgs/{id}/teams/{tid}/budget
+GET  /v1/orgs/{id}/teams/{tid}/budget
+PUT  /v1/wallets/{wallet}/budget
+GET  /v1/wallets/{wallet}/budget
 
-GET  /orgs/{org_id}/analytics
-GET  /orgs/{org_id}/audit-logs                          [RequireOrgAdmin]
+GET  /v1/orgs/{id}/stats
+GET  /v1/orgs/{id}/teams/{tid}/stats
+GET  /v1/orgs/{id}/audit-logs
 ```
 
 ## Public Routes
-
-### GET /
-Landing page (redirect or static content).
 
 ### GET /.well-known/agent.json
 **Handler:** `a2a/agent_card.rs`  
@@ -92,15 +93,12 @@ Landing page (redirect or static content).
 ## Chat Completions (x402 Payment Required)
 
 ### POST /v1/chat/completions
-**Handler:** `routes/chat/mod.rs` (~776 lines)  
-**Middleware:**
-1. TraceLayer (request/response logging)
-2. CorsLayer (CORS headers)
-3. RateLimitLayer (per-wallet/org sliding window)
-4. PromptGuardLayer (injection/jailbreak/PII detection)
-5. RequestIdLayer (generates X-Request-ID)
-6. X402Layer (extracts PAYMENT-SIGNATURE header)
-7. MetricsLayer (Prometheus request count/latency)
+**Handler:** `routes/chat/mod.rs` (~890 lines)  
+**Middleware (see "Middleware Chain" section below for the full router-level stack):**
+- `rate_limit::rate_limit` — per-wallet token bucket
+- `api_key::extract_api_key` — sets `OrgContext` when a `solvela_k_` bearer is present (additive)
+- `x402::extract_payment` — decodes the `payment-signature` request header into `PaymentInfo` extension (additive; never returns 402)
+- `TraceLayer`, `metrics::record_metrics`, `CorsLayer`, security headers
 
 **Request:**
 ```json
@@ -152,15 +150,15 @@ Landing page (redirect or static content).
 
 ### GET /v1/models
 **Handler:** `routes/models.rs`  
-**Response:** List all available models from ModelRegistry.
+**Response:** List all available models from ModelRegistry (OpenAI-compatible `data: [...]` shape).
 
-### GET /v1/models/{model_id}
-**Handler:** `routes/models.rs`  
-**Response:** Detailed model info (pricing, capabilities, context window).
+### GET /v1/supported
+**Handler:** `routes/supported.rs`  
+**Response:** List of supported model IDs/providers (lighter shape, no pricing).
 
-### GET /v1/pricing
+### GET /pricing
 **Handler:** `routes/pricing.rs`  
-**Response:** Per-token pricing table (input/output costs by model).
+**Response:** Per-token pricing table (input/output costs by model). Note: this endpoint is mounted at `/pricing`, not `/v1/pricing`.
 
 ---
 
@@ -175,12 +173,16 @@ Landing page (redirect or static content).
 ## Escrow Integration
 
 ### GET /v1/escrow/config
-**Handler:** `routes/escrow.rs`  
-**Response:** Escrow program config (PDA, fee payer, nonce accounts).
+**Handler:** `routes/escrow.rs::escrow_config`  
+**Response:** Escrow program config (program ID, USDC mint, fee payer, recipient).
 
-### GET /v1/escrow/claim/{tx_sig}
-**Handler:** `routes/escrow.rs`  
-**Response:** Claim status for a given transaction signature.
+### GET /v1/escrow/health
+**Handler:** `routes/escrow.rs::escrow_health`  
+**Response:** Health of the escrow claim worker (queue depth, recent failures).
+
+### POST /v1/escrow/settle
+**Handler:** `routes/escrow_settle.rs::handle_settle`  
+**Purpose:** Submit/settle a pending claim (operator/admin).
 
 ---
 
@@ -188,19 +190,7 @@ Landing page (redirect or static content).
 
 ### GET /v1/nonce
 **Handler:** `routes/nonce.rs`  
-**Response:** Current nonce account state (for durable transactions).
-
-### POST /v1/nonce/reserve
-**Handler:** `routes/nonce.rs`  
-**Response:** Reserve a nonce account for a client transaction.
-
----
-
-## Debug Routes
-
-### GET /debug/headers
-**Handler:** `routes/debug_headers.rs`  
-**Response:** Echo back request headers (for debugging payment encoding).
+**Response:** Current durable-nonce account state. There is no `POST /v1/nonce/reserve` route — nonce reservation happens internally during claim submission.
 
 ---
 
@@ -219,17 +209,23 @@ Landing page (redirect or static content).
 - `provider_requests{provider, status}` — Provider call counts
 - `escrow_claims{status}` — Escrow claim submissions
 
-### GET /admin/stats
+### GET /v1/admin/stats
 **Handler:** `routes/admin_stats.rs`  
-**Requires:** `SOLVELA_ADMIN_TOKEN` header  
+**Requires:** `Authorization: Bearer <SOLVELA_ADMIN_TOKEN>`  
 **Response:** System-wide statistics (uptime, memory, connections).
+
+### GET /v1/wallet/{address}/stats
+**Handler:** `routes/stats.rs::wallet_stats`  
+**Response:** Per-wallet aggregated usage stats.
 
 ---
 
-## Organization Management (API Key or Wallet Auth)
+## Organization Management (API Key or Admin Token Auth)
 
-### POST /orgs
-**Handler:** `routes/orgs/crud.rs`  
+Org-scoped routes use the additive `extract_api_key` middleware that populates an `OrgContext` from a `solvela_k_…` / `rcr_k_…` bearer token (legacy prefix). Handlers themselves do per-route auth — there are not currently any `RequireOrg` / `RequireOrgAdmin` extractors gating these routes at the router layer; instead the handler reads `Option<Extension<OrgContext>>` and falls back to the `SOLVELA_ADMIN_TOKEN` path. Mutating routes accept admin-token auth as a superuser bypass.
+
+### POST /v1/orgs
+**Handler:** `routes/orgs/crud.rs::create_org`  
 **Request:**
 ```json
 {
@@ -239,26 +235,20 @@ Landing page (redirect or static content).
 ```
 **Response:** Organization object with ID, owner_wallet.
 
-### GET /orgs/{org_id}
-**Handler:** `routes/orgs/crud.rs`  
-**Response:** Org details.
+### GET /v1/orgs
+**Handler:** `routes/orgs/crud.rs::list_orgs`  
+**Response:** List of orgs visible to the caller.
 
-### PATCH /orgs/{org_id}
-**Handler:** `routes/orgs/crud.rs`  
-**Requires:** `RequireOrgAdmin` extractor  
-**Request:** Partial org update (name, slug)
-
-### DELETE /orgs/{org_id}
-**Handler:** `routes/orgs/crud.rs`  
-**Requires:** `RequireOrgAdmin`
+### GET /v1/orgs/{id}
+**Handler:** `routes/orgs/crud.rs::get_org`  
+**Response:** Org details. Note: no `PATCH` or `DELETE` route is currently registered.
 
 ---
 
 ## Teams
 
-### POST /orgs/{org_id}/teams
-**Handler:** `routes/orgs/teams.rs`  
-**Requires:** `RequireOrgAdmin`  
+### POST /v1/orgs/{id}/teams
+**Handler:** `routes/orgs/teams.rs::create_team`  
 **Request:**
 ```json
 {
@@ -266,13 +256,12 @@ Landing page (redirect or static content).
 }
 ```
 
-### GET /orgs/{org_id}/teams
-**Handler:** `routes/orgs/teams.rs`  
+### GET /v1/orgs/{id}/teams
+**Handler:** `routes/orgs/teams.rs::list_teams`  
 **Response:** List all teams in org.
 
-### POST /orgs/{org_id}/teams/{team_id}/wallets
-**Handler:** `routes/orgs/teams.rs`  
-**Requires:** `RequireOrgAdmin`  
+### POST /v1/orgs/{id}/teams/{tid}/wallets
+**Handler:** `routes/orgs/teams.rs::assign_wallet`  
 **Request:**
 ```json
 {
@@ -281,13 +270,16 @@ Landing page (redirect or static content).
 ```
 **Purpose:** Associate wallet with team (for team-scoped budgets/usage).
 
+### GET /v1/orgs/{id}/teams/{tid}/wallets
+**Handler:** `routes/orgs/teams.rs::list_team_wallets`  
+**Response:** List wallets assigned to the team.
+
 ---
 
 ## Members
 
-### POST /orgs/{org_id}/members
-**Handler:** `routes/orgs/crud.rs`  
-**Requires:** `RequireOrgAdmin`  
+### POST /v1/orgs/{id}/members
+**Handler:** `routes/orgs/teams.rs::add_member`  
 **Request:**
 ```json
 {
@@ -296,21 +288,16 @@ Landing page (redirect or static content).
 }
 ```
 
-### GET /orgs/{org_id}/members
-**Handler:** `routes/orgs/crud.rs`  
-**Response:** List all members (wallet, role, created_at).
-
-### DELETE /orgs/{org_id}/members/{member_id}
-**Handler:** `routes/orgs/crud.rs`  
-**Requires:** `RequireOrgAdmin`
+### GET /v1/orgs/{id}/members
+**Handler:** `routes/orgs/teams.rs::list_members`  
+**Response:** List all members (wallet, role, created_at). No DELETE route is currently registered.
 
 ---
 
 ## API Keys
 
-### POST /orgs/{org_id}/api-keys
-**Handler:** `routes/orgs/api_keys.rs`  
-**Requires:** `RequireOrgAdmin`  
+### POST /v1/orgs/{id}/api-keys
+**Handler:** `routes/orgs/api_keys.rs::create_api_key`  
 **Request:**
 ```json
 {
@@ -323,133 +310,109 @@ Landing page (redirect or static content).
 ```json
 {
   "id": "uuid",
-  "key": "solv_...",
-  "key_prefix": "solv_1a2b3c...",
+  "key": "solvela_k_...",
+  "key_prefix": "solvela_k_1a2b3c...",
   "name": "...",
   "created_at": "..."
 }
 ```
-Note: Full key only shown once; store securely.
+Note: Full key only shown once; store securely. The literal prefix is `solvela_k_` (the legacy `rcr_k_` prefix is still accepted on the auth side).
 
-### GET /orgs/{org_id}/api-keys
-**Handler:** `routes/orgs/api_keys.rs`  
+### GET /v1/orgs/{id}/api-keys
+**Handler:** `routes/orgs/api_keys.rs::list_api_keys`  
 **Response:** List API keys (without full key value).
 
-### DELETE /orgs/{org_id}/api-keys/{key_id}
-**Handler:** `routes/orgs/api_keys.rs`  
-**Requires:** `RequireOrgAdmin`
+### DELETE /v1/orgs/{id}/api-keys/{kid}
+**Handler:** `routes/orgs/api_keys.rs::revoke_api_key`
 
 ---
 
 ## Budgets
 
-### POST /orgs/{org_id}/budgets
-**Handler:** `routes/orgs/budget.rs`  
+Budgets are scoped per-team or per-wallet (not per-org-collection as a flat list).
+
+### PUT /v1/orgs/{id}/teams/{tid}/budget
+**Handler:** `routes/orgs/budget.rs::set_team_budget`  
 **Request:**
 ```json
 {
-  "wallet_address": "Hpq...",
+  "hourly_limit_usdc": 25.0,
   "daily_limit_usdc": 100.0,
   "monthly_limit_usdc": 2000.0
 }
 ```
 
-### GET /orgs/{org_id}/budgets
-**Handler:** `routes/orgs/budget.rs`  
-**Response:** List all budgets for org.
+### GET /v1/orgs/{id}/teams/{tid}/budget
+**Handler:** `routes/orgs/budget.rs::get_team_budget`
 
-### PUT /orgs/{org_id}/budgets/{wallet}
-**Handler:** `routes/orgs/budget.rs`  
-**Requires:** `RequireOrgAdmin`
+### PUT /v1/wallets/{wallet}/budget
+**Handler:** `routes/orgs/budget.rs::set_wallet_budget`
+
+### GET /v1/wallets/{wallet}/budget
+**Handler:** `routes/orgs/budget.rs::get_wallet_budget`
 
 ---
 
-## Analytics
+## Analytics / Stats
 
-### GET /orgs/{org_id}/analytics
-**Handler:** `routes/orgs/analytics.rs`  
-**Response:** Aggregated spend data (daily, hourly trends).
-```json
-{
-  "period": "2026-05-27T00:00:00Z",
-  "total_spend_usdc": 123.45,
-  "request_count": 456,
-  "top_models": ["gpt-4o", "claude-opus"],
-  "hourly_breakdown": [...]
-}
-```
+### GET /v1/orgs/{id}/stats
+**Handler:** `routes/orgs/analytics.rs::get_org_stats`  
+**Response:** Aggregated org spend data (totals, top models, by-period breakdowns).
+
+### GET /v1/orgs/{id}/teams/{tid}/stats
+**Handler:** `routes/orgs/analytics.rs::get_team_stats`  
+**Response:** Team-scoped spend stats.
 
 ---
 
 ## Audit Logs
 
-### GET /orgs/{org_id}/audit-logs
-**Handler:** `routes/orgs/audit.rs`  
-**Requires:** `RequireOrgAdmin`  
+### GET /v1/orgs/{id}/audit-logs
+**Handler:** `routes/orgs/audit.rs::list_audit_logs`  
 **Response:** Paginated list of org actions (team created, member added, budget updated, etc.).
 
 ---
 
 ## Middleware Chain (lib.rs, build_router())
 
-Layers applied **bottom-up** (innermost runs last):
+Layers applied to the router via `.layer(...)`. In Axum each `.layer()` wraps the layers below it (outer layers run first), so the order in code reads top-down as outer→inner:
 
 ```
-1. TraceLayer
-   └─ Logs every request/response with structured fields
-
-2. CorsLayer
-   └─ Adds CORS headers (Access-Control-Allow-Origin, etc.)
-
-3. RequestBodyLimitLayer (max 1MB)
-   └─ Protects against unbounded uploads
-
-4. TimeoutLayer (30s request timeout)
-   └─ Kills slow requests
-
-5. ConcurrencyLimitLayer (configurable max)
-   └─ Bounds in-flight request count
-
-6. RateLimitLayer
-   └─ Per-wallet/org sliding window (defaults from config)
-
-7. RequestIdLayer
-   └─ Generates/tracks X-Request-ID header
-
-8. PromptGuardLayer
-   └─ Checks for prompt injection, jailbreaks, PII
-
-9. X402Layer (payment extraction)
-   └─ Decodes PAYMENT-SIGNATURE header
-   └─ Returns 402 if missing (for protected routes)
-
-10. MetricsLayer
-    └─ Emits Prometheus metrics
-
-11. Router (actual handler)
-    └─ Routes request to handler function
+rate_limit::rate_limit        (token-bucket per wallet/IP; skips /health, /v1/models, /metrics)
+Extension(rate_limiter)       (shared limiter state)
+api_key::extract_api_key      (additive — sets OrgContext when a solvela_k_ bearer token is present)
+x402::extract_payment         (additive — decodes payment-signature header, never returns 402)
+RequestBodyLimitLayer(10 MiB)
+TraceLayer::new_for_http
+metrics::record_metrics
+CorsLayer
+SetResponseHeaderLayer × N    (x-content-type-options, etc.)
 ```
+
+Note: `x402::extract_payment` is intentionally additive — it never returns 402 from the middleware. Routes (notably `routes/chat/mod.rs`) return 402 themselves when they require payment and `PaymentInfo` is absent from extensions. This matches CLAUDE.md architectural rule #8 ("Payment middleware extracts, routes enforce").
+
+The default request-body cap is 10 MiB, not 1 MB. There is no separate `PromptGuardLayer` or `RequestIdLayer` mounted at the router level today (helpers exist as modules but are not wired as Tower layers).
 
 ---
 
 ## Extractors (Axum Patterns)
 
 ### RequireOrg
-Extracts `OrgContext` from request extensions. Populated by `api_key` middleware.
-- Requires: Valid API key (in Authorization header) or wallet signature
-- Provides: `org_id`, `wallet_address`, `role`
+Defined in `middleware/api_key.rs`. Extracts `OrgContext` from request extensions; errors `401` if absent. The current router does **not** wrap individual routes with this extractor — handlers consume `Option<Extension<OrgContext>>` directly and pair it with the admin-token bypass. The extractor is available for future tightening.
 
 ### RequireOrgAdmin
-Like `RequireOrg`, but requires role `admin` or `owner`.
+Like `RequireOrg`, but additionally requires role `admin` or `owner`.
 
 ### OrgContext
 ```rust
 pub struct OrgContext {
     pub org_id: Uuid,
-    pub wallet_address: String,
-    pub role: String,  // "owner", "admin", "member"
+    pub api_key_id: Uuid,
+    pub role: OrgRole,  // OrgRole::{Owner, Admin, Member}
 }
 ```
+
+`OrgContext` does **not** carry a wallet address — it is keyed off the API key that authenticated the request.
 
 ---
 

--- a/docs/CODEMAPS/data.md
+++ b/docs/CODEMAPS/data.md
@@ -4,8 +4,8 @@
 
 **Last Updated:** 2026-05-27  
 **Provider:** PostgreSQL 16 (optional; gateway degrades gracefully without it)  
-**Migrations:** `migrations/` (7 files, idempotent, auto-run on startup)  
-**ORM:** sqlx (compile-time checked SQL)
+**Migrations:** `migrations/` (9 files, idempotent, auto-run on startup)  
+**ORM:** sqlx (runtime-checked SQL via `sqlx::query`/`query_as`; no compile-time `query!` macros)
 
 ## Schema Overview
 
@@ -45,6 +45,7 @@ Optional per-wallet spending limits. Absence = unlimited.
 | Column | Type | Constraints | Notes |
 |--------|------|-----------|-------|
 | wallet_address | TEXT | PK | Solana wallet address |
+| hourly_limit_usdc | DECIMAL(18, 6) | NULLABLE | Hourly spend cap (added in migration 007) |
 | daily_limit_usdc | DECIMAL(18, 6) | NULLABLE | Daily spend cap (NULL = unlimited) |
 | monthly_limit_usdc | DECIMAL(18, 6) | NULLABLE | Monthly spend cap (NULL = unlimited) |
 | total_spent_usdc | DECIMAL(18, 6) | NOT NULL, DEFAULT 0, CHECK >= 0 | Cumulative spend (metadata) |
@@ -191,27 +192,33 @@ Org-scoped API credentials for programmatic access.
 - Support revocation (check `revoked_at IS NULL`)
 - Monitor usage via `last_used_at`
 
-**Key Format:** `solv_[random_24_chars]` (prefixed for automatic Tresorit/vault detection)
+**Key Format:** `solvela_k_[random]` — the canonical prefix used by `extract_api_key` (the legacy `rcr_k_` prefix is still accepted for back-compat).
 
 ---
 
 ### Audit & Compliance
 
-#### audit_logs (migration 006)
+#### audit_logs (migration 006, hardened in 009)
 Action tracking for compliance and debugging.
 
 | Column | Type | Constraints | Notes |
 |--------|------|-----------|-------|
 | id | UUID | PK, default gen_random_uuid() | Log entry ID |
-| org_id | UUID | FK → organizations(id) ON DELETE CASCADE | Org affected |
-| wallet_address | TEXT | NOT NULL | Actor wallet |
+| org_id | UUID | FK → organizations(id) ON DELETE SET NULL | Org affected |
+| actor_wallet | TEXT | NULLABLE | Actor wallet (NULL when admin token acted) |
+| actor_api_key | UUID | FK → api_keys(id) ON DELETE SET NULL | Actor API key id |
 | action | TEXT | NOT NULL | Action type (e.g., "team_created", "member_added") |
+| resource_type | TEXT | NOT NULL | Resource kind (org, team, member, …) |
+| resource_id | TEXT | NULLABLE | Resource identifier |
 | details | JSONB | NULLABLE | Action details (team name, role, etc.) |
+| ip_address | TEXT | NULLABLE | Originating IP for the admin action |
 | created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW() | Action timestamp |
 
 **Indexes:**
 - `idx_audit_org` — Find logs for org
+- `idx_audit_action` — Find logs by action
 - `idx_audit_created` — Find logs by timestamp
+- `idx_audit_actor` — Find logs by actor wallet (partial index, WHERE actor_wallet IS NOT NULL)
 
 **Usage:**
 - Compliance audit trail (SOC 2 Type II)
@@ -228,56 +235,56 @@ Action tracking for compliance and debugging.
 
 ---
 
-#### escrow_claim_queue (migration 002)
+#### escrow_claim_queue (migration 002, extended in 004 & 008)
 Pending USDC-SPL escrow claims (async processing).
 
 | Column | Type | Constraints | Notes |
 |--------|------|-----------|-------|
 | id | UUID | PK, default gen_random_uuid() | Queue entry ID |
-| agent_address | TEXT | NOT NULL | Agent wallet (claimer) |
-| service_id | BYTES | NOT NULL | Service ID (used in PDA seed) |
-| amount_usdc | DECIMAL(18, 6) | NOT NULL, CHECK > 0 | Amount to claim (in USDC) |
-| tx_signature | TEXT | NOT NULL | Solana transaction signature (unique) |
-| status | TEXT | NOT NULL, DEFAULT 'pending' | 'pending', 'submitted', 'confirmed', 'failed' |
-| retry_count | INTEGER | NOT NULL, DEFAULT 0 | Number of retry attempts |
-| next_retry_at | TIMESTAMPTZ | NOT NULL (migration 004) | When to retry next (exponential backoff) |
+| service_id | BYTEA | NOT NULL | 32-byte service ID (used in PDA seed) |
+| agent_pubkey | TEXT | NOT NULL | Base58 agent wallet (claimer) |
+| claim_amount | BIGINT | NOT NULL | Amount to claim in **atomic USDC units** (6 decimals) |
+| deposited_amount | BIGINT | NULLABLE | Verified deposit ceiling (atomic units) |
+| status | TEXT | NOT NULL, DEFAULT 'pending' | 'pending', 'in_progress', 'completed', 'failed' |
+| attempts | INTEGER | NOT NULL, DEFAULT 0 | Number of retry attempts |
+| last_attempt_at | TIMESTAMPTZ | NULLABLE | Timestamp of last attempt |
+| next_retry_at | TIMESTAMPTZ | NULLABLE (added in migration 004) | When to retry next (exponential backoff) |
+| tx_signature | TEXT | NULLABLE | Solana transaction signature (filled on success) |
 | error_message | TEXT | NULLABLE | Last error message (if failed) |
 | created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW() | Claim queued date |
-| updated_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW() | Last status update |
-
-**Unique:** `tx_signature` — Each claim signed once
+| completed_at | TIMESTAMPTZ | NULLABLE | When claim finished |
+| updated_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW() | Added in migration 008 (drives stale-claim recovery) |
 
 **Indexes:**
-- `idx_claim_status` — Find pending claims
-- `idx_claim_agent` — Find claims for agent
-- `idx_claim_retry` — Find claims due for retry
+- `idx_claim_queue_status` — Find pending claims by status
+- `idx_claim_queue_created` — Find claims by submission time
 
 **Usage:**
 - Background processor (`escrow/claim_processor.rs`) polls pending claims
-- Retries failed claims with exponential backoff (5s, 30s, 2m, 10m)
+- Retries failed claims with exponential backoff
 - Tracks claim lifecycle from submission to confirmation
+- Stale `in_progress` claims older than 5 minutes (by `updated_at`) are reclaimed by `fetch_pending_claims`
 
 ---
 
-#### hourly_spend_limits (migration 007)
-Per-org hourly spend tracking (for rate limiting).
+#### team_budgets (migration 007)
+Per-team spend caps. (Migration 007 is named `007_hourly_spend_limits.sql` but actually creates `team_budgets` and adds `hourly_limit_usdc` to `wallet_budgets`; there is no `hourly_spend_limits` table.)
 
 | Column | Type | Constraints | Notes |
 |--------|------|-----------|-------|
-| org_id | UUID | FK → organizations(id) ON DELETE CASCADE | Org |
-| hour_start | TIMESTAMPTZ | NOT NULL | Hour boundary (e.g., 2026-05-27 14:00:00 UTC) |
-| spent_usdc | DECIMAL(18, 6) | NOT NULL, DEFAULT 0, CHECK >= 0 | Amount spent in that hour |
+| team_id | UUID | PK, FK → teams(id) ON DELETE CASCADE | Team |
+| hourly_limit_usdc | DECIMAL(18, 6) | NULLABLE | Hourly spend cap |
+| daily_limit_usdc | DECIMAL(18, 6) | NULLABLE | Daily spend cap |
+| monthly_limit_usdc | DECIMAL(18, 6) | NULLABLE | Monthly spend cap |
 | created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW() | Record created |
+| updated_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW() | Last modified (auto-updated by trigger) |
 
-**Composite PK:** (org_id, hour_start)
-
-**Indexes:**
-- `idx_hourly_org_hour` — Fast lookups by org + hour
+**Triggers:**
+- `trg_team_budgets_updated_at` — Auto-update `updated_at` on any row change
 
 **Usage:**
-- Enforce hourly spend caps (future)
-- Detect spend spikes / anomalies
-- Rate limit expensive requests per org per hour
+- Enforce per-team spend caps
+- Rate limit expensive requests per team per period
 
 ---
 
@@ -287,11 +294,13 @@ Per-org hourly spend tracking (for rate limiting).
 |---|------|--------|---------|
 | 1 | `001_initial_schema.sql` | spend_logs, wallet_budgets | Initial payment tracking |
 | 2 | `002_escrow_claim_queue.sql` | escrow_claim_queue | Async escrow claim processing |
-| 3 | `003_phase_g_request_session_ids.sql` | spend_logs.session_id | Add session tracking to requests |
+| 3 | `003_phase_g_request_session_ids.sql` | spend_logs.request_id, spend_logs.session_id | Add request/session tracking |
 | 4 | `004_claim_queue_next_retry_at.sql` | escrow_claim_queue.next_retry_at | Backoff scheduling |
 | 5 | `005_organizations.sql` | organizations, teams, org_members, team_wallets, api_keys | Multi-tenant RBAC |
 | 6 | `006_audit_logs.sql` | audit_logs | Compliance audit trail |
-| 7 | `007_hourly_spend_limits.sql` | hourly_spend_limits | Rate limit tracking |
+| 7 | `007_hourly_spend_limits.sql` | wallet_budgets.hourly_limit_usdc, team_budgets | Team budgets + hourly caps |
+| 8 | `008_escrow_claim_queue_updated_at.sql` | escrow_claim_queue.updated_at | Stale-claim recovery |
+| 9 | `009_audit_actor_admin.sql` | audit_logs admin-actor backfill | Track admin-token actions |
 
 All migrations are **idempotent** (use `CREATE TABLE IF NOT EXISTS`). Applied automatically on gateway startup via `run_migrations()` (from `main.rs`). If migration fails and `DATABASE_URL` is set, gateway exits with non-zero status (fatal error).
 
@@ -346,9 +355,9 @@ let record = sqlx::query_as::<_, ApiKeyRecord>(
 
 If `REDIS_URL` is set, gateway caches chat responses:
 
-**Key:** SHA256(model + messages + temperature)  
+**Key:** SHA-256(model ‖ serialised messages ‖ temperature)  
 **Value:** JSON response  
-**TTL:** 24 hours (configurable)
+**TTL:** 600 seconds (10 minutes) default; configurable via `ResponseCacheConfig::default_ttl_secs`
 
 Enables:
 - Wallet-agnostic response cache (two agents with identical prompts share cached response)

--- a/docs/CODEMAPS/dependencies.md
+++ b/docs/CODEMAPS/dependencies.md
@@ -128,7 +128,7 @@ pub struct ProviderHealth {
 }
 ```
 
-**Health endpoint exposed at:** `GET /v1/health` (returns health status for each provider).
+Provider health is reported indirectly through `GET /health` and provider-specific metrics on `/metrics`. There is no dedicated `/v1/health` endpoint; the public liveness endpoint is `/health`.
 
 Used by:
 - **Router scorer** — Deprioritize slow providers
@@ -140,7 +140,7 @@ Used by:
 ## Solana Integration (x402 Crate)
 
 ### Solana RPC (solana_rpc.rs)
-**Endpoint:** From `SOLVELA_SOLANA_RPC_URL` (default: https://api.mainnet-beta.solana.com)  
+**Endpoint:** From `SOLVELA_SOLANA__RPC_URL` (or the legacy single-underscore `SOLVELA_SOLANA_RPC_URL`). `config/default.toml` ships with `https://api.devnet.solana.com` — production deployments must override to a mainnet-beta endpoint.  
 **Client:** `reqwest::Client`
 
 **Calls made:**
@@ -170,8 +170,8 @@ pub async fn get_latest_blockhash(
 ---
 
 ### USDC-SPL Token (spl_transfer.rs)
-**Mint Address:** `EPjFWaJY48sPHP1AY1jP5eUZNQxmögKYQ1nHSroM3zF` (mainnet)  
-**Decimals:** 6 (1 USDC = 1,000,000 lamports)
+**Mint Address:** `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` (mainnet; hard-coded in `crates/protocol/src/constants.rs::USDC_MINT`)  
+**Decimals:** 6 (1 USDC = 1,000,000 atomic units)
 
 **Operations:**
 - **Transfer** — SPL token transfer instruction (agent wallet → Solvela recipient)
@@ -194,7 +194,7 @@ pub fn verify_spl_transfer(
 ---
 
 ### Escrow Program (programs/escrow/ - Anchor)
-**Program ID:** From `SOLVELA_SOLANA_ESCROW_PROGRAM_ID`  
+**Program ID:** From `SOLVELA_SOLANA__ESCROW_PROGRAM_ID` (legacy `SOLVELA_SOLANA_ESCROW_PROGRAM_ID` also accepted). Mainnet deployment: `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`.  
 **Chain:** Mainnet-Beta (Solana)  
 **Language:** Anchor (Solana Rust framework)
 
@@ -254,7 +254,7 @@ pub fn verify_signature(
 **Purpose:** Rotate hot wallets for Solana fee payment (to avoid nonce conflicts).
 
 **State:**
-- Load private keys from env (SOLVELA_SOLANA_FEE_PAYER_KEY)
+- Load private keys from env (`SOLVELA_SOLANA__FEE_PAYER_KEY` plus `_2`…`_8` for the rotation pool)
 - Maintain pool of `Fee Payer` structs (wallet address + balance)
 - Round-robin selection on each claim
 
@@ -325,11 +325,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uu
 
 **Usage:**
 - **Response Cache** — Cache chat completions by (model, messages, temperature) hash
-- **Replay Protection** — Track PAYMENT-SIGNATURE nonces to prevent replay attacks
+- **Replay Protection** — Track `payment-signature` nonces to prevent replay attacks
 
 **Cache TTL:**
-- Response cache: 24 hours (configurable)
-- Replay protection: 120 seconds (matches Solana blockhash lifetime)
+- Response cache: 600 seconds / 10 minutes (default; see `cache::ResponseCacheConfig::default_ttl_secs`)
+- Replay protection: ~120 seconds (matches Solana blockhash lifetime)
 
 ```rust
 // cache.rs
@@ -355,7 +355,8 @@ pub async fn set(&self, key: &str, value: &str, ttl_secs: usize) -> Result<()> {
 |-------|---------|---------|---------|
 | **axum** | 0.8 | Web framework | gateway (routes, middleware) |
 | **tokio** | 1 (full) | Async runtime | All binaries |
-| **tower** + **tower-http** | 0.5/0.6 | Middleware layers | gateway |
+| **tower** | 0.5 | Tower service traits | gateway |
+| **tower-http** | 0.6 | HTTP middleware (cors, trace, timeout, limit, set-header, catch-panic) | gateway |
 | **reqwest** | 0.12 | HTTP client | Provider adapters, Solana RPC |
 | **serde** + **serde_json** | 1 | Serialization | All crates |
 | **sqlx** | 0.8 | PostgreSQL driver | gateway (optional) |
@@ -364,23 +365,23 @@ pub async fn set(&self, key: &str, value: &str, ttl_secs: usize) -> Result<()> {
 | **bs58** | 0.5 | Base58 encoding (Solana addrs) | x402 |
 | **sha2** + **hmac** | 0.11/0.13 | Hashing, HMAC | gateway (session tokens, cache keys) |
 | **base64** | 0.22 | Base64 encoding | Payment header decoding |
-| **tracing** + **tracing-subscriber** | 0.1 | Structured logging | All crates |
-| **metrics** + **metrics-exporter-prometheus** | 0.24/0.18 | Prometheus metrics | gateway |
+| **tracing** + **tracing-subscriber** | 0.1 / 0.3 | Structured logging | All crates |
+| **metrics** + **metrics-exporter-prometheus** | 0.24 / 0.18 | Prometheus metrics | gateway |
 | **clap** | 4 | CLI parsing | cli (derive macros) |
 | **thiserror** | 2 | Error macros | Libraries |
 | **anyhow** | 1 | Error context | Binaries |
-| **uuid** + **chrono** | 1 | UUIDs, timestamps | All crates |
+| **uuid** + **chrono** | 1 / 0.4 | UUIDs, timestamps | All crates |
 | **toml** | 1.1 | Config parsing | gateway |
 | **dotenvy** | 0.15 | .env file loading | gateway |
 | **zeroize** | 1 | Secure key cleanup | x402 (secret material) |
-| **lru** | 0.17 | LRU cache | gateway (replay protection fallback) |
+| **lru** | 0.18 | LRU cache | gateway (replay protection fallback) |
 
 ---
 
 ## Configuration Files Integration
 
 ### config/default.toml
-Loaded on startup; env vars override.
+Loaded on startup; env vars override. The shipped defaults point at devnet — production deploys override via env.
 
 ```toml
 [server]
@@ -388,19 +389,26 @@ host = "0.0.0.0"
 port = 8402
 
 [solana]
-rpc_url = "https://api.mainnet-beta.solana.com"
-recipient_wallet = "Hpq..."  # USDC recipient address
-usdc_mint = "EPjFWaJY..."
+rpc_url = "https://api.devnet.solana.com"
+recipient_wallet = ""
+usdc_mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 
-[logging]
-level = "info"
+[monitor]
+warn_threshold_sol = 0.1
+critical_threshold_sol = 0.02
+check_interval_secs = 300
 
-[cache]
-ttl_seconds = 86400  # 24 hours
+[cache.semantic]
+enabled = false
+threshold = 0.85
+hit_price_percent = 30
+ttl_secs = 600
 
-[rate_limit]
-requests_per_minute = 60
+[providers]
+# Provider API keys come from env: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, XAI_API_KEY, DEEPSEEK_API_KEY.
 ```
+
+There are no `[logging]` or `[rate_limit]` sections in `config/default.toml`; log level is set via `RUST_LOG` and rate-limit defaults live in `crates/gateway/src/middleware/rate_limit.rs` (60 req / 60 s per wallet, hard-coded).
 
 ### config/models.toml
 Model registry; 26+ models with per-token pricing.
@@ -425,39 +433,17 @@ Service marketplace registry (external LLM service metadata).
 
 ## SDK Integrations
 
-### TypeScript SDK (sdks/typescript/)
-Wraps gateway API for Node.js/browser.
-```typescript
-const solvela = new SolvelaClient({ gatewayUrl: "..." });
-const response = await solvela.chat.completions({
-  model: "gpt-4o",
-  messages: [...],
-});
-```
+All SDKs live in-tree under `sdks/` (see `docs/runbooks/sdk-consolidation.md` for the consolidation history). The illustrative snippets below show the shape of each SDK's published API — consult each SDK's README for exact import paths and constructor signatures.
 
-### Python SDK (sdks/python/)
-Wraps gateway API for Python.
-```python
-client = SolvelaClient(gateway_url="...")
-response = client.chat.completions(model="gpt-4o", messages=[...])
-```
-
-### Go SDK (sdks/go/)
-Wraps gateway API for Go.
-```go
-client := solvela.NewClient(solvelaURL)
-resp, err := client.ChatCompletions(ctx, &solvela.ChatRequest{...})
-```
-
-### Vercel AI SDK Provider (sdks/ai-sdk-provider/)
-Integrates Solvela with Vercel AI SDK.
-```typescript
-import { solvela } from "@solvela/ai-sdk";
-const model = solvela("gpt-4o");
-```
-
-### Claude MCP Server (sdks/mcp/)
-Adds Solvela as a Claude desktop tool.
+- **TypeScript** (`sdks/typescript/`) — published as `@solvela/sdk` on npm
+- **Python** (`sdks/python/`) — published as `solvela-sdk` on PyPI
+- **Go** (`sdks/go/`) — module `github.com/solvela-ai/solvela/sdks/go`
+- **Rust** (`sdks/rust/`) — `solvela-client` family on crates.io (non-workspace member, like `programs/escrow/`)
+- **Vercel AI SDK provider** (`sdks/ai-sdk-provider/`)
+- **OpenClaw provider** (`sdks/openclaw-provider/`)
+- **Signer core** (`sdks/signer-core/`)
+- **MCP server** (`sdks/mcp/`) — Claude Desktop / MCP host integration
+- **CLI distribution shim** (`sdks/cli-npm/`)
 
 ---
 
@@ -470,12 +456,12 @@ Adds Solvela as a Claude desktop tool.
 - `DEEPSEEK_API_KEY` — DeepSeek API key
 - `XAI_API_KEY` — xAI API key
 
-**Solana Configuration:**
-- `SOLVELA_SOLANA_RPC_URL` — Solana RPC endpoint
-- `SOLVELA_SOLANA_RECIPIENT_WALLET` — USDC recipient address
-- `SOLVELA_SOLANA_USDC_MINT` — USDC mint (default mainnet)
-- `SOLVELA_SOLANA_ESCROW_PROGRAM_ID` — Escrow program ID
-- `SOLVELA_SOLANA_FEE_PAYER_KEY` — Fee payer private key (base64 or JSON)
+**Solana Configuration** (double-underscore is canonical; single-underscore form accepted as fallback):
+- `SOLVELA_SOLANA__RPC_URL` — Solana RPC endpoint
+- `SOLVELA_SOLANA__RECIPIENT_WALLET` — USDC recipient address
+- `SOLVELA_SOLANA__USDC_MINT` — USDC mint (default mainnet)
+- `SOLVELA_SOLANA__ESCROW_PROGRAM_ID` — Escrow program ID
+- `SOLVELA_SOLANA__FEE_PAYER_KEY` (plus `_2`…`_8`) — Fee payer private key(s) (base64 or JSON byte array)
 
 **Data Storage:**
 - `DATABASE_URL` — PostgreSQL connection string (optional)

--- a/docs/CODEMAPS/frontend.md
+++ b/docs/CODEMAPS/frontend.md
@@ -20,7 +20,8 @@ src/app/
 │
 ├── dashboard/
 │   ├── layout.tsx                      (dashboard layout, sidebar nav)
-│   ├── page.tsx                        (overview: wallet, recent requests)
+│   ├── page.tsx                        (dashboard root)
+│   ├── overview/page.tsx               (overview: recent requests)
 │   ├── usage/page.tsx                  (spend analytics, trends)
 │   ├── models/page.tsx                 (model catalog, pricing)
 │   ├── wallet/page.tsx                 (wallet balances, transaction history)
@@ -31,7 +32,7 @@ src/app/
 │
 └── docs/
     ├── layout.tsx                      (docs layout with sidebar)
-    └── [...slug]/page.tsx              (markdown docs (via Source))
+    └── [[...slug]]/page.tsx            (Fumadocs catch-all route)
 ```
 
 ## Core Components
@@ -108,40 +109,42 @@ Uses **Recharts** for charting.
 ## Utilities
 
 ### lib/api.ts
-HTTP client wrapper for gateway API.
+Flat collection of async helpers calling the gateway directly (no nested `api` object). Each helper is an exported `async function`.
 ```typescript
-export const api = {
-  chat: {
-    completions(req: ChatRequest): Promise<ChatResponse>,
-    stream(req: ChatRequest): ReadableStream,
-  },
-  models: {
-    list(): Promise<Model[]>,
-    get(id: string): Promise<Model>,
-  },
-  orgs: {
-    get(id: string): Promise<Org>,
-    update(id, data),
-    members: { list(), add(), remove() },
-    teams: { list(), create() },
-    apiKeys: { list(), create(), revoke() },
-    budgets: { list(), set() },
-  },
-  wallet: {
-    balance(): Promise<Decimal>,
-    history(): Promise<Transaction[]>,
-  },
-};
+// Public read endpoints
+export async function fetchHealth(): Promise<HealthResponse>;
+export async function fetchPricing(): Promise<PricingResponse>;
+export async function fetchModels(): Promise<{ data: PricingResponse["models"] }>;
+export async function fetchServices(): Promise<ServicesResponse | null>;
+export async function fetchEscrowConfig(): Promise<EscrowConfig | null>;
+export async function fetchEscrowHealth(): Promise<EscrowHealth | null>;
+export async function fetchPublicMetrics(): Promise<PublicMetricsResponse>;
+
+// Admin (require Authorization: Bearer <admin-token>)
+export async function fetchAdminStats(token: string): Promise<AdminStatsResponse>;
+
+// Org-scoped (require Authorization: Bearer <solvela_k_...>)
+export async function fetchOrgs(): Promise<ApiResult<OrgEntry[]>>;
+export async function fetchTeams(orgId: string): Promise<ApiResult<TeamEntry[]>>;
+export async function fetchMembers(orgId: string): Promise<ApiResult<MemberEntry[]>>;
+export async function fetchApiKeys(orgId: string): Promise<ApiResult<ApiKeyEntry[]>>;
+export async function createApiKey(...): Promise<ApiResult<CreateApiKeyResponse>>;
+export async function revokeApiKey(...): Promise<ApiResult<void>>;
+export async function fetchAuditLogs(orgId: string): Promise<ApiResult<AuditLogEntry[]>>;
+export async function fetchOrgStats(orgId: string): Promise<ApiResult<OrgStats>>;
+export async function createTeam(orgId: string, name: string): Promise<ApiResult<TeamEntry>>;
+export async function setTeamBudget(...): Promise<ApiResult<TeamBudget>>;
+export async function fetchTeamBudget(...): Promise<ApiResult<TeamBudget>>;
 ```
+The dashboard does not call `/v1/chat/completions` directly from the client — chat is exercised through the gateway only.
 
 ### lib/auth.ts
-Wallet connection + session management.
+Thin `localStorage`-backed API-key helpers. The dashboard authenticates via API key, not a Solana wallet adapter.
 ```typescript
-export const useAuth = () => {
-  const wallet = useWallet();  // Solana wallet adapter
-  const [session, setSession] = useState(null);
-  // ... connect, sign message, verify signature
-};
+export function getApiKey(): string | null;
+export function setApiKey(key: string): void;
+export function clearApiKey(): void;
+export function hasApiKey(): boolean;
 ```
 
 ### lib/mock-data.ts
@@ -202,40 +205,17 @@ Responsive breakpoints: `sm` (640px), `md` (768px), `lg` (1024px), `xl` (1280px)
 
 ## API Integration
 
-**Proxy-based access:**
-- Dashboard sends requests to `/api/proxy/*`
-- Proxy forwards to `http://localhost:8402/v1/*`
-- Handles auth headers, request/response transformation
+The dashboard calls the gateway over HTTP directly from client components using `lib/api.ts` helpers; the gateway base URL comes from `NEXT_PUBLIC_GATEWAY_URL`. A server-side helper at `src/proxy.ts` exists for cases where the request must be forwarded with a server-only token.
 
-See `src/proxy.ts`:
-```typescript
-export default async function handler(req, res) {
-  const { path, method, body } = req;
-  const response = await fetch(`http://localhost:8402${path}`, {
-    method,
-    headers: { "Authorization": `Bearer ${process.env.GATEWAY_API_KEY}` },
-    body,
-  });
-  return res.json(response.json());
-}
-```
+The literal route `/api/proxy/*` does **not** exist — the only server route under `app/api/` is `app/api/search/route.ts` (the Fumadocs search endpoint).
 
 ## Testing
 
-- **Vitest** — Unit tests for utils, hooks
-- **React Testing Library** — Component tests
+- **Vitest** — Unit tests for utils and `lib/` helpers
 - **Config:** `vitest.config.ts`
-- **Test files:** `src/__tests__/*.test.ts` (or `.tsx`)
+- **Test files:** `dashboard/src/__tests__/*.test.ts` (currently `mock-data.test.ts`, `api.test.ts`, `utils.test.ts`, `metrics-aggregator.test.ts`)
 
-```typescript
-import { render, screen } from '@testing-library/react';
-import { Dashboard } from './dashboard/page';
-
-test('displays welcome message', () => {
-  render(<Dashboard />);
-  expect(screen.getByText(/welcome/i)).toBeInTheDocument();
-});
-```
+Run with `npm --prefix dashboard test`. The dashboard does not currently bundle React component tests or an end-to-end Playwright suite — there is no `e2e` npm script in `dashboard/package.json`.
 
 ## Build & Deployment
 

--- a/docs/product/faq.md
+++ b/docs/product/faq.md
@@ -12,7 +12,7 @@ In an escrow payment, USDC is held by a smart contract on Solana -- a program wi
 
 ## What happens if the payment fails?
 
-If the payment signature is invalid, the amount is wrong, or the transaction didn't settle on Solana, RCR rejects the request immediately with a clear error message. The agent is not charged. No partial charges, no pending states. Either the payment is verified and the request proceeds, or it doesn't.
+If the payment signature is invalid, the amount is wrong, or the transaction didn't settle on Solana, Solvela rejects the request immediately with a clear error message. The agent is not charged. No partial charges, no pending states. Either the payment is verified and the request proceeds, or it doesn't.
 
 ## What happens if the LLM provider is down after payment?
 
@@ -34,7 +34,7 @@ Not today. Solvela currently supports only Solana with USDC-SPL. The architectur
 
 ## How much does it cost?
 
-The cost per request depends on the model used and the number of tokens consumed. RCR adds a **5% platform fee** on top of the provider's cost. Every response includes a cost breakdown:
+The cost per request depends on the model used and the number of tokens consumed. Solvela adds a **5% platform fee** on top of the provider's cost. Every response includes a cost breakdown:
 
 - **Provider cost**: What the LLM provider charges (e.g., $0.0025)
 - **Platform fee**: 5% of the provider cost (e.g., $0.000125)
@@ -57,7 +57,7 @@ The escrow is a smart contract on Solana that holds funds in a neutral account u
 
 **How it works:**
 1. You deposit the maximum estimated cost into the escrow (a program-controlled account on Solana).
-2. RCR processes your request.
+2. Solvela processes your request.
 3. The smart contract releases the actual cost to the gateway operator and refunds the rest to you.
 4. If the gateway never claims (server crash, network issue), you reclaim everything after the timeout.
 

--- a/docs/product/how-it-works.md
+++ b/docs/product/how-it-works.md
@@ -36,7 +36,7 @@ This is like walking up to a vending machine and seeing the price on the display
 
 ### Step 2: Sign the Payment
 
-The agent sees the price (say, $0.002625 in USDC) and signs a payment transaction on Solana. This is a cryptographic signature -- the agent authorizes the transfer from its wallet but the money moves on the Solana blockchain, not through RCR's servers.
+The agent sees the price (say, $0.002625 in USDC) and signs a payment transaction on Solana. This is a cryptographic signature -- the agent authorizes the transfer from its wallet but the money moves on the Solana blockchain, not through Solvela's servers.
 
 The agent sends the signed payment back to Solvela along with the original request.
 
@@ -58,7 +58,7 @@ This means any HTTP client (including AI agents) can pay for API calls using a s
 
 Not every question needs the most expensive model. Asking "what's 2+2?" doesn't require the same horsepower as "write me a compiler."
 
-RCR's smart router analyzes each request across 15 dimensions -- things like whether the request contains code, requires reasoning, uses technical terminology, or needs creative writing. Based on this analysis, it picks the best model from five providers (OpenAI, Anthropic, Google, xAI, DeepSeek) for the job.
+Solvela's smart router analyzes each request across 15 dimensions -- things like whether the request contains code, requires reasoning, uses technical terminology, or needs creative writing. Based on this analysis, it picks the best model from five providers (OpenAI, Anthropic, Google, xAI, DeepSeek) for the job.
 
 The agent sends one request and gets the optimal response. No need to know which provider to call or which model to pick.
 
@@ -81,7 +81,7 @@ For expensive operations -- long multi-turn conversations, batch processing, or 
 
 Solvela offers a trustless escrow option:
 
-1. **Deposit**: The agent deposits the maximum estimated cost into an escrow account on Solana. This account is controlled by a smart contract (an on-chain program), not by RCR.
+1. **Deposit**: The agent deposits the maximum estimated cost into an escrow account on Solana. This account is controlled by a smart contract (an on-chain program), not by Solvela.
 2. **Service delivery**: Solvela processes the request and tracks the actual cost.
 3. **Settlement**: After service delivery, the smart contract releases the actual cost to the gateway operator and automatically refunds the remainder to the agent.
 4. **Timeout protection**: If the gateway never claims the funds (say, the server goes down), the agent can reclaim the full deposit after a timeout period. No trust required.
@@ -90,7 +90,7 @@ The escrow is entirely on-chain. The gateway software can claim only what was ea
 
 ## Enterprise Features
 
-Organizations can manage multiple agents and team members through RCR's enterprise features:
+Organizations can manage multiple agents and team members through Solvela's enterprise features:
 
 - **Teams**: Group agents and team members. Set spend limits per team or per hour.
 - **API keys**: Authenticate programmatically instead of with wallet signatures.

--- a/docs/product/how-it-works.md
+++ b/docs/product/how-it-works.md
@@ -22,7 +22,7 @@ AI agents are becoming autonomous. They run 24/7, make decisions, and call APIs 
 - **API keys** require an account, and if the key leaks, someone else runs up the bill.
 - **Monthly subscriptions** don't make sense for agents that might make 3 calls or 3 million.
 
-Solvela (RCR) solves this. An AI agent just needs a Solana wallet with some USDC (a dollar-pegged stablecoin), and it can pay for any LLM API call instantly, with no account and no human in the loop.
+Solvela solves this. An AI agent just needs a Solana wallet with some USDC (a dollar-pegged stablecoin), and it can pay for any LLM API call instantly, with no account and no human in the loop.
 
 ## The Payment Flow
 
@@ -30,7 +30,7 @@ Every request follows three steps:
 
 ### Step 1: Ask the Price
 
-The agent sends a request to RCR -- for example, "I want to ask Claude a question about quantum physics." RCR looks at the request, figures out which model to use and how much it will cost, and responds with the price.
+The agent sends a request to Solvela -- for example, "I want to ask Claude a question about quantum physics." Solvela looks at the request, figures out which model to use and how much it will cost, and responds with the price.
 
 This is like walking up to a vending machine and seeing the price on the display before you insert your coins.
 
@@ -38,17 +38,17 @@ This is like walking up to a vending machine and seeing the price on the display
 
 The agent sees the price (say, $0.002625 in USDC) and signs a payment transaction on Solana. This is a cryptographic signature -- the agent authorizes the transfer from its wallet but the money moves on the Solana blockchain, not through RCR's servers.
 
-The agent sends the signed payment back to RCR along with the original request.
+The agent sends the signed payment back to Solvela along with the original request.
 
 ### Step 3: Verify and Deliver
 
-RCR verifies that the payment is valid and settled on Solana. If everything checks out, RCR forwards the request to the LLM provider (OpenAI, Anthropic, Google, etc.), gets the response, and sends it back to the agent.
+Solvela verifies that the payment is valid and settled on Solana. If everything checks out, Solvela forwards the request to the LLM provider (OpenAI, Anthropic, Google, etc.), gets the response, and sends it back to the agent.
 
 The whole process takes under a second.
 
 ## What Is x402?
 
-RCR uses a protocol called **x402**. The name comes from HTTP status code 402 -- "Payment Required" -- which was reserved in the original HTTP spec for future use but never standardized.
+Solvela uses a protocol called **x402**. The name comes from HTTP status code 402 -- "Payment Required" -- which was reserved in the original HTTP spec for future use but never standardized.
 
 x402 adds a payment layer to HTTP, the same protocol that powers every website. Think of it like how HTTPS added encryption to HTTP -- x402 adds payments. When a server needs payment, it returns a 402 response with the price and accepted payment methods. The client pays and retries the request. The server verifies and serves the resource.
 
@@ -64,7 +64,7 @@ The agent sends one request and gets the optimal response. No need to know which
 
 ## The 5% Fee
 
-RCR charges a 5% platform fee on every request. If the LLM provider charges $0.0025, the total cost to the agent is $0.002625.
+Solvela charges a 5% platform fee on every request. If the LLM provider charges $0.0025, the total cost to the agent is $0.002625.
 
 This fee covers:
 
@@ -79,10 +79,10 @@ Every response includes a cost breakdown showing the provider cost, the platform
 
 For expensive operations -- long multi-turn conversations, batch processing, or image generation -- paying upfront for the maximum possible cost is wasteful. What if the conversation ends early?
 
-RCR offers a trustless escrow option:
+Solvela offers a trustless escrow option:
 
 1. **Deposit**: The agent deposits the maximum estimated cost into an escrow account on Solana. This account is controlled by a smart contract (an on-chain program), not by RCR.
-2. **Service delivery**: RCR processes the request and tracks the actual cost.
+2. **Service delivery**: Solvela processes the request and tracks the actual cost.
 3. **Settlement**: After service delivery, the smart contract releases the actual cost to the gateway operator and automatically refunds the remainder to the agent.
 4. **Timeout protection**: If the gateway never claims the funds (say, the server goes down), the agent can reclaim the full deposit after a timeout period. No trust required.
 

--- a/docs/product/regulatory-position.md
+++ b/docs/product/regulatory-position.md
@@ -160,7 +160,7 @@ There is no data-subject-access workflow because there is no data subject under 
 **Question**: Could the PDA escrow account be classified as a "custodial wallet" by regulators?
 
 **Relevant facts**:
-- The escrow program has been **deployed to Solana mainnet** (program ID: `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`, tx: `XGtZf6KHWnis6bY8T8NCULsngdC2kqy3GkuppVriyFFqJ8ud2NiBkAgcBRsYjvUMmMZcLUmYBw9RhhUnNNRYnZx`) with a 20-test suite (14 LiteSVM integration tests in `programs/escrow/tests/integration.rs` + 6 unit tests in `programs/escrow/tests/unit.rs`).
+- The escrow program has been **deployed to Solana mainnet** (program ID: `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`, tx: `XGtZf6KHWnis6bY8T8NCULsngdC2kqy3GkuppVriyFFqJ8ud2NiBkAgcBRsYjvUMmMZcLUmYBw9RhhUnNNRYnZx`) with a 33-test suite (24 LiteSVM integration tests in `programs/escrow/tests/integration.rs` + 9 unit tests in `programs/escrow/tests/unit.rs`).
 - The PDA is controlled by the on-chain program logic, not by the gateway operator. No one holds a private key to the PDA.
 - The program logic enforces: claim amounts cannot exceed deposited amount, claims must occur before expiry slot, agent can unilaterally reclaim after timeout.
 - **Upgrade authority is currently retained** by the deployer (`B7reP7rzzYsKwteQqCgwfx76xQmNTL4bQ7yk4tQTxL1A`). This allows bug fixes but regulators could argue de facto control. Authority can be revoked at any time via `solana program set-upgrade-authority --final` to make the program immutable. **Pre-acquisition action item**: verify current authority on-chain (`solana program show 9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`) and decide whether to finalize before any due diligence cycle.

--- a/docs/runbooks/sdk-consolidation.md
+++ b/docs/runbooks/sdk-consolidation.md
@@ -1,6 +1,12 @@
 # Runbook: SDK consolidation into the monorepo
 
-> Status as of 2026-05-12: Go SDK done ([#252](https://github.com/solvela-ai/solvela/pull/252), [#257](https://github.com/solvela-ai/solvela/pull/257)). TypeScript, Python, and Rust client remaining.
+> **Status as of 2026-05-28: COMPLETE.** All four SDKs are in-tree at `sdks/<lang>/` and have shipped `.github/workflows/sdks-<lang>.yml`:
+> - Go — `sdks/go/` (tag `sdks/go/v0.1.0`)
+> - TypeScript — `sdks/typescript/` (tag `sdks/typescript/v0.2.2`)
+> - Python — `sdks/python/` (tag `sdks/python/v0.2.0`)
+> - Rust client — `sdks/rust/` (tag `sdks/rust/v0.2.3`, with monorepo-native crates.io publish via `release-crates.yml`)
+>
+> This runbook is preserved as a reference pattern for any future SDK pulls. The per-language sections below describe the procedure that was used; do not re-run them against repos that have already been archived.
 
 ## Why this exists
 


### PR DESCRIPTION
Section 5 of the pre-1.0 docs accuracy sweep tracked in #410.

## Summary
Heaviest-touch branch in the audit — the codemaps had drifted significantly from current code.

**Highest-severity finding:** `docs/CODEMAPS/dependencies.md:173-174` carried a **garbled USDC mint** (`EPjFWaJY48sPHP1AY1jP5eUZNQxmögKYQ1nHSroM3zF` — note the `ö`). Any operator who copy-pasted this would have hit an "invalid pubkey" failure at runtime. Real value: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`.

Other key fixes:
- `docs/CODEMAPS/backend.md` route tree completely rewritten against `build_router` in `lib.rs`. Removed fabricated routes (`PATCH/DELETE /orgs/{org_id}`, `POST /v1/nonce/reserve`, `GET /v1/escrow/claim/{tx_sig}`, several more); added real ones (`/v1/orgs/{id}/teams/{tid}/budget`, `/v1/services/register`, `/v1/escrow/settle`, etc.).
- Schema column lists corrected for `spend_logs`, `audit_logs`, `escrow_claim_queue`; replaced fictional `hourly_spend_limits` table with the real `team_budgets` table from migration 007.
- Response cache TTL is 600s (not 24h); Docker is 2-stage (not 3); migrations are 9 (not 7); sqlx is runtime-checked (not compile-time prepared).
- API key prefix is `solvela_k_` (not `solv_`).
- `OrgContext` corrected (`org_id`, `api_key_id`, `role: OrgRole`; no `wallet_address`).
- Multiple env-var examples switched to canonical double-underscore form.
- 13 instances of legacy "RCR" naming replaced in `product/faq.md` and `product/how-it-works.md`. **Did NOT mass-replace inside `product/regulatory-position.md`** — flagged for a separate PR after legal review.

Full audit report: https://github.com/solvela-ai/solvela/issues/410#issuecomment-4566669710

**Operator note:** Section 5's agent committed but didn't post its tracking-issue comment before returning. The orchestrator posted the report on its behalf (see comment URL above).

## Test plan
- [ ] CI green
- [ ] Visual diff review for the route-tree rewrite in `backend.md`
- [ ] Confirm regulatory-position.md RCR cleanup is a separate follow-up

Tracking: #410
