### PR TITLE
test(escrow): guard USDC_MINT value per feature in CI (#436)

### DIFF
--- a/.github/workflows/escrow.yml
+++ b/.github/workflows/escrow.yml
@@ -72,7 +72,7 @@ jobs:
       - run: cargo test --test unit
 
   mainnet-build:
-    name: cargo check --features mainnet
+    name: mainnet build + USDC-mint guard
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -83,6 +83,12 @@ jobs:
       # actual deploy uses this flag, so without this job a mainnet-only
       # compile error would go unnoticed until release day.
       - run: cargo check --lib --features mainnet
+      # Guard the *value* of USDC_MINT, not just that it compiles. A default
+      # build (devnet mint) once shipped to mainnet and rejected every real
+      # deposit with ConstraintAddress 2012 — see CHANGELOG 2026-05-31, #436.
+      # `test_usdc_mint_matches_active_feature` asserts the mainnet mint here;
+      # the `unit` job asserts the devnet mint on the default build.
+      - run: cargo test --test unit --features mainnet test_usdc_mint_matches_active_feature
 
   sbf-build:
     name: cargo build-sbf

--- a/programs/escrow/tests/unit.rs
+++ b/programs/escrow/tests/unit.rs
@@ -144,4 +144,35 @@ mod tests {
         // `cargo test` surface so a regression that removes it is loud.
         let _err = solvela_escrow::errors::EscrowError::DuplicateClaimAccounts;
     }
+
+    #[test]
+    fn test_usdc_mint_matches_active_feature() {
+        // Release guard (issue #436): assert the *value* of USDC_MINT for the
+        // active build, not just that it compiles. The deployed mainnet program
+        // MUST be built with `--features mainnet`; a default build bakes in the
+        // devnet mint and the `address = USDC_MINT` constraint on deposit/claim
+        // then rejects every real-USDC payment with ConstraintAddress 2012
+        // (0x7dc) — exactly the bug that shipped to mainnet (CHANGELOG
+        // 2026-05-31). CI runs this under both feature configurations: the
+        // `unit` job (default → devnet) and the mainnet job (`--features
+        // mainnet` → mainnet).
+        use std::str::FromStr;
+        let mainnet = Pubkey::from_str("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").unwrap();
+        let devnet = Pubkey::from_str("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU").unwrap();
+
+        #[cfg(feature = "mainnet")]
+        assert_eq!(
+            solvela_escrow::USDC_MINT,
+            mainnet,
+            "USDC_MINT must be the mainnet USDC mint when built with --features mainnet"
+        );
+        #[cfg(not(feature = "mainnet"))]
+        assert_eq!(
+            solvela_escrow::USDC_MINT, devnet,
+            "default build must target the devnet USDC mint; build with --features mainnet for mainnet deploys"
+        );
+
+        // Reference both in every config so neither binding warns as unused.
+        let _ = (mainnet, devnet);
+    }
 }


### PR DESCRIPTION
Closes #436.

## Why
The escrow `mainnet-build` CI job only ran `cargo check --features mainnet` — it verified the mainnet build *compiles*, but never asserted the **value** of `USDC_MINT`. That's the exact gap that let a default-feature (devnet-mint) build reach mainnet, where `address = USDC_MINT` rejected every real-USDC deposit with `ConstraintAddress 2012` (see CHANGELOG 2026-05-31).

## What
- **`test_usdc_mint_matches_active_feature`** (in `tests/unit.rs`) asserts the exact `USDC_MINT` pubkey for the active build: mainnet mint under `--features mainnet`, devnet mint otherwise. The mint isn't stored contiguously in the `.so`, so this constant-value check (not a byte-grep) is the reliable guard.
- **`escrow.yml`** — the mainnet job now runs that test under `--features mainnet` (asserts the mainnet mint); the existing `unit` job already runs it on the default build (asserts devnet). Either feature being mis-wired now fails CI.

## Verification (local, both configs)
- `cargo test --test unit test_usdc_mint_matches_active_feature` → pass (devnet)
- `cargo test --test unit --features mainnet …` → pass (mainnet)
- `cargo fmt --check`, clippy gate (`--features mainnet,cpi,no-entrypoint,no-idl,no-log-ix-name -D warnings`) clean.

## Remaining (not in this PR)
- The `sbf-build` job uploads a **default (devnet-mint)** `solvela_escrow.so` artifact; the *deployable* artifact should be a separate `--features mainnet` build. Tracked as a follow-up under #436.
- Post-deploy on-chain deposit-simulation smoke (needs RPC creds in CI) — separate concern, also #436.