### PR TITLE
fix(x402): surface deterministic settlement rejections as non-retryable (#435)

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -12,7 +12,7 @@ use axum::http::HeaderMap;
 use serde_json::{json, Value};
 use tracing::{info, warn};
 
-use solvela_protocol::{ChatMessage, ChatRequest, Role};
+use solvela_protocol::{ChatMessage, ChatRequest, Role, SettlementFailureKind};
 use solvela_router::profiles::{self, Profile};
 use solvela_router::scorer;
 
@@ -400,14 +400,34 @@ async fn handle_payment_submitted(
 
         if !settlement.success {
             // Settlement detail (tx_signature, RPC error) is logged by the facilitator;
-            // do not surface it to the client.
+            // do not surface it to the client. Distinguish a deterministic on-chain
+            // rejection (a dead end) from a transient failure so an A2A agent isn't
+            // told to retry a transaction that can never confirm (issue #435). Only
+            // the numeric program code crosses the boundary (GHSA-cgqx-mg48-949v).
             tracing::warn!(
                 error = ?settlement.error,
+                failure_kind = ?settlement.failure_kind,
                 "A2A payment settlement returned success=false"
             );
+            let message = match settlement.failure_kind {
+                Some(SettlementFailureKind::Rejected { program_error_code }) => {
+                    match program_error_code {
+                        Some(code) => format!(
+                            "Payment was rejected on-chain (program error {code}); \
+                             this transaction cannot succeed and should not be retried."
+                        ),
+                        None => "Payment was rejected on-chain; this transaction \
+                             cannot succeed and should not be retried."
+                            .to_string(),
+                    }
+                }
+                Some(SettlementFailureKind::Timeout)
+                | Some(SettlementFailureKind::Submission)
+                | None => "Payment settlement failed. Transaction was not confirmed.".to_string(),
+            };
             return Err(JsonRpcErrorData {
                 code: ERR_PAYMENT_FAILED,
-                message: "Payment settlement failed. Transaction was not confirmed.".to_string(),
+                message,
                 data: None,
             });
         }

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -21,7 +21,7 @@ use axum::Json;
 use metrics::{counter, histogram};
 use tracing::{info, warn};
 
-use solvela_protocol::ChatRequest;
+use solvela_protocol::{ChatRequest, SettlementFailureKind};
 use solvela_router::profiles::{self, Profile};
 use solvela_router::scorer;
 
@@ -491,16 +491,45 @@ pub async fn chat_completions(
             // R1 FIX: Check settlement.success flag
             match state.facilitator.verify_and_settle(&payload).await {
                 Ok(settlement) if !settlement.success => {
-                    // Settlement returned Ok but the transaction was not confirmed
+                    // Settlement returned Ok but the transaction did not succeed.
+                    // Distinguish a deterministic on-chain rejection (a dead end —
+                    // retrying the same signed tx can never confirm) from a
+                    // transient timeout/transport failure (issue #435). The full
+                    // error detail stays server-side; the client only ever sees the
+                    // numeric program error code, never raw RPC internals
+                    // (GHSA-cgqx-mg48-949v).
                     counter!("solvela_payments_total", "status" => "failed").increment(1);
                     tracing::warn!(
                         tx_signature = %settlement.tx_signature.as_deref().unwrap_or("unknown"),
                         error = ?settlement.error,
-                        "payment settlement failed: transaction not confirmed"
+                        failure_kind = ?settlement.failure_kind,
+                        "payment settlement failed"
                     );
-                    return Err(GatewayError::InvalidPayment(
-                        "Payment transaction could not be confirmed. Please retry.".to_string(),
-                    ));
+                    // Exhaustive on purpose — no `_` wildcard, so a future
+                    // `SettlementFailureKind` variant can't be silently funneled
+                    // into the retryable bucket and re-open #435.
+                    let message = match settlement.failure_kind {
+                        Some(SettlementFailureKind::Rejected { program_error_code }) => {
+                            match program_error_code {
+                                Some(code) => format!(
+                                    "Payment was rejected on-chain (program error {code}); \
+                                     this transaction cannot succeed and should not be retried."
+                                ),
+                                None => "Payment was rejected on-chain; this transaction \
+                                     cannot succeed and should not be retried."
+                                    .to_string(),
+                            }
+                        }
+                        // Transient failures, plus the unclassified `None` case
+                        // (only reachable from an external verifier — retry is the
+                        // safe default since replay protection prevents double-spend).
+                        Some(SettlementFailureKind::Timeout)
+                        | Some(SettlementFailureKind::Submission)
+                        | None => {
+                            "Payment transaction could not be confirmed. Please retry.".to_string()
+                        }
+                    };
+                    return Err(GatewayError::InvalidPayment(message));
                 }
                 Ok(settlement) => {
                     escrow_deposited_amount = settlement.verified_amount;

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -103,6 +103,7 @@ impl PaymentVerifier for AlwaysPassVerifier {
             network: SOLANA_NETWORK.to_string(),
             error: None,
             verified_amount: None,
+            failure_kind: None,
         })
     }
 }
@@ -141,6 +142,54 @@ impl PaymentVerifier for AlwaysPassEscrowVerifier {
             network: SOLANA_NETWORK.to_string(),
             error: None,
             verified_amount: Some(2625),
+            failure_kind: None,
+        })
+    }
+}
+
+/// An escrow verifier that passes verification but fails settlement, returning
+/// a `SettlementResult` whose `failure_kind` is derived from a caller-supplied
+/// raw error string by the *real* `classify_settlement_error`. This exercises
+/// classification + the route's failure-message mapping together, rather than
+/// hand-stamping a `failure_kind` the production path might never produce.
+struct SettleFailsEscrowVerifier {
+    raw_error: String,
+}
+
+#[async_trait::async_trait]
+impl PaymentVerifier for SettleFailsEscrowVerifier {
+    fn network(&self) -> &str {
+        SOLANA_NETWORK
+    }
+
+    fn scheme(&self) -> &str {
+        "escrow"
+    }
+
+    async fn verify_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<VerificationResult, X402Error> {
+        Ok(VerificationResult {
+            valid: true,
+            reason: None,
+            verified_amount: Some(2625),
+        })
+    }
+
+    async fn settle_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<SettlementResult, X402Error> {
+        Ok(SettlementResult {
+            success: false,
+            tx_signature: Some("MockFailedTxSig".to_string()),
+            network: SOLANA_NETWORK.to_string(),
+            error: Some(self.raw_error.clone()),
+            verified_amount: Some(2625),
+            failure_kind: Some(solvela_x402::solana_rpc::classify_settlement_error(
+                &self.raw_error,
+            )),
         })
     }
 }
@@ -1271,12 +1320,20 @@ async fn semantic_hit_full_atomic_fallback_serves_usage_less_entry() {
 
 /// Build a test app with mock providers and escrow support enabled.
 fn test_app_with_mock_provider_and_escrow() -> axum::Router {
+    test_app_with_mock_provider_and_escrow_verifier(Arc::new(AlwaysPassEscrowVerifier))
+}
+
+/// Like [`test_app_with_mock_provider_and_escrow`] but lets the caller inject the
+/// escrow verifier, so settlement-failure paths can be exercised end-to-end.
+fn test_app_with_mock_provider_and_escrow_verifier(
+    escrow_verifier: Arc<dyn PaymentVerifier>,
+) -> axum::Router {
     let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
     let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
 
     let facilitator = solvela_x402::facilitator::Facilitator::new(vec![
         Arc::new(AlwaysPassVerifier),
-        Arc::new(AlwaysPassEscrowVerifier),
+        escrow_verifier,
     ]);
 
     let mut config = AppConfig::default();
@@ -2414,6 +2471,103 @@ async fn test_escrow_payment_header_accepted() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["object"], "chat.completion");
     assert_eq!(json["choices"][0]["message"]["content"], "[mock response]");
+}
+
+#[tokio::test]
+async fn test_deterministic_escrow_rejection_is_not_retryable() {
+    // Issue #435: a hard on-chain program rejection (ConstraintAddress 2012,
+    // surfaced as a preflight error) must NOT tell the agent to retry, and must
+    // include the program error code. Drives the real classify + route mapping.
+    let raw = r#"submission failed: rpc error: {"code":-32002,"message":"Transaction simulation failed: Error processing Instruction 0: custom program error: 0x7dc","data":{"err":{"InstructionError":[0,{"Custom":2012}]}}}"#;
+    let app =
+        test_app_with_mock_provider_and_escrow_verifier(Arc::new(SettleFailsEscrowVerifier {
+            raw_error: raw.to_string(),
+        }));
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_escrow_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let message = json["error"]["message"].as_str().unwrap();
+    // Must surface the program error code and must NOT suggest a retry.
+    assert!(
+        message.contains("2012"),
+        "expected program error code 2012 in message, got: {message}"
+    );
+    assert!(
+        message.to_lowercase().contains("should not be retried"),
+        "expected a non-retryable message, got: {message}"
+    );
+    assert!(
+        !message.to_lowercase().contains("please retry"),
+        "deterministic rejection must not say 'please retry', got: {message}"
+    );
+    // The raw RPC blob must never leak to the client (GHSA-cgqx-mg48-949v).
+    assert!(
+        !message.contains("InstructionError") && !message.contains("-32002"),
+        "raw RPC internals leaked to client: {message}"
+    );
+}
+
+#[tokio::test]
+async fn test_transient_escrow_timeout_is_retryable() {
+    // Counterpart to the rejection test: a genuine confirmation timeout (no
+    // on-chain error) keeps the retryable message.
+    let raw = "settlement failed: transaction not confirmed within 30s";
+    let app =
+        test_app_with_mock_provider_and_escrow_verifier(Arc::new(SettleFailsEscrowVerifier {
+            raw_error: raw.to_string(),
+        }));
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_escrow_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let message = json["error"]["message"].as_str().unwrap();
+    assert!(
+        message.to_lowercase().contains("please retry"),
+        "transient timeout should remain retryable, got: {message}"
+    );
 }
 
 #[tokio::test]

--- a/crates/protocol/src/settlement.rs
+++ b/crates/protocol/src/settlement.rs
@@ -11,6 +11,35 @@ pub struct VerificationResult {
     pub verified_amount: Option<u64>,
 }
 
+/// Why a settlement failed, used to decide whether a retry could ever succeed.
+///
+/// The gateway maps this to the client-facing message: a `Rejected` payment is
+/// a dead end (telling the agent to "please retry" wastes its time and tokens),
+/// whereas `Timeout`/`Submission` are genuinely worth retrying.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SettlementFailureKind {
+    /// The transaction was deterministically rejected by the chain — either at
+    /// preflight or after landing with an on-chain `InstructionError`. The same
+    /// signed transaction can NEVER confirm on retry. `program_error_code`
+    /// carries only the numeric program error (e.g. an Anchor constraint code
+    /// such as `2012`/`ConstraintAddress`); it deliberately never carries raw
+    /// RPC internals (RPC URL, full error JSON) — see GHSA-cgqx-mg48-949v.
+    Rejected {
+        /// Numeric on-chain program error code, when one could be extracted.
+        /// Solana program error codes are `u32` (e.g. Anchor's `2012` /
+        /// `ConstraintAddress`); `None` when the rejection carried no `Custom`
+        /// code (a builtin instruction error) or none could be parsed.
+        program_error_code: Option<u32>,
+    },
+    /// Submitted but not confirmed within the budget, with no on-chain error
+    /// observed. The blockhash may simply have been slow to land — retry may work.
+    Timeout,
+    /// Submission failed at the RPC/transport layer (network blip, RPC down,
+    /// expired blockhash). Retry may work.
+    Submission,
+}
+
 /// Result of payment settlement.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SettlementResult {
@@ -27,4 +56,10 @@ pub struct SettlementResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub verified_amount: Option<u64>,
+    /// Classification of the failure when `success` is false; `None` on success
+    /// or when the failure was not classified. Lets the gateway distinguish a
+    /// permanent rejection from a transient timeout when shaping the client error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub failure_kind: Option<SettlementFailureKind>,
 }

--- a/crates/x402/src/escrow/verifier.rs
+++ b/crates/x402/src/escrow/verifier.rs
@@ -436,12 +436,15 @@ impl PaymentVerifier for EscrowVerifier {
             }
             Err(e) => {
                 tracing::warn!(error = %e, "escrow deposit submission failed");
+                let raw = format!("submission failed: {e}");
+                let failure_kind = crate::solana_rpc::classify_settlement_error(&raw);
                 return Ok(SettlementResult {
                     success: false,
                     tx_signature: Some(sig_b58),
                     network: SOLANA_NETWORK.to_string(),
-                    error: Some(format!("submission failed: {e}")),
+                    error: Some(raw),
                     verified_amount,
+                    failure_kind: Some(failure_kind),
                 });
             }
         }
@@ -462,14 +465,26 @@ impl PaymentVerifier for EscrowVerifier {
                 network: SOLANA_NETWORK.to_string(),
                 error: None,
                 verified_amount,
+                failure_kind: None,
             }),
-            Err(e) => Ok(SettlementResult {
-                success: false,
-                tx_signature: Some(sig_b58),
-                network: SOLANA_NETWORK.to_string(),
-                error: Some(e.to_string()),
-                verified_amount,
-            }),
+            Err(e) => {
+                let raw = e.to_string();
+                let failure_kind = crate::solana_rpc::classify_settlement_error(&raw);
+                tracing::warn!(
+                    error = %e,
+                    signature = %sig_b58,
+                    ?failure_kind,
+                    "escrow deposit confirmation failed"
+                );
+                Ok(SettlementResult {
+                    success: false,
+                    tx_signature: Some(sig_b58),
+                    network: SOLANA_NETWORK.to_string(),
+                    error: Some(raw),
+                    verified_amount,
+                    failure_kind: Some(failure_kind),
+                })
+            }
         }
     }
 }

--- a/crates/x402/src/facilitator.rs
+++ b/crates/x402/src/facilitator.rs
@@ -107,6 +107,7 @@ mod tests {
                 network: SOLANA_NETWORK.to_string(),
                 error: None,
                 verified_amount: None,
+                failure_kind: None,
             })
         }
     }

--- a/crates/x402/src/solana.rs
+++ b/crates/x402/src/solana.rs
@@ -415,11 +415,27 @@ impl PaymentVerifier for SolanaVerifier {
         // Validate the transaction can be decoded
         let _tx = self.decode_and_validate_transaction(&solana_payload.transaction)?;
 
-        // Broadcast the transaction
-        let signature = self
-            .send_transaction(&solana_payload.transaction)
-            .await
-            .map_err(|e| Error::SettlementFailed(format!("send failed: {e}")))?;
+        // Broadcast the transaction. A send-time failure is returned as a
+        // classified `Ok(SettlementResult { success: false })` rather than an
+        // `Err` so the gateway can distinguish a deterministic preflight
+        // rejection (non-retryable) from a transient send failure (retryable) —
+        // mirrors the escrow path and closes the direct-scheme half of #435.
+        let signature = match self.send_transaction(&solana_payload.transaction).await {
+            Ok(sig) => sig,
+            Err(e) => {
+                let raw = format!("send failed: {e}");
+                let failure_kind = crate::solana_rpc::classify_settlement_error(&raw);
+                warn!(error = %e, ?failure_kind, "solana payment send failed");
+                return Ok(SettlementResult {
+                    success: false,
+                    tx_signature: None,
+                    network: SOLANA_NETWORK.to_string(),
+                    error: Some(raw),
+                    verified_amount: None,
+                    failure_kind: Some(failure_kind),
+                });
+            }
+        };
 
         info!(signature = %signature, "transaction sent, waiting for confirmation");
 
@@ -444,6 +460,7 @@ impl PaymentVerifier for SolanaVerifier {
                     network: SOLANA_NETWORK.to_string(),
                     error: None,
                     verified_amount: None,
+                    failure_kind: None,
                 })
             }
             Err(e) => {
@@ -452,12 +469,15 @@ impl PaymentVerifier for SolanaVerifier {
                     error = %e,
                     "settlement confirmation failed"
                 );
+                let raw = e.to_string();
+                let failure_kind = crate::solana_rpc::classify_settlement_error(&raw);
                 Ok(SettlementResult {
                     success: false,
                     tx_signature: Some(signature),
                     network: SOLANA_NETWORK.to_string(),
-                    error: Some(e.to_string()),
+                    error: Some(raw),
                     verified_amount: None,
+                    failure_kind: Some(failure_kind),
                 })
             }
         }
@@ -498,6 +518,7 @@ fn validate_nonce_account(
 mod tests {
     use super::*;
     use crate::solana_types::{ParsedMessage, Pubkey};
+    use crate::types::{PaymentAccept, Resource, SettlementFailureKind, SolanaPayload};
 
     // -----------------------------------------------------------------------
     // Helpers for building test transactions
@@ -1028,5 +1049,65 @@ mod tests {
             }
             other => panic!("expected InvalidTransaction, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Settlement failure classification (issue #435, direct/exact scheme)
+    // -----------------------------------------------------------------------
+
+    /// Build a valid, signed direct PaymentPayload that passes
+    /// `decode_and_validate_transaction` (real ed25519 signature over the
+    /// message), so `settle_payment` proceeds to the broadcast step.
+    fn signed_direct_payload() -> PaymentPayload {
+        let signer = test_signer_pubkey();
+        let recipient = Pubkey::from_str(TEST_RECIPIENT).unwrap();
+        let msg = build_spl_transfer_message(&signer, &recipient, 5000);
+        let tx = encode_base64(&wrap_in_transaction(&msg));
+        PaymentPayload {
+            x402_version: 2,
+            resource: Resource {
+                url: "/v1/chat/completions".to_string(),
+                method: "POST".to_string(),
+            },
+            accepted: PaymentAccept {
+                scheme: "exact".to_string(),
+                network: SOLANA_NETWORK.to_string(),
+                amount: "5000".to_string(),
+                asset: TEST_USDC_MINT.to_string(),
+                pay_to: TEST_RECIPIENT.to_string(),
+                max_timeout_seconds: 300,
+                escrow_program_id: None,
+            },
+            payload: PayloadData::Direct(SolanaPayload { transaction: tx }),
+        }
+    }
+
+    #[tokio::test]
+    async fn settle_send_failure_returns_classified_ok_not_err() {
+        // Regression for the direct-scheme half of #435: a send-time RPC failure
+        // must surface as `Ok(SettlementResult { success: false, failure_kind })`
+        // so the gateway can classify it — NOT propagate as `Err`, which the
+        // route flattens into a generic "retry" message. Point at an unroutable
+        // local address so the send fails instantly with no network egress.
+        let verifier = SolanaVerifier::new(
+            "http://127.0.0.1:1",
+            TEST_RECIPIENT,
+            TEST_USDC_MINT,
+            reqwest::Client::new(),
+        )
+        .expect("verifier");
+
+        let result = verifier
+            .settle_payment(&signed_direct_payload())
+            .await
+            .expect("send failure must be Ok(success=false), not Err");
+
+        assert!(!result.success);
+        // A transport failure (connection refused) is transient → Submission,
+        // which the gateway maps to the retryable message. A deterministic
+        // program rejection would instead classify as Rejected (covered by the
+        // classifier unit tests in solana_rpc.rs).
+        assert_eq!(result.failure_kind, Some(SettlementFailureKind::Submission));
+        assert!(result.error.is_some());
     }
 }

--- a/crates/x402/src/solana_rpc.rs
+++ b/crates/x402/src/solana_rpc.rs
@@ -10,6 +10,7 @@ use reqwest::Client;
 use tracing::{debug, info, warn};
 
 use crate::traits::Error;
+use crate::types::SettlementFailureKind;
 
 /// Submit a base64-encoded signed transaction to Solana RPC.
 ///
@@ -62,15 +63,86 @@ pub async fn send_transaction(
 /// Check if an error from `send_transaction` indicates the transaction is
 /// already on-chain (idempotency — a successful resubmission).
 ///
-/// Covers known variants: "already processed" (lowercase/titlecase/spaced),
-/// `AlreadyProcessed` enum form, JSON-RPC code -32002.
+/// Covers known variants: "already processed" (lowercase/titlecase/spaced) and
+/// the `AlreadyProcessed` enum form.
+///
+/// NB: this deliberately does NOT match on the bare JSON-RPC code `-32002`.
+/// `-32002` is `SendTransactionPreflightFailure`, the umbrella code for ALL
+/// preflight rejections — including deterministic program errors such as
+/// `ConstraintAddress` (2012). Treating any `-32002` as "already processed"
+/// made the gateway swallow a hard rejection as an idempotent resubmission,
+/// then dead-end in the 30s confirmation poll and report it as a transient
+/// "could not be confirmed, please retry" timeout (issue #435). A genuine
+/// already-processed response always carries the "already processed" /
+/// "already been processed" message text, which the matches above cover.
 pub fn is_already_processed_error(err: &Error) -> bool {
-    let s = err.to_string();
-    let lower = s.to_lowercase();
+    let lower = err.to_string().to_lowercase();
     lower.contains("already processed")
         || lower.contains("already been processed")
         || lower.contains("alreadyprocessed")
-        || s.contains("-32002")
+}
+
+/// Classify a raw settlement error string into a retry verdict.
+///
+/// Pure (no I/O). The input is whatever error text the settlement path
+/// produced — a `send_transaction` preflight error, a `getSignatureStatuses`
+/// `err` value, or a confirmation-budget timeout message. The output is the
+/// safe, typed [`SettlementFailureKind`] the gateway switches on; this function
+/// extracts only the numeric program error code, never raw RPC internals.
+pub fn classify_settlement_error(raw: &str) -> SettlementFailureKind {
+    // A program error means the program ran and rejected the transaction. The
+    // same signed transaction can never confirm on retry. Solana surfaces this
+    // two ways: the structured `InstructionError` (JSON / Debug form) and the
+    // human-readable "custom program error: 0x..." preflight message.
+    if raw.contains("InstructionError") || raw.contains("custom program error") {
+        return SettlementFailureKind::Rejected {
+            program_error_code: extract_program_error_code(raw),
+        };
+    }
+    // Confirmation budget exhausted with no on-chain error observed — the
+    // blockhash may simply have been slow to land. Worth a retry.
+    if raw.contains("not confirmed within") {
+        return SettlementFailureKind::Timeout;
+    }
+    // Everything else — RPC transport failure, expired blockhash, generic send
+    // failure. Transient, so the client may retry.
+    SettlementFailureKind::Submission
+}
+
+/// Extract the numeric on-chain program error code from a raw error string.
+///
+/// Handles the structured JSON form (`"Custom":2012`), the Debug form
+/// (`Custom(2012)`), and the preflight text form (`custom program error: 0x7dc`).
+/// Returns `None` when the instruction error is non-`Custom` (e.g. a builtin
+/// like `InsufficientFunds`) or no code can be parsed. The markers are anchored
+/// (`"Custom":` / `Custom(`) rather than a bare `Custom` substring so an
+/// unrelated occurrence of the word can't anchor the scan on the wrong digits.
+fn extract_program_error_code(raw: &str) -> Option<u32> {
+    // Form 1: structured/Debug — `"Custom":2012` or `Custom(2012)`.
+    for marker in ["\"Custom\":", "Custom("] {
+        if let Some(idx) = raw.find(marker) {
+            let digits: String = raw[idx + marker.len()..]
+                .chars()
+                .skip_while(|c| c.is_whitespace())
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if let Ok(code) = digits.parse::<u32>() {
+                return Some(code);
+            }
+        }
+    }
+    // Form 2: `custom program error: 0x7dc` — hex run after the marker.
+    const HEX_MARKER: &str = "custom program error: 0x";
+    if let Some(idx) = raw.find(HEX_MARKER) {
+        let hex: String = raw[idx + HEX_MARKER.len()..]
+            .chars()
+            .take_while(|c| c.is_ascii_hexdigit())
+            .collect();
+        if let Ok(code) = u32::from_str_radix(&hex, 16) {
+            return Some(code);
+        }
+    }
+    None
 }
 
 /// Poll `getSignatureStatuses` until the transaction reaches `confirmed` or
@@ -257,15 +329,127 @@ mod tests {
     }
 
     #[test]
-    fn test_is_already_processed_error_jsonrpc_code() {
-        let e =
-            Error::Rpc(r#"{"code":-32002,"message":"Transaction simulation failed"}"#.to_string());
+    fn test_is_already_processed_error_jsonrpc_code_with_text() {
+        // A genuine already-processed response carries the message text even
+        // when it also carries the -32002 code — that text is what we match on.
+        let e = Error::Rpc(
+            r#"{"code":-32002,"message":"Transaction simulation failed: This transaction has already been processed"}"#
+                .to_string(),
+        );
         assert!(is_already_processed_error(&e));
+    }
+
+    #[test]
+    fn test_is_already_processed_error_bare_code_is_not_already_processed() {
+        // Bare -32002 (SendTransactionPreflightFailure) must NOT be treated as
+        // already-processed — it is the umbrella code for deterministic program
+        // rejections like ConstraintAddress. Regression guard for issue #435.
+        let e = Error::Rpc(
+            r#"{"code":-32002,"message":"Transaction simulation failed: Error processing Instruction 0: custom program error: 0x7dc","data":{"err":{"InstructionError":[0,{"Custom":2012}]}}}"#
+                .to_string(),
+        );
+        assert!(!is_already_processed_error(&e));
     }
 
     #[test]
     fn test_is_already_processed_error_unrelated() {
         let e = Error::Rpc("blockhash not found".to_string());
         assert!(!is_already_processed_error(&e));
+    }
+
+    #[test]
+    fn classify_preflight_custom_program_error_is_rejected() {
+        // Real shape of a mainnet preflight ConstraintAddress rejection: carries
+        // both the "custom program error: 0x7dc" text and the structured
+        // InstructionError/Custom(2012). 0x7dc == 2012.
+        let raw = r#"submission failed: rpc error: {"code":-32002,"message":"Transaction simulation failed: Error processing Instruction 0: custom program error: 0x7dc","data":{"err":{"InstructionError":[0,{"Custom":2012}]}}}"#;
+        assert_eq!(
+            classify_settlement_error(raw),
+            SettlementFailureKind::Rejected {
+                program_error_code: Some(2012)
+            }
+        );
+    }
+
+    #[test]
+    fn classify_landed_on_chain_error_is_rejected() {
+        // A tx that landed and then failed execution (getSignatureStatuses err).
+        let raw = r#"transaction failed on-chain: {"InstructionError":[0,{"Custom":6001}]}"#;
+        assert_eq!(
+            classify_settlement_error(raw),
+            SettlementFailureKind::Rejected {
+                program_error_code: Some(6001)
+            }
+        );
+    }
+
+    #[test]
+    fn classify_builtin_instruction_error_has_no_code() {
+        // Non-Custom builtin errors still classify as Rejected, just without a code.
+        let raw =
+            r#"transaction failed on-chain: {"InstructionError":[1,"InsufficientFundsForRent"]}"#;
+        assert_eq!(
+            classify_settlement_error(raw),
+            SettlementFailureKind::Rejected {
+                program_error_code: None
+            }
+        );
+    }
+
+    #[test]
+    fn classify_debug_form_custom_code_is_extracted() {
+        // Rust Debug rendering of the err (e.g. via `{err:?}`): `Custom(2012)`.
+        let raw = "transaction failed on-chain: InstructionError(0, Custom(2012))";
+        assert_eq!(
+            classify_settlement_error(raw),
+            SettlementFailureKind::Rejected {
+                program_error_code: Some(2012)
+            }
+        );
+    }
+
+    #[test]
+    fn classify_custom_as_string_value_yields_no_spurious_code() {
+        // "Custom" appearing as a string value (not the `"Custom":` key / `Custom(`
+        // form) must not anchor the scan onto unrelated digits — code stays None,
+        // still classified Rejected via the InstructionError marker.
+        let raw = r#"transaction failed on-chain: {"InstructionError":[7,"Custom"]}"#;
+        assert_eq!(
+            classify_settlement_error(raw),
+            SettlementFailureKind::Rejected {
+                program_error_code: None
+            }
+        );
+    }
+
+    #[test]
+    fn classify_hex_only_program_error_is_rejected_with_code() {
+        // Only the text form present (no structured InstructionError) — extract hex.
+        let raw = "submission failed: Error processing Instruction 0: custom program error: 0x1771";
+        assert_eq!(
+            classify_settlement_error(raw),
+            SettlementFailureKind::Rejected {
+                program_error_code: Some(6001)
+            }
+        );
+    }
+
+    #[test]
+    fn classify_confirmation_timeout_is_timeout() {
+        let raw = "settlement failed: transaction not confirmed within 30s";
+        assert_eq!(
+            classify_settlement_error(raw),
+            SettlementFailureKind::Timeout
+        );
+    }
+
+    #[test]
+    fn classify_transport_failure_is_submission() {
+        // Expired blockhash / RPC blip — genuinely retryable, not a rejection.
+        let raw = "submission failed: rpc error: blockhash not found";
+        assert_eq!(
+            classify_settlement_error(raw),
+            SettlementFailureKind::Submission
+        );
     }
 }


### PR DESCRIPTION
Closes #435.

## Problem
A deterministic on-chain escrow rejection (e.g. Anchor `ConstraintAddress` 2012 / `0x7dc`) was reported to agents as:

```json
{"error":{"type":"invalid_payment","message":"Payment transaction could not be confirmed. Please retry."}}
```

The transaction can *never* confirm on retry — it's a hard program rejection — so "please retry" sends agents down a dead end (wasting tokens and time). Discovered 2026-05-31 while debugging the mainnet escrow path; cost a full debugging session.

## Root cause (two compounding bugs)
1. **`is_already_processed_error` over-matched.** It treated bare JSON-RPC `-32002` as "already processed", but `-32002` is `SendTransactionPreflightFailure` — the umbrella code for **all** preflight rejections. A `ConstraintAddress` rejection was therefore swallowed as an idempotent resubmission, then dead-ended in the 30s confirmation poll and surfaced as a transient timeout. Now matched on the `"already processed"` message text only (a genuine already-processed response always carries it).
2. **The route discarded the captured error.** Every failed settlement was flattened to the same retry message, even though the program error code was sitting in `settlement.error`.

## Fix
- New `SettlementFailureKind` (`Rejected { program_error_code } / Timeout / Submission`) on `SettlementResult`, classified by a pure `classify_settlement_error` in `x402::solana_rpc`.
- Gateway maps `Rejected` → a **non-retryable** message carrying only the numeric program code; `Timeout`/`Submission`/unclassified stay retryable. The match is exhaustive (no `_` wildcard) so a future variant can't silently re-open this bug.
- Raw RPC internals never cross the client boundary — only the numeric code (GHSA-cgqx-mg48-949v); full detail stays in server logs at every failing branch.
- Applied to **escrow**, **direct (exact)**, and **A2A** settlement paths. The direct path previously propagated send failures as `Err`, bypassing classification entirely — now returns a classified `Ok(success=false)`.

## Tests
- `classify_settlement_error` unit tests over real Solana error strings: preflight `Custom`, landed `InstructionError`, builtin/no-code, Debug `Custom(...)` form, `Custom`-as-string edge, timeout, transport failure.
- Regression guard that bare `-32002` is **not** treated as already-processed.
- Route-level integration tests: deterministic rejection → non-retryable + code, no RPC leak; transient timeout → retryable.
- Offline direct-scheme send-failure test (unroutable RPC `127.0.0.1:1`) asserting `Ok(success=false, Submission)` rather than `Err`.

## Review
Two rounds of `rust-reviewer` + `silent-failure-hunter` (money-path practice). Round 1 caught the direct-scheme `Err`-bypass and the `Custom`-anchor/`u32` issues (all fixed); round 2 caught the A2A gap and a missing escrow-confirmation log (both fixed) and otherwise approved.

## Deliberate scoping / known gaps
- **Preflight `simulateTransaction` (issue suggestion) intentionally skipped** — `sendTransaction` already runs preflight (`skipPreflight:false`), so the deterministic error returns at submit; a separate simulate is a redundant RPC round-trip.
- **A2A settlement-failure has no integration test** — the A2A tests use an empty facilitator; the new mapping is line-identical to the integration-tested chat route. Verified by inspection + shared classifier coverage.
- **`is_already_processed_error` on non-standard RPC nodes** — relies on the standard agave message text; nodes that only surface "already processed" in `data.logs` aren't covered. No double-charge risk (replay protection guards before settle). Out of scope.

## Verification
`cargo test` green for protocol (21), x402 (145), gateway lib (629) + integration (138). `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -D warnings` clean. (The 12 `escrow_queue` `#[sqlx::test]` failures need a live Postgres and are unrelated to this diff.)