### PR TITLE
chore(dependabot): ignore @earendil-works/pi-* in openclaw-provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,10 @@ updates:
         versions: ["<14.0.0"]
       - dependency-name: "@solana/web3.js"
         versions: ["<2"]
+      # OpenClaw plugin contract: pi-* peer deps must stay exactly pinned.
+      # See memory project_openclaw_direction_2026_05; PRs #389 and #391
+      # were closed for this reason.
+      - dependency-name: "@earendil-works/pi-*"
 
   - package-ecosystem: npm
     directory: /integrations/openclaw


### PR DESCRIPTION
## Summary

Add an `ignore` rule for `@earendil-works/pi-*` packages in `/sdks/openclaw-provider` so Dependabot stops regenerating bumps for them.

These packages are part of the OpenClaw plugin contract and must stay exactly pinned at `0.74.0`. Without this rule, Dependabot opens the same PRs weekly — #389 (`pi-agent-core`) and #391 (`pi-ai`) were just closed for this reason.

Only `/sdks/openclaw-provider/package.json` consumes `@earendil-works/pi-*`; `/integrations/openclaw` does not, so no change needed there.

## Test plan

- [x] `.github/dependabot.yml` parses (YAML edit only, in-place under existing `ignore` block)
- [ ] Next weekly Dependabot run skips `@earendil-works/pi-agent-core` and `@earendil-works/pi-ai` bumps