### PR TITLE
fix(sdk): surface malformed balance RPC responses instead of silent zero

### DIFF
--- a/sdks/rust/crates/solvela-client/src/balance.rs
+++ b/sdks/rust/crates/solvela-client/src/balance.rs
@@ -210,7 +210,11 @@ impl BalanceMonitor {
             return Err(BalanceError::RpcError(error.to_string()));
         }
 
-        Ok(json["result"]["value"]["uiAmount"].as_f64().unwrap_or(0.0))
+        // Parse via the shared helper (same logic as `usdc_balance_of`). A
+        // structurally unexpected body errors here rather than silently
+        // storing 0.0 into the monitor's atomic, which would wrongly trip the
+        // low-balance callback / free-tier fallback. See issue #323.
+        crate::rpc_error::parse_token_balance(&json).map_err(BalanceError::ParseResponse)
     }
 }
 

--- a/sdks/rust/crates/solvela-client/src/client.rs
+++ b/sdks/rust/crates/solvela-client/src/client.rs
@@ -688,7 +688,43 @@ impl SolvelaClient {
             )));
         }
 
-        let ui_amount = json["result"]["value"]["uiAmount"].as_f64().unwrap_or(0.0);
+        // At this point the response carried no `error` object, so the account
+        // exists and the body must contain `result.value`. A missing
+        // `result`/`value` means a structurally unexpected response (proxy
+        // error page, truncated body, wrong RPC method) — surface it as an
+        // error rather than silently reporting a 0 balance, which would
+        // wrongly trip the free-tier fallback and suppress payments.
+        let value = json
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .ok_or_else(|| {
+                ClientError::BalanceError(
+                    "RPC response missing result.value (unexpected shape)".to_string(),
+                )
+            })?;
+
+        // Prefer the deprecated `uiAmount` float when present, but it may be
+        // `null`; fall back to the authoritative `amount` (atomic string) +
+        // `decimals`, which `getTokenAccountBalance` always returns for an
+        // existing account. Only a response missing BOTH is treated as an
+        // error — a real zero balance still parses as 0.0 here.
+        let ui_amount = if let Some(n) = value.get("uiAmount").and_then(serde_json::Value::as_f64) {
+            n
+        } else if let (Some(amount), Some(decimals)) = (
+            value.get("amount").and_then(serde_json::Value::as_str),
+            value.get("decimals").and_then(serde_json::Value::as_u64),
+        ) {
+            let raw: u64 = amount.parse().map_err(|e| {
+                ClientError::BalanceError(format!("invalid token amount '{amount}': {e}"))
+            })?;
+            #[allow(clippy::cast_precision_loss)] // USDC amounts fit within the f64 mantissa
+            let ui = raw as f64 / 10f64.powi(i32::try_from(decimals).unwrap_or(6));
+            ui
+        } else {
+            return Err(ClientError::BalanceError(
+                "RPC response missing balance fields (uiAmount/amount)".to_string(),
+            ));
+        };
 
         Ok(ui_amount)
     }
@@ -1062,6 +1098,82 @@ mod tests {
             .await
             .unwrap();
         assert!((balance - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_usdc_balance_falls_back_to_amount_when_ui_amount_null() {
+        // `uiAmount` is a deprecated field that can be `null`; the balance must
+        // be computed from the authoritative `amount` + `decimals`, NOT treated
+        // as 0.0. 2_500_000 atomic / 10^6 = 2.5 USDC.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "context": { "slot": 1 },
+                    "value": {
+                        "amount": "2500000",
+                        "decimals": 6,
+                        "uiAmount": serde_json::Value::Null,
+                        "uiAmountString": "2.5"
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: "http://unused".to_string(),
+                rpc_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let balance = client
+            .usdc_balance_of(&client.wallet.address())
+            .await
+            .unwrap();
+        assert!((balance - 2.5).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_usdc_balance_errors_on_malformed_response_not_silent_zero() {
+        // No `error` object and no `result.value` — a structurally unexpected
+        // body (e.g. a proxy error page). This MUST be an error, not a silent
+        // 0.0 that would trip the free-tier fallback and suppress payments.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": { "context": { "slot": 1 } }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: "http://unused".to_string(),
+                rpc_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let result = client.usdc_balance_of(&client.wallet.address()).await;
+        assert!(
+            matches!(result, Err(ClientError::BalanceError(_))),
+            "malformed RPC response must error, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/sdks/rust/crates/solvela-client/src/client.rs
+++ b/sdks/rust/crates/solvela-client/src/client.rs
@@ -634,8 +634,11 @@ impl SolvelaClient {
     ///
     /// # Errors
     ///
-    /// Returns `ClientError::BalanceError` if the address is invalid or the
-    /// RPC call fails for a reason other than "account not found".
+    /// Returns `ClientError::BalanceError` if the address is invalid, the RPC
+    /// call fails for a reason other than "account not found", or the RPC
+    /// returns an HTTP 200 with a structurally unexpected body (missing
+    /// `result.value`, no usable balance fields, or a negative balance) —
+    /// these surface as errors rather than a silent `0.0`.
     pub async fn usdc_balance_of(&self, address: &str) -> Result<f64, ClientError> {
         let owner: Pubkey = address
             .parse()
@@ -688,45 +691,12 @@ impl SolvelaClient {
             )));
         }
 
-        // At this point the response carried no `error` object, so the account
-        // exists and the body must contain `result.value`. A missing
-        // `result`/`value` means a structurally unexpected response (proxy
-        // error page, truncated body, wrong RPC method) — surface it as an
-        // error rather than silently reporting a 0 balance, which would
-        // wrongly trip the free-tier fallback and suppress payments.
-        let value = json
-            .get("result")
-            .and_then(|r| r.get("value"))
-            .ok_or_else(|| {
-                ClientError::BalanceError(
-                    "RPC response missing result.value (unexpected shape)".to_string(),
-                )
-            })?;
-
-        // Prefer the deprecated `uiAmount` float when present, but it may be
-        // `null`; fall back to the authoritative `amount` (atomic string) +
-        // `decimals`, which `getTokenAccountBalance` always returns for an
-        // existing account. Only a response missing BOTH is treated as an
-        // error — a real zero balance still parses as 0.0 here.
-        let ui_amount = if let Some(n) = value.get("uiAmount").and_then(serde_json::Value::as_f64) {
-            n
-        } else if let (Some(amount), Some(decimals)) = (
-            value.get("amount").and_then(serde_json::Value::as_str),
-            value.get("decimals").and_then(serde_json::Value::as_u64),
-        ) {
-            let raw: u64 = amount.parse().map_err(|e| {
-                ClientError::BalanceError(format!("invalid token amount '{amount}': {e}"))
-            })?;
-            #[allow(clippy::cast_precision_loss)] // USDC amounts fit within the f64 mantissa
-            let ui = raw as f64 / 10f64.powi(i32::try_from(decimals).unwrap_or(6));
-            ui
-        } else {
-            return Err(ClientError::BalanceError(
-                "RPC response missing balance fields (uiAmount/amount)".to_string(),
-            ));
-        };
-
-        Ok(ui_amount)
+        // The error-object case is handled above; parse the balance via the
+        // shared helper so this and `BalanceMonitor` behave identically. The
+        // helper errors (never silently returns 0.0) on a structurally
+        // unexpected body, which would otherwise trip the free-tier fallback
+        // and suppress payments. A real zero balance still parses as Ok(0.0).
+        crate::rpc_error::parse_token_balance(&json).map_err(ClientError::BalanceError)
     }
 
     /// Return the last known USDC balance, or `None` if it has never been polled.

--- a/sdks/rust/crates/solvela-client/src/rpc_error.rs
+++ b/sdks/rust/crates/solvela-client/src/rpc_error.rs
@@ -34,10 +34,98 @@ pub(crate) fn is_account_not_found(json: &Value) -> bool {
     msg.contains("could not find account") || msg.contains("Account does not exist")
 }
 
+/// Parse the USDC balance (UI units) from a `getTokenAccountBalance` response
+/// whose top-level `error` has already been handled by the caller.
+///
+/// Shared by `SolvelaClient::usdc_balance_of` and `BalanceMonitor` so both
+/// sites parse identically. Requires `result.value`; prefers the deprecated
+/// `uiAmount` float but falls back to the authoritative `amount` (atomic
+/// string) + `decimals`, which the RPC always returns for an existing account.
+///
+/// Returns `Err(message)` — never a silent `0.0` — for a structurally
+/// unexpected body (missing `result.value`, missing both balance fields,
+/// non-numeric `amount`, out-of-range `decimals`, or a negative balance). A
+/// silent zero here would wrongly trip the free-tier fallback and suppress
+/// payments. A *real* zero balance (`amount: "0"`) still parses as `Ok(0.0)`.
+pub(crate) fn parse_token_balance(json: &Value) -> Result<f64, String> {
+    let value = json
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .ok_or_else(|| "RPC response missing result.value (unexpected shape)".to_string())?;
+
+    let ui_amount = if let Some(n) = value.get("uiAmount").and_then(Value::as_f64) {
+        n
+    } else if let (Some(amount), Some(decimals)) = (
+        value.get("amount").and_then(Value::as_str),
+        value.get("decimals").and_then(Value::as_u64),
+    ) {
+        let raw: u64 = amount
+            .parse()
+            .map_err(|e| format!("invalid token amount '{amount}': {e}"))?;
+        let exp = i32::try_from(decimals)
+            .map_err(|_| format!("RPC returned out-of-range decimals: {decimals}"))?;
+        #[allow(clippy::cast_precision_loss)] // USDC supply fits within the f64 mantissa
+        let ui = raw as f64 / 10f64.powi(exp);
+        ui
+    } else {
+        return Err("RPC response missing balance fields (uiAmount/amount)".to_string());
+    };
+
+    if ui_amount < 0.0 {
+        return Err(format!("RPC returned a negative balance: {ui_amount}"));
+    }
+    Ok(ui_amount)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn parse_balance_prefers_ui_amount_when_present() {
+        // uiAmount disagrees with amount on purpose — uiAmount must win.
+        let j = json!({"result": {"value": {"uiAmount": 1.5, "amount": "9999999", "decimals": 6}}});
+        assert!((parse_token_balance(&j).unwrap() - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_balance_falls_back_to_amount_when_ui_amount_null() {
+        let j =
+            json!({"result": {"value": {"uiAmount": null, "amount": "2500000", "decimals": 6}}});
+        assert!((parse_token_balance(&j).unwrap() - 2.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_balance_real_zero_is_ok_not_error() {
+        let j = json!({"result": {"value": {"uiAmount": null, "amount": "0", "decimals": 6}}});
+        assert!(parse_token_balance(&j).unwrap().abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_balance_non_six_decimals() {
+        let j =
+            json!({"result": {"value": {"uiAmount": null, "amount": "1000000000", "decimals": 9}}});
+        assert!((parse_token_balance(&j).unwrap() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_balance_missing_value_errors() {
+        let j = json!({"result": {"context": {"slot": 1}}});
+        assert!(parse_token_balance(&j).is_err());
+    }
+
+    #[test]
+    fn parse_balance_non_numeric_amount_errors() {
+        let j = json!({"result": {"value": {"uiAmount": null, "amount": "NaN", "decimals": 6}}});
+        assert!(parse_token_balance(&j).is_err());
+    }
+
+    #[test]
+    fn parse_balance_negative_errors() {
+        let j = json!({"result": {"value": {"uiAmount": -1.5}}});
+        assert!(parse_token_balance(&j).is_err());
+    }
 
     #[test]
     fn canonical_account_not_found_message_matches() {


### PR DESCRIPTION
## Problem

`usdc_balance_of` ended with `json["result"]["value"]["uiAmount"].as_f64().unwrap_or(0.0)`. The RPC `error`-object case is already handled (#323), but a structurally **unexpected 200 response** (proxy error page, truncated body, wrong RPC method) has no `error` object and no usable `result.value` — so it silently reported a **0 balance**. A zero balance trips the free-tier fallback and **suppresses payments**, making a malfunctioning RPC indistinguishable from an empty wallet.

Flagged as a Critical-rated silent failure during the PR #451 money-path review; split out as its own fix.

## Fix

- Require `result.value`; a missing one → `BalanceError` (not `0.0`).
- Prefer the deprecated `uiAmount` float, but fall back to the authoritative `amount` (atomic string) + `decimals` when it's `null` — so a legitimately-null `uiAmount` (and a real **0** balance) still parses correctly.
- Error only when **both** `uiAmount` and `amount` are absent.

## Tests

- `test_usdc_balance_falls_back_to_amount_when_ui_amount_null` — `uiAmount: null`, `amount: "2500000"`, `decimals: 6` → 2.5 USDC.
- `test_usdc_balance_errors_on_malformed_response_not_silent_zero` — no `value`, no `error` → `BalanceError`, not `0.0`.
- Existing parse / missing-account / real-error tests unchanged.

clippy clean, fmt clean, `solvela-client` 106 lib + 13 integration + doctest green.