### PR TITLE
docs(audit/section-6): align integration, dashboard, scripts, and brand docs with current code

### DIFF
--- a/brand/README.md
+++ b/brand/README.md
@@ -113,4 +113,4 @@ If touching the SVGs:
 
 ## Trademark
 
-`SOLVELA` is the subject of a planned USPTO trademark application (classes 9 + 42). See `docs/trademark/SOLVELA-USPTO-application.md`. The marks in this directory are © Solvela Contributors and are licensed under MIT for code-form uses; the **wordmark and stylized S logo** are not licensed under MIT and may not be used to represent products that are not Solvela. See the project `README.md` Licensing section.
+`SOLVELA` is the subject of a planned USPTO trademark application (classes 9 + 42). The marks in this directory are © Solvela Contributors and are licensed under MIT for code-form uses; the **wordmark and stylized S logo** are not licensed under MIT and may not be used to represent products that are not Solvela. See the project `README.md` Licensing section.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -55,7 +55,7 @@ deployments set these in Vercel.
 |---|---|---|
 | `NEXT_PUBLIC_GATEWAY_URL` | `src/lib/api.ts` | Solvela gateway base URL. Defaults to `http://localhost:8402` for local dev. |
 | `NEXT_PUBLIC_SITE_URL` | `src/lib/theme-config.ts` | Canonical site URL for OG / Twitter card metadata. Falls back through `VERCEL_PROJECT_PRODUCTION_URL` → `VERCEL_URL` → `http://localhost:3000`. |
-| `GATEWAY_ADMIN_KEY` | `src/lib/api.ts` | Server-only admin bearer token used for privileged gateway calls (Overview / Models pages). Never exposed to the browser. |
+| `GATEWAY_ADMIN_KEY` | `src/lib/api.ts` | Server-only admin bearer token used for privileged gateway calls (Overview, Models, and Metrics pages). Never exposed to the browser. |
 | `SOLVELA_SOLANA_RECIPIENT_WALLET` | `src/app/dashboard/wallet/page.tsx` | Public recipient wallet shown on the Wallet page. Legacy `RCR_SOLANA_RECIPIENT_WALLET` is also accepted as a fallback. |
 | `VERCEL_PROJECT_PRODUCTION_URL`, `VERCEL_URL` | `src/lib/theme-config.ts` | Set automatically by Vercel; consumed for canonical URL detection. |
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,36 +1,72 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Solvela dashboard
 
-## Getting Started
+The product web app at [solvela.vercel.app](https://solvela.vercel.app). A
+Next.js 16 App Router project that combines the Solvela dashboard pages
+(Overview / Usage / Models / Wallet / Settings) with the public docs site
+powered by Fumadocs. Styled with Tailwind and a serif / terminal-card
+design system.
 
-First, run the development server:
+For deeper context on the directory layout, design system, and module
+conventions, read [`AGENTS.md`](./AGENTS.md) and the nested `AGENTS.md`
+files under `src/`.
+
+## Local development
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+# One-time install (from repo root or any directory).
+npm --prefix dashboard install
+
+# Dev server — opens on http://localhost:3000
+npm --prefix dashboard run dev
+
+# Vitest unit tests
+npm --prefix dashboard test
+
+# ESLint
+npm --prefix dashboard run lint
+
+# Production build
+npm --prefix dashboard run build
+
+# Serve the production build locally
+npm --prefix dashboard run start
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Or from inside `dashboard/`:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+cd dashboard
+npm install
+npm run dev
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+The page entry point lives at `src/app/page.tsx` (the project uses the
+`src/` layout, not the bare `app/` layout). Dashboard pages live under
+`src/app/dashboard/`; the docs site is under `src/app/docs/` with MDX
+content under `content/docs/`.
 
-## Learn More
+## Environment variables
 
-To learn more about Next.js, take a look at the following resources:
+All env vars are optional locally — the dashboard falls back to a localhost
+gateway and to inert values for missing wallets / admin keys. Production
+deployments set these in Vercel.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+| Variable | Where read | Description |
+|---|---|---|
+| `NEXT_PUBLIC_GATEWAY_URL` | `src/lib/api.ts` | Solvela gateway base URL. Defaults to `http://localhost:8402` for local dev. |
+| `NEXT_PUBLIC_SITE_URL` | `src/lib/theme-config.ts` | Canonical site URL for OG / Twitter card metadata. Falls back through `VERCEL_PROJECT_PRODUCTION_URL` → `VERCEL_URL` → `http://localhost:3000`. |
+| `GATEWAY_ADMIN_KEY` | `src/lib/api.ts` | Server-only admin bearer token used for privileged gateway calls (Overview / Models pages). Never exposed to the browser. |
+| `SOLVELA_SOLANA_RECIPIENT_WALLET` | `src/app/dashboard/wallet/page.tsx` | Public recipient wallet shown on the Wallet page. Legacy `RCR_SOLANA_RECIPIENT_WALLET` is also accepted as a fallback. |
+| `VERCEL_PROJECT_PRODUCTION_URL`, `VERCEL_URL` | `src/lib/theme-config.ts` | Set automatically by Vercel; consumed for canonical URL detection. |
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+`next.config.mjs` itself reads no custom env vars — it only declares the
+MDX rewrites and Fumadocs config. Env wiring lives in
+`src/lib/*` and a small number of server-rendered pages.
 
-## Deploy on Vercel
+## Deployment
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Deployed to Vercel from `main`. Production URL: `solvela.vercel.app`.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+See the operator notes in [`AGENTS.md`](./AGENTS.md) for design-system
+guardrails and the project's "exercise the change in a browser before
+claiming done" rule.

--- a/dashboard/content/docs/AGENTS.md
+++ b/dashboard/content/docs/AGENTS.md
@@ -19,13 +19,15 @@ MDX content for the public docs site at `/docs`. Fumadocs traverses this tree, r
 | `api/` | HTTP API reference — endpoints, 402 shape, headers |
 | `concepts/` | Conceptual docs — x402, Solvela vs traditional APIs, pricing, escrow |
 | `sdks/` | Per-SDK quickstarts (Python, TypeScript, Go, MCP) |
+| `enterprise/` | Enterprise / org-tier docs — orgs, teams, API keys, audit log, budgets |
+| `operations/` | Operator docs — deploy, observability, runbooks |
 
 ## For AI Agents
 
 ### Working In This Directory
 - Every new MDX file needs to appear in the relevant `meta.json` — Fumadocs does not auto-list files.
 - Keep pages focused on one task; split long docs into a folder with its own `meta.json`.
-- Use Fumadocs callouts / tabs via the components exposed in `src/app/components/docs/` or `src/components/mdx.tsx`.
+- Use Fumadocs callouts / tabs via the MDX components exposed in `src/app/components/docs/mdx/`.
 - Code blocks: include a language tag so Shiki highlights correctly.
 
 ### Testing Requirements

--- a/dashboard/src/AGENTS.md
+++ b/dashboard/src/AGENTS.md
@@ -7,7 +7,9 @@
 All application code for the dashboard + docs site. Routing lives under `app/`; shared UI lives under `components/`; library code and data access live under `lib/`; tests live under `__tests__/`.
 
 ## Key Files
-_(no loose files — see subdirectories)_
+| File | Description |
+|------|-------------|
+| `proxy.ts` | Host-based proxy/rewrite logic exported for Next.js middleware — keeps `/_next/`, search API, and common static paths on canonical routes |
 
 ## Subdirectories
 | Directory | Purpose |
@@ -16,7 +18,6 @@ _(no loose files — see subdirectories)_
 | `components/` | Shared React components (see `components/AGENTS.md`) |
 | `lib/` | Helpers, API client, theme config, data mocks (see `lib/AGENTS.md`) |
 | `__tests__/` | Vitest unit tests (see `__tests__/AGENTS.md`) |
-| `shims/` | Local shims for third-party packages (e.g., `fumadocs-ui`) |
 | `test/` | Test setup helpers |
 | `types/` | Ambient type declarations |
 

--- a/dashboard/src/app/AGENTS.md
+++ b/dashboard/src/app/AGENTS.md
@@ -13,6 +13,7 @@ Next.js App Router entry. `layout.tsx` is the root layout (html/body, font, prov
 | `page.tsx` | Marketing landing page |
 | `globals.css` | Tailwind directives + global CSS variables (design tokens) |
 | `favicon.ico` | Tab icon |
+| `sitemap.ts` | Next.js `MetadataRoute.Sitemap` — emits the public `/sitemap.xml` |
 
 ## Subdirectories
 | Directory | Purpose |
@@ -22,6 +23,8 @@ Next.js App Router entry. `layout.tsx` is the root layout (html/body, font, prov
 | `docs/` | Fumadocs-backed docs site at `/docs/*` (see `docs/AGENTS.md`) |
 | `providers/` | Client-side React providers (theme, etc.) (see `providers/AGENTS.md`) |
 | `components/` | Route-scoped components (e.g., docs MDX helpers) (see `components/AGENTS.md`) |
+| `metrics/` | Public trust-evidence page at `/metrics` — on-chain IDs, gateway health, license posture; SSR, no analytics (single `page.tsx`) |
+| `sponsor/` | Sponsorship / backers landing page (single `page.tsx`) |
 
 ## For AI Agents
 

--- a/dashboard/src/app/dashboard/AGENTS.md
+++ b/dashboard/src/app/dashboard/AGENTS.md
@@ -10,6 +10,7 @@ The authenticated product dashboard. One subdirectory per top-level page: Overvi
 | File | Description |
 |------|-------------|
 | `layout.tsx` | Shell layout — renders `Shell`/`Sidebar`/`Topbar` around `{children}` |
+| `page.tsx` | `/dashboard` index — redirects to `/dashboard/overview` |
 
 ## Subdirectories
 | Directory | Purpose |

--- a/dashboard/src/components/AGENTS.md
+++ b/dashboard/src/components/AGENTS.md
@@ -4,12 +4,10 @@
 # components
 
 ## Purpose
-Shared React components used across the dashboard and (where appropriate) the docs site. Split into: `charts` (Recharts wrappers), `layout` (shell/sidebar/topbar), `ui` (primitives like cards/badges), plus `mdx.tsx` for docs prose rendering.
+Shared React components used across the dashboard and (where appropriate) the docs site. Split into: `charts` (Recharts wrappers), `layout` (shell/sidebar/topbar), `landing` (marketing-page panels), and `ui` (primitives like cards/badges). MDX component mapping for the docs site lives at `src/app/components/docs/mdx/`, not here.
 
 ## Key Files
-| File | Description |
-|------|-------------|
-| `mdx.tsx` | MDX component mapping (H1/H2/links/code blocks) used by Fumadocs |
+_(no loose files — see subdirectories)_
 
 ## Subdirectories
 | Directory | Purpose |
@@ -17,6 +15,7 @@ Shared React components used across the dashboard and (where appropriate) the do
 | `charts/` | Recharts-based visualizations (see `charts/AGENTS.md`) |
 | `layout/` | App shell — sidebar, topbar, Shell wrapper (see `layout/AGENTS.md`) |
 | `ui/` | Primitive UI components — card, badge, stat, status dot (see `ui/AGENTS.md`) |
+| `landing/` | Marketing landing page panels — hero, escrow diagram, provider row, SDK CTAs, ticker (no AGENTS.md yet) |
 
 ## For AI Agents
 

--- a/dashboard/src/lib/AGENTS.md
+++ b/dashboard/src/lib/AGENTS.md
@@ -12,10 +12,11 @@ Non-component library code — data access, helpers, content source, theme/icon 
 | `api.ts` | HTTP client for the Solvela gateway (server-side fetch wrappers) |
 | `auth.ts` | Auth session helpers (client-side) |
 | `mock-data.ts` | Deterministic mock datasets for local dev / demos |
+| `metrics-aggregator.ts` | Aggregates the gateway's Prometheus / admin stats into shapes the dashboard pages render |
+| `diagram-colors.ts` | Shared colour tokens used by landing-page diagrams (escrow flow, etc.) |
 | `source.ts` | Fumadocs content source — exposes the `content/docs` tree |
 | `utils.ts` | General helpers — `cn()`, formatters, number/time utilities |
 | `icons.tsx` | Central icon exports |
-| `layout.shared.tsx` | Shared layout fragments used by both dashboard + docs |
 | `theme-config.ts` | Colour palette, typography tokens, per-theme overrides |
 
 ## Subdirectories

--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -17,9 +17,9 @@ _(no loose files — see subdirectories)_
 
 > **Two OpenClaw plugins coexist on purpose.** This directory ships
 > `@solvela/router` (intercept-style, v0.1.0, stable). The newer
-> `@solvela/openclaw-provider` (wrapStreamFn-style, v1.0.0-draft, not yet
-> published) lives at `../sdks/openclaw-provider/`. Don't merge them —
-> they target different OpenClaw plugin contracts. See
+> `@solvela/openclaw-provider` (wrapStreamFn / catalog / resolveDynamicModel
+> surface, v0.1.0, not yet published) lives at `../sdks/openclaw-provider/`.
+> Don't merge them — they target different OpenClaw plugin contracts. See
 > `openclaw/README.md` for the user-facing "which one to install"
 > decision matrix.
 

--- a/integrations/elizaos/AGENTS.md
+++ b/integrations/elizaos/AGENTS.md
@@ -26,12 +26,12 @@ ElizaOS plugin that lets ElizaOS agents pay for LLM calls via Solvela. Exposes a
 
 ### Testing Requirements
 ```bash
-cd integrations/elizaos && npm install && npm test
+cd integrations/elizaos && npm install && npm run build
 ```
-(Use whatever script `package.json` actually defines; add one if missing.)
+There is no test suite yet — `npm test` is a placeholder that prints `no tests yet`. The README's Limitations section tracks this.
 
 ### Common Patterns
-- Thin action wrapper around a Solvela HTTP call — handle 402 by asking ElizaOS to sign, then retry with `PAYMENT-SIGNATURE` header.
+- Thin action wrapper around a Solvela HTTP call. Today the 402 path returns a cost summary; when wallet signing lands, the action should ask ElizaOS to sign and retry with the `PAYMENT-SIGNATURE` header.
 
 ## Dependencies
 

--- a/integrations/elizaos/src/actions/AGENTS.md
+++ b/integrations/elizaos/src/actions/AGENTS.md
@@ -9,7 +9,7 @@ ElizaOS actions — units of work the agent can invoke. Each action is a standal
 ## Key Files
 | File | Description |
 |------|-------------|
-| `chat.ts` | The `chat` action — sends the agent's current context to Solvela's `/v1/chat/completions`, handles the 402 by asking ElizaOS to sign, then retries with the `PAYMENT-SIGNATURE` header |
+| `chat.ts` | The `CHAT_VIA_SOLVELA` action — sends the agent's current context to Solvela's `/v1/chat/completions`. On 402 it returns a human-readable payment-required message (cost summary). Wallet signing and sign-and-retry are not yet implemented — see the package README's Limitations section. |
 
 ## Subdirectories
 _(none)_
@@ -18,8 +18,8 @@ _(none)_
 
 ### Working In This Directory
 - Every action follows the ElizaOS action schema — name, similes, validate, handler, examples.
-- Do not hold private keys; use whatever signing hook ElizaOS exposes.
-- Handle both 200 and 402 responses. On 402, sign and retry once; propagate any remaining error to the agent runtime.
+- Do not hold private keys; when wallet signing lands, use whatever signing hook ElizaOS exposes.
+- Handle both 200 and 402 responses. Today the 402 path returns a cost summary; once wallet signing lands the action should sign and retry once, then propagate any remaining error to the agent runtime.
 
 ### Testing Requirements
 ```bash
@@ -27,12 +27,12 @@ npm --prefix integrations/elizaos test
 ```
 
 ### Common Patterns
-- Stream responses back to ElizaOS when the user requested streaming; otherwise return the final text.
+- Return the final text via the `callback({ text })` shape ElizaOS expects. Streaming responses through ElizaOS is not yet wired up.
 
 ## Dependencies
 
 ### Internal
-- Plugin providers (`../providers`) for the gateway HTTP client.
+- The plugin's gateway URL setting (`SOLVELA_GATEWAY_URL`), read via `runtime.getSetting()`. The `../providers/gateway.ts` provider exposes liveness context to the runtime but is not a shared HTTP client.
 
 ### External
 - `@elizaos/core`.

--- a/integrations/elizaos/src/providers/AGENTS.md
+++ b/integrations/elizaos/src/providers/AGENTS.md
@@ -4,12 +4,12 @@
 # providers
 
 ## Purpose
-ElizaOS providers — injected context / clients that actions can use. Hosts the pre-configured Solvela gateway HTTP client here so actions stay thin.
+ElizaOS providers — context strings ElizaOS injects into prompts so the agent runtime knows what's available. The gateway provider tells the runtime whether the configured Solvela gateway is reachable.
 
 ## Key Files
 | File | Description |
 |------|-------------|
-| `gateway.ts` | Gateway provider — returns an HTTP client configured against the Solvela base URL, including x402 request/response handling |
+| `gateway.ts` | Gateway provider — `get()` resolves the `SOLVELA_GATEWAY_URL` setting (default `http://localhost:8402`), pings `/health`, and returns a short status string for the runtime (online / non-200 / unreachable). It is not an HTTP client for actions to call. |
 
 ## Subdirectories
 _(none)_
@@ -17,17 +17,18 @@ _(none)_
 ## For AI Agents
 
 ### Working In This Directory
-- Base URL is configurable via an env var (e.g., `SOLVELA_GATEWAY_URL`) with a sensible default.
+- Base URL is configurable via the `SOLVELA_GATEWAY_URL` runtime setting (read via `runtime.getSetting()`, not `process.env`) with a sensible localhost default.
 - Provider must be stateless across invocations; no in-memory caching of signed payments.
-- Expose a typed client (not a raw `fetch`) so actions get compile-time guarantees on request shape.
+- Keep the return value a plain string suited for prompt injection — ElizaOS providers contribute context, not callable APIs.
 
 ### Testing Requirements
 ```bash
-npm --prefix integrations/elizaos test
+cd integrations/elizaos && npm run build
 ```
+There is no test suite yet — `npm test` prints a placeholder.
 
 ### Common Patterns
-- Use `fetch` (Node 20+) or an injected `undici`-style client; avoid heavy axios/superagent.
+- Use `fetch` (Node 20+); avoid heavy axios/superagent. Failures are swallowed into a descriptive status string so probe errors never crash the agent.
 
 ## Dependencies
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -9,7 +9,7 @@ The Solvela monorepo ships **two** OpenClaw plugins with different shapes. Pick 
 | Plugin | Path | OpenClaw hook | Status |
 |---|---|---|---|
 | **`@solvela/router`** (this package) | `integrations/openclaw/` | `intercept` / `interceptStream` | Stable v0.1.0 OSS plugin. Works against older OpenClaw versions and supports the classic intercept pattern. |
-| **`@solvela/openclaw-provider`** | `sdks/openclaw-provider/` | `wrapStreamFn` | Newer first-class **provider** plugin — registers Solvela in OpenClaw's model picker so users select it like any other LLM. Built on OpenClaw's post-refactor `wrapStreamFn` contract. `1.0.0-draft`, not yet on npm; publish gated on the OpenClaw LTS announcement. |
+| **`@solvela/openclaw-provider`** | `sdks/openclaw-provider/` | `wrapStreamFn` + `catalog` + `resolveDynamicModel` | Newer first-class **provider** plugin — registers Solvela in OpenClaw's model picker so users select it like any other LLM. Built on OpenClaw's post-refactor `wrapStreamFn` contract. `0.1.0`, not yet on npm; publish gated on the OpenClaw LTS announcement. |
 
 If you're on a recent OpenClaw and want users to see "Solvela" in the model picker, use **`@solvela/openclaw-provider`** (once it ships). If you want a drop-in plugin that intercepts existing LLM calls without UI changes, use this package.
 

--- a/migrations/AGENTS.md
+++ b/migrations/AGENTS.md
@@ -16,6 +16,8 @@ PostgreSQL SQL migrations. Applied automatically on gateway startup via `run_mig
 | `005_organizations.sql` | Enterprise org/team/member tables + API-key table |
 | `006_audit_logs.sql` | Per-org audit-log table |
 | `007_hourly_spend_limits.sql` | Adds hourly spend limits alongside existing monthly budgets |
+| `008_escrow_claim_queue_updated_at.sql` | Adds `updated_at` to `escrow_claim_queue` so the worker can recover stale `in_progress` claims |
+| `009_audit_actor_admin.sql` | Records actor identity for audit entries written through the global admin token (G5 H6) |
 
 ## Subdirectories
 _(none)_


### PR DESCRIPTION
Section 6 of the pre-1.0 docs accuracy sweep tracked in #410.

## Summary
- **`dashboard/README.md` was still untouched create-next-app boilerplate.** Replaced with project-accurate dev/build/test commands and the four real env vars consumed by source (`NEXT_PUBLIC_GATEWAY_URL`, `NEXT_PUBLIC_SITE_URL`, `GATEWAY_ADMIN_KEY`, `SOLVELA_SOLANA_RECIPIENT_WALLET`).
- **Two stale `1.0.0-draft` openclaw version refs** in `integrations/openclaw/README.md` and `integrations/AGENTS.md`; actual is `0.1.0`.
- **ElizaOS docs described aspirational behavior, not shipped code** — AGENTS.md files claimed action was named `chat`, signed and retried on 402, depended on a provider HTTP client, and had a test suite. Real action is `CHAT_VIA_SOLVELA` returning a cost-summary message, no signing, no retry, placeholder `npm test`.
- **Multiple dashboard AGENTS.md files referenced nonexistent paths** (`shims/`, loose `mdx.tsx`, `layout.shared.tsx`) and omitted real ones (`proxy.ts`, `sitemap.ts`, `metrics/`, `sponsor/`, `landing/`, migrations 008+009, content/docs `enterprise/` + `operations/`).
- **`brand/README.md`** linked to a missing trademark doc (`docs/trademark/SOLVELA-USPTO-application.md` doesn't exist; `docs/trademark/` directory doesn't exist).

Scripts audit READMEs were entirely accurate — every command verified against `--help`, every workflow file present, default model matches.

Full audit report: https://github.com/solvela-ai/solvela/issues/410#issuecomment-4566622646

**Cross-section note:** the openclaw `1.0.0-draft` fix here overlaps with Section 3's PR which fixed the same lie in `sdks/openclaw-provider/README.md`. No file overlap between branches.

**Flagged but not fixed** (out of scope or source-code issues): openclaw DTS build fails (TS5101 deprecation), dashboard `npm run lint` broken locally by `eslint-plugin-react` incompat, `dashboard/src/__tests__/AGENTS.md` omits `metrics-aggregator.test.ts`.

## Test plan
- [ ] CI green
- [ ] Visual diff review
- [ ] Confirm dashboard README replacement reads sensibly

Tracking: #410
