### PR TITLE
chore(dependabot): ignore litesvm >=0.7 in programs/escrow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,12 @@ updates:
       - dependency-name: atty       # unmaintained, no fix exists
       - dependency-name: derivative # unmaintained, no fix exists
       - dependency-name: paste      # unmaintained, no fix exists
+      # litesvm >=0.7 pulls solana-keypair/solana-signature 3.x, which fail
+      # to compile against the escrow's pinned stack (DecodeError: Error trait
+      # bound). Same blocker class as the Anchor 0.31 -> 1.0 migration. Held at
+      # 0.6.x until the Solana 3.x line unblocks. PR #350 closed for this reason.
+      - dependency-name: litesvm
+        versions: [">=0.7"]
 
   # ── Dashboard (Next.js, Vercel prod) ────────────────────────────────────
   - package-ecosystem: npm


### PR DESCRIPTION
Stops dependabot re-opening the litesvm bump every week now that #350 is closed as blocked.

## Why
litesvm 0.7+ pulls `solana-keypair`/`solana-signature` 3.x, which fail to compile against the escrow's pinned Solana/Anchor stack:

```
error[E0277]: the trait bound `DecodeError: std::error::Error` is not satisfied
  --> solana-keypair-3.1.2/src/lib.rs:53
```

Same blocker class as the Anchor 0.31 → 1.0 migration (#155/#156) — moving the test harness forward drags Solana 3.x back in, counter to the #113 rollback. Held at 0.6.x until that upstream situation resolves.

## Change
Adds a `litesvm` `versions: [">=0.7"]` ignore to the `programs/escrow` cargo block, alongside the existing Solana-1.x transitive ignores. Config-only; no dependency or code change.