### PR TITLE
test(escrow): CI release guard asserting mainnet build targets the mainnet USDC mint (#436)

### DIFF
--- a/.github/workflows/escrow.yml
+++ b/.github/workflows/escrow.yml
@@ -72,17 +72,27 @@ jobs:
       - run: cargo test --test unit
 
   mainnet-build:
-    name: cargo check --features mainnet
+    name: Mainnet build + USDC-mint release guard (--features mainnet)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       # Mainnet deploys MUST be built with `--features mainnet` — without
       # it the program targets the devnet USDC mint and would silently
-      # reject all mainnet USDC deposits (`mint mismatch`). Only the
+      # reject all mainnet USDC deposits (`ConstraintAddress`). Only the
       # actual deploy uses this flag, so without this job a mainnet-only
       # compile error would go unnoticed until release day.
-      - run: cargo check --lib --features mainnet
+      #
+      # Running the unit suite under --features mainnet (rather than a bare
+      # `cargo check`) also exercises the #436 release guard
+      # (test_usdc_mint_matches_active_build_feature), which asserts the
+      # compiled USDC_MINT == the mainnet mint. That's the check that would
+      # have caught the 2026-05-31 devnet-mint-on-mainnet incident (#435):
+      # the wrong mint isn't a contiguous byte run in the .so, so only the
+      # compiled constant — not a byte-grep — reliably detects it. The
+      # default `unit` job above runs the same test with no features and
+      # pins the devnet mint, so the guard holds in both directions.
+      - run: cargo test --test unit --features mainnet
 
   sbf-build:
     name: cargo build-sbf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Solvela (formerly RustyClawRouter), in reverse chronological order.
 
+## 2026-05-31 — Escrow USDC-mint release guard in CI ([#436](https://github.com/solvela-ai/solvela/issues/436))
+
+Closes the gap that let a **devnet-mint** escrow build reach mainnet unnoticed (the incident below). Added `test_usdc_mint_matches_active_build_feature` to `programs/escrow/tests/unit.rs`: a feature-aware assertion that the compiled `USDC_MINT` equals the **mainnet** mint when built with `--features mainnet`, else the **devnet** mint. The `escrow.yml` `mainnet-build` job now runs `cargo test --test unit --features mainnet` (was a bare `cargo check --lib`), so the assertion executes in CI; the default `unit` job pins the devnet mint. A mint that doesn't match its build feature now fails CI in either direction.
+
+- **Why a test, not a byte-grep** — the mint constant isn't a contiguous 32-byte run in the `.so`, so grepping the artifact can't catch the wrong mint. Asserting the *compiled* constant per feature is the reliable check (raw `Pubkey` comparison, not a base58 string, so the guard doesn't ride on `Display` stability).
+- **Scope** — this guards the source→feature mapping at CI time. Deploy-time enforcement (build-then-assert-then-`solana program deploy` as a scripted step) and a post-deploy deposit-simulation smoke remain the larger follow-ups proposed in #436.
+
 ## 2026-05-31 — Escrow mainnet program rebuilt with the correct USDC mint
 
 The on-chain escrow program (`9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`) had been deployed from a **default-feature build**, baking in the **devnet** USDC mint (`4zMMC9…`) instead of mainnet (`EPjFW…`). Because `deposit`/`claim` pin `address = USDC_MINT`, every real-USDC escrow payment was rejected on-chain with `AnchorError ConstraintAddress 2012` (`0x7dc`) — the entire escrow scheme was non-functional on mainnet (the `exact` scheme was unaffected). No funds were ever at risk: deposits reverted atomically.

--- a/programs/escrow/tests/unit.rs
+++ b/programs/escrow/tests/unit.rs
@@ -9,6 +9,7 @@
 
 #[cfg(test)]
 mod tests {
+    use anchor_lang::prelude::pubkey;
     use anchor_lang::Space;
     use solana_sdk::pubkey::Pubkey;
     use solvela_escrow::state::Escrow;
@@ -133,6 +134,40 @@ mod tests {
         // form so a bad bump fails the build, not a single test.
         const _: () = assert!(solvela_escrow::MAX_ESCROW_SLOTS >= 100_000);
         const _: () = assert!(solvela_escrow::MAX_ESCROW_SLOTS <= 1_000_000);
+    }
+
+    #[test]
+    fn test_usdc_mint_matches_active_build_feature() {
+        // Release guard for #436. The deployed mainnet bytecode MUST be built
+        // with `--features mainnet`, which swaps USDC_MINT from the devnet mint
+        // to the mainnet mint (see lib.rs). A default-feature .so silently
+        // deployed to mainnet rejects every real-USDC deposit with
+        // ConstraintAddress (the 2026-05-31 incident, #435), and a naive
+        // byte-grep of the .so can't detect it because the mint isn't a
+        // contiguous 32-byte run in the artifact — so assert the *compiled*
+        // constant here instead.
+        //
+        // This test is feature-aware so it guards both directions: the
+        // escrow.yml `mainnet-build` CI job runs it with `--features mainnet`
+        // (pinning the mainnet mint) while the default `unit` job pins devnet.
+        // A mint that doesn't match the active build fails CI either way.
+        // Compare raw 32-byte Pubkeys (not Display strings) so the guard
+        // doesn't depend on base58 formatting staying stable.
+        const MAINNET_USDC_MINT: Pubkey = pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+        const DEVNET_USDC_MINT: Pubkey = pubkey!("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
+
+        let expected = if cfg!(feature = "mainnet") {
+            MAINNET_USDC_MINT
+        } else {
+            DEVNET_USDC_MINT
+        };
+
+        assert_eq!(
+            solvela_escrow::USDC_MINT,
+            expected,
+            "USDC_MINT does not match the active build feature — a mainnet \
+             deploy MUST be built with `--features mainnet` (#436)."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes #436. Adds the missing release guard that would have caught the 2026-05-31 incident (#435), where a **default-feature (devnet-mint)** escrow build was deployed to mainnet and rejected every real-USDC deposit with `ConstraintAddress`.

- **New test** `test_usdc_mint_matches_active_build_feature` (`programs/escrow/tests/unit.rs`): feature-aware assertion that the compiled `solvela_escrow::USDC_MINT` equals the **mainnet** mint (`EPjFW…`) when built with `--features mainnet`, else the **devnet** mint (`4zMM…`). Compares raw `Pubkey` values (not base58 strings), so the guard doesn't depend on `Display` formatting staying stable.
- **CI wiring** (`.github/workflows/escrow.yml`): the `mainnet-build` job now runs `cargo test --test unit --features mainnet` instead of a bare `cargo check --lib --features mainnet`, so the assertion actually executes. The default `unit` job already runs the same test with no features, pinning the devnet mint. A mint that doesn't match its build feature now fails CI **in either direction**.

## Why a test, not a byte-grep
The mint constant isn't a contiguous 32-byte run in the `.so`, so grepping the artifact can't detect the wrong mint. Asserting the *compiled* constant per feature is the reliable check — exactly the approach #436 proposed.

## Scope / follow-ups
This guards the **source→feature mapping at CI time**. The larger items in #436 — deploy-time enforcement (build → assert → `solana program deploy` as a scripted step) and a post-deploy deposit-simulation smoke — remain open as follow-ups.

## Testing
- `cargo test --test unit` (devnet) — 10 passed
- `cargo test --test unit --features mainnet` (mainnet) — 10 passed
- Negative check: temporarily mutating the expected mint makes the test fail loudly (verified, reverted)
- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --features mainnet,cpi,no-entrypoint,no-idl,no-log-ix-name -- -D warnings` clean