### PR TITLE
feat(sdk): implement x402 escrow signing in Rust client SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3648,6 +3648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solvela-escrow-tx"
+version = "0.2.0"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "sha2 0.11.0",
+ "thiserror",
+]
+
+[[package]]
 name = "solvela-protocol"
 version = "0.2.2"
 dependencies = [
@@ -3681,6 +3693,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "solvela-escrow-tx",
  "solvela-protocol",
  "sqlx",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3657,6 +3657,7 @@ dependencies = [
  "ed25519-dalek",
  "sha2 0.11.0",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/gateway",
     "crates/x402",
+    "crates/escrow-tx",
     "crates/router",
     "crates/cli",
     "crates/protocol",
@@ -88,5 +89,6 @@ dotenvy = "0.15"
 # `version` is required by crates.io at publish time so consumers get the
 # published artifact when they pull from the registry.
 solvela-x402 = { path = "crates/x402", version = "0.2" }           # renamed from `x402` — that name is taken on crates.io
+solvela-escrow-tx = { path = "crates/escrow-tx", version = "0.2" } # no-deps escrow deposit-tx builder, shared with the Rust SDK
 solvela-router = { path = "crates/router", version = "0.2" }
 solvela-protocol = { path = "crates/protocol", version = "0.2" }

--- a/crates/cli/src/commands/solana_tx.rs
+++ b/crates/cli/src/commands/solana_tx.rs
@@ -315,7 +315,7 @@ pub async fn build_escrow_deposit(
 ) -> Result<String> {
     let recent_blockhash = fetch_blockhash(rpc_url, client).await?;
     solvela_x402::escrow::deposit::build_deposit_tx(&solvela_x402::escrow::deposit::DepositParams {
-        agent_keypair_b58: payer_keypair_b58.to_string(),
+        agent_keypair_b58: zeroize::Zeroizing::new(payer_keypair_b58.to_string()),
         provider_wallet_b58: provider_wallet.to_string(),
         usdc_mint_b58: USDC_MINT.to_string(),
         escrow_program_id_b58: escrow_program_id.to_string(),

--- a/crates/escrow-tx/Cargo.toml
+++ b/crates/escrow-tx/Cargo.toml
@@ -20,3 +20,4 @@ bs58 = { workspace = true }
 sha2 = { workspace = true }
 ed25519-dalek = { workspace = true }
 curve25519-dalek = { workspace = true }
+zeroize = { workspace = true }

--- a/crates/escrow-tx/Cargo.toml
+++ b/crates/escrow-tx/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solvela-escrow-tx"
+version = "0.2.0"
+edition.workspace = true
+license = "Apache-2.0"
+repository.workspace = true
+description = "No-deps escrow deposit transaction builder for Solvela client SDKs — PDA/ATA derivation, Anchor discriminator, signed Solana legacy transaction construction. Pure crypto, no solana-sdk or HTTP."
+authors = ["Solvela Contributors"]
+homepage = "https://solvela.ai"
+readme = "README.md"
+keywords = ["x402", "solana", "usdc", "escrow", "anchor"]
+categories = ["api-bindings", "cryptography"]
+# MSRV deliberately not declared so crates.io MSRV isn't over-claimed; this crate
+# must stay buildable on the SDK's rust-version (1.91) and the monorepo's 1.94.
+
+[dependencies]
+thiserror = { workspace = true }
+base64 = { workspace = true }
+bs58 = { workspace = true }
+sha2 = { workspace = true }
+ed25519-dalek = { workspace = true }
+curve25519-dalek = { workspace = true }

--- a/crates/escrow-tx/src/deposit.rs
+++ b/crates/escrow-tx/src/deposit.rs
@@ -4,7 +4,7 @@
 //! `deposit` instruction. The transaction is returned as a base64-encoded string
 //! suitable for submission to any Solana RPC endpoint.
 
-use super::pda::{
+use crate::pda::{
     anchor_discriminator, decode_bs58_pubkey, derive_ata_address, find_program_address,
     ATA_PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID,
 };
@@ -29,6 +29,24 @@ pub enum DepositError {
     #[error("failed to derive {0}")]
     DerivationFailed(&'static str),
 }
+
+// ---------------------------------------------------------------------------
+// Golden vector (money-path drift guard)
+// ---------------------------------------------------------------------------
+
+/// Byte-exact base64 deposit transaction for a fixed input. Pins the deposit-tx
+/// wire layout so any change to the discriminator, account ordering, instruction
+/// data, expiry math, or signing breaks the build. Asserted by
+/// `tests/golden_vector.rs` here and by `deposit_tx_golden_vector` in
+/// `solvela-x402`. Fixed input: agent keypair from seed `[42u8; 32]`, provider
+/// `9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM`, USDC mint
+/// `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`, program
+/// `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`, `service_id=[7u8; 32]`,
+/// `expiry_slot=1_000_750`, `recent_blockhash=[0xABu8; 32]`, `amount=2625`.
+///
+/// DO NOT hand-edit. If this changes, the deposit-tx layout changed — recompute
+/// only after confirming the new layout is still accepted on-chain.
+pub const GOLDEN_VECTOR_B64: &str = "Ad449R7ht12UKokgbDUYh29Ey/wDEwPioT/QtJOPKwSO4RHIaFRqS0DH+bPpEo2vCK78jbRLpP/6FV/5TY+qLw8BAAYKGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWFyvMLyv5o/k5XBGVxL9QMaEsQP6v01aK7nXazb0N/wMBS12eVticTdq8DzgM47jC/J8D1uNnFG6ZNqwpSU6GOelSnAbR4dY/56biCP6roeTxLQ8Q4TL7a2ArnBn2RW9HJ+jAiHYL/eHd3PMsF/IJuCQu5SqvEx+s2I0OosbQsG8sb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKmMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgo61GtoIM8r3akxjdsa2N5CEHZ8QBYuAbfwPDOL78eGrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urqwEJCQAEBQECAwYHCDjyI8aJUuHytkEKAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcuRQ8AAAAAAA==";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -198,7 +216,7 @@ pub fn build_deposit_tx(params: &DepositParams) -> Result<String, DepositError> 
     ix_data.extend_from_slice(&params.amount.to_le_bytes());
     ix_data.extend_from_slice(&params.service_id);
     ix_data.extend_from_slice(&params.expiry_slot.to_le_bytes());
-    debug_assert_eq!(ix_data.len(), 56, "deposit ix_data must be 56 bytes");
+    assert_eq!(ix_data.len(), 56, "deposit ix_data must be 56 bytes");
 
     // Instruction account indices remapped to the new sorted order.
     // Anchor program expects: agent, provider, mint, escrow, agent_ata, vault, token, ata, system
@@ -245,7 +263,10 @@ pub fn build_deposit_tx(params: &DepositParams) -> Result<String, DepositError> 
 /// - 32-byte recent blockhash
 /// - compact-u16 instruction count (always 1)
 /// - instruction: program_id_index || compact-u16 accts || accts || compact-u16 data_len || data
-pub(super) fn build_legacy_message(
+///
+/// Exposed `pub` so `solvela-x402`'s `refund.rs` can reuse it verbatim via the
+/// re-exported `deposit` module (`super::deposit::build_legacy_message`).
+pub fn build_legacy_message(
     header: [u8; 3],
     accounts: &[[u8; 32]],
     program_id: &[u8; 32],
@@ -255,9 +276,22 @@ pub(super) fn build_legacy_message(
     ix_data: &[u8],
 ) -> Vec<u8> {
     let total_accounts = accounts.len() + 1; // +1 for the program key
-    debug_assert!(
+                                             // FIX-4: hard asserts (not debug_assert) so a >127 count cannot silently
+                                             // truncate to a single compact-u16 byte in release builds, producing a
+                                             // malformed transaction that could misdirect funds.
+    assert!(
         total_accounts <= 127,
         "compact-u16 single-byte encoding assumes <= 127 accounts; got {total_accounts}"
+    );
+    assert!(
+        ix_account_indices.len() <= 127,
+        "compact-u16 single-byte encoding assumes <= 127 instruction accounts; got {}",
+        ix_account_indices.len()
+    );
+    assert!(
+        ix_data.len() <= 127,
+        "compact-u16 single-byte encoding assumes <= 127 instruction data bytes; got {}",
+        ix_data.len()
     );
 
     let mut msg = Vec::new();

--- a/crates/escrow-tx/src/deposit.rs
+++ b/crates/escrow-tx/src/deposit.rs
@@ -28,6 +28,15 @@ pub enum DepositError {
     /// A PDA or ATA derivation failed.
     #[error("failed to derive {0}")]
     DerivationFailed(&'static str),
+    /// A length that must fit in a single compact-u16 byte exceeded 127.
+    ///
+    /// `build_legacy_message` encodes account counts, instruction-account
+    /// counts, and instruction-data lengths as a single `u8`, which is only a
+    /// valid Solana compact-u16 encoding for values ≤ 127. A larger value would
+    /// silently truncate (high bit becomes a continuation flag) and produce a
+    /// malformed transaction that could misdirect funds, so we reject it.
+    #[error("{field} length {len} exceeds the 127-byte compact-u16 single-byte limit")]
+    MessageTooLong { field: &'static str, len: usize },
 }
 
 // ---------------------------------------------------------------------------
@@ -55,7 +64,11 @@ pub const GOLDEN_VECTOR_B64: &str = "Ad449R7ht12UKokgbDUYh29Ey/wDEwPioT/QtJOPKwS
 /// Parameters required to build an escrow deposit transaction.
 pub struct DepositParams {
     /// Base58-encoded 64-byte ed25519 keypair (32-byte secret || 32-byte pubkey).
-    pub agent_keypair_b58: String,
+    ///
+    /// Wrapped in [`zeroize::Zeroizing`] so the raw secret material is wiped
+    /// from memory when the params are dropped, rather than lingering in a
+    /// plain `String` heap allocation.
+    pub agent_keypair_b58: zeroize::Zeroizing<String>,
     /// Base58-encoded provider wallet pubkey.
     pub provider_wallet_b58: String,
     /// Base58-encoded USDC mint pubkey.
@@ -104,31 +117,42 @@ impl std::fmt::Debug for DepositParams {
 pub fn build_deposit_tx(params: &DepositParams) -> Result<String, DepositError> {
     use base64::Engine;
     use ed25519_dalek::{Signer, SigningKey};
+    use zeroize::{Zeroize, Zeroizing};
 
     // Step 1: Validate amount
     if params.amount == 0 {
         return Err(DepositError::ZeroAmount);
     }
 
-    // Step 2: Decode the 64-byte keypair and validate derived pubkey
-    let keypair_bytes = bs58::decode(&params.agent_keypair_b58)
-        .into_vec()
-        .map_err(|e| DepositError::InvalidKeypair(format!("invalid base58: {e}")))?;
+    // Step 2: Decode the 64-byte keypair and validate derived pubkey.
+    // Both the bs58-decoded Vec and the fixed-size array hold the raw secret
+    // key, so they are wrapped in `Zeroizing` to wipe on drop (and on every
+    // early return below).
+    let keypair_bytes = Zeroizing::new(
+        bs58::decode(&*params.agent_keypair_b58)
+            .into_vec()
+            .map_err(|e| DepositError::InvalidKeypair(format!("invalid base58: {e}")))?,
+    );
     if keypair_bytes.len() != 64 {
         return Err(DepositError::InvalidKeypair(format!(
             "must be 64 bytes, got {}",
             keypair_bytes.len()
         )));
     }
-    let mut keypair_arr = [0u8; 64];
+    let mut keypair_arr = Zeroizing::new([0u8; 64]);
     keypair_arr.copy_from_slice(&keypair_bytes);
 
     let signing_key = SigningKey::from_keypair_bytes(&keypair_arr)
         .map_err(|e| DepositError::InvalidKeypair(format!("ed25519 error: {e}")))?;
     let agent_pubkey = signing_key.verifying_key().to_bytes();
 
-    // Validate that the stored pubkey in bytes 32..64 matches the derived one
-    let stored_pubkey = &keypair_bytes[32..64];
+    // Validate that the stored pubkey in bytes 32..64 matches the derived one.
+    // Copy the public half out so `keypair_bytes` can be eagerly zeroized
+    // immediately afterwards — the secret half is no longer needed.
+    let mut stored_pubkey = [0u8; 32];
+    stored_pubkey.copy_from_slice(&keypair_bytes[32..64]);
+    keypair_arr.zeroize();
+    drop(keypair_bytes);
     if stored_pubkey != agent_pubkey {
         return Err(DepositError::InvalidKeypair(
             "derived pubkey does not match stored pubkey".to_string(),
@@ -235,7 +259,7 @@ pub fn build_deposit_tx(params: &DepositParams) -> Result<String, DepositError> 
         9u8, // program_id_index = 9 (last account)
         &ix_account_indices,
         &ix_data,
-    );
+    )?;
 
     // Step 9: Sign the message with the agent keypair
     let signature = signing_key.sign(&msg);
@@ -259,13 +283,31 @@ pub fn build_deposit_tx(params: &DepositParams) -> Result<String, DepositError> 
 ///
 /// Layout:
 /// - header (3 bytes)
-/// - compact-u16 account count + N×32 byte keys (data accounts + program key)
+/// - account count (single u8 — see below) + N×32 byte keys (data accounts + program key)
 /// - 32-byte recent blockhash
-/// - compact-u16 instruction count (always 1)
-/// - instruction: program_id_index || compact-u16 accts || accts || compact-u16 data_len || data
+/// - instruction count (single u8): always 1
+/// - instruction: program_id_index || acct_count(u8) || accts || data_len(u8) || data
+///
+/// Note on the length prefixes: Solana's wire format is compact-u16 (1–3 bytes,
+/// 7 bits per byte with a continuation flag). This serializer pushes a **single
+/// `u8`** for each length, which is the *correct* compact-u16 encoding only for
+/// lengths ≤ 127. For any length ≥ 128 a real compact-u16 would emit a
+/// continuation byte; emitting a bare `u8` there would set the high bit and
+/// corrupt the encoding. Every escrow tx this builds (deposit: 10 accounts, 9
+/// instruction accounts, 56 data bytes; refund: 9 accounts, 8 instruction
+/// accounts, 8 data bytes) is comfortably under 127, so the single-byte path is
+/// always taken — but to keep that invariant honest we return
+/// [`DepositError::MessageTooLong`] rather than silently truncating.
 ///
 /// Exposed `pub` so `solvela-x402`'s `refund.rs` can reuse it verbatim via the
-/// re-exported `deposit` module (`super::deposit::build_legacy_message`).
+/// re-exported `deposit` module (`super::deposit::build_legacy_message`); it
+/// therefore cannot be `pub(crate)`.
+///
+/// # Errors
+///
+/// Returns [`DepositError::MessageTooLong`] if the total account count, the
+/// instruction-account count, or the instruction-data length exceeds 127 (the
+/// single-byte compact-u16 limit).
 pub fn build_legacy_message(
     header: [u8; 3],
     accounts: &[[u8; 32]],
@@ -274,32 +316,35 @@ pub fn build_legacy_message(
     program_id_index: u8,
     ix_account_indices: &[u8],
     ix_data: &[u8],
-) -> Vec<u8> {
+) -> Result<Vec<u8>, DepositError> {
     let total_accounts = accounts.len() + 1; // +1 for the program key
-                                             // FIX-4: hard asserts (not debug_assert) so a >127 count cannot silently
-                                             // truncate to a single compact-u16 byte in release builds, producing a
-                                             // malformed transaction that could misdirect funds.
-    assert!(
-        total_accounts <= 127,
-        "compact-u16 single-byte encoding assumes <= 127 accounts; got {total_accounts}"
-    );
-    assert!(
-        ix_account_indices.len() <= 127,
-        "compact-u16 single-byte encoding assumes <= 127 instruction accounts; got {}",
-        ix_account_indices.len()
-    );
-    assert!(
-        ix_data.len() <= 127,
-        "compact-u16 single-byte encoding assumes <= 127 instruction data bytes; got {}",
-        ix_data.len()
-    );
+    if total_accounts > 127 {
+        return Err(DepositError::MessageTooLong {
+            field: "account count",
+            len: total_accounts,
+        });
+    }
+    if ix_account_indices.len() > 127 {
+        return Err(DepositError::MessageTooLong {
+            field: "instruction account count",
+            len: ix_account_indices.len(),
+        });
+    }
+    if ix_data.len() > 127 {
+        return Err(DepositError::MessageTooLong {
+            field: "instruction data length",
+            len: ix_data.len(),
+        });
+    }
 
+    // SAFETY (length casts): each `as u8` below is guarded by the `> 127` checks
+    // above, so every value fits in the single-byte compact-u16 range [0, 127].
     let mut msg = Vec::new();
 
     // Header
     msg.extend_from_slice(&header);
 
-    // Account keys (compact-u16 count + keys)
+    // Account keys (single-byte compact-u16 count + keys)
     msg.push(total_accounts as u8);
     for acc in accounts {
         msg.extend_from_slice(acc);
@@ -309,17 +354,17 @@ pub fn build_legacy_message(
     // Recent blockhash
     msg.extend_from_slice(recent_blockhash);
 
-    // Instruction count (compact-u16): always 1
+    // Instruction count (single-byte compact-u16): always 1
     msg.push(1u8);
 
     // Instruction
     msg.push(program_id_index); // program_id_index
-    msg.push(ix_account_indices.len() as u8); // compact-u16: account count
+    msg.push(ix_account_indices.len() as u8); // single-byte compact-u16: account count
     msg.extend_from_slice(ix_account_indices); // account indices
-    msg.push(ix_data.len() as u8); // compact-u16: data length
+    msg.push(ix_data.len() as u8); // single-byte compact-u16: data length
     msg.extend_from_slice(ix_data); // instruction data
 
-    msg
+    Ok(msg)
 }
 
 // ---------------------------------------------------------------------------
@@ -348,7 +393,7 @@ mod tests {
 
     fn base_params() -> DepositParams {
         DepositParams {
-            agent_keypair_b58: test_agent_keypair_b58(),
+            agent_keypair_b58: zeroize::Zeroizing::new(test_agent_keypair_b58()),
             provider_wallet_b58: PROVIDER.to_string(),
             usdc_mint_b58: USDC_MINT.to_string(),
             escrow_program_id_b58: ESCROW_PROGRAM.to_string(),
@@ -427,8 +472,70 @@ mod tests {
     #[test]
     fn test_build_deposit_tx_invalid_keypair_rejected() {
         let mut params = base_params();
-        params.agent_keypair_b58 = "notavalidkeypair!!!".to_string();
+        params.agent_keypair_b58 = zeroize::Zeroizing::new("notavalidkeypair!!!".to_string());
         let result = build_deposit_tx(&params);
         assert!(result.is_err(), "invalid keypair should be rejected");
+    }
+
+    #[test]
+    fn test_deposit_params_debug_redacts_keypair() {
+        let params = base_params();
+        let debug_str = format!("{params:?}");
+        assert!(
+            debug_str.contains("[REDACTED]"),
+            "Debug output must redact the keypair: {debug_str}"
+        );
+        assert!(
+            !debug_str.contains(&*params.agent_keypair_b58),
+            "Debug output must not contain the raw keypair: {debug_str}"
+        );
+    }
+
+    #[test]
+    fn test_build_legacy_message_rejects_too_many_accounts() {
+        // 127 data accounts + 1 program key = 128 total → exceeds the limit.
+        let accounts = vec![[0u8; 32]; 127];
+        let result = build_legacy_message(
+            [1, 0, 0],
+            &accounts,
+            &[0u8; 32],
+            &[0u8; 32],
+            127,
+            &[0u8],
+            &[0u8],
+        );
+        assert!(
+            matches!(
+                result,
+                Err(DepositError::MessageTooLong {
+                    field: "account count",
+                    len: 128
+                })
+            ),
+            "expected MessageTooLong(account count), got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_legacy_message_rejects_long_ix_data() {
+        let result = build_legacy_message(
+            [1, 0, 0],
+            &[[0u8; 32]],
+            &[0u8; 32],
+            &[0u8; 32],
+            1,
+            &[0u8],
+            &[0u8; 128], // 128 instruction-data bytes → exceeds the limit
+        );
+        assert!(
+            matches!(
+                result,
+                Err(DepositError::MessageTooLong {
+                    field: "instruction data length",
+                    len: 128
+                })
+            ),
+            "expected MessageTooLong(instruction data length), got: {result:?}"
+        );
     }
 }

--- a/crates/escrow-tx/src/lib.rs
+++ b/crates/escrow-tx/src/lib.rs
@@ -1,0 +1,15 @@
+//! Solvela escrow transaction builder.
+//!
+//! Pure, dependency-light construction of signed Solana escrow `deposit`
+//! transactions for client SDKs. No `solana-sdk`, no HTTP client — only the
+//! crypto primitives needed to derive PDAs/ATAs, compute the Anchor
+//! instruction discriminator, serialize a Solana legacy message, and sign it
+//! with an ed25519 keypair.
+//!
+//! This crate is the shared source of truth for escrow deposit-tx byte layout.
+//! It is consumed by `solvela-x402` (which re-exports it) and by the Rust
+//! client SDK (`solvela-client`). The byte layout is on-chain-verified and is
+//! pinned by a golden-vector test in both this crate and `solvela-x402`.
+
+pub mod deposit;
+pub mod pda;

--- a/crates/escrow-tx/src/pda.rs
+++ b/crates/escrow-tx/src/pda.rs
@@ -165,25 +165,11 @@ mod tests {
         );
     }
 
-    /// Cross-check: the stand-alone `solana_types::derive_ata` should now also
-    /// produce the canonical ATA after the hash-order fix.
-    #[test]
-    fn test_solana_types_derive_ata_matches() {
-        use crate::solana_types::{derive_ata as sol_derive_ata, Pubkey};
-
-        let wallet = Pubkey(
-            decode_bs58_pubkey("4P8mSmvv3nfzUtoqhNKG1mfGrHMVbXvKBXR7fDivv6qp")
-                .expect("valid wallet"),
-        );
-        let mint = Pubkey(
-            decode_bs58_pubkey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").expect("valid mint"),
-        );
-        let ata = sol_derive_ata(&wallet, &mint, &Pubkey::TOKEN_PROGRAM_ID).expect("derivation");
-        assert_eq!(
-            ata.to_string(),
-            "CYHVCkLwiEjMBdRiz5MsrrCbVL2YTZuv57TjV3ggxoSN"
-        );
-    }
+    // NOTE: the `test_solana_types_derive_ata_matches` cross-check that pinned
+    // this `derive_ata_address` against `crate::solana_types::derive_ata` lives
+    // in `solvela-x402` (`crates/x402/src/escrow/mod.rs`), since `solana_types`
+    // is an x402-internal module not present in this no-deps crate. It validates
+    // the re-exported `pda` derivation, so it still guards the same invariant.
 
     /// Regression test for escrow PDA derivation against an externally-computed
     /// canonical Solana value.

--- a/crates/escrow-tx/tests/golden_vector.rs
+++ b/crates/escrow-tx/tests/golden_vector.rs
@@ -24,7 +24,7 @@ fn golden_keypair_b58() -> String {
 
 fn golden_params() -> DepositParams {
     DepositParams {
-        agent_keypair_b58: golden_keypair_b58(),
+        agent_keypair_b58: zeroize::Zeroizing::new(golden_keypair_b58()),
         provider_wallet_b58: PROVIDER.to_string(),
         usdc_mint_b58: USDC_MINT.to_string(),
         escrow_program_id_b58: ESCROW_PROGRAM.to_string(),

--- a/crates/escrow-tx/tests/golden_vector.rs
+++ b/crates/escrow-tx/tests/golden_vector.rs
@@ -1,0 +1,54 @@
+//! Byte-exact golden vector for the escrow deposit transaction.
+//!
+//! This pins the on-chain-verified deposit-tx wire layout against a fixed
+//! input so any drift in the discriminator, account ordering, instruction data,
+//! expiry math, or ed25519 signing fails CI. The identical vector is asserted
+//! in `solvela-x402` (`deposit_tx_golden_vector`) so both crates agree.
+
+use solvela_escrow_tx::deposit::{build_deposit_tx, DepositParams, GOLDEN_VECTOR_B64};
+
+const PROVIDER: &str = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const ESCROW_PROGRAM: &str = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+
+/// Build the deterministic 64-byte agent keypair from seed `[42u8; 32]`.
+fn golden_keypair_b58() -> String {
+    use ed25519_dalek::SigningKey;
+    let seed = [42u8; 32];
+    let signing_key = SigningKey::from_bytes(&seed);
+    let mut keypair_bytes = [0u8; 64];
+    keypair_bytes[..32].copy_from_slice(&signing_key.to_bytes());
+    keypair_bytes[32..].copy_from_slice(signing_key.verifying_key().as_bytes());
+    bs58::encode(&keypair_bytes).into_string()
+}
+
+fn golden_params() -> DepositParams {
+    DepositParams {
+        agent_keypair_b58: golden_keypair_b58(),
+        provider_wallet_b58: PROVIDER.to_string(),
+        usdc_mint_b58: USDC_MINT.to_string(),
+        escrow_program_id_b58: ESCROW_PROGRAM.to_string(),
+        amount: 2625,
+        service_id: [7u8; 32],
+        expiry_slot: 1_000_750,
+        recent_blockhash: [0xABu8; 32],
+    }
+}
+
+#[test]
+fn deposit_tx_matches_golden_vector() {
+    let b64 = build_deposit_tx(&golden_params()).expect("golden build should succeed");
+    assert_eq!(
+        b64, GOLDEN_VECTOR_B64,
+        "deposit-tx byte layout drifted from the pinned golden vector"
+    );
+}
+
+/// Deterministic: same fixed input always yields the same bytes (the build is
+/// pure — no nonce, no clock).
+#[test]
+fn deposit_tx_is_deterministic() {
+    let a = build_deposit_tx(&golden_params()).unwrap();
+    let b = build_deposit_tx(&golden_params()).unwrap();
+    assert_eq!(a, b);
+}

--- a/crates/protocol/src/constants.rs
+++ b/crates/protocol/src/constants.rs
@@ -7,6 +7,13 @@ pub const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 /// Solana mainnet network identifier for x402.
 pub const SOLANA_NETWORK: &str = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
 
+/// Solvela escrow program ID deployed on Solana mainnet.
+///
+/// Pinned alongside [`USDC_MINT`] and [`SOLANA_NETWORK`] so clients can enforce
+/// the expected escrow program by default and reject a malicious gateway that
+/// advertises a different (attacker-controlled) escrow program.
+pub const MAINNET_ESCROW_PROGRAM_ID: &str = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+
 /// Maximum timeout for payment authorization (5 minutes).
 pub const MAX_TIMEOUT_SECONDS: u64 = 300;
 

--- a/crates/x402/Cargo.toml
+++ b/crates/x402/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings", "cryptography"]
 
 [dependencies]
 solvela-protocol = { workspace = true }
+solvela-escrow-tx = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/x402/src/escrow/mod.rs
+++ b/crates/x402/src/escrow/mod.rs
@@ -92,7 +92,7 @@ mod reexport_tests {
     #[test]
     fn deposit_tx_golden_vector() {
         let params = DepositParams {
-            agent_keypair_b58: golden_keypair_b58(),
+            agent_keypair_b58: zeroize::Zeroizing::new(golden_keypair_b58()),
             provider_wallet_b58: PROVIDER.to_string(),
             usdc_mint_b58: USDC_MINT.to_string(),
             escrow_program_id_b58: ESCROW_PROGRAM.to_string(),
@@ -103,5 +103,128 @@ mod reexport_tests {
         };
         let b64 = build_deposit_tx(&params).expect("golden build should succeed");
         assert_eq!(b64, solvela_escrow_tx::deposit::GOLDEN_VECTOR_B64);
+    }
+
+    /// Independent-oracle round-trip: build a deposit tx with the client-side
+    /// builder, then validate the resulting bytes using x402's *verifier-side*
+    /// parsing and PDA/ATA re-derivation logic — the same logic
+    /// `EscrowVerifier::verify_payment` runs, but exercised here WITHOUT live
+    /// RPC (no `getSlot`; we replicate the verifier's pure structural checks).
+    ///
+    /// The golden vector above only asserts builder bytes against a frozen
+    /// constant — it is one-sided and cannot catch *symmetric* drift where the
+    /// builder and the verifier change together. This test closes that gap:
+    /// builder-produced bytes are decoded and checked by independent
+    /// verifier-side derivations (escrow PDA, vault ATA, agent ATA from the
+    /// agent pubkey + service_id + program id), so a drift in account ordering,
+    /// discriminator, amount, service_id, or expiry math fails here even if the
+    /// golden constant were regenerated in lockstep.
+    #[test]
+    fn deposit_tx_validated_by_verifier_side_derivation() {
+        use super::pda::{anchor_discriminator, find_program_address};
+        use crate::solana_types::{derive_ata, Pubkey, VersionedTransaction};
+        use ed25519_dalek::SigningKey;
+
+        // --- Known params (distinct from the golden vector to avoid coupling) ---
+        let seed = [42u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let agent_pubkey = signing_key.verifying_key().to_bytes();
+
+        let service_id = [9u8; 32];
+        let amount: u64 = 7777;
+        let expiry_slot: u64 = 1_234_567;
+
+        let b64 = build_deposit_tx(&DepositParams {
+            agent_keypair_b58: zeroize::Zeroizing::new(golden_keypair_b58()),
+            provider_wallet_b58: PROVIDER.to_string(),
+            usdc_mint_b58: USDC_MINT.to_string(),
+            escrow_program_id_b58: ESCROW_PROGRAM.to_string(),
+            amount,
+            service_id,
+            expiry_slot,
+            recent_blockhash: [0x11u8; 32],
+        })
+        .expect("deposit build should succeed");
+
+        // --- Decode the builder bytes via the verifier's own tx parser ---
+        use base64::Engine;
+        let tx_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .expect("valid base64");
+        let tx = VersionedTransaction::from_bytes(&tx_bytes).expect("decodes as versioned tx");
+        let message = tx.parse_message().expect("message parses");
+
+        // --- Independently re-derive every account the verifier re-derives ---
+        let program_id = decode_bs58_pubkey(ESCROW_PROGRAM).expect("program id");
+        let usdc_mint = decode_bs58_pubkey(USDC_MINT).expect("mint");
+        let provider = decode_bs58_pubkey(PROVIDER).expect("provider");
+        let (escrow_pda, _bump) =
+            find_program_address(&[b"escrow", &agent_pubkey, &service_id], &program_id)
+                .expect("escrow PDA");
+        let agent_ata = derive_ata(
+            &Pubkey(agent_pubkey),
+            &Pubkey(usdc_mint),
+            &Pubkey::TOKEN_PROGRAM_ID,
+        )
+        .expect("agent ATA");
+        let vault_ata = derive_ata(
+            &Pubkey(escrow_pda),
+            &Pubkey(usdc_mint),
+            &Pubkey::TOKEN_PROGRAM_ID,
+        )
+        .expect("vault ATA");
+
+        // --- Locate the escrow `deposit` instruction (verifier-side search) ---
+        let deposit_ix = message
+            .instructions
+            .iter()
+            .find(|ix| {
+                message
+                    .account_keys
+                    .get(ix.program_id_index as usize)
+                    .map(|k| k.0 == program_id)
+                    .unwrap_or(false)
+            })
+            .expect("escrow deposit instruction present");
+
+        // --- Discriminator + instruction-data fields ---
+        let expected_disc = anchor_discriminator("deposit");
+        assert_eq!(
+            deposit_ix.data.len(),
+            56,
+            "deposit ix data must be 56 bytes"
+        );
+        assert_eq!(&deposit_ix.data[..8], &expected_disc, "discriminator drift");
+
+        let ix_amount = u64::from_le_bytes(deposit_ix.data[8..16].try_into().unwrap());
+        assert_eq!(
+            ix_amount, amount,
+            "encoded amount must equal builder amount"
+        );
+
+        let ix_service_id: [u8; 32] = deposit_ix.data[16..48].try_into().unwrap();
+        assert_eq!(ix_service_id, service_id, "service_id drift");
+
+        let ix_expiry = u64::from_le_bytes(deposit_ix.data[48..56].try_into().unwrap());
+        assert_eq!(ix_expiry, expiry_slot, "expiry_slot drift");
+
+        // --- Account layout: positions must map to the re-derived accounts ---
+        // Verifier layout: 0=agent, 1=provider, 2=mint, 3=escrow, 4=agent_ata, 5=vault.
+        let key_at = |pos: usize| -> [u8; 32] {
+            let idx = deposit_ix.accounts[pos] as usize;
+            message.account_keys[idx].0
+        };
+        assert_eq!(key_at(0), agent_pubkey, "ix account 0 must be agent");
+        assert_eq!(key_at(1), provider, "ix account 1 must be provider");
+        assert_eq!(key_at(2), usdc_mint, "ix account 2 must be mint");
+        assert_eq!(key_at(3), escrow_pda, "ix account 3 must be escrow PDA");
+        assert_eq!(key_at(4), agent_ata.0, "ix account 4 must be agent ATA");
+        assert_eq!(key_at(5), vault_ata.0, "ix account 5 must be vault ATA");
+
+        // Program key must be the escrow program (consistency with the search).
+        assert_eq!(
+            message.account_keys[deposit_ix.program_id_index as usize].0, program_id,
+            "program id account must be the escrow program",
+        );
     }
 }

--- a/crates/x402/src/escrow/mod.rs
+++ b/crates/x402/src/escrow/mod.rs
@@ -11,12 +11,97 @@ pub mod claim_processor;
 pub mod claim_queue;
 
 mod claimer;
-pub mod deposit;
-pub mod pda;
 pub mod refund;
 mod verifier;
+
+// `deposit` and `pda` were extracted into the dependency-light `solvela-escrow-tx`
+// crate so the Rust client SDK can reuse the on-chain-verified deposit-tx byte
+// layout without pulling in x402's HTTP/Solana deps. Re-exported here so every
+// existing internal reference (`super::pda::...`, `super::deposit::*`,
+// `crate::escrow::deposit::*`) keeps resolving unchanged.
+pub use solvela_escrow_tx::{deposit, pda};
 
 #[cfg(feature = "postgres")]
 pub use claim_processor::{EscrowMetrics, EscrowMetricsSnapshot};
 pub use claimer::{do_claim_with_params, EscrowClaimer};
 pub use verifier::EscrowVerifier;
+
+#[cfg(test)]
+mod reexport_tests {
+    //! Tests that stay in x402 because they validate the re-exported
+    //! `solvela-escrow-tx` types against x402-internal modules
+    //! (`solana_types`) that the no-deps crate intentionally lacks, plus a
+    //! byte-exact golden vector pinned identically in both crates.
+
+    use super::deposit::{build_deposit_tx, DepositParams};
+    use super::pda::{decode_bs58_pubkey, derive_ata_address};
+
+    const PROVIDER: &str = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const ESCROW_PROGRAM: &str = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+
+    /// Cross-check: the re-exported `pda::derive_ata_address` must agree with
+    /// x402's own `solana_types::derive_ata` on the canonical on-chain ATA.
+    /// Moved out of `solvela-escrow-tx` (which has no `solana_types`) so the
+    /// re-export stays pinned to the same value.
+    #[test]
+    fn reexported_pda_matches_solana_types_derive_ata() {
+        use crate::solana_types::{derive_ata as sol_derive_ata, Pubkey};
+
+        let wallet_b = decode_bs58_pubkey("4P8mSmvv3nfzUtoqhNKG1mfGrHMVbXvKBXR7fDivv6qp")
+            .expect("valid wallet");
+        let mint_b =
+            decode_bs58_pubkey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").expect("valid mint");
+
+        // Re-exported escrow-tx derivation.
+        let ata_escrow_tx = derive_ata_address(&wallet_b, &mint_b).expect("derivation");
+
+        // x402 solana_types derivation.
+        let ata_solana_types = sol_derive_ata(
+            &Pubkey(wallet_b),
+            &Pubkey(mint_b),
+            &Pubkey::TOKEN_PROGRAM_ID,
+        )
+        .expect("derivation");
+
+        assert_eq!(
+            bs58::encode(ata_escrow_tx).into_string(),
+            ata_solana_types.to_string(),
+            "re-exported escrow-tx ATA derivation must match solana_types"
+        );
+        assert_eq!(
+            ata_solana_types.to_string(),
+            "CYHVCkLwiEjMBdRiz5MsrrCbVL2YTZuv57TjV3ggxoSN"
+        );
+    }
+
+    fn golden_keypair_b58() -> String {
+        use ed25519_dalek::SigningKey;
+        let seed = [42u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let mut keypair_bytes = [0u8; 64];
+        keypair_bytes[..32].copy_from_slice(&signing_key.to_bytes());
+        keypair_bytes[32..].copy_from_slice(signing_key.verifying_key().as_bytes());
+        bs58::encode(&keypair_bytes).into_string()
+    }
+
+    /// Byte-exact golden vector — MUST stay identical to the one in
+    /// `solvela-escrow-tx`'s `golden_vector.rs`. Any drift in the deposit-tx
+    /// byte layout (discriminator, account ordering, expiry math, signing)
+    /// breaks both assertions. This is the money-path drift guard.
+    #[test]
+    fn deposit_tx_golden_vector() {
+        let params = DepositParams {
+            agent_keypair_b58: golden_keypair_b58(),
+            provider_wallet_b58: PROVIDER.to_string(),
+            usdc_mint_b58: USDC_MINT.to_string(),
+            escrow_program_id_b58: ESCROW_PROGRAM.to_string(),
+            amount: 2625,
+            service_id: [7u8; 32],
+            expiry_slot: 1_000_750,
+            recent_blockhash: [0xABu8; 32],
+        };
+        let b64 = build_deposit_tx(&params).expect("golden build should succeed");
+        assert_eq!(b64, solvela_escrow_tx::deposit::GOLDEN_VECTOR_B64);
+    }
+}

--- a/crates/x402/src/escrow/refund.rs
+++ b/crates/x402/src/escrow/refund.rs
@@ -33,6 +33,11 @@ pub enum RefundError {
     /// agent pubkey, service_id, and program id.
     #[error("derived PDA {derived} does not match expected {expected}")]
     PdaMismatch { derived: String, expected: String },
+    /// Message serialization failed because a length exceeded the single-byte
+    /// compact-u16 limit (127). Propagated from
+    /// [`super::deposit::build_legacy_message`].
+    #[error("message serialization failed: {0}")]
+    MessageBuild(#[from] super::deposit::DepositError),
 }
 
 // ---------------------------------------------------------------------------
@@ -217,7 +222,7 @@ pub fn build_refund_tx(params: &RefundParams) -> Result<String, RefundError> {
         8u8, // program_id_index = 8 (last account)
         &ix_account_indices,
         &ix_data,
-    );
+    )?;
 
     // Step 8: Sign the message with the agent keypair
     let signature = signing_key.sign(&msg);

--- a/crates/x402/src/escrow/verifier.rs
+++ b/crates/x402/src/escrow/verifier.rs
@@ -567,7 +567,7 @@ mod tests {
         let mut full = [0u8; 64];
         full[..32].copy_from_slice(&seed);
         full[32..].copy_from_slice(verifying_key.as_bytes());
-        let agent_keypair_b58 = bs58::encode(&full).into_string();
+        let agent_keypair_b58 = zeroize::Zeroizing::new(bs58::encode(&full).into_string());
 
         let service_id = [7u8; 32];
         let params = DepositParams {
@@ -655,7 +655,7 @@ mod tests {
         let mut full = [0u8; 64];
         full[..32].copy_from_slice(&seed);
         full[32..].copy_from_slice(verifying_key.as_bytes());
-        let agent_keypair_b58 = bs58::encode(&full).into_string();
+        let agent_keypair_b58 = zeroize::Zeroizing::new(bs58::encode(&full).into_string());
         let agent_pubkey_b58 = bs58::encode(verifying_key.as_bytes()).into_string();
 
         let params = DepositParams {
@@ -781,7 +781,7 @@ mod tests {
         let mut full = [0u8; 64];
         full[..32].copy_from_slice(&seed);
         full[32..].copy_from_slice(verifying_key.as_bytes());
-        let agent_keypair_b58 = bs58::encode(&full).into_string();
+        let agent_keypair_b58 = zeroize::Zeroizing::new(bs58::encode(&full).into_string());
         let agent_pubkey_b58 = bs58::encode(verifying_key.as_bytes()).into_string();
 
         let service_id = [7u8; 32];

--- a/dashboard/content/docs/sdks/rust.mdx
+++ b/dashboard/content/docs/sdks/rust.mdx
@@ -57,7 +57,11 @@ solvela chat --model auto "Complex analysis task..."
 # Skip the cost-confirmation prompt (for scripted use)
 solvela chat --yes "Write a short story about a Rust programmer."
 
-# Force a specific payment scheme (default: prefer escrow over exact)
+# Force a specific payment scheme. The `solvela` CLI defaults to escrow when
+# the gateway advertises it, falling back to exact. (Note: the `solvela-client`
+# Rust SDK library is the opposite — it defaults to `exact` and treats escrow as
+# opt-in via `ClientBuilder::prefer_escrow(true)`, since escrow adds a per-call
+# claim fee.)
 solvela chat --scheme exact "Quick one-shot question."
 ```
 

--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -456,6 +456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,7 +628,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -639,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -651,6 +657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -727,7 +734,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -741,7 +748,7 @@ dependencies = [
  "derivation-path",
  "ed25519-dalek",
  "hmac",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1393,7 +1400,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2266,6 +2273,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2-const-stable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3045,7 +3063,7 @@ checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac",
  "pbkdf2",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3083,7 +3101,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "solana-define-syscall 4.0.1",
  "solana-hash 4.3.0",
 ]
@@ -3312,11 +3330,14 @@ dependencies = [
  "ed25519-dalek",
  "eventsource-stream",
  "futures",
+ "getrandom 0.2.17",
  "lru",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "solana-sdk",
+ "solvela-escrow-tx",
  "solvela-protocol",
  "spl-token",
  "thiserror 2.0.18",
@@ -3375,6 +3396,18 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wiremock",
+]
+
+[[package]]
+name = "solvela-escrow-tx"
+version = "0.2.0"
+dependencies = [
+ "base64",
+ "bs58",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -3408,6 +3408,7 @@ dependencies = [
  "ed25519-dalek",
  "sha2 0.11.0",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
@@ -4392,6 +4393,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -22,6 +22,11 @@ keywords = ["solana", "x402", "usdc", "payments", "llm"]
 # fails CI in the same PR. Version pin matches the monorepo's crates/protocol.
 solvela-protocol = { path = "../../crates/protocol", version = "0.2" }
 
+# Escrow deposit-tx builder — shared no-deps crate from the monorepo. Local path
+# dep so the on-chain-verified deposit byte layout stays in lockstep with the
+# gateway/CLI; a golden-vector test pins it identically in both crates.
+solvela-escrow-tx = { path = "../../crates/escrow-tx", version = "0.2" }
+
 # Solana
 solana-sdk = "~4.0"
 spl-token = "9"
@@ -40,6 +45,8 @@ bs58 = "0.5"
 ed25519-dalek = "2"
 bip39 = { version = "2", features = ["rand"] }
 bincode = "1"
+sha2 = "0.10"
+getrandom = "0.2"
 
 # Async
 tokio = { version = "1", features = ["full"] }

--- a/sdks/rust/crates/solvela-client-cli/src/commands/wallet.rs
+++ b/sdks/rust/crates/solvela-client-cli/src/commands/wallet.rs
@@ -156,7 +156,9 @@ fn export(wallet_args: &WalletArgs, yes: bool) -> Result<(), String> {
         }
     }
 
-    println!("{}", wallet.to_keypair_b58());
+    // `to_keypair_b58` returns `Zeroizing<String>` (wiped on drop); deref to
+    // `&str` for display so the secret isn't copied into a fresh `String`.
+    println!("{}", &*wallet.to_keypair_b58());
 
     Ok(())
 }

--- a/sdks/rust/crates/solvela-client/Cargo.toml
+++ b/sdks/rust/crates/solvela-client/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 
 [dependencies]
 solvela-protocol = { workspace = true }
+solvela-escrow-tx = { workspace = true }
 solana-sdk = { workspace = true }
 spl-token = { workspace = true }
 reqwest = { workspace = true }
@@ -32,6 +33,8 @@ zeroize = { workspace = true }
 ed25519-dalek = { workspace = true }
 lru = { workspace = true }
 ahash = { workspace = true }
+sha2 = { workspace = true }
+getrandom = { workspace = true }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/sdks/rust/crates/solvela-client/src/client.rs
+++ b/sdks/rust/crates/solvela-client/src/client.rs
@@ -821,10 +821,23 @@ impl SolvelaClient {
             warn!("prefer_escrow is set but the gateway advertised no escrow scheme; falling back to exact");
             accepts.iter().find(|a| is_exact(a))
         } else {
-            accepts
-                .iter()
-                .find(|a| is_exact(a))
-                .or_else(|| accepts.iter().find(|a| is_escrow(a)))
+            // Default: prefer exact. Only fall back to an escrow accept when no
+            // exact scheme was advertised. Mirror of the FIX-1 reasoning: the
+            // escrow path incurs a gateway claim fee, so silently using it when
+            // the caller didn't ask for it is a surprising cost — warn loudly
+            // so the downgrade is observable in logs.
+            if let Some(exact) = accepts.iter().find(|a| is_exact(a)) {
+                return Some(exact);
+            }
+            if let Some(escrow) = accepts.iter().find(|a| is_escrow(a)) {
+                warn!(
+                    "no exact scheme advertised; falling back to escrow, which \
+                     incurs a gateway claim fee. Set prefer_escrow to silence \
+                     this, or expect an exact scheme from the gateway."
+                );
+                return Some(escrow);
+            }
+            None
         }
     }
 }
@@ -1163,6 +1176,102 @@ mod tests {
             }
             PayloadData::Direct(_) => panic!("expected Escrow payload variant"),
         }
+    }
+
+    #[tokio::test]
+    async fn escrow_tampered_pay_to_rejected_before_signing() {
+        // FIX-3(b)(i): on the escrow path, a `pay_to` that does not match the
+        // configured `expected_recipient` must be rejected with RecipientMismatch
+        // BEFORE any transaction is signed. The recipient check runs ahead of the
+        // scheme branch, so no RPC is mounted — if signing were reached it would
+        // fail on the unreachable RPC instead of returning RecipientMismatch.
+        let mock_server = MockServer::start().await;
+
+        let trusted_recipient = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                rpc_url: "http://127.0.0.1:1".to_string(), // unreachable on purpose
+                prefer_escrow: true,
+                expected_recipient: Some(trusted_recipient.clone()),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        // 402 advertises an escrow scheme whose pay_to is an attacker wallet,
+        // different from the trusted recipient the client pins.
+        let mut pr = escrow_payment_required();
+        let attacker_pay_to = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+        assert_ne!(attacker_pay_to, trusted_recipient);
+        pr.accepts[0].pay_to = attacker_pay_to.clone();
+
+        let result = client.sign_payment_for_402(&pr).await;
+        match result.unwrap_err() {
+            ClientError::RecipientMismatch { expected, actual } => {
+                assert_eq!(expected, trusted_recipient);
+                assert_eq!(actual, attacker_pay_to);
+            }
+            other => panic!("expected RecipientMismatch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn escrow_deposit_amount_equals_advertised_amount() {
+        // FIX-3(b)(ii): the escrow deposit must be built with amount ==
+        // accept.amount (the `amount_atomic` parsed once from the advertised
+        // accept), never re-parsed or recomputed. Decode the signed deposit tx
+        // and assert the Anchor `deposit` instruction-data amount (u64 LE
+        // immediately after the 8-byte discriminator) equals the advertised
+        // amount.
+        let mock_server = MockServer::start().await;
+        mount_solana_rpc(&mock_server).await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                rpc_url: format!("{}/", mock_server.uri()),
+                prefer_escrow: true,
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let pr = escrow_payment_required();
+        let advertised_amount: u64 = pr.accepts[0].amount.parse().unwrap();
+
+        let header = client.sign_payment_for_402(&pr).await.unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&header)
+            .unwrap();
+        let payload: PaymentPayload = serde_json::from_slice(&decoded).unwrap();
+
+        let deposit_tx_b64 = match payload.payload {
+            PayloadData::Escrow(p) => p.deposit_tx,
+            PayloadData::Direct(_) => panic!("expected Escrow payload"),
+        };
+        let tx_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&deposit_tx_b64)
+            .unwrap();
+
+        // Find the Anchor `deposit` discriminator in the instruction-data region,
+        // then read the u64 LE amount that immediately follows it.
+        let disc = solvela_escrow_tx::pda::anchor_discriminator("deposit");
+        let disc_pos = tx_bytes
+            .windows(8)
+            .position(|w| w == disc)
+            .expect("deposit discriminator present in tx bytes");
+        let amount_bytes: [u8; 8] = tx_bytes[disc_pos + 8..disc_pos + 16]
+            .try_into()
+            .expect("8 amount bytes after discriminator");
+        let encoded_amount = u64::from_le_bytes(amount_bytes);
+
+        assert_eq!(
+            encoded_amount, advertised_amount,
+            "deposit amount must equal the advertised accept.amount, not a re-parsed value"
+        );
     }
 
     #[tokio::test]

--- a/sdks/rust/crates/solvela-client/src/client.rs
+++ b/sdks/rust/crates/solvela-client/src/client.rs
@@ -61,6 +61,19 @@ impl SolvelaClient {
             );
         }
 
+        // FIX-3: the escrow program is pinned to the known mainnet deployment by
+        // default. If a caller explicitly disabled the pin, warn that a
+        // malicious gateway could redirect escrow deposits to an attacker's
+        // program.
+        if config.expected_escrow_program_id.is_none() {
+            warn!(
+                "SolvelaClient created with the escrow-program pin disabled; \
+                 a malicious gateway could redirect escrow deposits to an \
+                 attacker-controlled program. Set \
+                 ClientBuilder::expected_escrow_program_id to re-enable the pin."
+            );
+        }
+
         let cache = if config.enable_cache {
             Some(crate::cache::ResponseCache::new())
         } else {
@@ -565,17 +578,57 @@ impl SolvelaClient {
             }
         }
 
-        let signed_tx = signer::sign_exact_payment(
-            &self.wallet,
-            &self.config.rpc_url,
-            &self.http,
-            &accept.pay_to,
-            amount_atomic,
-        )
-        .await?;
-
-        let payload = signer::build_payment_payload(&payment_required.resource, accept, &signed_tx);
-        Ok((signer::encode_payment_header(&payload), amount_atomic))
+        // Branch on the chosen scheme. `expected_recipient` (pay_to) and
+        // `max_payment_amount` checks above apply to BOTH paths.
+        let payload = match accept.scheme.as_str() {
+            "exact" => {
+                let signed_tx = signer::sign_exact_payment(
+                    &self.wallet,
+                    &self.config.rpc_url,
+                    &self.http,
+                    &accept.pay_to,
+                    amount_atomic,
+                )
+                .await?;
+                signer::build_payment_payload(&payment_required.resource, accept, &signed_tx)
+            }
+            "escrow" => {
+                // Security: validate the escrow program ID matches the expected
+                // one (prevents a malicious gateway redirecting the deposit to
+                // an attacker's program). Mirrors the `expected_recipient` check.
+                if let Some(ref expected) = self.config.expected_escrow_program_id {
+                    let actual = accept.escrow_program_id.as_deref().unwrap_or("");
+                    if actual != expected {
+                        return Err(ClientError::EscrowProgramMismatch {
+                            expected: expected.clone(),
+                            actual: actual.to_string(),
+                        });
+                    }
+                }
+                let (deposit_tx, service_id) = signer::sign_escrow_payment(
+                    &self.wallet,
+                    &self.config.rpc_url,
+                    &self.http,
+                    accept,
+                    amount_atomic,
+                )
+                .await?;
+                let agent_pubkey = self.wallet.pubkey().to_string();
+                signer::build_escrow_payment_payload(
+                    &payment_required.resource,
+                    accept,
+                    &deposit_tx,
+                    &service_id,
+                    &agent_pubkey,
+                )
+            }
+            other => {
+                return Err(ClientError::PaymentRejected(format!(
+                    "unsupported payment scheme: {other}"
+                )));
+            }
+        };
+        Ok((signer::encode_payment_header(&payload)?, amount_atomic))
     }
 
     /// Sign a payment for `payment_required`, send the paid request, and
@@ -720,26 +773,59 @@ impl SolvelaClient {
 
     /// Pick the best compatible payment scheme from the 402 accepts list.
     ///
-    /// Currently only "exact" (direct transfer) is supported. Escrow signing
-    /// is not yet implemented — escrow schemes are filtered out even when
-    /// `prefer_escrow` is true. Once `sign_escrow_payment` is added, this
-    /// method should respect `config.prefer_escrow` ordering.
+    /// Both "exact" (direct USDC-SPL transfer) and "escrow" (deposit to a PDA
+    /// vault) are supported. Ordering is controlled by `config.prefer_escrow`:
+    /// - `false` (default): prefer exact, fall back to escrow only if no exact
+    ///   scheme is advertised. Escrow incurs a claim fee, so exact is cheaper
+    ///   for micro-calls.
+    /// - `true`: prefer escrow, fall back to exact.
     ///
-    /// Security: validates `network` and `asset` in addition to `scheme` so
-    /// that a malicious gateway cannot trick the client into signing a
-    /// payment on an unexpected chain or in an unexpected token (HIGH-1).
+    /// Security: validates `network` and `asset` (and, for escrow,
+    /// `escrow_program_id.is_some()`) in addition to `scheme` so a malicious
+    /// gateway cannot trick the client into signing on an unexpected chain or
+    /// in an unexpected token (HIGH-1). The caller branches on the returned
+    /// `accept.scheme`.
     fn pick_scheme<'a>(
         &self,
         accepts: &'a [solvela_protocol::PaymentAccept],
     ) -> Option<&'a solvela_protocol::PaymentAccept> {
-        // TODO: respect self.config.prefer_escrow once escrow signing is implemented
-        let _ = self.config.prefer_escrow;
-        // Only exact scheme is implemented; escrow signing is not yet available.
-        // Reject any accept whose network or asset doesn't match Solana mainnet
-        // USDC-SPL — the only combination this client can sign for.
-        accepts
-            .iter()
-            .find(|a| a.scheme == "exact" && a.network == SOLANA_NETWORK && a.asset == USDC_MINT)
+        let is_exact = |a: &solvela_protocol::PaymentAccept| {
+            a.scheme == "exact" && a.network == SOLANA_NETWORK && a.asset == USDC_MINT
+        };
+        let is_escrow = |a: &solvela_protocol::PaymentAccept| {
+            a.scheme == "escrow"
+                && a.network == SOLANA_NETWORK
+                && a.asset == USDC_MINT
+                && a.escrow_program_id.is_some()
+        };
+
+        if self.config.prefer_escrow {
+            // FIX-1: no silent escrow→exact downgrade. If the gateway advertised
+            // a valid escrow scheme, use it. If it advertised an escrow scheme
+            // that fails validation (wrong network/asset, or missing program
+            // id), return None so the caller surfaces an error rather than
+            // silently paying via the cheaper-but-unwanted exact transfer. Only
+            // fall back to exact when NO escrow scheme was advertised at all.
+            if let Some(escrow) = accepts.iter().find(|a| is_escrow(a)) {
+                return Some(escrow);
+            }
+            let escrow_advertised = accepts.iter().any(|a| a.scheme == "escrow");
+            if escrow_advertised {
+                warn!(
+                    "prefer_escrow is set and the gateway advertised an escrow \
+                     scheme, but none passed validation (network/asset/program \
+                     id); refusing to downgrade to exact"
+                );
+                return None;
+            }
+            warn!("prefer_escrow is set but the gateway advertised no escrow scheme; falling back to exact");
+            accepts.iter().find(|a| is_exact(a))
+        } else {
+            accepts
+                .iter()
+                .find(|a| is_exact(a))
+                .or_else(|| accepts.iter().find(|a| is_escrow(a)))
+        }
     }
 }
 
@@ -757,6 +843,7 @@ impl std::fmt::Debug for SolvelaClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine as _;
     use futures::StreamExt;
     use solvela_protocol::*;
     use wiremock::matchers::{method, path};
@@ -835,6 +922,246 @@ mod tests {
                 completion_tokens: 8,
                 total_tokens: 18,
             }),
+        }
+    }
+
+    /// A valid (well-formed base58) escrow program ID for tests.
+    const TEST_ESCROW_PROGRAM: &str = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+
+    /// A 402 whose only accept is an escrow scheme.
+    fn escrow_payment_required() -> PaymentRequired {
+        let mut pr = sample_payment_required();
+        pr.accepts[0].scheme = "escrow".to_string();
+        pr.accepts[0].escrow_program_id = Some(TEST_ESCROW_PROGRAM.to_string());
+        pr
+    }
+
+    /// Mount a Solana RPC mock at `/` serving both `getLatestBlockhash` and
+    /// `getSlot` (the two calls `sign_escrow_payment` makes concurrently).
+    async fn mount_solana_rpc(server: &MockServer) {
+        // The escrow signer posts JSON-RPC to the RPC root; respond based on
+        // the `method` field. wiremock can't body-match easily here, so we
+        // serve a combined responder that satisfies either method by including
+        // both result shapes is not valid JSON-RPC. Instead, key on method via
+        // a body matcher.
+        use wiremock::matchers::body_partial_json;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_partial_json(serde_json::json!({"method": "getSlot"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": 1_000_000_u64
+            })))
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_partial_json(
+                serde_json::json!({"method": "getLatestBlockhash"}),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "context": {"slot": 1_000_000_u64},
+                    "value": {
+                        // 32 zero bytes base58-encoded.
+                        "blockhash": "11111111111111111111111111111111",
+                        "lastValidBlockHeight": 1_000_300_u64
+                    }
+                }
+            })))
+            .mount(server)
+            .await;
+    }
+
+    #[test]
+    fn pick_scheme_prefers_escrow_when_configured() {
+        let config = ClientConfig {
+            prefer_escrow: true,
+            ..ClientConfig::default()
+        };
+        let client = SolvelaClient::new(test_wallet(), config).unwrap();
+
+        // Advertise both exact and escrow.
+        let mut pr = sample_payment_required();
+        pr.accepts.push(PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: SOLANA_NETWORK.to_string(),
+            amount: "2625".to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: pr.accepts[0].pay_to.clone(),
+            max_timeout_seconds: MAX_TIMEOUT_SECONDS,
+            escrow_program_id: Some(TEST_ESCROW_PROGRAM.to_string()),
+        });
+
+        let chosen = client.pick_scheme(&pr.accepts).unwrap();
+        assert_eq!(chosen.scheme, "escrow");
+    }
+
+    #[test]
+    fn pick_scheme_defaults_to_exact() {
+        // Default config (prefer_escrow = false): exact wins even when escrow
+        // is also advertised.
+        let client = SolvelaClient::new(test_wallet(), ClientConfig::default()).unwrap();
+        let mut pr = sample_payment_required();
+        pr.accepts.push(PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: SOLANA_NETWORK.to_string(),
+            amount: "2625".to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: pr.accepts[0].pay_to.clone(),
+            max_timeout_seconds: MAX_TIMEOUT_SECONDS,
+            escrow_program_id: Some(TEST_ESCROW_PROGRAM.to_string()),
+        });
+        let chosen = client.pick_scheme(&pr.accepts).unwrap();
+        assert_eq!(chosen.scheme, "exact");
+    }
+
+    #[test]
+    fn pick_scheme_escrow_fallback_when_no_exact() {
+        // Default config but only escrow advertised → falls back to escrow.
+        let client = SolvelaClient::new(test_wallet(), ClientConfig::default()).unwrap();
+        let pr = escrow_payment_required();
+        let chosen = client.pick_scheme(&pr.accepts).unwrap();
+        assert_eq!(chosen.scheme, "escrow");
+    }
+
+    #[test]
+    fn pick_scheme_rejects_escrow_without_program_id() {
+        let config = ClientConfig {
+            prefer_escrow: true,
+            ..ClientConfig::default()
+        };
+        let client = SolvelaClient::new(test_wallet(), config).unwrap();
+        let mut pr = escrow_payment_required();
+        pr.accepts[0].escrow_program_id = None; // no program id → not pickable
+        assert!(client.pick_scheme(&pr.accepts).is_none());
+    }
+
+    #[test]
+    fn pick_scheme_rejects_escrow_wrong_network_or_asset() {
+        let config = ClientConfig {
+            prefer_escrow: true,
+            ..ClientConfig::default()
+        };
+        let client = SolvelaClient::new(test_wallet(), config).unwrap();
+
+        let mut pr = escrow_payment_required();
+        pr.accepts[0].network = "ethereum:1".to_string();
+        assert!(client.pick_scheme(&pr.accepts).is_none());
+
+        let mut pr2 = escrow_payment_required();
+        pr2.accepts[0].asset = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+        assert!(client.pick_scheme(&pr2.accepts).is_none());
+    }
+
+    #[test]
+    fn prefer_escrow_does_not_silently_downgrade_to_exact_when_escrow_invalid() {
+        // FIX-1: prefer_escrow=true, gateway advertises BOTH an exact scheme and
+        // an escrow scheme — but the escrow accept fails validation (here:
+        // missing program id). The client must NOT silently downgrade to the
+        // advertised exact scheme; pick_scheme returns None so the caller
+        // surfaces NoCompatibleScheme.
+        let config = ClientConfig {
+            prefer_escrow: true,
+            ..ClientConfig::default()
+        };
+        let client = SolvelaClient::new(test_wallet(), config).unwrap();
+
+        // accepts[0] is a valid exact scheme (from sample_payment_required).
+        let mut pr = sample_payment_required();
+        // Add an escrow scheme that is advertised but invalid (no program id).
+        pr.accepts.push(PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: SOLANA_NETWORK.to_string(),
+            amount: "2625".to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: pr.accepts[0].pay_to.clone(),
+            max_timeout_seconds: MAX_TIMEOUT_SECONDS,
+            escrow_program_id: None, // invalid → fails is_escrow validation
+        });
+
+        assert!(
+            client.pick_scheme(&pr.accepts).is_none(),
+            "must not downgrade to exact when an escrow scheme was advertised but invalid"
+        );
+
+        // Contrast: when NO escrow scheme is advertised at all, falling back to
+        // exact is allowed.
+        let exact_only = sample_payment_required();
+        let chosen = client.pick_scheme(&exact_only.accepts).unwrap();
+        assert_eq!(chosen.scheme, "exact");
+    }
+
+    #[tokio::test]
+    async fn escrow_program_mismatch_errors() {
+        let mock_server = MockServer::start().await;
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                prefer_escrow: true,
+                expected_escrow_program_id: Some(
+                    "EscRowExpected1111111111111111111111111111".to_string(),
+                ),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        // Advertised escrow program differs from the expected one.
+        let pr = escrow_payment_required();
+        let result = client.sign_payment_for_402(&pr).await;
+        match result.unwrap_err() {
+            ClientError::EscrowProgramMismatch { expected, actual } => {
+                assert_eq!(expected, "EscRowExpected1111111111111111111111111111");
+                assert_eq!(actual, TEST_ESCROW_PROGRAM);
+            }
+            other => panic!("expected EscrowProgramMismatch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn escrow_402_produces_escrow_payment_header() {
+        let mock_server = MockServer::start().await;
+        mount_solana_rpc(&mock_server).await;
+
+        let wallet = test_wallet();
+        let expected_agent = wallet.pubkey().to_string();
+
+        let client = SolvelaClient::new(
+            wallet,
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                rpc_url: format!("{}/", mock_server.uri()),
+                prefer_escrow: true,
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let pr = escrow_payment_required();
+        let header = client.sign_payment_for_402(&pr).await.unwrap();
+
+        // The header base64-decodes to a PaymentPayload with an Escrow variant.
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&header)
+            .unwrap();
+        let payload: PaymentPayload = serde_json::from_slice(&decoded).unwrap();
+        assert_eq!(payload.accepted.scheme, "escrow");
+        match payload.payload {
+            PayloadData::Escrow(p) => {
+                assert!(!p.deposit_tx.is_empty());
+                assert_eq!(p.agent_pubkey, expected_agent);
+                // service_id is base64 of 32 bytes.
+                let sid = base64::engine::general_purpose::STANDARD
+                    .decode(&p.service_id)
+                    .unwrap();
+                assert_eq!(sid.len(), 32);
+            }
+            PayloadData::Direct(_) => panic!("expected Escrow payload variant"),
         }
     }
 

--- a/sdks/rust/crates/solvela-client/src/config.rs
+++ b/sdks/rust/crates/solvela-client/src/config.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use solvela_protocol::MAINNET_ESCROW_PROGRAM_ID;
+
 /// Default maximum payment amount in atomic USDC units (10 USDC).
 ///
 /// This is a conservative default to bound exposure to overcharge attacks
@@ -16,8 +18,12 @@ pub struct ClientConfig {
     pub gateway_url: String,
     /// Solana RPC URL.
     pub rpc_url: String,
-    /// Prefer escrow payment scheme over exact (safer for agents).
-    /// Currently defaults to `false` because escrow signing is not yet implemented.
+    /// Prefer the escrow payment scheme over exact when the gateway advertises
+    /// both. Escrow signing IS implemented, but this is opt-in (default `false`):
+    /// escrow incurs an on-chain claim fee, so for micro-calls the exact
+    /// transfer is cheaper. Set `true` for agents that want the escrow
+    /// dispute/refund guarantees. When `false` the client uses exact and only
+    /// falls back to escrow if the gateway advertises no exact scheme.
     pub prefer_escrow: bool,
     /// Request timeout.
     pub timeout: Duration,
@@ -43,6 +49,11 @@ pub struct ClientConfig {
     /// Optional free tier fallback model. When set and wallet balance is zero,
     /// requests are routed to this model instead of paying.
     pub free_fallback_model: Option<String>,
+    /// Optional expected escrow program ID. If set, the client will reject 402
+    /// responses whose escrow `escrow_program_id` differs, preventing a
+    /// malicious gateway from redirecting an escrow deposit to an attacker's
+    /// program. Mirrors `expected_recipient` for the escrow path.
+    pub expected_escrow_program_id: Option<String>,
 }
 
 impl Default for ClientConfig {
@@ -62,6 +73,12 @@ impl Default for ClientConfig {
             enable_quality_check: false,
             max_quality_retries: 1,
             free_fallback_model: None,
+            // Pin the escrow program to the known mainnet deployment by default,
+            // mirroring the hardcoded `USDC_MINT`/`SOLANA_NETWORK`. A malicious
+            // gateway advertising a different escrow program is rejected without
+            // the caller having to configure anything. Override (or disable via
+            // `None`) through the builder if needed.
+            expected_escrow_program_id: Some(MAINNET_ESCROW_PROGRAM_ID.to_string()),
         }
     }
 }
@@ -81,6 +98,13 @@ pub struct ClientBuilder {
     enable_quality_check: Option<bool>,
     max_quality_retries: Option<u32>,
     free_fallback_model: Option<String>,
+    /// `None` = not set (inherit the default pin); `Some(inner)` = explicit
+    /// override, where `inner` may itself be `None` to disable the pin. The
+    /// three states (unset / override / explicitly-disabled) are intentional —
+    /// we must distinguish "inherit the default mainnet pin" from "the caller
+    /// deliberately turned the pin off".
+    #[allow(clippy::option_option)]
+    expected_escrow_program_id: Option<Option<String>>,
 }
 
 impl ClientBuilder {
@@ -99,6 +123,7 @@ impl ClientBuilder {
             enable_quality_check: None,
             max_quality_retries: None,
             free_fallback_model: None,
+            expected_escrow_program_id: None,
         }
     }
 
@@ -174,6 +199,24 @@ impl ClientBuilder {
         self
     }
 
+    /// Override the expected escrow program ID. By default the client pins the
+    /// known mainnet escrow program (see [`ClientConfig::default`]); use this to
+    /// point at a different deployment.
+    #[must_use]
+    pub fn expected_escrow_program_id(mut self, id: &str) -> Self {
+        self.expected_escrow_program_id = Some(Some(id.to_string()));
+        self
+    }
+
+    /// Explicitly disable the escrow-program pin, allowing any advertised escrow
+    /// program. This removes a security guarantee — the client construction will
+    /// emit a warning. Prefer [`Self::expected_escrow_program_id`] instead.
+    #[must_use]
+    pub fn disable_escrow_program_pin(mut self) -> Self {
+        self.expected_escrow_program_id = Some(None);
+        self
+    }
+
     /// Build a `ClientConfig` from the builder state, using defaults for unset values.
     #[must_use]
     pub fn build_config(self) -> ClientConfig {
@@ -195,6 +238,11 @@ impl ClientBuilder {
                 .max_quality_retries
                 .unwrap_or(defaults.max_quality_retries),
             free_fallback_model: self.free_fallback_model.or(defaults.free_fallback_model),
+            // `Some(inner)` = explicit override (possibly `None` to disable);
+            // `None` = inherit the default pin.
+            expected_escrow_program_id: self
+                .expected_escrow_program_id
+                .unwrap_or(defaults.expected_escrow_program_id),
         }
     }
 }
@@ -278,6 +326,42 @@ mod tests {
             config.max_payment_amount,
             Some(DEFAULT_MAX_PAYMENT_AMOUNT_ATOMIC)
         );
+        // The escrow program is pinned to the known mainnet deployment by
+        // default, mirroring the hardcoded USDC_MINT / SOLANA_NETWORK.
+        assert_eq!(
+            config.expected_escrow_program_id.as_deref(),
+            Some(MAINNET_ESCROW_PROGRAM_ID)
+        );
+    }
+
+    #[test]
+    fn test_builder_defaults_pin_escrow_program() {
+        // The builder inherits the default escrow-program pin when not set.
+        let config = ClientBuilder::new().build_config();
+        assert_eq!(
+            config.expected_escrow_program_id.as_deref(),
+            Some(MAINNET_ESCROW_PROGRAM_ID)
+        );
+    }
+
+    #[test]
+    fn test_builder_override_escrow_program_id() {
+        let config = ClientBuilder::new()
+            .expected_escrow_program_id("EscRowOverride11111111111111111111111111111")
+            .build_config();
+        assert_eq!(
+            config.expected_escrow_program_id.as_deref(),
+            Some("EscRowOverride11111111111111111111111111111")
+        );
+    }
+
+    #[test]
+    fn test_builder_disable_escrow_program_pin() {
+        // Explicitly disabling the pin must yield None (not the default pin).
+        let config = ClientBuilder::new()
+            .disable_escrow_program_pin()
+            .build_config();
+        assert!(config.expected_escrow_program_id.is_none());
     }
 
     #[test]

--- a/sdks/rust/crates/solvela-client/src/error.rs
+++ b/sdks/rust/crates/solvela-client/src/error.rs
@@ -68,6 +68,9 @@ pub enum ClientError {
     #[error("payment recipient mismatch: expected {expected}, got {actual}")]
     RecipientMismatch { expected: String, actual: String },
 
+    #[error("escrow program mismatch: expected {expected}, got {actual}")]
+    EscrowProgramMismatch { expected: String, actual: String },
+
     #[error("payment amount {amount} exceeds maximum allowed {max}")]
     AmountExceedsMax { amount: u64, max: u64 },
 

--- a/sdks/rust/crates/solvela-client/src/signer.rs
+++ b/sdks/rust/crates/solvela-client/src/signer.rs
@@ -5,13 +5,31 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::transaction::Transaction;
 
 use solvela_protocol::{
-    PayloadData, PaymentAccept, PaymentPayload, Resource, SolanaPayload, USDC_MINT, X402_VERSION,
+    EscrowPayload, PayloadData, PaymentAccept, PaymentPayload, Resource, SolanaPayload, USDC_MINT,
+    X402_VERSION,
 };
 
 use crate::error::SignerError;
 use crate::wallet::Wallet;
 
 const USDC_DECIMALS: u8 = 6;
+
+/// Hard upper bound on how many Solana slots into the future an escrow's expiry
+/// may be set. Mirrors the CLI's `MAX_ESCROW_EXPIRY_SLOTS_AHEAD`
+/// (`crates/cli/src/commands/util.rs`). Solana slots are ~400 ms, so `10_000`
+/// slots ≈ 66 minutes — above any legitimate `max_timeout_seconds` while still
+/// rejecting a malicious/misconfigured gateway from pushing expiry to never.
+const MAX_ESCROW_EXPIRY_SLOTS_AHEAD: u64 = 10_000;
+
+/// Minimum number of Solana slots into the future an escrow's expiry must be
+/// set. This mirrors AND exceeds the gateway's `MIN_EXPIRY_BUFFER_SLOTS = 50`:
+/// the gateway rejects a deposit whose `expiry_slot` is fewer than 50 slots
+/// ahead of the current slot, so a too-near expiry would have the deposit
+/// bounced. The extra headroom (150 vs. 50) absorbs network latency and
+/// slot-skew between the slot we read here and the slot the gateway observes
+/// when it verifies, preventing a borderline-but-valid expiry from being
+/// rejected. ~150 slots ≈ 60 s.
+const MIN_ESCROW_EXPIRY_SLOTS_AHEAD: u64 = 150;
 
 /// Associated Token Program ID (well-known constant).
 const ASSOCIATED_TOKEN_PROGRAM_ID: &str = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
@@ -142,14 +160,199 @@ pub(crate) fn build_payment_payload(
 
 /// Encode a `PaymentPayload` as a base64 JSON string for the PAYMENT-SIGNATURE header.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if `PaymentPayload` cannot be serialized to JSON, which should
-/// never occur since all fields implement `Serialize`.
+/// Returns `SignerError::TransactionBuild` if `PaymentPayload` cannot be
+/// serialized to JSON (should never occur since all fields implement
+/// `Serialize`, but we propagate rather than panic in library code).
+pub(crate) fn encode_payment_header(payload: &PaymentPayload) -> Result<String, SignerError> {
+    let json = serde_json::to_string(payload)
+        .map_err(|e| SignerError::TransactionBuild(format!("payload serialize: {e}")))?;
+    Ok(base64::engine::general_purpose::STANDARD.encode(json.as_bytes()))
+}
+
+// ---------------------------------------------------------------------------
+// Escrow signing
+// ---------------------------------------------------------------------------
+
+/// Fetch the current slot from a Solana RPC endpoint via JSON-RPC.
+///
+/// Mirrors the CLI's `fetch_current_slot` (`crates/cli/src/commands/solana_tx.rs`)
+/// and the `get_latest_blockhash` style above — uses `getSlot` with commitment
+/// `confirmed`.
+///
+/// # Errors
+///
+/// Returns `SignerError::RpcError` if the request fails, the HTTP status is not
+/// success, the body is unparseable, the RPC returns an error object, or the
+/// `result` field is missing.
+pub(crate) async fn get_current_slot(
+    rpc_url: &str,
+    http: &reqwest::Client,
+) -> Result<u64, SignerError> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getSlot",
+        "params": [{"commitment": "confirmed"}]
+    });
+
+    let resp = http
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| SignerError::RpcError(e.to_string()))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(SignerError::RpcError(format!("RPC returned HTTP {status}")));
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| SignerError::RpcError(format!("failed to parse getSlot response: {e}")))?;
+
+    if let Some(err_obj) = json.get("error") {
+        return Err(SignerError::RpcError(format!("RPC error: {err_obj}")));
+    }
+
+    json["result"]
+        .as_u64()
+        .ok_or_else(|| SignerError::RpcError("getSlot response missing result field".to_string()))
+}
+
+/// Compute the Solana slot at which an escrow PDA created now should expire.
+///
+/// Saturating arithmetic, then clamped into
+/// `[MIN_ESCROW_EXPIRY_SLOTS_AHEAD, MAX_ESCROW_EXPIRY_SLOTS_AHEAD]`. The
+/// saturation closes the wrap-to-zero case (instantly-refundable PDA →
+/// reverse-payment race) and the cap closes the unbounded-future case.
+///
+/// The minimum floor (`MIN_ESCROW_EXPIRY_SLOTS_AHEAD`) mirrors and exceeds the
+/// gateway's `MIN_EXPIRY_BUFFER_SLOTS = 50`: a too-near expiry would otherwise
+/// be bounced by the gateway, and the extra headroom absorbs network/slot-skew
+/// between the slot we read and the slot the gateway verifies against. Note:
+/// the CLI's `escrow_expiry_slot` (`crates/cli/src/commands/util.rs`) currently
+/// lacks this floor and should be brought in line separately.
+fn escrow_expiry_slot(current_slot: u64, max_timeout_seconds: u64) -> u64 {
+    let timeout_slots = max_timeout_seconds.saturating_mul(1000).saturating_div(400);
+    let effective =
+        timeout_slots.clamp(MIN_ESCROW_EXPIRY_SLOTS_AHEAD, MAX_ESCROW_EXPIRY_SLOTS_AHEAD);
+    current_slot.saturating_add(effective)
+}
+
+/// Generate a unique 32-byte `service_id`.
+///
+/// Issue #118 security invariant (see `crates/x402/src/escrow/AGENTS.md`): the
+/// `service_id` MUST mix a per-request CSPRNG nonce so two identical requests
+/// never share a `service_id` → escrow PDA → vault ATA, which would be
+/// off-chain-derivable before broadcast (front-running, confidentiality leak).
+/// The signer does not have the request body at this layer, so we hash 32
+/// CSPRNG bytes directly — the nonce is the entire input, which satisfies the
+/// hard invariant (distinct per call). Mirrors the CLI's `generate_service_id`
+/// `SHA-256(body || nonce)` shape as closely as the available inputs allow.
+fn generate_service_id() -> Result<[u8; 32], SignerError> {
+    use sha2::{Digest, Sha256};
+    let mut nonce = [0u8; 32];
+    getrandom::getrandom(&mut nonce)
+        .map_err(|e| SignerError::TransactionBuild(format!("getrandom failed: {e}")))?;
+    let mut hasher = Sha256::new();
+    hasher.update(nonce);
+    let hash = hasher.finalize();
+    let mut id = [0u8; 32];
+    id.copy_from_slice(&hash);
+    Ok(id)
+}
+
+/// Build and sign an escrow `deposit` transaction for an escrow-scheme payment.
+///
+/// Concurrently fetches the current slot and a recent blockhash, derives a
+/// fresh CSPRNG-backed `service_id`, computes the expiry slot via the
+/// CLI-identical formula, and delegates the byte-exact transaction construction
+/// to the shared, on-chain-verified `solvela_escrow_tx::deposit::build_deposit_tx`.
+///
+/// Returns `(deposit_tx_b64, service_id)` so the caller can build the payload.
+///
+/// `amount_atomic` is the already-parsed, already-budget-validated payment
+/// amount supplied by the caller (mirrors `sign_exact_payment`), so the amount
+/// is parsed exactly once on the request path.
+///
+/// # Errors
+///
+/// Returns `SignerError::RpcError` if slot/blockhash fetch fails,
+/// `SignerError::TransactionBuild` if the escrow program ID is missing, the
+/// `pay_to` address is not a valid Solana pubkey, the CSPRNG fails, or the
+/// deposit-tx build fails.
+pub(crate) async fn sign_escrow_payment(
+    wallet: &Wallet,
+    rpc_url: &str,
+    http: &reqwest::Client,
+    accept: &PaymentAccept,
+    amount_atomic: u64,
+) -> Result<(String, [u8; 32]), SignerError> {
+    let escrow_program_id = accept.escrow_program_id.as_deref().ok_or_else(|| {
+        SignerError::TransactionBuild("escrow scheme missing program ID".to_string())
+    })?;
+
+    // FIX-7: fail fast — validate `pay_to` parses as a Solana pubkey before any
+    // RPC calls or CSPRNG work, so a malformed recipient is rejected cheaply.
+    let _provider_pubkey: Pubkey = accept.pay_to.parse().map_err(|e| {
+        SignerError::TransactionBuild(format!("invalid escrow pay_to address: {e}"))
+    })?;
+
+    let service_id = generate_service_id()?;
+
+    // Fetch current slot and recent blockhash concurrently — both are needed
+    // before the deposit tx can be built, and they are independent.
+    let (slot_res, blockhash_res) = tokio::join!(
+        get_current_slot(rpc_url, http),
+        get_latest_blockhash(rpc_url, http),
+    );
+    let current_slot = slot_res?;
+    let blockhash = blockhash_res?;
+    let recent_blockhash: [u8; 32] = blockhash.to_bytes();
+
+    let expiry_slot = escrow_expiry_slot(current_slot, accept.max_timeout_seconds);
+
+    let deposit_tx =
+        solvela_escrow_tx::deposit::build_deposit_tx(&solvela_escrow_tx::deposit::DepositParams {
+            agent_keypair_b58: wallet.to_keypair_b58(),
+            provider_wallet_b58: accept.pay_to.clone(),
+            usdc_mint_b58: USDC_MINT.to_string(),
+            escrow_program_id_b58: escrow_program_id.to_string(),
+            amount: amount_atomic,
+            service_id,
+            expiry_slot,
+            recent_blockhash,
+        })
+        .map_err(|e| {
+            SignerError::TransactionBuild(format!("escrow deposit tx build failed: {e}"))
+        })?;
+
+    Ok((deposit_tx, service_id))
+}
+
+/// Build the escrow `PaymentPayload` for the PAYMENT-SIGNATURE header.
 #[must_use]
-pub(crate) fn encode_payment_header(payload: &PaymentPayload) -> String {
-    let json = serde_json::to_string(payload).expect("PaymentPayload should always serialize");
-    base64::engine::general_purpose::STANDARD.encode(json.as_bytes())
+pub(crate) fn build_escrow_payment_payload(
+    resource: &Resource,
+    accept: &PaymentAccept,
+    deposit_tx_b64: &str,
+    service_id: &[u8; 32],
+    agent_pubkey: &str,
+) -> PaymentPayload {
+    PaymentPayload {
+        x402_version: X402_VERSION,
+        resource: resource.clone(),
+        accepted: accept.clone(),
+        payload: PayloadData::Escrow(EscrowPayload {
+            deposit_tx: deposit_tx_b64.to_string(),
+            service_id: base64::engine::general_purpose::STANDARD.encode(service_id),
+            agent_pubkey: agent_pubkey.to_string(),
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -222,6 +425,96 @@ mod tests {
         }
     }
 
+    // --- escrow expiry math (mirrors CLI escrow_expiry_slot) ---
+
+    #[test]
+    fn escrow_expiry_typical_300s() {
+        // 300 s × 2.5 slots/s = 750 slots ahead. NO min floor.
+        assert_eq!(escrow_expiry_slot(1_000_000, 300), 1_000_750);
+    }
+
+    #[test]
+    fn escrow_expiry_clamps_huge_values() {
+        assert_eq!(
+            escrow_expiry_slot(1_000_000, u64::MAX),
+            1_000_000 + MAX_ESCROW_EXPIRY_SLOTS_AHEAD,
+        );
+    }
+
+    #[test]
+    fn escrow_expiry_zero_seconds_applies_min_floor() {
+        // FIX-2: a too-small timeout is floored to MIN_ESCROW_EXPIRY_SLOTS_AHEAD
+        // so the gateway (MIN_EXPIRY_BUFFER_SLOTS = 50) does not bounce it.
+        assert_eq!(
+            escrow_expiry_slot(1_000_000, 0),
+            1_000_000 + MIN_ESCROW_EXPIRY_SLOTS_AHEAD,
+        );
+    }
+
+    #[test]
+    fn escrow_expiry_typical_300s_unaffected_by_floor() {
+        // 300 s → 750 slots is between the floor (150) and cap (10_000), so the
+        // normal case is unchanged.
+        assert_eq!(escrow_expiry_slot(1_000_000, 300), 1_000_750);
+    }
+
+    #[test]
+    fn escrow_expiry_saturates_current_slot_overflow() {
+        assert_eq!(escrow_expiry_slot(u64::MAX - 100, 300), u64::MAX);
+    }
+
+    // --- service_id CSPRNG invariant (#118) ---
+
+    #[test]
+    fn identical_input_distinct_service_ids() {
+        // The signer takes no body, so the only input is the CSPRNG nonce.
+        // Two calls must never collide.
+        let a = generate_service_id().unwrap();
+        let b = generate_service_id().unwrap();
+        assert_ne!(a, b, "service_id must mix a per-call CSPRNG nonce (#118)");
+        assert_eq!(a.len(), 32);
+    }
+
+    // --- escrow payload shape ---
+
+    #[test]
+    fn build_escrow_payment_payload_shape() {
+        let program_id = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+        let accept = PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: solvela_protocol::SOLANA_NETWORK.to_string(),
+            amount: "2625".to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: Pubkey::new_unique().to_string(),
+            max_timeout_seconds: 300,
+            escrow_program_id: Some(program_id.to_string()),
+        };
+        let resource = Resource {
+            url: "/v1/chat/completions".to_string(),
+            method: "POST".to_string(),
+        };
+        let service_id = [7u8; 32];
+        let agent = Pubkey::new_unique().to_string();
+
+        let payload =
+            build_escrow_payment_payload(&resource, &accept, "ZGVwb3NpdA==", &service_id, &agent);
+
+        assert_eq!(payload.x402_version, X402_VERSION);
+        assert_eq!(payload.accepted.scheme, "escrow");
+        match &payload.payload {
+            PayloadData::Escrow(p) => {
+                assert_eq!(p.deposit_tx, "ZGVwb3NpdA==");
+                assert_eq!(p.agent_pubkey, agent);
+                // service_id is standard-base64 of the 32 bytes.
+                assert_eq!(
+                    p.service_id,
+                    base64::engine::general_purpose::STANDARD.encode(service_id)
+                );
+            }
+            PayloadData::Direct(_) => panic!("expected Escrow variant"),
+        }
+    }
+
     #[test]
     fn test_encode_payment_header_roundtrip() {
         let accept = solvela_protocol::PaymentAccept {
@@ -240,7 +533,7 @@ mod tests {
         };
 
         let payload = build_payment_payload(&resource, &accept, "dGVzdA==");
-        let encoded = encode_payment_header(&payload);
+        let encoded = encode_payment_header(&payload).unwrap();
 
         // Decode and verify roundtrip
         let decoded_bytes = base64::engine::general_purpose::STANDARD

--- a/sdks/rust/crates/solvela-client/src/signer.rs
+++ b/sdks/rust/crates/solvela-client/src/signer.rs
@@ -463,6 +463,66 @@ mod tests {
         assert_eq!(escrow_expiry_slot(u64::MAX - 100, 300), u64::MAX);
     }
 
+    // --- FIX-5: client floor vs gateway buffer compatibility ---
+
+    /// The gateway's `MIN_EXPIRY_BUFFER_SLOTS`, hardcoded here because the SDK
+    /// cannot depend on the x402 crate. Source of truth:
+    /// `crates/x402/src/escrow/verifier.rs` (`MIN_EXPIRY_BUFFER_SLOTS = 50`),
+    /// which mirrors the on-chain `MIN_EXPIRY_BUFFER` in
+    /// `programs/escrow/src/instructions/deposit.rs`. If the gateway value ever
+    /// rises above 150, these tests must be revisited.
+    const GATEWAY_MIN_EXPIRY_BUFFER_SLOTS: u64 = 50;
+
+    #[test]
+    fn client_floor_at_least_gateway_buffer() {
+        // The client's floor must be >= the gateway's lower bound so a deposit
+        // floored to the client minimum is never bounced for being too close.
+        // Route the floor through `escrow_expiry_slot` (a 0-second timeout hits
+        // the floor exactly) so the comparison is computed at runtime rather
+        // than const-folded.
+        let current = 1_000_000u64;
+        let floored_buffer = escrow_expiry_slot(current, 0) - current;
+        assert_eq!(
+            floored_buffer, MIN_ESCROW_EXPIRY_SLOTS_AHEAD,
+            "a 0-second timeout must produce exactly the client floor"
+        );
+        assert!(
+            floored_buffer >= GATEWAY_MIN_EXPIRY_BUFFER_SLOTS,
+            "client expiry floor ({floored_buffer}) must be >= gateway buffer ({GATEWAY_MIN_EXPIRY_BUFFER_SLOTS})"
+        );
+    }
+
+    #[test]
+    fn client_never_signs_below_gateway_buffer_for_any_timeout() {
+        // For ANY max_timeout_seconds (including 0 and the saturating extreme),
+        // the slots between the chosen expiry and the current slot must be at
+        // least the gateway's lower bound. The verifier enforces only this
+        // LOWER bound — there is NO upper bound in
+        // `crates/x402/src/escrow/verifier.rs` (verified), so the client's
+        // cap (MAX_ESCROW_EXPIRY_SLOTS_AHEAD = 10_000) is always accepted and
+        // the floor-up for short timeouts is known-safe.
+        let current = 1_000_000u64;
+        for t in [
+            0u64,
+            1,
+            10,
+            19, // 19 s × 2.5 = 47.5 → 47 slots, below the gateway buffer pre-floor
+            20,
+            59,
+            60,
+            300,
+            3600,
+            u64::MAX,
+        ] {
+            let expiry = escrow_expiry_slot(current, t);
+            let buffer = expiry - current;
+            assert!(
+                buffer >= GATEWAY_MIN_EXPIRY_BUFFER_SLOTS,
+                "timeout {t}s produced buffer {buffer} < gateway minimum {GATEWAY_MIN_EXPIRY_BUFFER_SLOTS}"
+            );
+        }
+    }
+
     // --- service_id CSPRNG invariant (#118) ---
 
     #[test]

--- a/sdks/rust/crates/solvela-client/src/wallet.rs
+++ b/sdks/rust/crates/solvela-client/src/wallet.rs
@@ -157,10 +157,13 @@ impl Wallet {
 
     /// Return the keypair as a base58-encoded string.
     ///
-    /// The caller is responsible for zeroizing the returned string when done.
+    /// Returned inside [`zeroize::Zeroizing`] so the secret-bearing string is
+    /// wiped on drop. This keeps the zeroization chain intact end-to-end:
+    /// `Wallet`'s buffer is zeroizing, and the base58 form handed to
+    /// `DepositParams::agent_keypair_b58` (also `Zeroizing<String>`) is too.
     #[must_use]
-    pub fn to_keypair_b58(&self) -> String {
-        bs58::encode(*self.keypair_bytes).into_string()
+    pub fn to_keypair_b58(&self) -> Zeroizing<String> {
+        Zeroizing::new(bs58::encode(*self.keypair_bytes).into_string())
     }
 
     /// Access the inner keypair for transaction signing.


### PR DESCRIPTION
## What & why

The `solvela-client` Rust SDK previously signed only the **exact** direct-transfer scheme — `pick_scheme` filtered escrow out and `prefer_escrow` was a no-op. A consumer that asked for trustless escrow **silently settled via a direct transfer** (confirmed on-chain: payer `9QGt…RSno`, tx `21ddEwBG…`, a bare `transferChecked` with the escrow program never touched). This makes the "trustless escrow" path real for the SDK.

## Approach C — single source of truth

- New no-deps crate **`solvela-escrow-tx`**: the proven deposit-tx builder + PDA derivation, **moved verbatim** from `crates/x402/src/escrow/` (git renames, history preserved). Consumed by x402 (re-exported — internal API unchanged), the CLI, and the SDK.
- **Byte-exact golden vector** asserted in *both* `escrow-tx` and `x402` to guard against wire drift between the gateway verifier and the client builder.

## SDK escrow path (mirrors the proven `crates/cli` flow)

- `signer.rs`: `get_current_slot` (getSlot), CSPRNG `service_id` (#118 invariant), `escrow_expiry_slot`, `sign_escrow_payment`, `build_escrow_payment_payload`.
- `client.rs`: `pick_scheme` honors `prefer_escrow` and **never silently downgrades escrow→exact**; dispatch enforces recipient + amount + escrow-program-id pinning *before* signing.
- `config.rs`: `prefer_escrow` stays **opt-in** (default exact) to avoid per-call claim fees on micro-calls; escrow-program pin **defaults to the mainnet program**.

## Money-path review (rust + security + silent-failure agents, then a fix round)

- ❌→✅ no silent escrow→exact downgrade when escrow is advertised-but-invalid
- ❌→✅ `expiry_slot` floored at 150 slots (≥ gateway `MIN_EXPIRY_BUFFER_SLOTS=50` + slop) — fixes the `max_timeout=0` instant-expiry hole
- ❌→✅ escrow program id pinned to `MAINNET_ESCROW_PROGRAM_ID` by default
- ❌→✅ hard `assert!` (not `debug_assert!`) on the legacy-message ≤127 invariants
- ❌→✅ `encode_payment_header` returns `Result` (no `expect` on the hot path)

## Docs

Corrects `dashboard/content/docs/sdks/rust.mdx`: the SDK defaults to **exact** (opt-in escrow); only the `solvela` CLI defaults to escrow.

## Tests

- Main workspace: `solvela-escrow-tx` 12 + golden vector 2, `solvela-x402` 134, `solvela-cli` 190 — all green; `gateway` compiles; clippy clean; fmt clean.
- SDK workspace: client lib 122 + integration 13 + cli 27 + cli-args 6 + proxy 7 + doctest 1 — all green; clippy clean; fmt clean.

## Follow-ups (deliberately out of scope)

- **Publish ordering** (release time): `solvela-escrow-tx` must publish before `solvela-x402` and the SDK (path+version dual-spec); `solvela-protocol` gains an additive `pub const` (version bump on next publish).
- **Deferred, pre-existing, separate PRs:** balance-query `unwrap_or(0.0)` silent-zero; `DepositParams` keypair `Zeroizing` (affects CLI identically); `crates/cli` `escrow_expiry_slot` shares the missing-floor issue fixed here.
- **Not in this PR:** session/prepaid (batched-claim) settlement — the real fix for micro-call economics; this lays its foundation.