### PR TITLE
ci(auto-approve): exclude money-path PRs + zero-secret required-checks sync

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -51,6 +51,23 @@ jobs:
             ];
             const ALLOW = ['sky64'];
 
+            // Money-path surfaces: code that signs / verifies / settles payments,
+            // computes cost, or touches escrow / USDC. A PR touching ANY of these
+            // is NOT auto-approved — it requires a human review even on green CI,
+            // because here CI is not a sufficient gate (funds move).
+            const MONEY_PATH = [
+              /^crates\/x402\//,
+              /^crates\/escrow-tx\//,
+              /^programs\/escrow\//,
+              /^crates\/protocol\/src\/(payment|settlement|cost|constants)\.rs$/,
+              /^crates\/gateway\/src\/routes\/chat\/(cost|payment)\.rs$/,
+              /^crates\/gateway\/src\/escrow\//,
+              /^crates\/gateway\/src\/a2a\//,
+              /^crates\/gateway\/src\/usage\.rs$/,
+              /(^|\/)signer\.(rs|ts|py|go)$/, // SDK signing modules (any language)
+              /^sdks\/.*\/escrow/,            // SDK escrow paths
+            ];
+
             const prs = (await github.rest.repos.listPullRequestsAssociatedWithCommit(
               { owner, repo, commit_sha: sha })).data;
 
@@ -60,6 +77,16 @@ jobs:
               if (pr.base.ref !== 'main') continue;
               if (pr.head.repo.full_name !== pr.base.repo.full_name) continue; // no forks
               if (!ALLOW.includes(pr.user.login)) continue;
+
+              // --- money-path exclusion: never auto-approve; needs human review ---
+              const files = await github.paginate(github.rest.pulls.listFiles,
+                { owner, repo, pull_number: pr.number, per_page: 100 });
+              const moneyHit = files.find(f => MONEY_PATH.some(re => re.test(f.filename)));
+              if (moneyHit) {
+                core.notice(`PR #${pr.number} touches money-path (${moneyHit.filename}); `
+                  + 'skipping auto-approve — human review required');
+                continue;
+              }
 
               // --- all required checks green for this exact SHA ---
               const runs = await github.paginate(github.rest.checks.listForRef,

--- a/.github/workflows/required-checks-sync.yml
+++ b/.github/workflows/required-checks-sync.yml
@@ -1,0 +1,75 @@
+# Guards against drift between the `REQUIRED` list hard-coded in
+# `auto-approve.yml` and the checks that actually run on `main`.
+#
+# Scope & limits (read before extending):
+# - This is a ZERO-SECRET assert. It cannot read branch-protection settings
+#   (that needs an admin-read token), so it checks the direction it CAN see:
+#   every name in `REQUIRED` must correspond to a check that actually ran on
+#   the previous `main` commit. This catches a renamed/removed/typo'd entry
+#   (which would otherwise make the auto-approver wait forever for a check
+#   that never reports).
+# - It does NOT detect the opposite drift (branch protection gains a required
+#   check not in `REQUIRED`). That direction is safe anyway: branch protection
+#   enforces required checks at MERGE time regardless of the bot's approval, so
+#   a stale `REQUIRED` can at worst cause a cosmetically-early approval — the
+#   merge itself stays blocked until the real required checks pass.
+# - Runs on push to `main` (post-merge, when drift lands) and on demand. Not on
+#   PRs, so it never blocks contributors and can't be red on its own PR.
+name: Required-checks sync
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  checks: read
+  contents: read
+
+jobs:
+  assert-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+
+            // Parse the REQUIRED list straight out of auto-approve.yml so there
+            // is a single source of truth (no second copy to drift).
+            const wf = fs.readFileSync('.github/workflows/auto-approve.yml', 'utf8');
+            const block = wf.match(/const REQUIRED = \[([\s\S]*?)\];/);
+            if (!block) {
+              core.setFailed('Could not locate `const REQUIRED = [...]` in auto-approve.yml');
+              return;
+            }
+            const required = [...block[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+            if (required.length === 0) {
+              core.setFailed('auto-approve.yml REQUIRED list parsed as empty');
+              return;
+            }
+
+            // Compare against checks that ran on the commit BEFORE this push —
+            // a fully-built commit, so no race with in-flight runs.
+            const before = context.payload.before;
+            if (!before || /^0+$/.test(before)) {
+              core.notice('No prior commit (new branch / force-push); skipping.');
+              return;
+            }
+
+            const runs = await github.paginate(github.rest.checks.listForRef,
+              { owner, repo, ref: before, per_page: 100 });
+            const ran = new Set(runs.map(r => r.name));
+
+            const missing = required.filter(n => !ran.has(n));
+            if (missing.length) {
+              core.setFailed(
+                `auto-approve.yml REQUIRED lists check(s) that did not run on ${before.slice(0, 7)}: `
+                + `${missing.map(n => `"${n}"`).join(', ')}. `
+                + 'A required check was renamed/removed — update the REQUIRED list in '
+                + '.github/workflows/auto-approve.yml (and branch protection) to match.');
+              return;
+            }
+            core.notice(`OK — all ${required.length} REQUIRED checks ran on ${before.slice(0, 7)}.`);


### PR DESCRIPTION
Two hardening changes to `.github/workflows/auto-approve.yml`, per follow-up to the auto-approve rollout.

## 1. Money-path exclusion
A PR touching **any** payment/escrow/cost/signing surface is **never auto-approved** — it requires a human review even on green CI, because CI alone is not a sufficient gate when funds move. Matched paths:
- `crates/x402/`, `crates/escrow-tx/`, `programs/escrow/`
- `crates/protocol/src/{payment,settlement,cost,constants}.rs`
- `crates/gateway/src/routes/chat/{cost,payment}.rs`, `…/escrow/`, `…/a2a/`, `…/usage.rs`
- any `signer.{rs,ts,py,go}` (SDK signing, any language), `sdks/**/escrow*`

Implemented via `pulls.listFiles` + a `MONEY_PATH` regex list; on a hit the run `core.notice`s and skips (leaving the PR for manual review).

## 2. Required-checks sync assert (new `required-checks-sync.yml`)
**Zero-secret.** On push to `main`, it parses the `REQUIRED` list out of `auto-approve.yml` (single source of truth) and asserts every entry actually ran as a check on the **prior** main commit — catching a renamed/removed/typo'd required check that would otherwise make the auto-approver wait forever.

**Documented limitation:** it cannot read branch-protection settings (that needs an admin-read token/secret), so it does **not** detect the inverse drift (a newly-*required* check missing from `REQUIRED`). That direction is already safe: branch protection enforces required checks at **merge** time regardless of the bot's approval, so a stale `REQUIRED` can at worst cause a cosmetically-early approval — the merge stays blocked until the real checks pass. Runs only on push-to-main + manual dispatch (never on PRs, so it can't block contributors or be red on its own PR).

Validated locally: both YAML parse; both `script:` bodies pass `node --check` (wrapped as github-script runs them).