### PR TITLE
feat(sdk-python): x402 escrow deposit signing (Track 1 / T1.1)

### DIFF
--- a/sdks/python/src/solvela/escrow.py
+++ b/sdks/python/src/solvela/escrow.py
@@ -1,0 +1,299 @@
+"""Escrow deposit-transaction builder for the Python SDK.
+
+Byte-exact port of the canonical Rust builder ``crates/escrow-tx/src/deposit.rs``
+(+ ``pda.rs``). The output MUST reproduce ``GOLDEN_VECTOR_B64`` for the fixed
+golden-vector input; the gateway verifier (``crates/x402/src/escrow/``)
+independently re-derives the same layout, so any divergence here is a
+fund-misdirection bug, not a style nit.
+
+Wire layout (single source of truth — see the Rust file and the ``solvela-x402``
+skill):
+
+* Escrow PDA seeds: ``[b"escrow", agent_pubkey(32), service_id(32)]``.
+* Vault ATA: ``ATA(escrow_pda, usdc_mint)``.
+* Instruction data (56 bytes): ``anchor_discriminator("deposit")[8]`` ``||``
+  ``amount: u64 LE`` ``||`` ``service_id: [u8;32]`` ``||`` ``expiry_slot: u64 LE``.
+* Account list sorted by writability; program key appended last (index 9).
+* Instruction account-index order: ``[0, 4, 5, 1, 2, 3, 6, 7, 8]``.
+* Legacy message header ``[1, 0, 6]``; length prefixes are single-byte
+  compact-u16 (valid only for lengths <= 127 — reject larger rather than
+  truncating).
+* Wire tx: ``compact-u16(1) || ed25519_signature(64) || message`` then base64
+  (standard alphabet).
+
+We deliberately do NOT use ``solders.message.Message`` /
+``solders.transaction.Transaction`` to assemble the message: those compute their
+own account ordering and would not match the canonical writability-sorted layout
+byte-for-byte. We use ``solders`` only for the primitives whose output is
+canonical and already pinned as ground truth: ``Pubkey.find_program_address``
+(PDA + ATA derivation) and ``Keypair`` ed25519 signing.
+
+Library: solders >= 0.21, < 0.30 (declared in pyproject.toml; tested against
+0.27.1). Anchor discriminator and account ordering are computed locally with the
+stdlib ``hashlib``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+
+from solvela.errors import SignerError
+
+# ---------------------------------------------------------------------------
+# Well-known program constants (match crates/escrow-tx/src/pda.rs).
+# ---------------------------------------------------------------------------
+
+ATA_PROGRAM_ID = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+SYSTEM_PROGRAM_ID = "11111111111111111111111111111111"
+
+# Single-byte compact-u16 limit. Lengths above this would need a continuation
+# byte; emitting a bare u8 there would corrupt the encoding, so we reject.
+_COMPACT_U16_SINGLE_BYTE_MAX = 127
+
+
+class DepositError(SignerError):
+    """Raised when an escrow deposit transaction cannot be built.
+
+    Subclasses ``SignerError`` so it stays inside the SDK's typed error
+    hierarchy (callers using ``except SignerError`` / ``except ClientError``
+    catch it).
+    """
+
+
+# ---------------------------------------------------------------------------
+# Derivation helpers (solders provides the canonical primitives).
+# ---------------------------------------------------------------------------
+
+
+def anchor_discriminator(name: str) -> bytes:
+    """Compute the Anchor instruction discriminator: ``sha256("global:<name>")[..8]``."""
+    return hashlib.sha256(f"global:{name}".encode()).digest()[:8]
+
+
+def derive_escrow_pda(
+    agent_pubkey: bytes, service_id: bytes, program_id: Pubkey
+) -> tuple[Pubkey, int]:
+    """Derive the escrow PDA from seeds ``[b"escrow", agent, service_id]``.
+
+    Returns ``(pda, bump)``. Delegates to ``solders`` /
+    ``solana-program``'s ``find_program_address``, which is the canonical
+    on-chain algorithm (pinned as ground truth in the Rust test suite).
+    """
+    pda, bump = Pubkey.find_program_address([b"escrow", agent_pubkey, service_id], program_id)
+    return pda, bump
+
+
+def derive_ata_address(wallet: Pubkey, mint: Pubkey) -> Pubkey:
+    """Derive the Associated Token Account address for a wallet and mint."""
+    ata_program = Pubkey.from_string(ATA_PROGRAM_ID)
+    token_program = Pubkey.from_string(TOKEN_PROGRAM_ID)
+    derived, _bump = Pubkey.find_program_address(
+        [bytes(wallet), bytes(token_program), bytes(mint)],
+        ata_program,
+    )
+    return derived
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DepositParams:
+    """Inputs for :func:`build_deposit_tx`.
+
+    The ``service_id``, ``expiry_slot``, and ``recent_blockhash`` are injected
+    so the builder is a pure, deterministic function (golden-vector testable).
+    Production code (``KeypairSigner.sign_payment``) generates the CSPRNG
+    ``service_id``, computes ``expiry_slot`` from the current slot, and fetches
+    the blockhash, then calls this builder.
+    """
+
+    # Base58-encoded 64-byte ed25519 keypair (32-byte secret || 32-byte pubkey).
+    agent_keypair_b58: str
+    provider_wallet_b58: str
+    usdc_mint_b58: str
+    escrow_program_id_b58: str
+    # Atomic USDC units (6 decimals). MUST be > 0.
+    amount: int
+    # 32-byte service identifier that seeds the escrow PDA.
+    service_id: bytes
+    # Slot at which the escrow deposit expires.
+    expiry_slot: int
+    # Recent blockhash (32 bytes) from getLatestBlockhash.
+    recent_blockhash: bytes
+
+    def __repr__(self) -> str:
+        # Never leak the keypair into logs / tracebacks.
+        return (
+            "DepositParams("
+            "agent_keypair_b58=REDACTED, "
+            f"provider_wallet_b58={self.provider_wallet_b58!r}, "
+            f"usdc_mint_b58={self.usdc_mint_b58!r}, "
+            f"escrow_program_id_b58={self.escrow_program_id_b58!r}, "
+            f"amount={self.amount}, expiry_slot={self.expiry_slot})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Legacy message serializer (manual — must match the Rust byte layout exactly).
+# ---------------------------------------------------------------------------
+
+
+def _build_legacy_message(
+    header: bytes,
+    accounts: list[Pubkey],
+    program_id: Pubkey,
+    recent_blockhash: bytes,
+    program_id_index: int,
+    ix_account_indices: bytes,
+    ix_data: bytes,
+) -> bytes:
+    """Serialize a Solana legacy transaction message.
+
+    Layout: header(3) || acct_count(u8) || N*32 keys (+ program key) ||
+    blockhash(32) || ix_count(u8)=1 || program_id_index(u8) || ix_acct_count(u8)
+    || ix_acct_indices || data_len(u8) || data.
+
+    Length prefixes are emitted as a single ``u8`` — the correct compact-u16
+    encoding only for lengths <= 127. Larger values are rejected (not
+    truncated), mirroring the Rust builder.
+    """
+    total_accounts = len(accounts) + 1  # +1 for the appended program key
+    if total_accounts > _COMPACT_U16_SINGLE_BYTE_MAX:
+        raise DepositError(
+            f"account count {total_accounts} exceeds the 127-byte compact-u16 single-byte limit"
+        )
+    if len(ix_account_indices) > _COMPACT_U16_SINGLE_BYTE_MAX:
+        raise DepositError(
+            f"instruction account count {len(ix_account_indices)} exceeds the "
+            "127-byte compact-u16 single-byte limit"
+        )
+    if len(ix_data) > _COMPACT_U16_SINGLE_BYTE_MAX:
+        raise DepositError(
+            f"instruction data length {len(ix_data)} exceeds the 127-byte "
+            "compact-u16 single-byte limit"
+        )
+
+    msg = bytearray()
+    msg += header
+    msg.append(total_accounts)
+    for acc in accounts:
+        msg += bytes(acc)
+    msg += bytes(program_id)  # program key is the last account
+    msg += recent_blockhash
+    msg.append(1)  # instruction count
+    msg.append(program_id_index)
+    msg.append(len(ix_account_indices))
+    msg += ix_account_indices
+    msg.append(len(ix_data))
+    msg += ix_data
+    return bytes(msg)
+
+
+# ---------------------------------------------------------------------------
+# Public builder
+# ---------------------------------------------------------------------------
+
+
+def build_deposit_tx(params: DepositParams) -> str:
+    """Build a signed escrow ``deposit`` transaction, base64-encoded.
+
+    Returns a base64 (standard alphabet) wire-format Solana legacy transaction
+    ready for the gateway / ``sendTransaction``.
+
+    Raises:
+        DepositError: zero amount, malformed keypair/address, bad service_id or
+            blockhash length, or message-too-long.
+    """
+    # Step 1: reject zero amount (fail-closed money-path invariant).
+    if params.amount <= 0:
+        raise DepositError("deposit amount must be greater than zero")
+    if params.amount > 0xFFFF_FFFF_FFFF_FFFF:
+        raise DepositError("deposit amount exceeds u64 range")
+
+    if len(params.service_id) != 32:
+        raise DepositError(f"service_id must be 32 bytes, got {len(params.service_id)}")
+    if len(params.recent_blockhash) != 32:
+        raise DepositError(f"recent_blockhash must be 32 bytes, got {len(params.recent_blockhash)}")
+
+    # Step 2: load the keypair and recover the agent pubkey.
+    try:
+        keypair = Keypair.from_base58_string(params.agent_keypair_b58)
+    except Exception as exc:  # noqa: BLE001 — normalize to typed error
+        raise DepositError(f"invalid agent keypair: {exc}") from exc
+    agent_pubkey = keypair.pubkey()
+    agent_pubkey_bytes = bytes(agent_pubkey)
+
+    # Step 3: parse addresses.
+    try:
+        provider = Pubkey.from_string(params.provider_wallet_b58)
+        usdc_mint = Pubkey.from_string(params.usdc_mint_b58)
+        escrow_program = Pubkey.from_string(params.escrow_program_id_b58)
+        token_program = Pubkey.from_string(TOKEN_PROGRAM_ID)
+        ata_program = Pubkey.from_string(ATA_PROGRAM_ID)
+        system_program = Pubkey.from_string(SYSTEM_PROGRAM_ID)
+    except Exception as exc:  # noqa: BLE001 — normalize to typed error
+        raise DepositError(f"invalid address: {exc}") from exc
+
+    # Step 4: derive escrow PDA and ATAs.
+    escrow_pda, _bump = derive_escrow_pda(agent_pubkey_bytes, params.service_id, escrow_program)
+    agent_ata = derive_ata_address(agent_pubkey, usdc_mint)
+    vault_ata = derive_ata_address(escrow_pda, usdc_mint)
+
+    # Step 5: account list sorted by writability (writable signer, writable
+    # non-signers, readonly non-signers). The program key is appended last
+    # (index 9) inside the message serializer.
+    accounts = [
+        agent_pubkey,  # 0: signer, writable
+        escrow_pda,  # 1: writable, non-signer
+        agent_ata,  # 2: writable, non-signer
+        vault_ata,  # 3: writable, non-signer
+        provider,  # 4: readonly
+        usdc_mint,  # 5: readonly
+        token_program,  # 6: readonly
+        ata_program,  # 7: readonly
+        system_program,  # 8: readonly
+    ]
+
+    # Step 6: instruction data = discriminator || amount(LE u64) || service_id
+    # || expiry_slot(LE u64) = 8 + 8 + 32 + 8 = 56 bytes.
+    ix_data = bytearray()
+    ix_data += anchor_discriminator("deposit")
+    ix_data += params.amount.to_bytes(8, "little")
+    ix_data += params.service_id
+    ix_data += params.expiry_slot.to_bytes(8, "little")
+    if len(ix_data) != 56:  # invariant guard, mirrors the Rust assert
+        raise DepositError(f"deposit ix_data must be 56 bytes, got {len(ix_data)}")
+
+    # Anchor program account order remapped into the writability-sorted layout.
+    ix_account_indices = bytes([0, 4, 5, 1, 2, 3, 6, 7, 8])
+
+    # Step 7: legacy message. Header [1, 0, 6]; program_id_index = 9 (last).
+    message = _build_legacy_message(
+        header=bytes([1, 0, 6]),
+        accounts=accounts,
+        program_id=escrow_program,
+        recent_blockhash=params.recent_blockhash,
+        program_id_index=9,
+        ix_account_indices=ix_account_indices,
+        ix_data=bytes(ix_data),
+    )
+
+    # Step 8: sign the raw message bytes with the agent keypair (ed25519).
+    signature = keypair.sign_message(message)
+
+    # Step 9: assemble wire tx: compact-u16(1) || signature(64) || message.
+    tx_bytes = bytearray()
+    tx_bytes.append(0x01)  # compact-u16: 1 signature
+    tx_bytes += bytes(signature)
+    tx_bytes += message
+
+    return base64.b64encode(bytes(tx_bytes)).decode()

--- a/sdks/python/src/solvela/escrow.py
+++ b/sdks/python/src/solvela/escrow.py
@@ -132,6 +132,16 @@ class DepositParams:
     after the byte-layout-relevant fields are checked. To produce a variant
     (e.g. in tests), use ``dataclasses.replace(params, ...)`` which re-runs
     validation, never attribute assignment.
+
+    .. warning::
+        ``agent_keypair_b58`` is secret key material that is **NOT wiped from
+        Python heap memory**. Unlike the Rust builder (which holds the key in a
+        ``Zeroizing<String>`` zeroed on drop), CPython cannot reliably overwrite
+        an immutable ``str`` — copies may linger in the interned-string table,
+        f-string buffers, and GC arenas until reclaimed. Callers MUST keep a
+        ``DepositParams`` short-lived (build the tx, then drop it) and MUST NEVER
+        store it in a cache, module-global, or long-lived attribute. No ctypes
+        scrub is attempted here — it would give false assurance.
     """
 
     # Base58-encoded 64-byte ed25519 keypair (32-byte secret || 32-byte pubkey).
@@ -243,6 +253,13 @@ def build_deposit_tx(params: DepositParams) -> str:
 
     Returns a base64 (standard alphabet) wire-format Solana legacy transaction
     ready for the gateway / ``sendTransaction``.
+
+    .. warning::
+        ``params.agent_keypair_b58`` is secret key material that is **NOT wiped
+        from Python heap memory** after this call (unlike the Rust builder's
+        ``Zeroizing<String>``). CPython cannot reliably overwrite an immutable
+        ``str``. Keep the ``DepositParams`` short-lived and never cache it; see
+        the :class:`DepositParams` docstring.
 
     Raises:
         DepositError: zero amount, malformed keypair/address, bad service_id or

--- a/sdks/python/src/solvela/escrow.py
+++ b/sdks/python/src/solvela/escrow.py
@@ -56,6 +56,19 @@ SYSTEM_PROGRAM_ID = "11111111111111111111111111111111"
 # byte; emitting a bare u8 there would corrupt the encoding, so we reject.
 _COMPACT_U16_SINGLE_BYTE_MAX = 127
 
+# Maximum value representable as a little-endian u64 (the on-chain amount field).
+_U64_MAX = 0xFFFF_FFFF_FFFF_FFFF
+
+
+def _is_strict_int(value: object) -> bool:
+    """True only for a real ``int`` — rejects ``float`` and ``bool``.
+
+    Money-path guard: ``bool`` is an ``int`` subclass, and a ``float`` amount
+    would be silently truncated by ``int(...)`` / ``.to_bytes`` and mis-charge
+    the agent. Both must be refused at the boundary.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
+
 
 class DepositError(SignerError):
     """Raised when an escrow deposit transaction cannot be built.
@@ -105,7 +118,7 @@ def derive_ata_address(wallet: Pubkey, mint: Pubkey) -> Pubkey:
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class DepositParams:
     """Inputs for :func:`build_deposit_tx`.
 
@@ -114,6 +127,11 @@ class DepositParams:
     Production code (``KeypairSigner.sign_payment``) generates the CSPRNG
     ``service_id``, computes ``expiry_slot`` from the current slot, and fetches
     the blockhash, then calls this builder.
+
+    Frozen + validated at construction: a money-path struct must not be mutated
+    after the byte-layout-relevant fields are checked. To produce a variant
+    (e.g. in tests), use ``dataclasses.replace(params, ...)`` which re-runs
+    validation, never attribute assignment.
     """
 
     # Base58-encoded 64-byte ed25519 keypair (32-byte secret || 32-byte pubkey).
@@ -121,7 +139,7 @@ class DepositParams:
     provider_wallet_b58: str
     usdc_mint_b58: str
     escrow_program_id_b58: str
-    # Atomic USDC units (6 decimals). MUST be > 0.
+    # Atomic USDC units (6 decimals). MUST be a positive int (no float/bool).
     amount: int
     # 32-byte service identifier that seeds the escrow PDA.
     service_id: bytes
@@ -129,6 +147,23 @@ class DepositParams:
     expiry_slot: int
     # Recent blockhash (32 bytes) from getLatestBlockhash.
     recent_blockhash: bytes
+
+    def __post_init__(self) -> None:
+        # Reject a float/bool amount BEFORE any to_bytes / arithmetic use:
+        # ``int(2.9)`` would silently truncate the on-chain transfer amount,
+        # and ``True`` is an ``int`` subclass that would deposit 1 atomic unit.
+        if not _is_strict_int(self.amount):
+            raise DepositError("deposit amount must be an integer number of atomic USDC units")
+        if self.amount <= 0:
+            raise DepositError("deposit amount must be greater than zero")
+        if self.amount > _U64_MAX:
+            raise DepositError("deposit amount exceeds u64 range")
+        if len(self.service_id) != 32:
+            raise DepositError(f"service_id must be 32 bytes, got {len(self.service_id)}")
+        if len(self.recent_blockhash) != 32:
+            raise DepositError(
+                f"recent_blockhash must be 32 bytes, got {len(self.recent_blockhash)}"
+            )
 
     def __repr__(self) -> str:
         # Never leak the keypair into logs / tracebacks.
@@ -213,10 +248,15 @@ def build_deposit_tx(params: DepositParams) -> str:
         DepositError: zero amount, malformed keypair/address, bad service_id or
             blockhash length, or message-too-long.
     """
-    # Step 1: reject zero amount (fail-closed money-path invariant).
+    # Step 1: fail-closed money-path guards on the amount. ``DepositParams``
+    # already validates these at construction, but we re-check here (defense in
+    # depth) BEFORE any ``.to_bytes`` use so a hand-constructed params object
+    # that bypassed __post_init__ can never silently truncate a float amount.
+    if not _is_strict_int(params.amount):
+        raise DepositError("deposit amount must be an integer number of atomic USDC units")
     if params.amount <= 0:
         raise DepositError("deposit amount must be greater than zero")
-    if params.amount > 0xFFFF_FFFF_FFFF_FFFF:
+    if params.amount > _U64_MAX:
         raise DepositError("deposit amount exceeds u64 range")
 
     if len(params.service_id) != 32:
@@ -224,11 +264,15 @@ def build_deposit_tx(params: DepositParams) -> str:
     if len(params.recent_blockhash) != 32:
         raise DepositError(f"recent_blockhash must be 32 bytes, got {len(params.recent_blockhash)}")
 
-    # Step 2: load the keypair and recover the agent pubkey.
+    # Step 2: load the keypair and recover the agent pubkey. The raw solders
+    # exception is NOT interpolated and the chain is dropped: a malformed
+    # keypair string is (or contains) secret key material, and some solders
+    # error variants can echo the offending input. Surface a generic message
+    # only — never the raw input or the underlying exception text.
     try:
         keypair = Keypair.from_base58_string(params.agent_keypair_b58)
-    except Exception as exc:  # noqa: BLE001 — normalize to typed error
-        raise DepositError(f"invalid agent keypair: {exc}") from exc
+    except Exception:  # noqa: BLE001 — normalize to typed error, no secret leak
+        raise DepositError("invalid agent keypair: bad base58 or wrong length") from None
     agent_pubkey = keypair.pubkey()
     agent_pubkey_bytes = bytes(agent_pubkey)
 

--- a/sdks/python/src/solvela/signer.py
+++ b/sdks/python/src/solvela/signer.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import base64
+import json
 import secrets
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
+
+import httpx
 
 from solvela.constants import USDC_MINT, X402_VERSION
 from solvela.errors import SignerError
@@ -34,6 +37,14 @@ _MAX_ESCROW_EXPIRY_SLOTS_AHEAD = 10_000
 # headroom (150 vs 50) absorbs slot-skew between the slot we read and the slot
 # the gateway verifies against. ~150 slots ≈ 60 s.
 _MIN_ESCROW_EXPIRY_SLOTS_AHEAD = 150
+
+# Floor below which a getSlot result is implausible and rejected. A stub /
+# genesis / freshly-reset validator can answer getSlot with a near-zero slot;
+# computing an escrow expiry from that base yields an already-expired (or
+# trivially-near-expiry) deposit the gateway would bounce. Mainnet/devnet have
+# been well past this for years, so a real node never trips it. Fail closed
+# rather than silently signing a dead-on-arrival escrow deposit.
+_MIN_PLAUSIBLE_SLOT = 1_000_000
 
 if TYPE_CHECKING:
     from solders.pubkey import Pubkey
@@ -190,6 +201,14 @@ class KeypairSigner(Signer):
         if not program_id:
             raise SignerError("escrow scheme selected but escrow_program_id is missing")
 
+        # Reject a non-integer (float/bool) amount BEFORE it reaches the on-chain
+        # u64 amount field. ``int(2.9)`` would silently truncate the deposit and
+        # mis-charge the agent; ``bool`` is an ``int`` subclass that would
+        # deposit 1 atomic unit. Fail closed at the boundary.
+        if not (isinstance(amount_atomic, int) and not isinstance(amount_atomic, bool)):
+            raise SignerError(
+                "escrow deposit amount must be an integer number of atomic USDC units"
+            )
         if amount_atomic <= 0:
             raise SignerError("escrow deposit amount must be greater than zero")
 
@@ -261,10 +280,6 @@ class KeypairSigner(Signer):
         ``SignerError`` *before* any blind indexing — so a 429/5xx HTML body or
         an error payload never leaks node URLs / internals into a traceback.
         """
-        import json
-
-        import httpx
-
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.post(
                 self._rpc_url,
@@ -296,11 +311,9 @@ class KeypairSigner(Signer):
         failure, malformed body, RPC error, or missing/invalid ``result`` is a
         ``SignerError`` — never a silent default slot, which would let the
         escrow expiry be computed from a bogus base and bounced or mis-set.
+        Also rejects an implausibly-low slot (stub/genesis node) so the escrow
+        expiry is never computed from a near-zero base.
         """
-        import json
-
-        import httpx
-
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.post(
                 self._rpc_url,
@@ -324,6 +337,11 @@ class KeypairSigner(Signer):
             slot = data.get("result") if isinstance(data, dict) else None
             if not isinstance(slot, int) or isinstance(slot, bool) or slot < 0:
                 raise SignerError("getSlot RPC: missing or invalid result")
+            if slot < _MIN_PLAUSIBLE_SLOT:
+                raise SignerError(
+                    f"getSlot RPC returned implausibly low slot {slot} "
+                    f"(< {_MIN_PLAUSIBLE_SLOT}); refusing to build an escrow deposit"
+                )
             return slot
 
     @staticmethod

--- a/sdks/python/src/solvela/signer.py
+++ b/sdks/python/src/solvela/signer.py
@@ -2,18 +2,38 @@
 
 from __future__ import annotations
 
+import base64
+import secrets
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from solvela.constants import USDC_MINT, X402_VERSION
 from solvela.errors import SignerError
+from solvela.escrow import DepositParams, build_deposit_tx
 from solvela.types import (
     AtomicUsdc,
+    EscrowPayload,
     PaymentAccept,
     PaymentPayload,
     Resource,
     SolanaPayload,
 )
+
+# --- Escrow expiry-slot bounds (mirror the Rust SDK's signer.rs) ---
+#
+# Solana slots are ~400 ms. These bounds are ported verbatim from
+# sdks/rust/crates/solvela-client/src/signer.rs so the Python and Rust SDKs
+# choose compatible expiry slots and neither is bounced by the gateway.
+
+# Upper bound on how far ahead an escrow may expire (~66 min). Rejects a
+# malicious/misconfigured gateway from pushing expiry to "never".
+_MAX_ESCROW_EXPIRY_SLOTS_AHEAD = 10_000
+
+# Lower bound on expiry distance. Mirrors AND exceeds the gateway's
+# MIN_EXPIRY_BUFFER_SLOTS = 50 (crates/x402/src/escrow/verifier.rs); the extra
+# headroom (150 vs 50) absorbs slot-skew between the slot we read and the slot
+# the gateway verifies against. ~150 slots ≈ 60 s.
+_MIN_ESCROW_EXPIRY_SLOTS_AHEAD = 150
 
 if TYPE_CHECKING:
     from solders.pubkey import Pubkey
@@ -64,11 +84,37 @@ class KeypairSigner(Signer):
         resource: Resource,
         accepted: PaymentAccept,
     ) -> PaymentPayload:
-        """Build and sign a USDC-SPL transfer transaction."""
-        try:
-            import base64
+        """Build and sign a payment transaction, branching on the scheme.
 
-            import httpx
+        ``exact``  -> SPL-token transfer to the gateway's pay_to ATA
+                      (returns a ``SolanaPayload``).
+        ``escrow`` -> on-chain deposit into a per-request escrow PDA
+                      (returns an ``EscrowPayload``).
+
+        There is NO silent fallback: an ``escrow``-selected payment always
+        produces an escrow deposit, never an ``exact`` transfer, and an unknown
+        scheme is rejected. Routing an escrow-selected payment as an exact
+        transfer is the scheme-mismatch money-path bug this method guards
+        against (per the ``solvela-x402`` skill).
+        """
+        if accepted.scheme == "exact":
+            return await self._sign_exact_payment(amount_atomic, recipient, resource, accepted)
+        if accepted.scheme == "escrow":
+            return await self._sign_escrow_payment(amount_atomic, resource, accepted)
+        # `Scheme` is a closed Literal; PaymentAccept.from_dict already rejects
+        # unknown wire schemes. This branch fails closed if a new scheme is
+        # added to the enum without a financial branch here.
+        raise SignerError(f"Unsupported payment scheme: {accepted.scheme!r}")
+
+    async def _sign_exact_payment(
+        self,
+        amount_atomic: AtomicUsdc,
+        recipient: str,
+        resource: Resource,
+        accepted: PaymentAccept,
+    ) -> PaymentPayload:
+        """Build and sign a USDC-SPL transfer transaction (``exact`` scheme)."""
+        try:
             from solders.hash import Hash as Blockhash
             from solders.instruction import AccountMeta, Instruction
             from solders.keypair import Keypair as SoldersKeypair
@@ -88,41 +134,8 @@ class KeypairSigner(Signer):
             recipient_ata = self._derive_ata(recipient_pubkey, mint)
 
             # Get recent blockhash
-            async with httpx.AsyncClient(timeout=30) as client:
-                resp = await client.post(
-                    self._rpc_url,
-                    json={
-                        "jsonrpc": "2.0",
-                        "id": 1,
-                        "method": "getLatestBlockhash",
-                        "params": [{"commitment": "finalized"}],
-                    },
-                )
-                # Surface HTTP-level failures (rate limit, 5xx, etc.) before
-                # attempting JSON decode. An HTML/text body from a 429 or
-                # gateway error would otherwise raise `json.JSONDecodeError`
-                # uncontextualised and embed the raw response in the
-                # traceback.
-                if resp.status_code != 200:
-                    raise SignerError(f"Blockhash RPC HTTP {resp.status_code}")
-                import json
-
-                try:
-                    data = resp.json()
-                except json.JSONDecodeError as err:
-                    raise SignerError("Blockhash RPC: malformed JSON body") from err
-                # Guard against missing keys / RPC error responses. Indexing
-                # blindly with `data["result"]["value"]["blockhash"]` would
-                # raise a `KeyError` whose message embeds the raw RPC payload
-                # — leaking node URLs, internal error messages, etc. into
-                # tracebacks and Sentry events.
-                result = data.get("result", {}).get("value", {}) if isinstance(data, dict) else {}
-                blockhash_str = result.get("blockhash") if isinstance(result, dict) else None
-                if not blockhash_str:
-                    rpc_err = data.get("error") if isinstance(data, dict) else None
-                    err_code = rpc_err.get("code") if isinstance(rpc_err, dict) else None
-                    raise SignerError(f"RPC did not return a blockhash (code: {err_code})")
-                blockhash = Blockhash.from_string(blockhash_str)
+            blockhash_str = await self._fetch_latest_blockhash()
+            blockhash = Blockhash.from_string(blockhash_str)
 
             # Build SPL Token transfer instruction
             # Transfer instruction = index 3, data = amount as little-endian u64
@@ -156,6 +169,162 @@ class KeypairSigner(Signer):
             raise
         except Exception as e:
             raise SignerError(f"Failed to sign payment: {e}") from e
+
+    async def _sign_escrow_payment(
+        self,
+        amount_atomic: AtomicUsdc,
+        resource: Resource,
+        accepted: PaymentAccept,
+    ) -> PaymentPayload:
+        """Build and sign an escrow ``deposit`` transaction (``escrow`` scheme).
+
+        Generates a fresh CSPRNG ``service_id``, computes the expiry slot from
+        the current slot and ``accepted.max_timeout_seconds`` (mirroring the
+        Rust SDK), fetches a recent blockhash, and delegates the byte-exact
+        transaction construction to the shared, golden-vector-pinned
+        ``solvela.escrow.build_deposit_tx``.
+        """
+        # Fail clearly if escrow was selected but no program ID was offered —
+        # never silently fall back to an exact transfer.
+        program_id = accepted.escrow_program_id
+        if not program_id:
+            raise SignerError("escrow scheme selected but escrow_program_id is missing")
+
+        if amount_atomic <= 0:
+            raise SignerError("escrow deposit amount must be greater than zero")
+
+        try:
+            # Per-request CSPRNG service_id (#118 invariant): two identical
+            # requests must never share a service_id -> escrow PDA -> vault ATA.
+            service_id = secrets.token_bytes(32)
+
+            current_slot = await self._fetch_current_slot()
+            expiry_slot = self._escrow_expiry_slot(current_slot, accepted.max_timeout_seconds)
+
+            from solders.hash import Hash as Blockhash
+
+            blockhash_str = await self._fetch_latest_blockhash()
+            recent_blockhash = bytes(Blockhash.from_string(blockhash_str))
+
+            deposit_tx = build_deposit_tx(
+                DepositParams(
+                    agent_keypair_b58=self._wallet.to_keypair_b58(),
+                    provider_wallet_b58=accepted.pay_to,
+                    usdc_mint_b58=USDC_MINT,
+                    escrow_program_id_b58=program_id,
+                    amount=int(amount_atomic),
+                    service_id=service_id,
+                    expiry_slot=expiry_slot,
+                    recent_blockhash=recent_blockhash,
+                )
+            )
+
+            payload = EscrowPayload(
+                deposit_tx=deposit_tx,
+                service_id=base64.b64encode(service_id).decode(),
+                agent_pubkey=self._wallet.address(),
+            )
+            return PaymentPayload(
+                x402_version=X402_VERSION,
+                resource=resource,
+                accepted=accepted,
+                payload=payload,
+            )
+        except SignerError:
+            raise
+        except Exception as e:
+            raise SignerError(f"Failed to sign escrow deposit: {e}") from e
+
+    @staticmethod
+    def _escrow_expiry_slot(current_slot: int, max_timeout_seconds: int) -> int:
+        """Compute the slot at which a now-created escrow PDA should expire.
+
+        Ported from the Rust SDK's ``escrow_expiry_slot``: ~2.5 slots/s
+        (1000 ms / 400 ms), clamped into
+        ``[_MIN_ESCROW_EXPIRY_SLOTS_AHEAD, _MAX_ESCROW_EXPIRY_SLOTS_AHEAD]``.
+        The floor mirrors and exceeds the gateway's MIN_EXPIRY_BUFFER_SLOTS so a
+        too-near expiry is never bounced; the cap rejects an unbounded-future
+        expiry. ``current_slot`` and the timeout are non-negative here (slot
+        comes from getSlot; timeout from a validated PaymentAccept).
+        """
+        timeout_slots = (max(max_timeout_seconds, 0) * 1000) // 400
+        effective = max(
+            _MIN_ESCROW_EXPIRY_SLOTS_AHEAD,
+            min(timeout_slots, _MAX_ESCROW_EXPIRY_SLOTS_AHEAD),
+        )
+        return current_slot + effective
+
+    async def _fetch_latest_blockhash(self) -> str:
+        """Fetch a recent blockhash string via JSON-RPC ``getLatestBlockhash``.
+
+        Surfaces HTTP-level failures, malformed JSON, and RPC error responses as
+        ``SignerError`` *before* any blind indexing — so a 429/5xx HTML body or
+        an error payload never leaks node URLs / internals into a traceback.
+        """
+        import json
+
+        import httpx
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                self._rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "getLatestBlockhash",
+                    "params": [{"commitment": "finalized"}],
+                },
+            )
+            if resp.status_code != 200:
+                raise SignerError(f"Blockhash RPC HTTP {resp.status_code}")
+            try:
+                data = resp.json()
+            except json.JSONDecodeError as err:
+                raise SignerError("Blockhash RPC: malformed JSON body") from err
+            result = data.get("result", {}).get("value", {}) if isinstance(data, dict) else {}
+            blockhash_str = result.get("blockhash") if isinstance(result, dict) else None
+            if not blockhash_str:
+                rpc_err = data.get("error") if isinstance(data, dict) else None
+                err_code = rpc_err.get("code") if isinstance(rpc_err, dict) else None
+                raise SignerError(f"RPC did not return a blockhash (code: {err_code})")
+            return str(blockhash_str)
+
+    async def _fetch_current_slot(self) -> int:
+        """Fetch the current slot via JSON-RPC ``getSlot`` (commitment confirmed).
+
+        Mirrors the Rust SDK's ``get_current_slot``. Fails closed: any HTTP
+        failure, malformed body, RPC error, or missing/invalid ``result`` is a
+        ``SignerError`` — never a silent default slot, which would let the
+        escrow expiry be computed from a bogus base and bounced or mis-set.
+        """
+        import json
+
+        import httpx
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                self._rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "getSlot",
+                    "params": [{"commitment": "confirmed"}],
+                },
+            )
+            if resp.status_code != 200:
+                raise SignerError(f"getSlot RPC HTTP {resp.status_code}")
+            try:
+                data = resp.json()
+            except json.JSONDecodeError as err:
+                raise SignerError("getSlot RPC: malformed JSON body") from err
+            rpc_err = data.get("error") if isinstance(data, dict) else None
+            if rpc_err is not None:
+                err_code = rpc_err.get("code") if isinstance(rpc_err, dict) else None
+                raise SignerError(f"getSlot RPC error (code: {err_code})")
+            slot = data.get("result") if isinstance(data, dict) else None
+            if not isinstance(slot, int) or isinstance(slot, bool) or slot < 0:
+                raise SignerError("getSlot RPC: missing or invalid result")
+            return slot
 
     @staticmethod
     def _derive_ata(owner: Pubkey, mint: Pubkey) -> Pubkey:

--- a/sdks/python/src/solvela/signer.py
+++ b/sdks/python/src/solvela/signer.py
@@ -179,7 +179,11 @@ class KeypairSigner(Signer):
         except SignerError:
             raise
         except Exception as e:
-            raise SignerError(f"Failed to sign payment: {e}") from e
+            # Drop the __cause__ chain (`from None`): a future inner exception
+            # could carry secret key material that a logger / Sentry would walk
+            # off __cause__. The `{e}` text stays in the message (sufficient for
+            # diagnostics) but the original exception object is not attached.
+            raise SignerError(f"Failed to sign payment: {e}") from None
 
     async def _sign_escrow_payment(
         self,
@@ -252,7 +256,11 @@ class KeypairSigner(Signer):
         except SignerError:
             raise
         except Exception as e:
-            raise SignerError(f"Failed to sign escrow deposit: {e}") from e
+            # Drop the __cause__ chain (`from None`): a future inner exception
+            # could carry secret key material that a logger / Sentry would walk
+            # off __cause__. The `{e}` text stays in the message (sufficient for
+            # diagnostics) but the original exception object is not attached.
+            raise SignerError(f"Failed to sign escrow deposit: {e}") from None
 
     @staticmethod
     def _escrow_expiry_slot(current_slot: int, max_timeout_seconds: int) -> int:

--- a/sdks/python/src/solvela/wallet.py
+++ b/sdks/python/src/solvela/wallet.py
@@ -59,8 +59,13 @@ class Wallet:
         """
         try:
             return cls(Keypair.from_bytes(raw))
-        except Exception as exc:
-            raise WalletError(f"Invalid keypair bytes: {exc}") from exc
+        except Exception:
+            # The raw input IS secret key material, and some solders error
+            # variants echo the offending input. Surface a generic static
+            # message only and drop the chain (`from None`) — never interpolate
+            # the exception or the input, which a logger / Sentry would capture
+            # as plaintext key bytes. Mirrors build_deposit_tx's keypair-parse fix.
+            raise WalletError("Invalid keypair bytes: bad length or encoding") from None
 
     @classmethod
     def from_keypair_b58(cls, b58: str) -> Wallet:
@@ -71,8 +76,13 @@ class Wallet:
         """
         try:
             return cls(Keypair.from_base58_string(b58))
-        except Exception as exc:
-            raise WalletError(f"Invalid base58 keypair: {exc}") from exc
+        except Exception:
+            # The base58 string IS secret key material, and some solders error
+            # variants echo the offending input. Surface a generic static
+            # message only and drop the chain (`from None`) — never interpolate
+            # the exception or the input, which a logger / Sentry would capture
+            # as a plaintext key. Mirrors build_deposit_tx's keypair-parse fix.
+            raise WalletError("Invalid base58 keypair: bad base58 or wrong length") from None
 
     @classmethod
     def from_env(cls, var: str) -> Wallet:

--- a/sdks/python/tests/unit/test_escrow.py
+++ b/sdks/python/tests/unit/test_escrow.py
@@ -1,0 +1,151 @@
+"""Unit tests for the escrow deposit-transaction builder.
+
+The golden-vector parity test is the contract: the Python deposit builder MUST
+reproduce ``crates/escrow-tx/src/deposit.rs``'s ``GOLDEN_VECTOR_B64`` byte-for-
+byte for its fixed input. If it diverges, the on-chain layout disagreement is a
+fund-misdirection bug — fix the Python builder, NEVER edit the expected golden
+value (the Rust/on-chain value is ground truth).
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from solders.keypair import Keypair  # type: ignore[import-untyped]
+from solders.pubkey import Pubkey  # type: ignore[import-untyped]
+
+from solvela.escrow import (
+    DepositError,
+    DepositParams,
+    anchor_discriminator,
+    build_deposit_tx,
+    derive_ata_address,
+    derive_escrow_pda,
+)
+
+# ---------------------------------------------------------------------------
+# Golden vector — byte-exact match against crates/escrow-tx/src/deposit.rs.
+# ---------------------------------------------------------------------------
+
+# Copied verbatim from `GOLDEN_VECTOR_B64` in crates/escrow-tx/src/deposit.rs.
+# DO NOT hand-edit. If this changes, the deposit-tx layout changed.
+GOLDEN_VECTOR_B64 = "Ad449R7ht12UKokgbDUYh29Ey/wDEwPioT/QtJOPKwSO4RHIaFRqS0DH+bPpEo2vCK78jbRLpP/6FV/5TY+qLw8BAAYKGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWFyvMLyv5o/k5XBGVxL9QMaEsQP6v01aK7nXazb0N/wMBS12eVticTdq8DzgM47jC/J8D1uNnFG6ZNqwpSU6GOelSnAbR4dY/56biCP6roeTxLQ8Q4TL7a2ArnBn2RW9HJ+jAiHYL/eHd3PMsF/IJuCQu5SqvEx+s2I0OosbQsG8sb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKmMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgo61GtoIM8r3akxjdsa2N5CEHZ8QBYuAbfwPDOL78eGrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urqwEJCQAEBQECAwYHCDjyI8aJUuHytkEKAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcuRQ8AAAAAAA=="  # noqa: E501
+
+PROVIDER = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+ESCROW_PROGRAM = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+
+
+def _golden_keypair_b58() -> str:
+    """64-byte keypair from seed [42] * 32 (matches the Rust golden fixture)."""
+    kp = Keypair.from_seed(bytes([42] * 32))
+    return str(kp)  # base58 64-byte keypair string
+
+
+def _golden_params() -> DepositParams:
+    return DepositParams(
+        agent_keypair_b58=_golden_keypair_b58(),
+        provider_wallet_b58=PROVIDER,
+        usdc_mint_b58=USDC_MINT,
+        escrow_program_id_b58=ESCROW_PROGRAM,
+        amount=2625,
+        service_id=bytes([7] * 32),
+        expiry_slot=1_000_750,
+        recent_blockhash=bytes([0xAB] * 32),
+    )
+
+
+class TestGoldenVector:
+    def test_deposit_tx_matches_rust_golden_vector(self) -> None:
+        """Byte-for-byte parity with the canonical Rust builder.
+
+        This is the sole correctness bar for the wire format.
+        """
+        out = build_deposit_tx(_golden_params())
+        assert out == GOLDEN_VECTOR_B64, (
+            "Python deposit-tx does not match the Rust golden vector. "
+            "The on-chain layout is ground truth — fix the Python builder, "
+            "do NOT edit the expected value."
+        )
+
+    def test_golden_vector_decodes_to_signed_tx(self) -> None:
+        raw = base64.b64decode(GOLDEN_VECTOR_B64)
+        # compact-u16(1) || sig(64) || message
+        assert raw[0] == 0x01
+        assert len(raw) > 1 + 64
+
+
+# ---------------------------------------------------------------------------
+# Derivation parity (PDA seeds + vault ATA).
+# ---------------------------------------------------------------------------
+
+
+class TestDerivation:
+    def test_escrow_pda_external_ground_truth(self) -> None:
+        # Mirrors crates/escrow-tx/src/pda.rs ground-truth test:
+        # agent=[1]*32, service_id=[2]*32 -> BEAUsvsWvV4o6y7XkC1bkyTq4FtQnKErcV3dzTFPT5hX, bump 255.
+        program = Pubkey.from_string(ESCROW_PROGRAM)
+        pda, bump = derive_escrow_pda(bytes([1] * 32), bytes([2] * 32), program)
+        assert str(pda) == "BEAUsvsWvV4o6y7XkC1bkyTq4FtQnKErcV3dzTFPT5hX"
+        assert bump == 255
+
+    def test_pda_seeds_are_escrow_agent_service_id(self) -> None:
+        program = Pubkey.from_string(ESCROW_PROGRAM)
+        agent = bytes([3] * 32)
+        service_id = bytes([9] * 32)
+        pda, _ = derive_escrow_pda(agent, service_id, program)
+        # Recompute with solders directly using the documented seed order.
+        expected, _ = Pubkey.find_program_address([b"escrow", agent, service_id], program)
+        assert pda == expected
+
+    def test_vault_ata_known_value(self) -> None:
+        # Mirrors crates/escrow-tx/src/pda.rs test_derive_ata_for_known_wallet.
+        wallet = Pubkey.from_string("4P8mSmvv3nfzUtoqhNKG1mfGrHMVbXvKBXR7fDivv6qp")
+        mint = Pubkey.from_string(USDC_MINT)
+        ata = derive_ata_address(wallet, mint)
+        assert str(ata) == "CYHVCkLwiEjMBdRiz5MsrrCbVL2YTZuv57TjV3ggxoSN"
+
+    def test_anchor_discriminator_deterministic(self) -> None:
+        d1 = anchor_discriminator("deposit")
+        d2 = anchor_discriminator("deposit")
+        assert d1 == d2
+        assert len(d1) == 8
+        assert anchor_discriminator("deposit") != anchor_discriminator("claim")
+
+
+# ---------------------------------------------------------------------------
+# Rejection / fail-closed behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestRejections:
+    def test_zero_amount_rejected(self) -> None:
+        params = _golden_params()
+        params.amount = 0
+        with pytest.raises(DepositError, match="zero"):
+            build_deposit_tx(params)
+
+    def test_invalid_keypair_rejected(self) -> None:
+        params = _golden_params()
+        params.agent_keypair_b58 = "notavalidkeypair!!!"
+        with pytest.raises(DepositError):
+            build_deposit_tx(params)
+
+    def test_invalid_provider_rejected(self) -> None:
+        params = _golden_params()
+        params.provider_wallet_b58 = "not-base58!!!"
+        with pytest.raises(DepositError):
+            build_deposit_tx(params)
+
+    def test_bad_service_id_length_rejected(self) -> None:
+        params = _golden_params()
+        params.service_id = bytes([7] * 31)
+        with pytest.raises(DepositError):
+            build_deposit_tx(params)
+
+    def test_bad_blockhash_length_rejected(self) -> None:
+        params = _golden_params()
+        params.recent_blockhash = bytes([0xAB] * 31)
+        with pytest.raises(DepositError):
+            build_deposit_tx(params)

--- a/sdks/python/tests/unit/test_escrow.py
+++ b/sdks/python/tests/unit/test_escrow.py
@@ -10,6 +10,9 @@ value (the Rust/on-chain value is ground truth).
 from __future__ import annotations
 
 import base64
+import dataclasses
+import re
+from pathlib import Path
 
 import pytest
 from solders.keypair import Keypair  # type: ignore[import-untyped]
@@ -121,31 +124,78 @@ class TestDerivation:
 
 class TestRejections:
     def test_zero_amount_rejected(self) -> None:
-        params = _golden_params()
-        params.amount = 0
+        # Frozen + validated at construction: replace re-runs __post_init__.
         with pytest.raises(DepositError, match="zero"):
-            build_deposit_tx(params)
+            dataclasses.replace(_golden_params(), amount=0)
+
+    def test_negative_amount_rejected(self) -> None:
+        with pytest.raises(DepositError, match="zero"):
+            dataclasses.replace(_golden_params(), amount=-1)
+
+    def test_float_amount_rejected(self) -> None:
+        # A float would be silently truncated by .to_bytes -> wrong charge.
+        with pytest.raises(DepositError, match="integer"):
+            dataclasses.replace(_golden_params(), amount=2625.0)  # type: ignore[arg-type]
+
+    def test_bool_amount_rejected(self) -> None:
+        # bool is an int subclass; True would deposit 1 atomic unit.
+        with pytest.raises(DepositError, match="integer"):
+            dataclasses.replace(_golden_params(), amount=True)  # type: ignore[arg-type]
 
     def test_invalid_keypair_rejected(self) -> None:
-        params = _golden_params()
-        params.agent_keypair_b58 = "notavalidkeypair!!!"
+        params = dataclasses.replace(_golden_params(), agent_keypair_b58="notavalidkeypair!!!")
         with pytest.raises(DepositError):
             build_deposit_tx(params)
 
+    def test_invalid_keypair_error_does_not_leak_secret(self) -> None:
+        # A malformed keypair string IS secret material. The raised message must
+        # not echo any fragment of the input or the raw solders exception text.
+        secret_b58 = str(Keypair.from_seed(bytes([99] * 32)))
+        params = dataclasses.replace(_golden_params(), agent_keypair_b58=secret_b58 + "X")
+        with pytest.raises(DepositError) as exc_info:
+            build_deposit_tx(params)
+        msg = str(exc_info.value)
+        assert secret_b58 not in msg
+        # No long base58 run from the input should appear in the message.
+        assert secret_b58[:16] not in msg
+        assert msg == "invalid agent keypair: bad base58 or wrong length"
+
     def test_invalid_provider_rejected(self) -> None:
-        params = _golden_params()
-        params.provider_wallet_b58 = "not-base58!!!"
+        params = dataclasses.replace(_golden_params(), provider_wallet_b58="not-base58!!!")
         with pytest.raises(DepositError):
             build_deposit_tx(params)
 
     def test_bad_service_id_length_rejected(self) -> None:
-        params = _golden_params()
-        params.service_id = bytes([7] * 31)
-        with pytest.raises(DepositError):
-            build_deposit_tx(params)
+        with pytest.raises(DepositError, match="service_id"):
+            dataclasses.replace(_golden_params(), service_id=bytes([7] * 31))
 
     def test_bad_blockhash_length_rejected(self) -> None:
-        params = _golden_params()
-        params.recent_blockhash = bytes([0xAB] * 31)
-        with pytest.raises(DepositError):
-            build_deposit_tx(params)
+        with pytest.raises(DepositError, match="blockhash"):
+            dataclasses.replace(_golden_params(), recent_blockhash=bytes([0xAB] * 31))
+
+
+class TestGoldenVectorDriftGuard:
+    """The Python golden-vector constant MUST equal the Rust source of truth.
+
+    If the Rust ``GOLDEN_VECTOR_B64`` ever changes, the on-chain wire layout
+    changed and this test fails loudly, forcing a resync of the Python constant
+    and builder rather than letting the two SDKs silently diverge.
+    """
+
+    def test_python_golden_matches_rust_source(self) -> None:
+        # tests/unit/test_escrow.py -> worktree root is parents[4].
+        worktree_root = Path(__file__).resolve().parents[4]
+        rust_src = worktree_root / "crates" / "escrow-tx" / "src" / "deposit.rs"
+        assert rust_src.is_file(), f"Rust deposit.rs not found at {rust_src}"
+        text = rust_src.read_text(encoding="utf-8")
+        m = re.search(r'GOLDEN_VECTOR_B64:\s*&str\s*=\s*"([^"]+)"', text)
+        assert m is not None, (
+            "could not locate GOLDEN_VECTOR_B64 in crates/escrow-tx/src/deposit.rs"
+        )
+        rust_value = m.group(1)
+        assert rust_value == GOLDEN_VECTOR_B64, (
+            "Python GOLDEN_VECTOR_B64 has drifted from the Rust source of truth "
+            "(crates/escrow-tx/src/deposit.rs). The on-chain layout is ground "
+            "truth: resync the Python constant AND re-verify build_deposit_tx "
+            "byte-parity — do NOT just paste the new value."
+        )

--- a/sdks/python/tests/unit/test_signer.py
+++ b/sdks/python/tests/unit/test_signer.py
@@ -415,3 +415,11 @@ class TestEscrowExpirySlot:
 
     def test_huge_timeout_clamped_to_cap(self) -> None:
         assert KeypairSigner._escrow_expiry_slot(1_000_000, 10**12) == 1_010_000
+
+    def test_negative_timeout_clamps_to_min_floor_not_backwards(self) -> None:
+        # A negative max_timeout_seconds must NOT push the expiry slot backwards
+        # (which would yield an already-expired / dead-on-arrival deposit). The
+        # `max(max_timeout_seconds, 0)` clamp floors the timeout to 0, so the
+        # result is current_slot + _MIN_ESCROW_EXPIRY_SLOTS_AHEAD (150).
+        assert KeypairSigner._escrow_expiry_slot(1_000_000, -1) == 1_000_150
+        assert KeypairSigner._escrow_expiry_slot(1_000_000, -(10**12)) == 1_000_150

--- a/sdks/python/tests/unit/test_signer.py
+++ b/sdks/python/tests/unit/test_signer.py
@@ -105,9 +105,13 @@ class TestSignPayment:
         assert payload.accepted.scheme == "exact"
 
         # The transaction is base64-encoded; decoding must succeed and the
-        # result must be a non-empty serialized Solana transaction.
+        # result must be a plausibly-shaped signed Solana transaction.
         tx_bytes = base64.b64decode(payload.payload.transaction)
-        assert len(tx_bytes) > 0
+        assert tx_bytes[0] == 0x01  # compact-u16 signature count = 1
+        assert len(tx_bytes) > 100  # sig(64) + message header/keys/blockhash/ix
+        # The SPL transfer amount (1 USDC = 1_000_000 atomic) must appear as a
+        # little-endian u64 inside the serialized instruction data.
+        assert (1_000_000).to_bytes(8, "little") in tx_bytes
 
     @pytest.mark.asyncio
     async def test_sign_payment_raises_on_rpc_429(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
@@ -280,6 +284,9 @@ class TestSchemeBranching:
                 resource=_resource(),
                 accepted=_escrow_accept(escrow_program_id=None),
             )
+        # Rejection must happen before any network call — no getSlot / blockhash
+        # RPC may be issued for an escrow payment we can't build.
+        assert len(httpx_mock.get_requests()) == 0
 
     @pytest.mark.asyncio
     async def test_escrow_zero_amount_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
@@ -288,6 +295,94 @@ class TestSchemeBranching:
         with pytest.raises(SignerError, match="greater than zero"):
             await signer.sign_payment(
                 amount_atomic=0,
+                recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                resource=_resource(),
+                accepted=_escrow_accept(),
+            )
+        # No network call for an amount we reject before building.
+        assert len(httpx_mock.get_requests()) == 0
+
+    @pytest.mark.asyncio
+    async def test_escrow_negative_amount_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        with pytest.raises(SignerError, match="greater than zero"):
+            await signer.sign_payment(
+                amount_atomic=-1,
+                recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                resource=_resource(),
+                accepted=_escrow_accept(),
+            )
+        assert len(httpx_mock.get_requests()) == 0
+
+    @pytest.mark.asyncio
+    async def test_escrow_float_amount_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        # A float amount would be silently truncated into the on-chain u64.
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        with pytest.raises(SignerError, match="integer"):
+            await signer.sign_payment(
+                amount_atomic=2625.0,  # type: ignore[arg-type]
+                recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                resource=_resource(),
+                accepted=_escrow_accept(),
+            )
+        assert len(httpx_mock.get_requests()) == 0
+
+    @pytest.mark.asyncio
+    async def test_escrow_stub_low_slot_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        # A stub/genesis node returning a near-zero slot must be refused, not
+        # used to compute an instantly-expired escrow deposit.
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        httpx_mock.add_response(url=_RPC_URL, json={"jsonrpc": "2.0", "id": 1, "result": 0})
+        with pytest.raises(SignerError, match="implausibly low slot"):
+            await signer.sign_payment(
+                amount_atomic=2625,
+                recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                resource=_resource(),
+                accepted=_escrow_accept(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_escrow_getslot_429_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        httpx_mock.add_response(url=_RPC_URL, status_code=429, text="<html>Rate limited</html>")
+        with pytest.raises(SignerError, match="getSlot RPC HTTP 429"):
+            await signer.sign_payment(
+                amount_atomic=2625,
+                recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                resource=_resource(),
+                accepted=_escrow_accept(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_escrow_getslot_malformed_json_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        httpx_mock.add_response(url=_RPC_URL, text="not valid json")
+        with pytest.raises(SignerError, match="getSlot RPC: malformed JSON"):
+            await signer.sign_payment(
+                amount_atomic=2625,
+                recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                resource=_resource(),
+                accepted=_escrow_accept(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_escrow_getslot_jsonrpc_error_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        # A JSON-RPC {"error": {...}} body must surface as SignerError carrying
+        # only the numeric code, never a silent default slot.
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        httpx_mock.add_response(
+            url=_RPC_URL,
+            json={"jsonrpc": "2.0", "id": 1, "error": {"code": -32000, "message": "node behind"}},
+        )
+        with pytest.raises(SignerError, match="getSlot RPC error"):
+            await signer.sign_payment(
+                amount_atomic=2625,
                 recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
                 resource=_resource(),
                 accepted=_escrow_accept(),

--- a/sdks/python/tests/unit/test_signer.py
+++ b/sdks/python/tests/unit/test_signer.py
@@ -10,8 +10,10 @@ from solders.pubkey import Pubkey  # type: ignore[import-untyped]
 from solvela.constants import SOLANA_NETWORK, USDC_MINT
 from solvela.errors import SignerError
 from solvela.signer import KeypairSigner, Signer
-from solvela.types import PaymentAccept, Resource, SolanaPayload
+from solvela.types import EscrowPayload, PaymentAccept, Resource, SolanaPayload
 from solvela.wallet import Wallet
+
+ESCROW_PROGRAM = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
 
 
 class TestSignerInterface:
@@ -159,3 +161,162 @@ class TestSignPayment:
                 resource=_resource(),
                 accepted=_accept(),
             )
+
+
+def _escrow_accept(escrow_program_id: str | None = ESCROW_PROGRAM) -> PaymentAccept:
+    return PaymentAccept(
+        scheme="escrow",
+        network=SOLANA_NETWORK,
+        amount="2625",
+        asset=USDC_MINT,
+        pay_to="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+        max_timeout_seconds=300,
+        escrow_program_id=escrow_program_id,
+    )
+
+
+def _mock_slot_and_blockhash(httpx_mock, slot: int = 1_000_000) -> None:  # type: ignore[no-untyped-def]
+    """Queue getSlot then getLatestBlockhash responses (escrow path order)."""
+    httpx_mock.add_response(
+        url=_RPC_URL,
+        json={"jsonrpc": "2.0", "id": 1, "result": slot},
+    )
+    httpx_mock.add_response(
+        url=_RPC_URL,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "context": {"slot": slot},
+                "value": {"blockhash": _FAKE_BLOCKHASH, "lastValidBlockHeight": slot},
+            },
+        },
+    )
+
+
+class TestSchemeBranching:
+    """`sign_payment` must branch on `accepted.scheme` with no silent fallback."""
+
+    @pytest.mark.asyncio
+    async def test_escrow_scheme_returns_escrow_payload(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        _mock_slot_and_blockhash(httpx_mock)
+
+        payload = await signer.sign_payment(
+            amount_atomic=2625,
+            recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+            resource=_resource(),
+            accepted=_escrow_accept(),
+        )
+
+        assert payload.accepted.scheme == "escrow"
+        assert isinstance(payload.payload, EscrowPayload)
+        # deposit_tx is a non-empty signed tx
+        tx_bytes = base64.b64decode(payload.payload.deposit_tx)
+        assert tx_bytes[0] == 0x01  # 1 signature
+        # service_id is base64 of exactly 32 bytes
+        assert len(base64.b64decode(payload.payload.service_id)) == 32
+        # agent_pubkey is the wallet's base58 address
+        assert payload.payload.agent_pubkey == wallet.address()
+
+    @pytest.mark.asyncio
+    async def test_escrow_service_id_is_unique_per_call(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        _mock_slot_and_blockhash(httpx_mock)
+        _mock_slot_and_blockhash(httpx_mock)
+
+        p1 = await signer.sign_payment(
+            amount_atomic=2625,
+            recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+            resource=_resource(),
+            accepted=_escrow_accept(),
+        )
+        p2 = await signer.sign_payment(
+            amount_atomic=2625,
+            recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+            resource=_resource(),
+            accepted=_escrow_accept(),
+        )
+        assert isinstance(p1.payload, EscrowPayload)
+        assert isinstance(p2.payload, EscrowPayload)
+        assert p1.payload.service_id != p2.payload.service_id
+
+    @pytest.mark.asyncio
+    async def test_exact_scheme_still_returns_solana_payload(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        # Regression: the exact path is unchanged by the escrow branch.
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        httpx_mock.add_response(
+            url=_RPC_URL,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "context": {"slot": 1},
+                    "value": {"blockhash": _FAKE_BLOCKHASH, "lastValidBlockHeight": 1},
+                },
+            },
+        )
+        payload = await signer.sign_payment(
+            amount_atomic=1_000_000,
+            recipient="11111111111111111111111111111112",
+            resource=_resource(),
+            accepted=_accept(),
+        )
+        assert isinstance(payload.payload, SolanaPayload)
+        assert payload.accepted.scheme == "exact"
+
+    @pytest.mark.asyncio
+    async def test_escrow_missing_program_id_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        # No RPC should be hit — rejection happens before any network call.
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        with pytest.raises(SignerError, match="escrow_program_id is missing"):
+            await signer.sign_payment(
+                amount_atomic=2625,
+                recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                resource=_resource(),
+                accepted=_escrow_accept(escrow_program_id=None),
+            )
+
+    @pytest.mark.asyncio
+    async def test_escrow_zero_amount_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        with pytest.raises(SignerError, match="greater than zero"):
+            await signer.sign_payment(
+                amount_atomic=0,
+                recipient="9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                resource=_resource(),
+                accepted=_escrow_accept(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_unknown_scheme_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        accept = _accept()
+        # Force an out-of-domain scheme past the type system to prove the
+        # signer fails closed rather than defaulting to a transfer.
+        object.__setattr__(accept, "scheme", "upto")
+        with pytest.raises(SignerError, match="Unsupported payment scheme"):
+            await signer.sign_payment(
+                amount_atomic=1_000_000,
+                recipient="11111111111111111111111111111112",
+                resource=_resource(),
+                accepted=accept,
+            )
+
+
+class TestEscrowExpirySlot:
+    def test_typical_300s(self) -> None:
+        # 300 s * 2.5 slots/s = 750 slots ahead.
+        assert KeypairSigner._escrow_expiry_slot(1_000_000, 300) == 1_000_750
+
+    def test_zero_seconds_applies_min_floor(self) -> None:
+        assert KeypairSigner._escrow_expiry_slot(1_000_000, 0) == 1_000_150
+
+    def test_huge_timeout_clamped_to_cap(self) -> None:
+        assert KeypairSigner._escrow_expiry_slot(1_000_000, 10**12) == 1_010_000

--- a/sdks/python/tests/unit/test_wallet.py
+++ b/sdks/python/tests/unit/test_wallet.py
@@ -46,6 +46,18 @@ class TestWalletKeypairBytes:
         restored = Wallet.from_keypair_bytes(raw)
         assert restored.address() == wallet.address()
 
+    def test_from_keypair_bytes_invalid_does_not_leak_input(self) -> None:
+        # Regression guard (M-1): the raw bytes ARE secret key material, so the
+        # error message must be a generic static string with no fragment of the
+        # offending input or the underlying solders exception interpolated.
+        bad = bytes(range(40))  # wrong length -> rejected
+        with pytest.raises(WalletError) as exc_info:
+            Wallet.from_keypair_bytes(bad)
+        msg = str(exc_info.value)
+        assert bad.hex() not in msg
+        assert "40" not in msg  # no echoed length detail
+        assert exc_info.value.__cause__ is None  # chain dropped (from None)
+
 
 class TestWalletKeypairB58:
     def test_from_keypair_b58(self) -> None:
@@ -53,6 +65,19 @@ class TestWalletKeypairB58:
         b58 = wallet.to_keypair_b58()
         restored = Wallet.from_keypair_b58(b58)
         assert restored.address() == wallet.address()
+
+    def test_from_keypair_b58_invalid_does_not_leak_input(self) -> None:
+        # Regression guard (M-1): the base58 string IS secret key material, so
+        # the error message must be a generic static string with no fragment of
+        # the offending input or the underlying solders exception interpolated.
+        bad_b58 = "5KQwrPbwdL6PhXujxW37FSSQ" + "Z" * 60  # not a valid keypair
+        with pytest.raises(WalletError) as exc_info:
+            Wallet.from_keypair_b58(bad_b58)
+        msg = str(exc_info.value)
+        assert bad_b58 not in msg
+        # No long substring of the input should survive into the message.
+        assert bad_b58[:16] not in msg
+        assert exc_info.value.__cause__ is None  # chain dropped (from None)
 
 
 class TestWalletEnv:


### PR DESCRIPTION
## What
Adds x402 **escrow** deposit signing to the Python SDK. `KeypairSigner.sign_payment()` now branches on `accepted.scheme`: `escrow` builds an on-chain escrow **deposit** transaction and returns an `EscrowPayload`; `exact` keeps the existing SPL-transfer path. Closes the silent scheme-mismatch gap (the signer previously ignored `accepted.scheme` and signed an `exact` transfer even when `escrow` was selected).

## Why
Track 1 of the escrow micropayment work — bring the Python SDK to parity with the Rust SDK's escrow signing. Today Python (and TS) are `exact`-only; an escrow-selected 402 silently produced the wrong scheme.

## How
- New `sdks/python/src/solvela/escrow.py`: a **byte-exact** port of the canonical Rust builder (`crates/escrow-tx/src/deposit.rs` + `pda.rs`) — `build_deposit_tx`, PDA/ATA derivation, anchor discriminator, manual writability-sorted legacy-message serializer. Uses `solders` 0.27.1 only for canonical primitives (`find_program_address`, `sign_message`); the message is serialized manually so account ordering can't diverge.
- `signer.py`: scheme branch + `_sign_escrow_payment` (CSPRNG `service_id`, expiry-slot bounds ported from the Rust client, fail-closed `getSlot`/blockhash fetch).

## Correctness — golden-vector parity is the contract
`test_deposit_tx_matches_rust_golden_vector` reproduces `GOLDEN_VECTOR_B64` byte-for-byte for the fixed input; a drift-guard test reads the Rust constant from source and asserts equality (fails if they desync). PDA/ATA pinned to the same external ground-truth values as the Rust tests.

## Money-path review (2 rounds)
- **Round 1** — `python-reviewer` + `silent-failure-hunter`: fixed float/non-int amount truncation (wrong-amount bug), keypair leak via exception message, fail-closed slot plausibility floor, `frozen=True` dataclass + `__post_init__` validation, strengthened exact-path test, getSlot failure-mode tests.
- **Round 2** — independent `security-reviewer`: no Criticals; fixed exception-chain hygiene (`from None`), `wallet.py` keypair-parse leak, zeroization-limitation docstrings, negative-timeout test.

## Tests / checks
231 unit+integration tests pass; golden-vector + drift-guard green; `ruff check`/`format` clean; `mypy src` (strict) clean. No byte-layout change. Client-side deposit signing only — no settlement-semantics change.

## Scope
Python SDK only (`sdks/python/`). Go + TS escrow parity are follow-up PRs in this track.