### PR TITLE
ci(escrow): run full unit suite under --features mainnet

### DIFF
--- a/.github/workflows/escrow.yml
+++ b/.github/workflows/escrow.yml
@@ -82,13 +82,17 @@ jobs:
       # reject all mainnet USDC deposits (`mint mismatch`). Only the
       # actual deploy uses this flag, so without this job a mainnet-only
       # compile error would go unnoticed until release day.
-      - run: cargo check --lib --features mainnet
-      # Guard the *value* of USDC_MINT, not just that it compiles. A default
+      #
+      # Run the *full* unit suite under `--features mainnet` (not just the
+      # one mint-guard test): it both compiles the lib — subsuming a bare
+      # `cargo check --lib` — and exercises every unit test under the
+      # mainnet feature, so any test that regressed only under that flag is
+      # caught here. The mint-value guard
+      # (`test_usdc_mint_matches_active_feature`) asserts the mainnet mint in
+      # this job; the default `unit` job asserts the devnet mint. A default
       # build (devnet mint) once shipped to mainnet and rejected every real
       # deposit with ConstraintAddress 2012 — see CHANGELOG 2026-05-31, #436.
-      # `test_usdc_mint_matches_active_feature` asserts the mainnet mint here;
-      # the `unit` job asserts the devnet mint on the default build.
-      - run: cargo test --test unit --features mainnet test_usdc_mint_matches_active_feature
+      - run: cargo test --test unit --features mainnet
 
   sbf-build:
     name: cargo build-sbf


### PR DESCRIPTION
## What
The escrow `mainnet-build` CI job runs the whole unit suite under `--features mainnet` instead of only the named mint-guard test, and drops the now-redundant `cargo check --lib --features mainnet`.

```diff
-      - run: cargo check --lib --features mainnet
-      - run: cargo test --test unit --features mainnet test_usdc_mint_matches_active_feature
+      - run: cargo test --test unit --features mainnet
```

## Why
- The test target compiles the lib, so `cargo test --test unit --features mainnet` **subsumes** the bare `cargo check --lib` — one step instead of two.
- Running the **full** suite (not just `test_usdc_mint_matches_active_feature`) catches any unit test that regresses only under the `mainnet` feature, not just the mint guard.
- The mint-value guard still asserts the **mainnet** mint in this job; the default `unit` job asserts the **devnet** mint — both directions stay covered (the #436 guard is unchanged).

This picks up the one nuance from the superseded #438 (vs the merged #439, which ran only the named test); see #438's close comment.

## Verified
- [x] `cargo test --test unit --features mainnet` → **10/10 pass** locally
- [x] `escrow.yml` parses as valid YAML
- [x] Pure CI change; no runtime/program/source change