### PR TITLE
fix(gateway): check+reserve budget before settlement, release on failure (M3, #173)

### DIFF
--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -253,6 +253,13 @@ pub async fn chat_completions(
     let escrow_deposited_amount: Option<u64>;
     // Gateway-advertised amount — used as defense-in-depth cap when deposit amount is unknown
     let client_amount: u64;
+    // M3: budget is checked + reserved BEFORE settlement inside the arm below, so
+    // an over-budget request never settles on-chain. These are bound there and
+    // consumed after the match (the `None` arm diverges).
+    let wallet_address: String;
+    let tx_signature: Option<String>;
+    let estimated_cost: f64;
+    let budget_reservation: crate::usage::BudgetReservation;
 
     match payment_payload {
         Some(payload) => {
@@ -487,6 +494,49 @@ pub async fn chat_completions(
                 ));
             }
 
+            // --- M3: check + reserve budget BEFORE settling on-chain ---
+            // The wallet's spend limit must be enforced before the payment is
+            // broadcast. Otherwise an over-budget request settles on-chain and is
+            // then rejected with a 4xx — the agent pays and gets no service. The
+            // reservation is released on any settlement failure below so reserving
+            // early never leaks budget for a payment that did not happen.
+            (wallet_address, tx_signature) = extract_payment_info(payment_header.unwrap());
+
+            // Reuse the C1 `expected_cost` computed above rather than calling
+            // `estimate_cost` again — one hot-path computation, and the budget
+            // gate is guaranteed to reserve against the exact figure the payment
+            // amount was validated against (no boundary divergence between the
+            // two sites).
+            estimated_cost = expected_cost.total.parse::<f64>().map_err(|_| {
+                GatewayError::Internal("failed to parse estimated cost as f64".to_string())
+            })?;
+
+            // GHSA-86cr-h3rx-vj6j: budget-enforcement guard. A corrupted model
+            // registry entry can produce NaN or ±Infinity in the cost total. NaN
+            // parses back to f64::NAN successfully, then every comparison in
+            // `check_budget` against wallet limits is `false` — silently bypassing
+            // the budget gate. Reject non-finite or negative values here,
+            // fail-closed, before the gate (and before settlement) runs.
+            if !estimated_cost.is_finite() || estimated_cost < 0.0 {
+                warn!(
+                    estimated_cost,
+                    model = %req.model,
+                    "model registry produced a non-finite or negative cost; refusing"
+                );
+                return Err(GatewayError::Internal(
+                    "estimated cost is not a valid finite non-negative number".to_string(),
+                ));
+            }
+
+            budget_reservation = match state
+                .usage
+                .check_budget(&wallet_address, estimated_cost)
+                .await
+            {
+                Ok(reservation) => reservation,
+                Err(e) => return Err(GatewayError::BadRequest(e.to_string())),
+            };
+
             // Verify and settle via Facilitator — hard enforcement
             // R1 FIX: Check settlement.success flag
             match state.facilitator.verify_and_settle(&payload).await {
@@ -529,6 +579,8 @@ pub async fn chat_completions(
                             "Payment transaction could not be confirmed. Please retry.".to_string()
                         }
                     };
+                    // M3: settlement did not happen — give the reserved budget back.
+                    state.usage.release_reservation(&budget_reservation).await;
                     return Err(GatewayError::InvalidPayment(message));
                 }
                 Ok(settlement) => {
@@ -549,6 +601,8 @@ pub async fn chat_completions(
                     // server-internal context. Full detail is in the warn! line above.
                     counter!("solvela_payments_total", "status" => "failed").increment(1);
                     warn!(error = %e, "payment verification failed");
+                    // M3: settlement did not happen — give the reserved budget back.
+                    state.usage.release_reservation(&budget_reservation).await;
                     return Err(GatewayError::InvalidPayment(
                         "Payment verification failed. Check your transaction and retry."
                             .to_string(),
@@ -566,45 +620,10 @@ pub async fn chat_completions(
         }
     }
 
-    // Extract tx_signature for usage tracking.
-    let (wallet_address, tx_signature) = extract_payment_info(payment_header.unwrap());
-
-    // Check budget before proxying to provider.
-    let estimated_cost = state
-        .model_registry
-        .estimate_cost(
-            &req.model,
-            estimate_input_tokens(&req),
-            req.max_tokens.unwrap_or(1000),
-        )
-        .map_err(|e| GatewayError::Internal(format!("failed to estimate cost: {e}")))?
-        .total
-        .parse::<f64>()
-        .map_err(|_| GatewayError::Internal("failed to parse estimated cost as f64".to_string()))?;
-
-    // GHSA-86cr-h3rx-vj6j: budget-enforcement guard. A corrupted model registry
-    // entry can produce NaN or ±Infinity in the cost total. NaN parses back to
-    // f64::NAN successfully, then every comparison in `check_budget` against
-    // wallet limits is `false` — silently bypassing the budget gate. Reject
-    // non-finite or negative values here, fail-closed, before the gate runs.
-    if !estimated_cost.is_finite() || estimated_cost < 0.0 {
-        warn!(
-            estimated_cost,
-            model = %req.model,
-            "model registry produced a non-finite or negative cost; refusing"
-        );
-        return Err(GatewayError::Internal(
-            "estimated cost is not a valid finite non-negative number".to_string(),
-        ));
-    }
-
-    if let Err(e) = state
-        .usage
-        .check_budget(&wallet_address, estimated_cost)
-        .await
-    {
-        return Err(GatewayError::BadRequest(e.to_string()));
-    }
+    // `wallet_address`, `tx_signature`, `estimated_cost`, and `budget_reservation`
+    // were bound inside the Some arm above — budget is now checked + reserved
+    // BEFORE settlement (M3), and the reservation reconciled by `log_spend`'s
+    // `(billed − estimated)` delta on success.
 
     // Step 5: Proxy to provider (with cache and fallback)
     let provider_name = &model_info.provider;

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -523,6 +523,10 @@ pub async fn chat_completions(
                     model = %req.model,
                     "model registry produced a non-finite or negative cost; refusing"
                 );
+                // No reservation committed yet — this guard fires BEFORE
+                // `check_budget`, so there is nothing to release here. Keep this
+                // guard ahead of the reserve: moving it after would turn this
+                // early return into a budget leak.
                 return Err(GatewayError::Internal(
                     "estimated cost is not a valid finite non-negative number".to_string(),
                 ));

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -352,8 +352,9 @@ impl UsageTracker {
         &self,
         wallet_address: &str,
         estimated_cost_usdc: f64,
-    ) -> Result<(), UsageError> {
+    ) -> Result<BudgetReservation, UsageError> {
         // No Redis configured — apply a conservative per-request hard cap.
+        // No counters are committed, so the reservation is empty (release is a no-op).
         if self.redis_client.is_none() {
             const NO_REDIS_REQUEST_CAP_USDC: f64 = 1.0;
             if estimated_cost_usdc > NO_REDIS_REQUEST_CAP_USDC {
@@ -363,12 +364,12 @@ impl UsageTracker {
                     spent: estimated_cost_usdc,
                 });
             }
-            return Ok(());
+            return Ok(BudgetReservation::default());
         }
 
         // Try Redis hot-path budget check.
         let Some(client) = &self.redis_client else {
-            return Ok(());
+            return Ok(BudgetReservation::default());
         };
 
         let mut conn = match client.get_multiplexed_async_connection().await {
@@ -513,7 +514,45 @@ impl UsageTracker {
             }
         }
 
-        Ok(())
+        Ok(BudgetReservation { committed })
+    }
+
+    /// Release a budget reservation previously returned by [`check_budget`].
+    ///
+    /// Decrements exactly the Redis counters `check_budget` incremented, so the
+    /// wallet's budget headroom is restored when a request is abandoned AFTER
+    /// reserving but BEFORE the spend is realized — chiefly when on-chain
+    /// payment settlement fails (M3). Without this, reserving before settlement
+    /// would leak the reservation and permanently consume budget for a payment
+    /// that never happened.
+    ///
+    /// Best-effort and infallible by design: Redis errors are logged, not
+    /// propagated. A failed release at worst leaves a counter over-counted until
+    /// its TTL expires (self-healing); returning an error here would only
+    /// complicate an already-failing request path. No-op when the reservation is
+    /// empty (no Redis, or no budget windows applied).
+    ///
+    /// [`check_budget`]: Self::check_budget
+    pub async fn release_reservation(&self, reservation: &BudgetReservation) {
+        if reservation.committed.is_empty() {
+            return;
+        }
+        let Some(client) = &self.redis_client else {
+            return;
+        };
+        let mut conn = match client.get_multiplexed_async_connection().await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    reserved_counters = ?reservation.committed,
+                    "failed to acquire Redis connection to release budget reservation; \
+                     these counters stay over-counted until their TTL expires"
+                );
+                return;
+            }
+        };
+        rollback_committed(&mut conn, &reservation.committed).await;
     }
 
     /// Get spending summary for a wallet.
@@ -548,6 +587,23 @@ impl UsageTracker {
 
         Err(UsageError::NotConfigured)
     }
+}
+
+/// A committed budget reservation returned by [`UsageTracker::check_budget`].
+///
+/// Holds the exact Redis counters (key + amount) that were incremented, so they
+/// can be released verbatim via [`UsageTracker::release_reservation`] if the
+/// request fails before the spend is realized. Capturing the precise keys —
+/// rather than re-deriving them at release time — makes the release correct even
+/// if an hour/day boundary rolls over between reserve and release. Empty when no
+/// Redis is configured or no budget windows applied; release is then a no-op.
+///
+/// Deliberately NOT `Clone`: a reservation maps 1:1 to committed Redis counters,
+/// so a clone released separately would double-decrement them. There is exactly
+/// one owner — the request that reserved.
+#[derive(Debug, Default)]
+pub struct BudgetReservation {
+    committed: Vec<(String, f64)>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -108,6 +108,57 @@ impl PaymentVerifier for AlwaysPassVerifier {
     }
 }
 
+/// An `exact`-scheme verifier whose `verify_payment` always passes and whose
+/// `settle_payment` records that it was reached by flipping a shared
+/// `AtomicBool` before returning success. It never panics — the test inspects
+/// the flag after the request to prove whether on-chain settlement was reached.
+///
+/// Used by the M3 regression tests: an over-budget request must be rejected
+/// (HTTP 400) BEFORE settlement, so the flag must stay `false`; a within-budget
+/// request must settle, so the flag must become `true`.
+struct SettleRecordingVerifier {
+    settled: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl PaymentVerifier for SettleRecordingVerifier {
+    fn network(&self) -> &str {
+        SOLANA_NETWORK
+    }
+
+    fn scheme(&self) -> &str {
+        "exact"
+    }
+
+    async fn verify_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<VerificationResult, X402Error> {
+        Ok(VerificationResult {
+            valid: true,
+            reason: None,
+            verified_amount: Some(2625),
+        })
+    }
+
+    async fn settle_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<SettlementResult, X402Error> {
+        // Record that settlement was reached — the core observable for M3.
+        self.settled
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        Ok(SettlementResult {
+            success: true,
+            tx_signature: Some("MockRecordedSettledTxSig".to_string()),
+            network: SOLANA_NETWORK.to_string(),
+            error: None,
+            verified_amount: None,
+            failure_kind: None,
+        })
+    }
+}
+
 /// A mock verifier for the escrow scheme.
 struct AlwaysPassEscrowVerifier;
 
@@ -423,10 +474,20 @@ fn test_app_with_mock_provider() -> axum::Router {
 
 /// Build a test app with mock providers and return both the router and state.
 fn test_app_with_mock_provider_and_state() -> (axum::Router, Arc<AppState>) {
+    test_app_with_mock_provider_and_exact_verifier(Arc::new(AlwaysPassVerifier))
+}
+
+/// Like [`test_app_with_mock_provider_and_state`] but lets the caller inject the
+/// `exact`-scheme verifier, so settlement-observing paths (e.g. proving that an
+/// over-budget request never reaches settlement — M3) can be exercised
+/// end-to-end. Mirrors how [`test_app_with_mock_provider_and_escrow_verifier`]
+/// parameterizes the escrow builder.
+fn test_app_with_mock_provider_and_exact_verifier(
+    exact_verifier: Arc<dyn PaymentVerifier>,
+) -> (axum::Router, Arc<AppState>) {
     let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
     let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
-    let facilitator =
-        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+    let facilitator = solvela_x402::facilitator::Facilitator::new(vec![exact_verifier]);
 
     let mut config = AppConfig::default();
     config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
@@ -4135,6 +4196,116 @@ async fn test_payment_verified_reaches_provider_path() {
             .to_str()
             .unwrap(),
         "verified"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// M3 regression (#173): budget check + reserve runs BEFORE on-chain settlement
+// ---------------------------------------------------------------------------
+
+/// M3 primary regression: an over-budget request must NEVER reach on-chain
+/// settlement.
+///
+/// Before the fix, the wallet budget check ran AFTER `verify_and_settle`, so an
+/// over-budget request settled on-chain (funds taken) and was THEN rejected with
+/// a 4xx — the agent paid and got no service. The fix moves the
+/// check + reserve ahead of settlement.
+///
+/// The `UsageTracker::noop()` tracker (no Redis) applies a $1.00 per-request hard
+/// cap. The test model `openai/gpt-4o` costs $10.00/M output tokens, so
+/// `max_tokens: 128000` estimates ~$1.28 — over the cap → `check_budget` returns
+/// `BudgetExceeded` → the route maps it to `BadRequest` → HTTP 400.
+///
+/// We inject a `SettleRecordingVerifier` that flips a shared `AtomicBool` if (and
+/// only if) `settle_payment` is reached. We assert the response is 400 AND the
+/// flag is still `false` — i.e. settlement was never reached, so no funds were
+/// taken. (Were the ordering reversed — settlement before the budget gate — the
+/// flag would be `true`, failing this test.)
+#[tokio::test]
+async fn test_over_budget_request_never_settles() {
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) =
+        test_app_with_mock_provider_and_exact_verifier(Arc::new(SettleRecordingVerifier {
+            settled: Arc::clone(&settled),
+        }));
+
+    // ~$1.28 estimated — over the $1.00 no-Redis hard cap.
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "max_tokens": 128000,
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "over-budget request must be rejected with 400"
+    );
+    assert!(
+        !settled.load(std::sync::atomic::Ordering::SeqCst),
+        "settlement must NOT be reached for an over-budget request — funds must not be taken"
+    );
+}
+
+/// M3 counterpart: a within-budget request must still settle and succeed.
+///
+/// Same app/verifier as the over-budget test, but a request that stays under the
+/// $1.00 cap (small/no `max_tokens`). Confirms the reorder didn't break the
+/// happy path: response is 200 and `settle_payment` WAS reached (flag `true`).
+#[tokio::test]
+async fn test_within_budget_request_settles_and_succeeds() {
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) =
+        test_app_with_mock_provider_and_exact_verifier(Arc::new(SettleRecordingVerifier {
+            settled: Arc::clone(&settled),
+        }));
+
+    // No max_tokens → well under the $1.00 cap.
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "within-budget request must succeed"
+    );
+    assert!(
+        settled.load(std::sync::atomic::Ordering::SeqCst),
+        "settlement must be reached for a within-budget request"
     );
 }
 

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -737,7 +737,8 @@ async fn check_budget_serializes_concurrent_callers(pool: PgPool) {
     let mut exceeded = 0usize;
     for h in handles {
         match h.await.expect("join") {
-            Ok(()) => ok += 1,
+            // M3: `check_budget` now returns a `BudgetReservation` on success.
+            Ok(_) => ok += 1,
             Err(UsageError::BudgetExceeded { .. }) => exceeded += 1,
             Err(other) => panic!("unexpected error: {other:?}"),
         }


### PR DESCRIPTION
Closes the **M3** item in #173.

## Problem
The wallet budget check ran **after** on-chain settlement (`verify_and_settle`). An over-budget request therefore settled the payment — the agent paid — and was *then* rejected with a 4xx. **Funds spent, no service.**

## Fix
Reorders `chat_completions` so wallet/cost extraction + the budget **check+reserve** run inside the payment arm **before** `verify_and_settle` (after the replay check). On any settlement failure, the reservation is released so reserving early never leaks budget for a payment that didn't happen.

- `check_budget` now returns a **`BudgetReservation`** receipt of the exact Redis counters it committed; new **`release_reservation`** decrements precisely those (correct even if an hour/day bucket rolls over mid-settle — unlike re-deriving keys). `BudgetReservation` is intentionally **non-`Clone`** (1:1 with committed counters; a clone released separately would double-decrement).
- The budget f64 **reuses the C1 `expected_cost`** instead of a second `estimate_cost` call, so the gate reserves against the exact figure the payment amount was validated against (no boundary divergence). Removes a redundant hot-path computation.
- Release-failure log now names the affected counters for diagnosis.

## Dependency
M3 was "blocked on #167" (atomic check+reserve). **#167 closed unmerged but its content shipped via #192** (merged 2026-05-09), so the atomic Lua reserve is in place — M3 is unblocked.

## Tests
- `test_over_budget_request_never_settles` — over-budget exact payment (`max_tokens: 128000` on gpt-4o ≈ \$1.28 > the noop \$1 cap) → **400**, and a `SettleRecordingVerifier`'s `AtomicBool` confirms `settle_payment` was **never reached**. This is the core proof funds aren't taken.
- `test_within_budget_request_settles_and_succeeds` — within-budget → **200**, settle flag **true** (happy path intact).

## Review
Two skilled reviewers (`rust-reviewer` + `silent-failure-hunter`). Acted on the in-scope findings: deduped the redundant `estimate_cost` (HIGH), dropped `Clone`, enriched the release-failure log.

## Known pre-existing gap (NOT changed here, NOT a regression)
On success paths that skip `log_spend` — **streaming** (no usage data), **provider failure after a successful settle**, and the rare **registry-corruption** guards — the reservation is left at the *estimate* rather than reconciled to actual usage. This behaved **identically before this change** (`check_budget` already ran before the provider call), and for the exact scheme it bills the estimate the agent actually paid on-chain. Whether to refund-on-failure vs. realize-as-spent is a product decision; precise reconciliation on every exit path is worth a focused follow-up. Flagging explicitly rather than silently expanding this PR's scope.

## Verification
`cargo test -p gateway` → 629 lib + 140 integration green (incl. the 2 new tests + the 3 `check_budget` unit tests). `cargo fmt` + `cargo clippy -p gateway --all-targets --all-features -D warnings` clean. (The `escrow_queue` `#[sqlx::test]` failures need a live Postgres and are unrelated.)