### PR TITLE
ci: auto-approve first-party PRs once all required checks are green

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,88 @@
+# Auto-approve a PR once all required checks on `main` are green.
+#
+# Why this exists: branch protection on `main` requires 1 approving review,
+# but Solvela is a solo-maintainer repo with no second human reviewer — so
+# every green PR otherwise needs a manual approve-as-bot step. This posts that
+# approval automatically (as `github-actions[bot]`) so the PR becomes
+# mergeable. It is APPROVE-ONLY: a human still triggers the actual merge.
+#
+# Security posture: this makes CI the effective gate to `main`. The guards
+# below keep the blast radius to first-party, non-fork PRs from a small author
+# allowlist. `required_conversation_resolution` on `main` still independently
+# blocks merge until review threads are resolved.
+#
+# Prerequisite (already enabled via API at creation time): org + repo setting
+# "Allow GitHub Actions to create and approve pull requests" must be ON, else
+# createReview returns 422.
+name: Auto-approve on green CI
+
+on:
+  check_suite:
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  checks: read
+  contents: read
+
+jobs:
+  approve:
+    # Only bother when the completed suite itself succeeded; the script
+    # re-verifies every required check regardless.
+    if: github.event.check_suite.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.check_suite.head_sha;
+
+            // KEEP IN SYNC with branch protection required checks on `main`.
+            // Adding/renaming a required check without updating this list
+            // would let the bot approve on an incomplete set.
+            const REQUIRED = [
+              'Rust (fmt, clippy, test)',
+              'Smoke test (boot gateway + curl endpoints)',
+              'Security audit (cargo-audit)',
+              'Docker build',
+              'Verify DCO sign-off on every commit',
+              'Semantic cache (redis-stack + embedding model)',
+            ];
+            const ALLOW = ['sky64'];
+
+            const prs = (await github.rest.repos.listPullRequestsAssociatedWithCommit(
+              { owner, repo, commit_sha: sha })).data;
+
+            for (const pr of prs) {
+              // --- guards ---
+              if (pr.state !== 'open' || pr.draft) continue;
+              if (pr.base.ref !== 'main') continue;
+              if (pr.head.repo.full_name !== pr.base.repo.full_name) continue; // no forks
+              if (!ALLOW.includes(pr.user.login)) continue;
+
+              // --- all required checks green for this exact SHA ---
+              const runs = await github.paginate(github.rest.checks.listForRef,
+                { owner, repo, ref: sha, per_page: 100 });
+              const conclusion = {};
+              for (const r of runs) conclusion[r.name] = r.conclusion;
+              if (!REQUIRED.every(n => conclusion[n] === 'success')) continue;
+
+              // --- don't approve over a CHANGES_REQUESTED review; idempotent ---
+              const reviews = await github.paginate(github.rest.pulls.listReviews,
+                { owner, repo, pull_number: pr.number });
+              if (reviews.some(r => r.state === 'CHANGES_REQUESTED')) continue;
+              const alreadyApproved = reviews.some(r =>
+                r.state === 'APPROVED'
+                && r.user.login === 'github-actions[bot]'
+                && r.commit_id === sha);
+              if (alreadyApproved) continue;
+
+              await github.rest.pulls.createReview({
+                owner, repo, pull_number: pr.number, event: 'APPROVE',
+                body: 'Auto-approved: all required checks green for '
+                    + `\`${sha.slice(0, 7)}\`. CI is the gate; `
+                    + 'conversation-resolution still enforced. Merge is manual.',
+              });
+              core.notice(`Auto-approved PR #${pr.number} at ${sha}`);
+            }


### PR DESCRIPTION
Adds `.github/workflows/auto-approve.yml`: posts an approving review (as `github-actions[bot]`) once **all 6 required checks** pass on a first-party PR, so it becomes mergeable without the manual approve-as-bot dance. **Approve-only** — a human still triggers the merge.

## How it works
- Trigger: `check_suite: completed`. The job re-verifies **all** required checks for the head SHA (doesn't trust a single suite's conclusion, since the 6 checks span `ci.yml` + `dco.yml`).
- Identity: `github-actions[bot]` via `GITHUB_TOKEN` — **no PAT/secret**. Requires org+repo "Allow GitHub Actions to create and approve pull requests" (enabled at creation via API).
- Guards: same-repo only (no forks), `base == main`, author allowlist (`sky64`), not draft, no existing `CHANGES_REQUESTED`, idempotent per head SHA.

## Security posture
This makes CI the effective gate to `main`. The CI surface is strong (Rust incl. live-Postgres money path, smoke, cargo-audit, Docker, DCO), and `required_conversation_resolution` still independently blocks merge until threads resolve. Guards limit auto-approval to your own non-fork PRs.

## Maintenance note
The 6 required-check names are hard-coded (reading them from the branch-protection API needs an admin token). **If a required check is added/renamed, update the `REQUIRED` list** or the bot would approve on an incomplete set. A follow-up could add a tiny CI assert that the list matches branch protection.

## Rollback
Delete the file. Existing approvals persist (`dismiss_stale_reviews: false`).

Self-test after merge: open a trivial PR and confirm it auto-approves on green; confirm a draft / red PR does not.