### PR TITLE
feat(gateway): native vision/image support (PR 2/2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,6 +3666,7 @@ version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -509,6 +509,7 @@ async fn handle_payment_submitted(
     let result = chat_with_model_fallback(
         &state.providers,
         &state.provider_health,
+        &state.model_registry,
         &model_info.provider,
         &model_info.model_id,
         chat_req,

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -57,6 +57,11 @@ async fn handle_new_request(
     state: &Arc<AppState>,
     params: &MessageSendParams,
 ) -> Result<Value, JsonRpcErrorData> {
+    // A2A is text-only today; reject image data parts before building any
+    // ChatRequest. See `reject_image_data_parts` — image bridging must route
+    // through the HTTP chat route's vision gate before being accepted here.
+    reject_image_data_parts(&params.message.parts)?;
+
     // Extract user text from message parts
     let user_text = extract_text_from_parts(&params.message.parts)?;
 
@@ -228,6 +233,13 @@ async fn handle_payment_submitted(
     task_id: &str,
     params: &MessageSendParams,
 ) -> Result<Value, JsonRpcErrorData> {
+    // A2A is text-only today; reject image data parts on the submission message
+    // before any provider-reaching work. The chat content actually dispatched
+    // here is rebuilt from the task's stored (already-text-gated)
+    // `original_message`, but defend the submission message too so an image
+    // part can never enter this path. See `reject_image_data_parts`.
+    reject_image_data_parts(&params.message.parts)?;
+
     // Load task record
     let record = task_store::load_task(state, task_id)
         .await
@@ -694,6 +706,39 @@ fn validate_submitted_against_offer(
     Ok(())
 }
 
+/// Reject any `Part::Data` carrying image content (`contentType` starting with
+/// `"image/"`).
+///
+/// A2A is **text-only today**: both intake paths construct a `ChatRequest` from
+/// `extract_text_from_parts` and call the chat pipeline DIRECTLY
+/// (`handle_payment_submitted` invokes `chat_with_model_fallback`), bypassing
+/// the HTTP chat route's pre-payment vision gate (`supports_vision`, Step 2a)
+/// and per-image `ImageUrl::parse()` validation (Step 2a'). `Part::Data` cannot
+/// reach `ContentPart::ImageUrl` today, but if a future change ever bridges an
+/// image `Part::Data` into chat content, it would reach the PAID provider
+/// pipeline ungated.
+///
+/// This guard closes that latent gap defensively. Any future image bridging
+/// here MUST route through the same `supports_vision` gate + `ImageUrl::parse()`
+/// validation as the HTTP chat route BEFORE images are accepted — do not relax
+/// this check to "support vision" without wiring those gates in first.
+fn reject_image_data_parts(parts: &[Part]) -> Result<(), JsonRpcErrorData> {
+    for part in parts {
+        if let Part::Data { content_type, .. } = part {
+            if content_type.starts_with("image/") {
+                return Err(JsonRpcErrorData {
+                    code: ERR_INVALID_PARAMS,
+                    message: "Image content is not supported over A2A; this endpoint accepts \
+                              text parts only"
+                        .to_string(),
+                    data: None,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Extract the first text content from message parts.
 fn extract_text_from_parts(parts: &[Part]) -> Result<String, JsonRpcErrorData> {
     for part in parts {
@@ -860,6 +905,158 @@ supports_vision = false
         assert!(result.is_err(), "should error on empty parts");
     }
 
+    #[test]
+    fn test_reject_image_data_parts_rejects_image_png() {
+        let parts = vec![Part::Data {
+            content_type: "image/png".to_string(),
+            data: json!("base64data"),
+        }];
+        let result = reject_image_data_parts(&parts);
+        let err = result.expect_err("image/png data part must be rejected"); // safe: just built image part
+        assert_eq!(err.code, ERR_INVALID_PARAMS);
+    }
+
+    #[test]
+    fn test_reject_image_data_parts_rejects_image_jpeg_among_text() {
+        let parts = vec![
+            Part::Text {
+                text: "describe this".to_string(),
+            },
+            Part::Data {
+                content_type: "image/jpeg".to_string(),
+                data: json!("base64data"),
+            },
+        ];
+        let err = reject_image_data_parts(&parts).expect_err("image/jpeg must be rejected"); // safe: built image part
+        assert_eq!(err.code, ERR_INVALID_PARAMS);
+    }
+
+    #[test]
+    fn test_reject_image_data_parts_allows_text_only() {
+        let parts = vec![Part::Text {
+            text: "hello".to_string(),
+        }];
+        assert!(
+            reject_image_data_parts(&parts).is_ok(),
+            "text-only parts must pass"
+        );
+    }
+
+    #[test]
+    fn test_reject_image_data_parts_allows_non_image_data() {
+        // Non-image data parts (e.g. application/json) are not the vision-gate
+        // concern and must still pass — extract_text_from_parts ignores them.
+        let parts = vec![Part::Data {
+            content_type: "application/json".to_string(),
+            data: json!({"key": "value"}),
+        }];
+        assert!(
+            reject_image_data_parts(&parts).is_ok(),
+            "non-image data parts must pass the image guard"
+        );
+    }
+
+    #[test]
+    fn test_reject_image_data_parts_empty_passes() {
+        assert!(
+            reject_image_data_parts(&[]).is_ok(),
+            "empty parts must pass the image guard"
+        );
+    }
+
+    /// SECURITY (defense-in-depth): a new `message/send` carrying an image
+    /// `Part::Data` must be rejected with ERR_INVALID_PARAMS BEFORE any cost
+    /// estimation or task-store work. The image guard runs first, so this
+    /// short-circuits ahead of the ERR_INTERNAL that cache:None would otherwise
+    /// produce — proving the guard fires before the paid pipeline is reached.
+    #[tokio::test]
+    async fn test_new_request_with_image_data_part_rejected() {
+        let state = test_state();
+        let params = MessageSendParams {
+            message: Message {
+                role: MessageRole::User,
+                parts: vec![
+                    Part::Text {
+                        text: "What is in this image?".to_string(),
+                    },
+                    Part::Data {
+                        content_type: "image/png".to_string(),
+                        data: json!("base64data"),
+                    },
+                ],
+                metadata: Some({
+                    let mut m = serde_json::Map::new();
+                    m.insert("model".to_string(), json!("test-model"));
+                    m
+                }),
+            },
+            task_id: None,
+        };
+
+        let result = handle_new_request(&state, &params).await;
+        let err = result.expect_err("image data part must be rejected"); // safe: built image part
+        assert_eq!(
+            err.code, ERR_INVALID_PARAMS,
+            "image guard must short-circuit with invalid-params before task-store work"
+        );
+    }
+
+    /// The image guard fires through the public dispatcher as well.
+    #[tokio::test]
+    async fn test_handle_message_send_rejects_image_data_part() {
+        let state = test_state();
+        let headers = HeaderMap::new();
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "message/send".to_string(),
+            id: json!("req-img"),
+            params: json!({
+                "message": {
+                    "role": "user",
+                    "parts": [
+                        {"kind": "text", "text": "Describe"},
+                        {"kind": "data", "contentType": "image/png", "data": "base64data"}
+                    ],
+                    "metadata": {"model": "test-model"}
+                }
+            }),
+        };
+
+        let result = handle_message_send(state, &headers, &request).await;
+        let err = result.expect_err("image data part must be rejected via dispatcher"); // safe: built image part
+        assert_eq!(err.code, ERR_INVALID_PARAMS);
+    }
+
+    /// Control: a normal text `message/send` is unaffected by the image guard.
+    /// With cache:None the request advances past the guard and fails at the
+    /// task store (ERR_INTERNAL) — proving the guard did NOT reject the text
+    /// request as invalid-params.
+    #[tokio::test]
+    async fn test_new_request_text_only_unaffected_by_image_guard() {
+        let state = test_state();
+        let params = MessageSendParams {
+            message: Message {
+                role: MessageRole::User,
+                parts: vec![Part::Text {
+                    text: "What is Solana?".to_string(),
+                }],
+                metadata: Some({
+                    let mut m = serde_json::Map::new();
+                    m.insert("model".to_string(), json!("test-model"));
+                    m
+                }),
+            },
+            task_id: None,
+        };
+
+        let result = handle_new_request(&state, &params).await;
+        let err = result.expect_err("cache:None blocks at task store"); // safe: cache:None
+        assert_eq!(
+            err.code, ERR_INTERNAL,
+            "text-only request must pass the image guard and reach the task store"
+        );
+    }
+
     #[tokio::test]
     async fn test_new_request_fails_without_redis() {
         // With cache: None, save_task now returns Err — task issuance must be blocked
@@ -940,6 +1137,47 @@ supports_vision = false
             result.unwrap_err().code, // safe: just asserted is_err
             ERR_MODEL_NOT_FOUND,
             "error code should be model not found"
+        );
+    }
+
+    /// The image guard also fires on the payment-submitted path: an image
+    /// `Part::Data` on the submission message must reject with
+    /// ERR_INVALID_PARAMS BEFORE the task is loaded (which would otherwise
+    /// yield ERR_TASK_NOT_FOUND for this nonexistent task).
+    #[tokio::test]
+    async fn test_payment_submitted_with_image_data_part_rejected() {
+        let state = test_state();
+        let headers = HeaderMap::new();
+        let params = MessageSendParams {
+            message: Message {
+                role: MessageRole::User,
+                parts: vec![
+                    Part::Text {
+                        text: "pay".to_string(),
+                    },
+                    Part::Data {
+                        content_type: "image/png".to_string(),
+                        data: json!("base64data"),
+                    },
+                ],
+                metadata: Some({
+                    let mut m = serde_json::Map::new();
+                    m.insert(
+                        x402_meta::STATUS_KEY.to_string(),
+                        json!(x402_meta::PAYMENT_SUBMITTED),
+                    );
+                    m
+                }),
+            },
+            task_id: Some("nonexistent_task_id".to_string()),
+        };
+
+        let result =
+            handle_payment_submitted(&state, &headers, "nonexistent_task_id", &params).await;
+        let err = result.expect_err("image data part must be rejected"); // safe: built image part
+        assert_eq!(
+            err.code, ERR_INVALID_PARAMS,
+            "image guard must short-circuit before task load"
         );
     }
 

--- a/crates/gateway/src/cache/exact.rs
+++ b/crates/gateway/src/cache/exact.rs
@@ -372,6 +372,61 @@ mod tests {
         );
     }
 
+    /// The exact-cache key must distinguish two prompts that share text but
+    /// carry different images — otherwise distinct multimodal prompts collide
+    /// and serve each other's responses. The `cache_key` content-normalization
+    /// deliberately keeps the ORIGINAL content (does not flatten) when image
+    /// parts are present, so the images are part of the hashed bytes.
+    #[test]
+    fn cache_key_distinguishes_distinct_images() {
+        use solvela_protocol::ImageUrl;
+        fn image_message(text: &str, url: &str) -> ChatMessage {
+            ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![
+                    ContentPart::Text {
+                        text: text.to_string(),
+                    },
+                    ContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: url.to_string(),
+                            detail: None,
+                        },
+                    },
+                ]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }
+        }
+        let a = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", "https://example.com/a.png")],
+            None,
+        );
+        let b = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", "https://example.com/b.png")],
+            None,
+        );
+        assert_ne!(
+            ResponseCache::cache_key(&a).expect("must serialise"),
+            ResponseCache::cache_key(&b).expect("must serialise"),
+            "distinct images with identical text must produce distinct cache keys"
+        );
+
+        // Same image + same text → same key (a legitimate hit is reachable).
+        let a2 = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", "https://example.com/a.png")],
+            None,
+        );
+        assert_eq!(
+            ResponseCache::cache_key(&a).expect("must serialise"),
+            ResponseCache::cache_key(&a2).expect("must serialise"),
+        );
+    }
+
     #[test]
     fn test_cache_key_different_for_different_temperatures() {
         let req_a = make_request("openai/gpt-4o", vec![user_message("Hello")], Some(0.7));

--- a/crates/gateway/src/cache/exact.rs
+++ b/crates/gateway/src/cache/exact.rs
@@ -36,9 +36,15 @@ fn short_hash_hex(bytes: &[u8]) -> String {
 /// `semantic.rs::image_rep_suffix` does for its embedded text.
 ///
 /// - `http(s)` URL → kept verbatim (already short and stable).
-/// - `data:` URI ([`ParsedImage::Base64`]) → `sha256:<first-32-hex>` of the raw
-///   base64 payload string bytes (verbatim — NOT decoded first), identical to
-///   `semantic.rs`'s convention so the two tiers agree on "same image".
+/// - `data:` URI ([`ParsedImage::Base64`]) → `sha256:<media_type>:<first-32-hex>`
+///   where the hash is over the raw base64 payload string bytes (verbatim — NOT
+///   decoded first). The declared `media_type` is part of the rep because the
+///   provider decodes the same bytes per declared MIME, so the same payload sent
+///   as `image/png` vs `image/jpeg` is a different request and must key
+///   differently (omitting `media_type` would collide them and serve a
+///   wrong-answer response for the other type). The payload-hash portion stays
+///   identical to `semantic.rs`'s convention so the two tiers agree on "same
+///   payload".
 /// - unparseable url → `rawsha256:<first-32-hex>` of the raw url string bytes.
 ///
 /// NOTE: the unparseable arm deliberately DIFFERS from `semantic.rs`, which
@@ -54,10 +60,21 @@ fn short_hash_hex(bytes: &[u8]) -> String {
 fn image_key_rep(image_url: &solvela_protocol::ImageUrl) -> String {
     match image_url.parse() {
         Ok(ParsedImage::Url { url }) => url,
-        Ok(ParsedImage::Base64 { data, .. }) => {
-            // Hash the payload (not the media-type) so the same bytes sent under
-            // different declared types still distinguish by content.
-            format!("sha256:{}", short_hash_hex(data.as_bytes()))
+        Ok(ParsedImage::Base64 { media_type, data }) => {
+            // Fold BOTH the declared `media_type` and the payload hash into the
+            // rep. The provider decodes the same base64 bytes according to the
+            // declared MIME (Anthropic `source.media_type`, Gemini
+            // `inlineData.mimeType`), so `data:image/png;base64,XYZ` and
+            // `data:image/jpeg;base64,XYZ` are DIFFERENT requests that can yield
+            // different responses — they must key differently. Dropping
+            // `media_type` here would collide them onto one key and serve one
+            // declared type's paid response for the other (a wrong-answer money
+            // loss). Format `sha256:<media_type>:<payload-hash>` cannot alias
+            // across different `(media_type, payload)` pairs: `media_type` is
+            // allowlisted to `image/{png,jpeg,webp}` (contains `/` but never
+            // `:`) and the hash is fixed-length hex (`0-9a-f`, never `:`), so
+            // the two `:` separators are unambiguous and no other split parses.
+            format!("sha256:{}:{}", media_type, short_hash_hex(data.as_bytes()))
         }
         Err(_) => {
             // Defensive (unreachable past the route's pre-settlement parse gate):
@@ -141,7 +158,9 @@ impl ResponseCache {
     /// genuinely different multimodal prompts collide) BUT each image's `url`
     /// is first substituted with a short, stable representation via
     /// [`message_with_bounded_images`]: an `http(s)` URL verbatim, or a
-    /// `sha256:<prefix>` of a `data:` URI's base64 payload. This bounds the
+    /// `sha256:<media_type>:<prefix>` of a `data:` URI's declared MIME plus its
+    /// base64 payload hash (the MIME is keyed because the provider decodes the
+    /// same bytes per declared type). This bounds the
     /// bytes hashed into the key — a `data:` URI can be up to
     /// `MAX_DATA_URI_BYTES` (10 MiB) — without weakening exact-match
     /// correctness (distinct images still produce distinct keys; the same image
@@ -613,6 +632,70 @@ mod tests {
             ResponseCache::cache_key(&x).expect("must serialise"),
             ResponseCache::cache_key(&y).expect("must serialise"),
             "payloads differing only in a late byte must still produce distinct keys"
+        );
+    }
+
+    /// A `data:` URI with a base64 payload of `payload` under an explicit
+    /// `media_type`. Lets a test vary the declared MIME while holding the
+    /// payload fixed.
+    fn data_uri_mime(media_type: &str, payload: &str) -> String {
+        format!("data:{media_type};base64,{payload}")
+    }
+
+    /// The declared `media_type` is part of the cache key. The SAME base64
+    /// payload sent as `image/png` vs `image/jpeg` MUST produce DIFFERENT keys:
+    /// the provider decodes the bytes per declared MIME (Anthropic
+    /// `source.media_type`, Gemini `inlineData.mimeType`), so the two are
+    /// genuinely different requests that can yield different responses. Folding
+    /// them onto one key would serve one declared type's paid response for the
+    /// other — a wrong-answer money loss.
+    ///
+    /// Falsifiability: dropping `media_type` from `image_key_rep`'s Base64 arm
+    /// (hashing the payload alone) makes the first assertion fail because the
+    /// two reps would be byte-identical. The second assertion guards the other
+    /// direction — same MIME + same payload still produces ONE key, so a
+    /// legitimate hit stays reachable.
+    #[test]
+    fn cache_key_data_uri_distinguishes_media_type() {
+        let payload = "A".repeat(64);
+
+        let png = make_request(
+            "openai/gpt-4o",
+            vec![image_message(
+                "describe",
+                &data_uri_mime("image/png", &payload),
+            )],
+            None,
+        );
+        let jpeg = make_request(
+            "openai/gpt-4o",
+            vec![image_message(
+                "describe",
+                &data_uri_mime("image/jpeg", &payload),
+            )],
+            None,
+        );
+        assert_ne!(
+            ResponseCache::cache_key(&png).expect("must serialise"),
+            ResponseCache::cache_key(&jpeg).expect("must serialise"),
+            "same payload under different declared media types must key differently \
+             (the provider decodes per MIME — they are different requests)"
+        );
+
+        // Same media type + same payload → same key (a legitimate hit is
+        // reachable; the media_type addition does not break stability).
+        let png2 = make_request(
+            "openai/gpt-4o",
+            vec![image_message(
+                "describe",
+                &data_uri_mime("image/png", &payload),
+            )],
+            None,
+        );
+        assert_eq!(
+            ResponseCache::cache_key(&png).expect("must serialise"),
+            ResponseCache::cache_key(&png2).expect("must serialise"),
+            "identical media type + payload must still produce one key"
         );
     }
 

--- a/crates/gateway/src/cache/exact.rs
+++ b/crates/gateway/src/cache/exact.rs
@@ -9,9 +9,93 @@
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
-use solvela_protocol::{ChatRequest, ChatResponse, MessageContent};
+use solvela_protocol::{ChatRequest, ChatResponse, ContentPart, MessageContent, ParsedImage};
 
 use super::{ResponseCache, CACHE_KEY_PREFIX};
+
+/// First 32 hex chars (16 bytes / 128 bits) of the SHA-256 of `bytes`. Stable
+/// and compact. Deliberately mirrors `semantic.rs::short_hash_hex` (same 16-byte
+/// prefix) so the exact and semantic tiers fold an image's `data:` payload into
+/// their keys with byte-identical representations — the two caches reason about
+/// "same image" the same way. Replicated here (rather than sharing) to keep this
+/// change contained to `exact.rs` and avoid restructuring module boundaries.
+/// 128 bits keeps birthday-collision probability negligible in the shared,
+/// wallet-agnostic cache.
+fn short_hash_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    hex::encode(&digest[..16])
+}
+
+/// A short, stable representation of an image URL for the cache key.
+///
+/// Substituted for the raw `ImageUrl.url` BEFORE serialising a message with
+/// image parts, so the SHA-256 key never folds in a multi-megabyte `data:`
+/// payload (up to `MAX_DATA_URI_BYTES` = 10 MiB) verbatim — matching what
+/// `semantic.rs::image_rep_suffix` does for its embedded text.
+///
+/// - `http(s)` URL → kept verbatim (already short and stable).
+/// - `data:` URI ([`ParsedImage::Base64`]) → `sha256:<first-32-hex>` of the raw
+///   base64 payload string bytes (verbatim — NOT decoded first), identical to
+///   `semantic.rs`'s convention so the two tiers agree on "same image".
+/// - unparseable url → `rawsha256:<first-32-hex>` of the raw url string bytes.
+///
+/// NOTE: the unparseable arm deliberately DIFFERS from `semantic.rs`, which
+/// returns `Skip` (bypassing the cache entirely) to avoid building an
+/// embedding-divergent key. The exact tier has no embedding and no
+/// divergent-key risk — the key is a literal SHA-256 over the substituted
+/// content — so substituting a stable hash of the raw url is safe and strictly
+/// better than skipping: two DISTINCT malformed urls must never collide onto
+/// one key (which would serve one input's paid response for the other). The
+/// route rejects malformed images pre-settlement, so this arm is defensive; the
+/// `rawsha256:` prefix keeps it in a distinct namespace from a real payload
+/// hash so a raw-url hash can never alias a base64-payload hash.
+fn image_key_rep(image_url: &solvela_protocol::ImageUrl) -> String {
+    match image_url.parse() {
+        Ok(ParsedImage::Url { url }) => url,
+        Ok(ParsedImage::Base64 { data, .. }) => {
+            // Hash the payload (not the media-type) so the same bytes sent under
+            // different declared types still distinguish by content.
+            format!("sha256:{}", short_hash_hex(data.as_bytes()))
+        }
+        Err(_) => {
+            // Defensive (unreachable past the route's pre-settlement parse gate):
+            // hash the raw url so two distinct malformed values still differ.
+            format!("rawsha256:{}", short_hash_hex(image_url.url.as_bytes()))
+        }
+    }
+}
+
+/// Rewrite a message that carries image parts so each image's `url` is replaced
+/// by its short [`image_key_rep`], bounding the bytes hashed into the cache key
+/// while preserving exact-match correctness (distinct images still differ; the
+/// same image is stable). Text parts and message ordering are preserved
+/// verbatim — only the image-url field is substituted.
+fn message_with_bounded_images(
+    msg: &solvela_protocol::ChatMessage,
+) -> solvela_protocol::ChatMessage {
+    let MessageContent::Parts(parts) = &msg.content else {
+        // Only `Parts` can carry images; `has_image_parts()` already guaranteed
+        // we are in the image branch, so this is defensive.
+        return msg.clone();
+    };
+    let bounded: Vec<ContentPart> = parts
+        .iter()
+        .map(|part| match part {
+            ContentPart::ImageUrl { image_url } => ContentPart::ImageUrl {
+                image_url: solvela_protocol::ImageUrl {
+                    url: image_key_rep(image_url),
+                    detail: image_url.detail.clone(),
+                },
+            },
+            ContentPart::Text { text } => ContentPart::Text { text: text.clone() },
+        })
+        .collect();
+    let mut rewritten = msg.clone();
+    rewritten.content = MessageContent::Parts(bounded);
+    rewritten
+}
 
 impl ResponseCache {
     /// Generate a cache key from a request.
@@ -53,9 +137,17 @@ impl ResponseCache {
     /// content carries no image parts is normalised to its canonical
     /// `Text(as_text())` form *for key computation only* (the caller's `req`
     /// is never mutated). Messages that contain image parts keep their
-    /// original serialisation: flattening would discard the image and let two
-    /// genuinely different multimodal prompts collide. (Image content is
-    /// rejected upstream today, so this branch is defensive.)
+    /// `Parts` structure (flattening would discard the image and let two
+    /// genuinely different multimodal prompts collide) BUT each image's `url`
+    /// is first substituted with a short, stable representation via
+    /// [`message_with_bounded_images`]: an `http(s)` URL verbatim, or a
+    /// `sha256:<prefix>` of a `data:` URI's base64 payload. This bounds the
+    /// bytes hashed into the key — a `data:` URI can be up to
+    /// `MAX_DATA_URI_BYTES` (10 MiB) — without weakening exact-match
+    /// correctness (distinct images still produce distinct keys; the same image
+    /// is stable). It mirrors the fold `semantic.rs::image_rep_suffix` already
+    /// applies. (Image content is validated upstream before settlement, so the
+    /// unparseable arm is defensive.)
     pub fn cache_key(req: &ChatRequest) -> Option<String> {
         // Normalise message content to a canonical text form so the same
         // prompt sent as a JSON string and as a text-parts array hashes
@@ -66,9 +158,12 @@ impl ResponseCache {
             .iter()
             .map(|msg| {
                 if msg.content.has_image_parts() {
-                    // Keep original content: flattening would drop the image
-                    // and let distinct multimodal prompts collide.
-                    msg.clone()
+                    // Keep the `Parts` structure (flattening would drop the
+                    // image and let distinct multimodal prompts collide) but
+                    // substitute each image url with a short, stable rep so a
+                    // 10 MiB `data:` payload is not hashed verbatim. Distinct
+                    // images still differ; the same image stays stable.
+                    message_with_bounded_images(msg)
                 } else {
                     let mut normalized = msg.clone();
                     normalized.content = MessageContent::Text(msg.content.as_text().into_owned());
@@ -424,6 +519,145 @@ mod tests {
         assert_eq!(
             ResponseCache::cache_key(&a).expect("must serialise"),
             ResponseCache::cache_key(&a2).expect("must serialise"),
+        );
+    }
+
+    /// Build a user message carrying one text part + one image part. Shared by
+    /// the bounded-image-key tests below.
+    fn image_message(text: &str, url: &str) -> ChatMessage {
+        use solvela_protocol::ImageUrl;
+        ChatMessage {
+            role: Role::User,
+            content: MessageContent::Parts(vec![
+                ContentPart::Text {
+                    text: text.to_string(),
+                },
+                ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: url.to_string(),
+                        detail: None,
+                    },
+                },
+            ]),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+
+    /// A valid `data:` URI with a base64 payload of `len` `A` characters.
+    /// `image/png;base64` is in the supported allowlist so `ImageUrl::parse`
+    /// returns `ParsedImage::Base64` (the path we want to fold to a short hash).
+    fn data_uri(payload: &str) -> String {
+        format!("data:image/png;base64,{payload}")
+    }
+
+    /// A `data:` URI image produces a stable key (same payload → same key, a
+    /// legitimate hit is reachable) and a different payload → a different key.
+    /// AND the key-input is BOUNDED: two payloads sharing a 10 KiB prefix that
+    /// differ only in a late byte must still produce distinct keys via the
+    /// payload hash — proving we hash the whole payload (through `sha256`),
+    /// not a truncated prefix, while never folding the multi-megabyte raw bytes
+    /// into the serialised key input verbatim.
+    #[test]
+    fn cache_key_data_uri_image_is_stable_distinct_and_bounded() {
+        // Same data URI → same key.
+        let payload_a = "A".repeat(10_000);
+        let a = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", &data_uri(&payload_a))],
+            None,
+        );
+        let a2 = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", &data_uri(&payload_a))],
+            None,
+        );
+        assert_eq!(
+            ResponseCache::cache_key(&a).expect("must serialise"),
+            ResponseCache::cache_key(&a2).expect("must serialise"),
+            "identical data-URI image + text must produce the same key (hit reachable)"
+        );
+
+        // Different data URI → different key.
+        let payload_b = "B".repeat(10_000);
+        let b = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", &data_uri(&payload_b))],
+            None,
+        );
+        assert_ne!(
+            ResponseCache::cache_key(&a).expect("must serialise"),
+            ResponseCache::cache_key(&b).expect("must serialise"),
+            "distinct data-URI payloads must produce distinct keys"
+        );
+
+        // Bounded but lossless: two payloads sharing a 10 KiB prefix differing
+        // only in the FINAL byte must still produce distinct keys. A truncated
+        // (prefix-only) hash would collide them and serve one paid response for
+        // the other; hashing the full payload via sha256 keeps them distinct.
+        let shared_prefix = "C".repeat(10_240);
+        let late_diff_x = format!("{shared_prefix}X");
+        let late_diff_y = format!("{shared_prefix}Y");
+        let x = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", &data_uri(&late_diff_x))],
+            None,
+        );
+        let y = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", &data_uri(&late_diff_y))],
+            None,
+        );
+        assert_ne!(
+            ResponseCache::cache_key(&x).expect("must serialise"),
+            ResponseCache::cache_key(&y).expect("must serialise"),
+            "payloads differing only in a late byte must still produce distinct keys"
+        );
+    }
+
+    /// A `data:` URI and an `http(s)` URL of the "same logical image" must NOT
+    /// collide onto one key. We construct the degenerate case where the http
+    /// URL's text equals the data URI's payload-hash representation namespace
+    /// boundary — i.e. confirm the two reps live in different shapes
+    /// (`sha256:<hex>` for a data URI vs the verbatim URL for http) so a crafted
+    /// URL cannot be made to alias a payload hash. Serving an http-image
+    /// response for a data-URI request (or vice versa) would be a wrong-answer
+    /// money loss.
+    #[test]
+    fn cache_key_data_uri_and_http_url_do_not_collide() {
+        let data = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", &data_uri("AAAA"))],
+            None,
+        );
+        let http = make_request(
+            "openai/gpt-4o",
+            vec![image_message("describe", "https://example.com/a.png")],
+            None,
+        );
+        assert_ne!(
+            ResponseCache::cache_key(&data).expect("must serialise"),
+            ResponseCache::cache_key(&http).expect("must serialise"),
+            "a data-URI image and an http URL must never share a cache key"
+        );
+
+        // Adversarial: an http URL whose literal text is the SAME string we'd
+        // emit for the data-URI rep would still not collide, because the data
+        // URI is replaced by `sha256:<hash-of-payload>`, not by its raw url. So
+        // even if a client sends `https://.../sha256:<hex>` it hashes its own
+        // (verbatim) url, never aliasing the payload hash of a different image.
+        let crafted = make_request(
+            "openai/gpt-4o",
+            vec![image_message(
+                "describe",
+                "https://x/sha256:0123456789abcdef0123456789abcdef",
+            )],
+            None,
+        );
+        assert_ne!(
+            ResponseCache::cache_key(&data).expect("must serialise"),
+            ResponseCache::cache_key(&crafted).expect("must serialise"),
         );
     }
 

--- a/crates/gateway/src/cache/semantic.rs
+++ b/crates/gateway/src/cache/semantic.rs
@@ -595,17 +595,6 @@ fn redis_value_to_string(v: &redis::Value) -> Option<String> {
     }
 }
 
-/// Canonicalise a chat request's messages into the single string we embed.
-/// Deterministic and order-sensitive (message order changes meaning). Each
-/// message contributes a `role: content` line; ordering is preserved.
-///
-/// Sampling params (`temperature` / `top_p`) are **not** embedded here. An
-/// earlier attempt appended them as a trailing `params:` line, but that does
-/// not separate hits: two prompts identical except for temperature embed to
-/// near-identical vectors (cosine ≈ 0.99 ≫ the 0.85 threshold), so the param
-/// line is invisible to the KNN gate and the wrong sampling regime gets served.
-/// Sampling params are instead enforced as exact RediSearch TAG predicates (see
-/// [`param_tag`] and the `@temperature` / `@top_p` filters in [`SemanticCache::get`]).
 /// A deterministic, compact textual representation of a message's image parts,
 /// or the empty string when there are none.
 ///
@@ -613,15 +602,18 @@ fn redis_value_to_string(v: &redis::Value) -> Option<String> {
 /// different images embed to distinct vectors (preventing a cross-image
 /// semantic-cache collision). Each image contributes ` image=<rep>`:
 /// - `http(s)` URL → the URL verbatim (already short and stable).
-/// - `data:` URI → `sha256:<first-32-hex>` (128-bit prefix) of the decoded
-///   base64 PAYLOAD bytes (not the raw URL string), so a multi-megabyte base64
+/// - `data:` URI → `sha256:<first-32-hex>` (128-bit prefix) of the raw base64
+///   payload string bytes (verbatim — the payload is NOT decoded first; see
+///   [`solvela_protocol::ParsedImage::Base64`]), so a multi-megabyte base64
 ///   blob does not bloat the embedded text or exceed the embed budget while
 ///   still distinguishing distinct images. 128 bits avoids birthday collisions
-///   in the shared, wallet-agnostic cache.
-/// - unparseable url → `raw:<sha256 first-32-hex>` of the raw string, so even a
-///   malformed image still separates distinct values (defensive; malformed
-///   images are rejected before settlement, but the cache layer must not
-///   collide them).
+///   in the shared, wallet-agnostic cache. (Two distinct base64 encodings of
+///   the same image hash differently — a benign cache *miss*, never a wrong
+///   hit.)
+/// - unparseable url → returns [`ImageRepResult::Skip`], so the caller bypasses
+///   the semantic cache entirely for this request rather than building a key
+///   that could diverge from a (hypothetical) parsed key. Defensive: malformed
+///   images are rejected at the route before settlement.
 fn image_rep_suffix(model: &str, content: &solvela_protocol::MessageContent) -> ImageRepResult {
     use solvela_protocol::ParsedImage;
 
@@ -683,7 +675,17 @@ fn short_hash_hex(bytes: &[u8]) -> String {
     hex::encode(&digest[..16])
 }
 
-/// Canonicalise a request into the embedded prompt string.
+/// Canonicalise a chat request's messages into the single string we embed.
+/// Deterministic and order-sensitive (message order changes meaning). Each
+/// message contributes a `role: content` line; ordering is preserved.
+///
+/// Sampling params (`temperature` / `top_p`) are **not** embedded here. An
+/// earlier attempt appended them as a trailing `params:` line, but that does
+/// not separate hits: two prompts identical except for temperature embed to
+/// near-identical vectors (cosine ≈ 0.99 ≫ the 0.85 threshold), so the param
+/// line is invisible to the KNN gate and the wrong sampling regime gets served.
+/// Sampling params are instead enforced as exact RediSearch TAG predicates (see
+/// [`param_tag`] and the `@temperature` / `@top_p` filters in [`SemanticCache::get`]).
 ///
 /// Returns `None` to signal the caller must SKIP the semantic cache for this
 /// request — currently only when a message carries an unparseable image (see

--- a/crates/gateway/src/cache/semantic.rs
+++ b/crates/gateway/src/cache/semantic.rs
@@ -323,7 +323,12 @@ impl SemanticCache {
         }
         // Don't store a prompt BGE would truncate (bug_002): its embedding would
         // reflect only the truncated prefix, risking a later wrong cross-hit.
-        let text = prompt_text(req);
+        // `None` => an unparseable image (unreachable given the route gate) means
+        // skip the cache entirely rather than build a possibly-divergent key.
+        let text = match prompt_text(req) {
+            Some(t) => t,
+            None => return,
+        };
         if !within_embed_budget(&text) {
             debug!(
                 model = %req.model,
@@ -410,7 +415,8 @@ impl SemanticCache {
     /// when the prompt exceeds [`MAX_EMBED_CHARS`] (BGE would truncate it; see
     /// bug_002) or when embedding fails.
     async fn embed_checked(&self, req: &ChatRequest) -> Option<Vec<f32>> {
-        let text = prompt_text(req);
+        // `None` => an unparseable image → skip the cache (get/store miss).
+        let text = prompt_text(req)?;
         if !within_embed_budget(&text) {
             debug!(
                 model = %req.model,
@@ -600,10 +606,93 @@ fn redis_value_to_string(v: &redis::Value) -> Option<String> {
 /// line is invisible to the KNN gate and the wrong sampling regime gets served.
 /// Sampling params are instead enforced as exact RediSearch TAG predicates (see
 /// [`param_tag`] and the `@temperature` / `@top_p` filters in [`SemanticCache::get`]).
-pub(crate) fn prompt_text(req: &ChatRequest) -> String {
-    req.messages
-        .iter()
-        .map(|m| {
+/// A deterministic, compact textual representation of a message's image parts,
+/// or the empty string when there are none.
+///
+/// Folded into [`prompt_text`] so two otherwise-identical prompts that carry
+/// different images embed to distinct vectors (preventing a cross-image
+/// semantic-cache collision). Each image contributes ` image=<rep>`:
+/// - `http(s)` URL → the URL verbatim (already short and stable).
+/// - `data:` URI → `sha256:<first-32-hex>` (128-bit prefix) of the decoded
+///   base64 PAYLOAD bytes (not the raw URL string), so a multi-megabyte base64
+///   blob does not bloat the embedded text or exceed the embed budget while
+///   still distinguishing distinct images. 128 bits avoids birthday collisions
+///   in the shared, wallet-agnostic cache.
+/// - unparseable url → `raw:<sha256 first-32-hex>` of the raw string, so even a
+///   malformed image still separates distinct values (defensive; malformed
+///   images are rejected before settlement, but the cache layer must not
+///   collide them).
+fn image_rep_suffix(model: &str, content: &solvela_protocol::MessageContent) -> ImageRepResult {
+    use solvela_protocol::ParsedImage;
+
+    let mut out = String::new();
+    for img in content.image_urls() {
+        let rep = match img.parse() {
+            Ok(ParsedImage::Url { url }) => url,
+            Ok(ParsedImage::Base64 { data, .. }) => {
+                // Hash the payload (not the media-type) so the same bytes sent
+                // as different declared types still distinguish by content; a
+                // short prefix is plenty to avoid collisions in a cache key.
+                format!("sha256:{}", short_hash_hex(data.as_bytes()))
+            }
+            Err(_) => {
+                // UNREACHABLE in production: the chat route validates every image
+                // via `ImageUrl::parse()` BEFORE settlement (routes/chat/mod.rs
+                // "Step 2a'"), so a request reaching the cache layer cannot carry
+                // an unparseable image. We nonetheless fail loud + safe rather
+                // than fall back to hashing the raw URL: a raw-URL fallback could
+                // build a key that diverges from a (hypothetical) parsed key for
+                // the same logical image, risking a wrong cross-hit. Instead we
+                // warn and signal the caller to SKIP the semantic cache entirely
+                // for this request (no get, no set) — never settle a paid
+                // response against a possibly-divergent key.
+                let truncated: String = img.url.chars().take(64).collect();
+                warn!(
+                    %model,
+                    image_url = %truncated,
+                    "semantic cache: unparseable image (unreachable given the route \
+                     parse gate); skipping semantic cache for this request"
+                );
+                return ImageRepResult::Skip;
+            }
+        };
+        out.push_str(" image=");
+        out.push_str(&rep);
+    }
+    ImageRepResult::Suffix(out)
+}
+
+/// Outcome of building the per-message image representation for [`prompt_text`].
+///
+/// `Skip` propagates an unparseable-image signal up so the request bypasses the
+/// semantic cache (rather than building a possibly-divergent key); see the
+/// `Err` arm of [`image_rep_suffix`].
+enum ImageRepResult {
+    Suffix(String),
+    Skip,
+}
+
+/// First 32 hex chars (16 bytes / 128 bits) of the SHA-256 of `bytes`. Stable
+/// and compact. 128 bits keeps the birthday-collision probability negligible in
+/// the shared, wallet-agnostic semantic cache (an 8-byte/64-bit prefix would
+/// collide after ~2^32 distinct images — too close for a cross-tenant cache).
+fn short_hash_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    hex::encode(&digest[..16])
+}
+
+/// Canonicalise a request into the embedded prompt string.
+///
+/// Returns `None` to signal the caller must SKIP the semantic cache for this
+/// request — currently only when a message carries an unparseable image (see
+/// [`image_rep_suffix`]; unreachable given the route's pre-settlement parse
+/// gate, but fail-safe rather than build a possibly-divergent key).
+pub(crate) fn prompt_text(req: &ChatRequest) -> Option<String> {
+    let mut lines: Vec<String> = Vec::with_capacity(req.messages.len());
+    for m in &req.messages {
+        {
             // Base line: `role: content`. For an assistant turn carrying
             // `tool_calls`, or a tool turn carrying `tool_call_id`, we append
             // a deterministic suffix so two conversation histories that
@@ -614,7 +703,26 @@ pub(crate) fn prompt_text(req: &ChatRequest) -> String {
             // and collide above the similarity threshold — wrong tool result
             // served from cache. The suffix is JSON to preserve structure;
             // missing fields are simply omitted (no `null` noise).
-            let base = format!("{}: {}", role_str(&m.role), m.content.as_text());
+            // Fold a stable per-image representation into the embedded text so
+            // two prompts that differ ONLY in their image(s) embed to distinct
+            // vectors. `as_text()` drops image parts entirely, so without this
+            // a "describe data:img-A" and "describe data:img-B" would produce
+            // identical `prompt_text` and collide above the similarity
+            // threshold — serving image A's cached answer for image B (a
+            // wrong-answer money loss). The rep is the http(s) URL verbatim, or
+            // a short stable hash of the data-URI bytes (so a multi-MB base64
+            // blob doesn't bloat the embedded text or blow the embed budget).
+            let image_suffix = match image_rep_suffix(&req.model, &m.content) {
+                ImageRepResult::Suffix(s) => s,
+                // Unparseable image → skip the semantic cache for this request.
+                ImageRepResult::Skip => return None,
+            };
+            let base = format!(
+                "{}: {}{}",
+                role_str(&m.role),
+                m.content.as_text(),
+                image_suffix
+            );
             let tool_calls_suffix = m
                 .tool_calls
                 .as_ref()
@@ -627,10 +735,10 @@ pub(crate) fn prompt_text(req: &ChatRequest) -> String {
                 .as_ref()
                 .map(|id| format!(" tool_call_id={id}"))
                 .unwrap_or_default();
-            format!("{base}{tool_calls_suffix}{tool_call_id_suffix}")
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+            lines.push(format!("{base}{tool_calls_suffix}{tool_call_id_suffix}"));
+        }
+    }
+    Some(lines.join("\n"))
 }
 
 /// Whether a prompt is short enough to embed without BGE silently truncating it
@@ -820,8 +928,8 @@ mod tests {
         a.messages.push(user_msg("second"));
         let mut b = req("m", "second");
         b.messages.push(user_msg("first"));
-        let ta = prompt_text(&a);
-        let tb = prompt_text(&b);
+        let ta = prompt_text(&a).expect("parseable prompt");
+        let tb = prompt_text(&b).expect("parseable prompt");
         assert!(
             !ta.is_empty(),
             "prompt_text must not be empty for non-empty messages"
@@ -848,8 +956,9 @@ mod tests {
             prompt_text(&b),
             "sampling params must NOT change the embedded text"
         );
-        assert!(!prompt_text(&a).contains("temperature"));
-        assert!(!prompt_text(&a).contains("top_p"));
+        let ta = prompt_text(&a).expect("parseable prompt");
+        assert!(!ta.contains("temperature"));
+        assert!(!ta.contains("top_p"));
     }
 
     /// Two conversation histories differing only in their assistant
@@ -899,7 +1008,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
         });
-        let text = prompt_text(&plain);
+        let text = prompt_text(&plain).expect("parseable prompt");
         assert!(
             !text.contains("tool_calls"),
             "plain (no tool_calls) message must not embed a tool_calls suffix; got: {text:?}"
@@ -932,8 +1041,115 @@ mod tests {
     fn prompt_text_includes_message_content() {
         let r = req("m", "explain semaphores");
         assert!(
-            prompt_text(&r).contains("explain semaphores"),
+            prompt_text(&r)
+                .expect("parseable prompt")
+                .contains("explain semaphores"),
             "prompt_text should include the user content"
+        );
+    }
+
+    fn image_req(text: &str, image_url: &str) -> ChatRequest {
+        use solvela_protocol::{ContentPart, ImageUrl, MessageContent};
+        ChatRequest {
+            model: "openai/gpt-4o".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![
+                    ContentPart::Text {
+                        text: text.to_string(),
+                    },
+                    ContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: image_url.to_string(),
+                            detail: None,
+                        },
+                    },
+                ]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        }
+    }
+
+    /// Two prompts with identical TEXT but DIFFERENT images must produce
+    /// distinct `prompt_text`, so they embed to distinct vectors and don't
+    /// collide above the similarity threshold (serving image A's cached answer
+    /// for image B is a wrong-answer money loss). Falsifiability: reverting the
+    /// `image_rep_suffix` fold (so `as_text()` drops the image) makes both
+    /// prompts identical and this assertion fails.
+    #[test]
+    fn prompt_text_distinguishes_distinct_images() {
+        let a = image_req("describe", "https://example.com/a.png");
+        let b = image_req("describe", "https://example.com/b.png");
+        assert_ne!(
+            prompt_text(&a),
+            prompt_text(&b),
+            "distinct image URLs must yield distinct prompt_text"
+        );
+
+        // Distinct data-URI payloads (same media type) must also separate.
+        let da = image_req("describe", "data:image/png;base64,AAAA");
+        let db = image_req("describe", "data:image/png;base64,BBBB");
+        assert_ne!(
+            prompt_text(&da),
+            prompt_text(&db),
+            "distinct data-URI payloads must yield distinct prompt_text"
+        );
+    }
+
+    /// The SAME image with the SAME surrounding text must yield identical
+    /// `prompt_text` (stable; a legitimate cache hit must still be reachable).
+    #[test]
+    fn prompt_text_stable_for_identical_image() {
+        let a = image_req("describe", "https://example.com/a.png");
+        let b = image_req("describe", "https://example.com/a.png");
+        assert_eq!(prompt_text(&a), prompt_text(&b));
+
+        // And a huge data-URI payload is folded to a short hash (the embedded
+        // text must not balloon with the raw base64 bytes).
+        let big = "data:image/png;base64,".to_string() + &"Q".repeat(100_000);
+        let r = image_req("describe", &big);
+        let pt = prompt_text(&r).expect("parseable data-URI image prompt");
+        assert!(
+            pt.len() < 200,
+            "data-URI image must be folded to a short hash, got {} chars",
+            pt.len()
+        );
+        assert!(pt.contains("image=sha256:"));
+    }
+
+    /// FIX 2 (PR #2 round-2 review): an unparseable image must make `prompt_text`
+    /// return `None` — the signal that the request SKIPS the semantic cache
+    /// entirely (no get/set) rather than fall back to a possibly-divergent
+    /// raw-URL key. This branch is unreachable in production (the route validates
+    /// every image via `parse()` before settlement), but the cache layer must
+    /// fail loud + safe if it is ever reached. Falsifiability: reverting to the
+    /// old raw-URL hash fallback makes this return `Some(..)` and the test fails.
+    #[test]
+    fn prompt_text_skips_on_unparseable_image() {
+        // `ftp://` is neither a `data:` URI nor an http(s) URL → parse() errors.
+        let r = image_req("describe", "ftp://example.com/not-an-image.png");
+        assert!(
+            prompt_text(&r).is_none(),
+            "an unparseable image must skip the semantic cache (None), not build a key"
+        );
+    }
+
+    /// A parseable image still yields `Some(..)` — the skip is scoped to the
+    /// unparseable case only (the happy path is unaffected).
+    #[test]
+    fn prompt_text_some_for_parseable_image() {
+        let r = image_req("describe", "https://example.com/a.png");
+        assert!(
+            prompt_text(&r).is_some(),
+            "a parseable image must still produce embedded text"
         );
     }
 

--- a/crates/gateway/src/cache/semantic.rs
+++ b/crates/gateway/src/cache/semantic.rs
@@ -602,14 +602,21 @@ fn redis_value_to_string(v: &redis::Value) -> Option<String> {
 /// different images embed to distinct vectors (preventing a cross-image
 /// semantic-cache collision). Each image contributes ` image=<rep>`:
 /// - `http(s)` URL → the URL verbatim (already short and stable).
-/// - `data:` URI → `sha256:<first-32-hex>` (128-bit prefix) of the raw base64
-///   payload string bytes (verbatim — the payload is NOT decoded first; see
-///   [`solvela_protocol::ParsedImage::Base64`]), so a multi-megabyte base64
-///   blob does not bloat the embedded text or exceed the embed budget while
-///   still distinguishing distinct images. 128 bits avoids birthday collisions
-///   in the shared, wallet-agnostic cache. (Two distinct base64 encodings of
-///   the same image hash differently — a benign cache *miss*, never a wrong
-///   hit.)
+/// - `data:` URI → `sha256:<media_type>:<first-32-hex>` (the declared MIME plus
+///   a 128-bit prefix) of the raw base64 payload string bytes (verbatim — the
+///   payload is NOT decoded first; see [`solvela_protocol::ParsedImage::Base64`]),
+///   so a multi-megabyte base64 blob does not bloat the embedded text or exceed
+///   the embed budget while still distinguishing distinct images. The declared
+///   `media_type` is part of the rep because it IS forwarded to providers
+///   (Anthropic `source.media_type`, Gemini `inlineData.mimeType`) and changes
+///   how the image decodes — so the SAME payload sent as `image/png` vs
+///   `image/jpeg` must embed distinctly (dropping `media_type` would collide
+///   them and risk serving one MIME's cached answer for the other — a
+///   wrong-answer money loss). This mirrors the exact tier's
+///   `sha256:<media_type>:<payload-hash>` rep (`cache/exact.rs`) so the two
+///   tiers agree on the same image. 128 bits avoids birthday collisions in the
+///   shared, wallet-agnostic cache. (Two distinct base64 encodings of the same
+///   image hash differently — a benign cache *miss*, never a wrong hit.)
 /// - unparseable url → returns [`ImageRepResult::Skip`], so the caller bypasses
 ///   the semantic cache entirely for this request rather than building a key
 ///   that could diverge from a (hypothetical) parsed key. Defensive: malformed
@@ -621,11 +628,21 @@ fn image_rep_suffix(model: &str, content: &solvela_protocol::MessageContent) -> 
     for img in content.image_urls() {
         let rep = match img.parse() {
             Ok(ParsedImage::Url { url }) => url,
-            Ok(ParsedImage::Base64 { data, .. }) => {
-                // Hash the payload (not the media-type) so the same bytes sent
-                // as different declared types still distinguish by content; a
-                // short prefix is plenty to avoid collisions in a cache key.
-                format!("sha256:{}", short_hash_hex(data.as_bytes()))
+            Ok(ParsedImage::Base64 { media_type, data }) => {
+                // Fold BOTH the declared `media_type` and the payload hash into
+                // the rep. The SAME base64 payload sent as `image/png` vs
+                // `image/jpeg` decodes differently downstream — `media_type` is
+                // forwarded to providers verbatim (Anthropic `source.media_type`,
+                // Gemini `inlineData.mimeType`) — so dropping `media_type` here
+                // would collide them and risk serving one MIME's cached answer
+                // for the other (a wrong-answer money loss). Mirrors the exact
+                // tier's `sha256:<media_type>:<payload-hash>` (`cache/exact.rs`)
+                // so the two tiers agree on the same image. The separators are
+                // unambiguous: `media_type` is route-allowlisted to
+                // `image/png|jpeg|webp` (contains `/`, never `:`) and the hash
+                // is hex (never `:`), so no `(media_type, payload)` pair can
+                // alias another.
+                format!("sha256:{}:{}", media_type, short_hash_hex(data.as_bytes()))
             }
             Err(_) => {
                 // UNREACHABLE in production: the chat route validates every image
@@ -1125,6 +1142,47 @@ mod tests {
             pt.len()
         );
         assert!(pt.contains("image=sha256:"));
+    }
+
+    /// The declared `media_type` is part of the embedded image rep. The SAME
+    /// base64 payload sent as `image/png` vs `image/jpeg` must yield DIFFERENT
+    /// `prompt_text` (the MIME is forwarded to providers — Anthropic
+    /// `source.media_type`, Gemini `inlineData.mimeType` — and changes how the
+    /// image decodes, so a png-declared answer must not be served for a
+    /// jpeg-declared request). Identical MIME + payload must stay stable.
+    /// Mirrors the exact tier's `cache_key_data_uri_distinguishes_media_type`.
+    ///
+    /// Falsifiability: dropping `media_type` from `image_rep_suffix`'s Base64
+    /// arm (the prior `format!("sha256:{}", ..)` form) collapses the two MIMEs
+    /// onto identical `prompt_text` and the `assert_ne!` fails.
+    #[test]
+    fn prompt_text_distinguishes_media_type_for_same_payload() {
+        let payload = "AAAA";
+        let png = image_req("describe", &format!("data:image/png;base64,{payload}"));
+        let jpeg = image_req("describe", &format!("data:image/jpeg;base64,{payload}"));
+        assert_ne!(
+            prompt_text(&png),
+            prompt_text(&jpeg),
+            "same base64 payload under different declared MIME must yield \
+             distinct prompt_text; otherwise a png answer could be served for \
+             a jpeg request (the MIME is forwarded to the provider verbatim)"
+        );
+
+        // Identical MIME + payload must stay stable (a legitimate hit must
+        // still be reachable).
+        let png2 = image_req("describe", &format!("data:image/png;base64,{payload}"));
+        assert_eq!(
+            prompt_text(&png),
+            prompt_text(&png2),
+            "identical MIME + payload must yield identical prompt_text"
+        );
+        // And the rep embeds the media_type before the hash, per the
+        // `sha256:<media_type>:<hash>` convention shared with the exact tier.
+        let pt = prompt_text(&png).expect("parseable data-URI image prompt");
+        assert!(
+            pt.contains("image=sha256:image/png:"),
+            "embedded rep must carry the media_type, got: {pt:?}"
+        );
     }
 
     /// FIX 2 (PR #2 round-2 review): an unparseable image must make `prompt_text`

--- a/crates/gateway/src/providers/anthropic.rs
+++ b/crates/gateway/src/providers/anthropic.rs
@@ -187,6 +187,27 @@ fn to_anthropic_request(req: &ChatRequest) -> Result<AnthropicRequest, String> {
         }
     };
 
+    // Anthropic's Messages API carries only `user` and `assistant` turns, so a
+    // `Tool`-role message is dropped by the filter below (tool results are not
+    // yet translated to Anthropic `tool_result` blocks). The route gate accepts
+    // image parts in tool-role messages because other providers (e.g. Gemini)
+    // forward them, so without this guard a tool-role image would pass the gate,
+    // settle payment, then vanish here silently — the agent pays for a vision
+    // request the model never sees. Reject it loudly instead. (Tool-role TEXT is
+    // still dropped by the filter; that is a pre-existing limitation tracked
+    // separately, not introduced here.)
+    if req
+        .messages
+        .iter()
+        .any(|m| m.role == Role::Tool && m.content.has_image_parts())
+    {
+        return Err(
+            "image content in tool-role messages is not supported for Anthropic models; \
+             place images in a user message"
+                .to_string(),
+        );
+    }
+
     // Filter to user/assistant messages only
     let mut messages: Vec<AnthropicMessage> = Vec::new();
     for m in req
@@ -815,6 +836,50 @@ mod tests {
         assert!(
             to_anthropic_request(&req).is_err(),
             "an image in a system message must reject the request, not be silently dropped"
+        );
+    }
+
+    #[test]
+    fn test_image_in_tool_message_is_rejected_not_dropped() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        // A WELL-FORMED image in a TOOL-role message. The Anthropic adapter only
+        // forwards user/assistant turns, so a tool-role message is dropped by
+        // the filter. The route gate accepts tool-role images (other providers
+        // forward them), so without an explicit guard the image would settle
+        // payment then vanish silently. Must reject loudly instead.
+        let req = ChatRequest {
+            model: "anthropic/claude-sonnet-4-6".to_string(),
+            messages: vec![
+                ChatMessage {
+                    role: Role::User,
+                    content: "what did the tool return?".into(),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                ChatMessage {
+                    role: Role::Tool,
+                    content: MessageContent::Parts(vec![ContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+                            detail: None,
+                        },
+                    }]),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: Some("call_1".to_string()),
+                },
+            ],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        assert!(
+            to_anthropic_request(&req).is_err(),
+            "an image in a tool-role message must reject for Anthropic, not be silently dropped"
         );
     }
 

--- a/crates/gateway/src/providers/anthropic.rs
+++ b/crates/gateway/src/providers/anthropic.rs
@@ -4,7 +4,7 @@ use tracing::warn;
 
 use solvela_protocol::{
     ChatChoice, ChatChunk, ChatChunkChoice, ChatDelta, ChatMessage, ChatRequest, ChatResponse,
-    ModelRegistration, Role, Usage,
+    MessageContent, ModelRegistration, ParseImageError, ParsedImage, Role, Usage,
 };
 
 use super::{ChatStream, LLMProvider, ProviderError};
@@ -47,10 +47,42 @@ struct AnthropicRequest {
     stream: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// Anthropic message content: a list of content blocks.
+///
+/// Anthropic's Messages API accepts `content` as either a bare string or an
+/// array of typed content blocks. We always emit the array form so a single
+/// code path carries both text-only and multimodal messages. For text-only
+/// messages this is a one-element `[{"type":"text","text":...}]`, which the
+/// API treats identically to a bare string.
+///
+/// Wire schema verified against the Anthropic Messages API docs
+/// (platform.claude.com/docs/en/api/messages, fetched 2026-06-03):
+///   text:  {"type":"text","text": "..."}
+///   image (base64): {"type":"image","source":{"type":"base64",
+///                     "media_type":"image/png","data":"<b64>"}}
+///   image (url):    {"type":"image","source":{"type":"url",
+///                     "url":"https://..."}}
+/// Outbound-only (request) — no `Deserialize`.
+#[derive(Debug, Serialize)]
 struct AnthropicMessage {
     role: String,
-    content: String,
+    content: Vec<AnthropicContentBlockOut>,
+}
+
+/// Outbound-only (request) — no `Deserialize`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicContentBlockOut {
+    Text { text: String },
+    Image { source: AnthropicImageSource },
+}
+
+/// Outbound-only (request) — no `Deserialize`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicImageSource {
+    Base64 { media_type: String, data: String },
+    Url { url: String },
 }
 
 #[derive(Debug, Deserialize)]
@@ -80,16 +112,73 @@ struct AnthropicUsage {
 // Format translation
 // ---------------------------------------------------------------------------
 
+/// Translate one OpenAI [`MessageContent`] into Anthropic content blocks.
+///
+/// Text-only content becomes a single text block (the API treats a
+/// one-element text array identically to a bare string). Multimodal content
+/// preserves part ORDER — interleaving of text and images is meaningful to
+/// the model — and translates each image via [`ImageUrl::parse`]
+/// (`data:` URI → base64 source; http(s) → url source). A malformed image
+/// URL returns `Err` so the request is rejected rather than silently dropping
+/// the image.
+fn content_to_anthropic_blocks(
+    content: &MessageContent,
+) -> Result<Vec<AnthropicContentBlockOut>, String> {
+    match content {
+        MessageContent::Text(s) => Ok(vec![AnthropicContentBlockOut::Text { text: s.clone() }]),
+        MessageContent::Parts(parts) => {
+            let mut blocks = Vec::with_capacity(parts.len());
+            for part in parts {
+                match part {
+                    solvela_protocol::ContentPart::Text { text } => {
+                        blocks.push(AnthropicContentBlockOut::Text { text: text.clone() });
+                    }
+                    solvela_protocol::ContentPart::ImageUrl { image_url } => {
+                        let source = match image_url
+                            .parse()
+                            .map_err(|e: ParseImageError| e.to_string())?
+                        {
+                            ParsedImage::Base64 { media_type, data } => {
+                                AnthropicImageSource::Base64 { media_type, data }
+                            }
+                            ParsedImage::Url { url } => AnthropicImageSource::Url { url },
+                        };
+                        blocks.push(AnthropicContentBlockOut::Image { source });
+                    }
+                }
+            }
+            Ok(blocks)
+        }
+    }
+}
+
 /// Convert an OpenAI-format request to Anthropic Messages API format.
-fn to_anthropic_request(req: &ChatRequest) -> AnthropicRequest {
+///
+/// Fallible: a malformed image data URI in any user/assistant message
+/// surfaces as `Err` rather than dropping the image. System messages are
+/// always flattened to text (Anthropic's `system` param is a plain string).
+fn to_anthropic_request(req: &ChatRequest) -> Result<AnthropicRequest, String> {
     // Extract system message(s) — Anthropic takes system as a separate param
+    // (a plain string), so it cannot carry image blocks. An image in a
+    // system/developer message would be silently dropped by `as_text()` while
+    // the vision gate still accepts the request — the agent pays but the model
+    // never sees the image. Reject it explicitly instead.
     let system: Option<String> = {
-        let system_msgs: Vec<String> = req
+        let mut system_msgs: Vec<String> = Vec::new();
+        for m in req
             .messages
             .iter()
             .filter(|m| m.role == Role::System || m.role == Role::Developer)
-            .map(|m| m.content.as_text().into_owned())
-            .collect();
+        {
+            if m.content.has_image_parts() {
+                return Err(
+                    "image content is not supported in system/developer messages; \
+                     place images in a user message"
+                        .to_string(),
+                );
+            }
+            system_msgs.push(m.content.as_text().into_owned());
+        }
 
         if system_msgs.is_empty() {
             None
@@ -99,19 +188,20 @@ fn to_anthropic_request(req: &ChatRequest) -> AnthropicRequest {
     };
 
     // Filter to user/assistant messages only
-    let messages: Vec<AnthropicMessage> = req
+    let mut messages: Vec<AnthropicMessage> = Vec::new();
+    for m in req
         .messages
         .iter()
         .filter(|m| m.role == Role::User || m.role == Role::Assistant)
-        .map(|m| AnthropicMessage {
-            role: match m.role {
-                Role::User => "user".to_string(),
-                Role::Assistant => "assistant".to_string(),
-                _ => "user".to_string(), // shouldn't happen due to filter
-            },
-            content: m.content.as_text().into_owned(),
-        })
-        .collect();
+    {
+        let role = match m.role {
+            Role::User => "user".to_string(),
+            Role::Assistant => "assistant".to_string(),
+            _ => "user".to_string(), // shouldn't happen due to filter
+        };
+        let content = content_to_anthropic_blocks(&m.content)?;
+        messages.push(AnthropicMessage { role, content });
+    }
 
     // Extract model_id part (e.g., "anthropic/claude-sonnet-4-20250514" → "claude-sonnet-4-20250514")
     let model = req
@@ -120,7 +210,7 @@ fn to_anthropic_request(req: &ChatRequest) -> AnthropicRequest {
         .unwrap_or(&req.model)
         .to_string();
 
-    AnthropicRequest {
+    Ok(AnthropicRequest {
         model,
         max_tokens: req.max_tokens.unwrap_or(4096),
         system,
@@ -128,7 +218,7 @@ fn to_anthropic_request(req: &ChatRequest) -> AnthropicRequest {
         temperature: req.temperature,
         top_p: req.top_p,
         stream: None,
-    }
+    })
 }
 
 /// Convert an Anthropic response to OpenAI-format ChatResponse.
@@ -414,7 +504,8 @@ impl LLMProvider for AnthropicProvider {
         req: ChatRequest,
     ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
         let original_model = req.model.clone();
-        let anthropic_req = to_anthropic_request(&req);
+        let anthropic_req = to_anthropic_request(&req)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
         let req_body = serde_json::to_value(&anthropic_req)?;
         let response = super::retry_with_backoff(2, || {
@@ -439,7 +530,10 @@ impl LLMProvider for AnthropicProvider {
 
     async fn chat_completion_stream(&self, req: ChatRequest) -> Result<ChatStream, ProviderError> {
         let model = req.model.clone();
-        let mut anthropic_req = to_anthropic_request(&req);
+        let mut anthropic_req = to_anthropic_request(&req).map_err(|e| -> ProviderError {
+            // Surface the malformed-image error rather than dropping the image.
+            e.into()
+        })?;
         anthropic_req.stream = Some(true);
 
         let response = self
@@ -462,8 +556,16 @@ impl LLMProvider for AnthropicProvider {
 mod tests {
     use super::*;
 
+    /// Helper: the text of a single text block, or panic.
+    fn block_text(block: &AnthropicContentBlockOut) -> &str {
+        match block {
+            AnthropicContentBlockOut::Text { text } => text,
+            AnthropicContentBlockOut::Image { .. } => panic!("expected a text block"),
+        }
+    }
+
     #[test]
-    fn test_user_text_parts_flattened_to_space_joined_string() {
+    fn test_user_text_parts_become_separate_text_blocks() {
         use solvela_protocol::vision::{ContentPart, MessageContent};
         let req = ChatRequest {
             model: "anthropic/claude-sonnet-4-20250514".to_string(),
@@ -489,10 +591,231 @@ mod tests {
             tool_choice: None,
         };
 
-        let anthropic_req = to_anthropic_request(&req);
+        let anthropic_req = to_anthropic_request(&req).unwrap();
         assert_eq!(anthropic_req.messages.len(), 1);
-        // String-based adapter flattens text parts with a single space.
-        assert_eq!(anthropic_req.messages[0].content, "first second");
+        // Each text part maps to its own text block, preserving order.
+        assert_eq!(anthropic_req.messages[0].content.len(), 2);
+        assert_eq!(block_text(&anthropic_req.messages[0].content[0]), "first");
+        assert_eq!(block_text(&anthropic_req.messages[0].content[1]), "second");
+    }
+
+    #[test]
+    fn test_text_only_string_message_is_single_text_block() {
+        let req = ChatRequest {
+            model: "anthropic/claude-sonnet-4-20250514".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: "hello".into(),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        let anthropic_req = to_anthropic_request(&req).unwrap();
+        // Wire-shape pin: a one-element text array, which the API treats
+        // identically to a bare string.
+        let v = serde_json::to_value(&anthropic_req.messages[0]).unwrap();
+        assert_eq!(
+            v["content"],
+            serde_json::json!([{"type":"text","text":"hello"}])
+        );
+    }
+
+    #[test]
+    fn test_user_image_data_uri_becomes_base64_block() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let req = ChatRequest {
+            model: "anthropic/claude-sonnet-4-6".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![
+                    ContentPart::Text {
+                        text: "what is this?".to_string(),
+                    },
+                    ContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+                            detail: None,
+                        },
+                    },
+                ]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        let anthropic_req = to_anthropic_request(&req).unwrap();
+        // Exact wire shape per Anthropic Messages API (verified 2026-06-03).
+        let v = serde_json::to_value(&anthropic_req.messages[0]).unwrap();
+        assert_eq!(
+            v["content"],
+            serde_json::json!([
+                {"type":"text","text":"what is this?"},
+                {"type":"image","source":{
+                    "type":"base64","media_type":"image/png","data":"iVBORw0KGgo="
+                }}
+            ])
+        );
+    }
+
+    #[test]
+    fn test_user_image_http_url_becomes_url_block() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let req = ChatRequest {
+            model: "anthropic/claude-sonnet-4-6".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "https://example.com/cat.png".to_string(),
+                        detail: Some("high".to_string()),
+                    },
+                }]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        let anthropic_req = to_anthropic_request(&req).unwrap();
+        let v = serde_json::to_value(&anthropic_req.messages[0]).unwrap();
+        assert_eq!(
+            v["content"],
+            serde_json::json!([
+                {"type":"image","source":{
+                    "type":"url","url":"https://example.com/cat.png"
+                }}
+            ])
+        );
+    }
+
+    #[test]
+    fn test_malformed_image_data_uri_is_rejected_not_dropped() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let req = ChatRequest {
+            model: "anthropic/claude-sonnet-4-6".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        // No scheme — neither data: nor http(s).
+                        url: "not-a-valid-image".to_string(),
+                        detail: None,
+                    },
+                }]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        assert!(
+            to_anthropic_request(&req).is_err(),
+            "a malformed image URL must reject the request, not silently drop the image"
+        );
+    }
+
+    #[test]
+    fn test_data_uri_without_base64_rejected_at_adapter() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        // A `data:` URI lacking the `;base64` token (URL-encoded inline text)
+        // must be rejected at the ADAPTER level, not only the protocol unit
+        // test — forwarding it would corrupt the image source.
+        let req = ChatRequest {
+            model: "anthropic/claude-sonnet-4-6".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "data:image/png,rawnotbase64".to_string(),
+                        detail: None,
+                    },
+                }]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        assert!(
+            to_anthropic_request(&req).is_err(),
+            "a non-base64 data URI must be rejected at the adapter"
+        );
+    }
+
+    #[test]
+    fn test_image_in_system_message_is_rejected_not_dropped() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        // A WELL-FORMED image in a SYSTEM message. Anthropic's `system` param is
+        // a plain string, so `as_text()` would silently drop the image while the
+        // request still settles — the agent pays, the model never sees it. Must
+        // reject instead.
+        let req = ChatRequest {
+            model: "anthropic/claude-sonnet-4-6".to_string(),
+            messages: vec![
+                ChatMessage {
+                    role: Role::System,
+                    content: MessageContent::Parts(vec![
+                        ContentPart::Text {
+                            text: "context".to_string(),
+                        },
+                        ContentPart::ImageUrl {
+                            image_url: ImageUrl {
+                                url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+                                detail: None,
+                            },
+                        },
+                    ]),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                ChatMessage {
+                    role: Role::User,
+                    content: "hi".into(),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+            ],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        assert!(
+            to_anthropic_request(&req).is_err(),
+            "an image in a system message must reject the request, not be silently dropped"
+        );
     }
 
     #[test]
@@ -523,7 +846,7 @@ mod tests {
             tool_choice: None,
         };
 
-        let anthropic_req = to_anthropic_request(&req);
+        let anthropic_req = to_anthropic_request(&req).unwrap();
         assert_eq!(
             anthropic_req.system,
             Some("You are a helpful assistant.".to_string())
@@ -568,7 +891,7 @@ mod tests {
             tool_choice: None,
         };
 
-        let anthropic_req = to_anthropic_request(&req);
+        let anthropic_req = to_anthropic_request(&req).unwrap();
 
         // Both System and Developer messages should be extracted into the system param
         assert_eq!(
@@ -578,7 +901,8 @@ mod tests {
         // Only the User message should remain in messages
         assert_eq!(anthropic_req.messages.len(), 1);
         assert_eq!(anthropic_req.messages[0].role, "user");
-        assert_eq!(anthropic_req.messages[0].content, "Hello!");
+        assert_eq!(anthropic_req.messages[0].content.len(), 1);
+        assert_eq!(block_text(&anthropic_req.messages[0].content[0]), "Hello!");
     }
 
     #[test]

--- a/crates/gateway/src/providers/fallback.rs
+++ b/crates/gateway/src/providers/fallback.rs
@@ -8,35 +8,44 @@ use std::time::Instant;
 use tracing::{info, warn};
 
 use solvela_protocol::{ChatRequest, ChatResponse};
+use solvela_router::models::ModelRegistry;
 
 use super::health::ProviderHealthTracker;
 use super::{ChatStream, ProviderError, ProviderRegistry};
 
-/// Defense-in-depth backstop: reject any request whose messages carry image
-/// content parts before it can reach a provider serialization step.
+/// Error surfaced when image content reaches a provider-NAME dispatch path
+/// (`chat_with_fallback` / `stream_with_fallback`). These paths route by
+/// provider name with no per-model capability info, so they cannot perform the
+/// `supports_vision` gate the model-aware paths do — they fail closed rather
+/// than dispatch an image to an un-capability-checked provider.
+const IMAGE_ON_PROVIDER_NAME_PATH_ERR: &str =
+    "image content requires a vision-capability-checked path; the provider-name \
+     dispatch path does not support image input — route via a model-aware path";
+
+/// True if a candidate model is INELIGIBLE for an image-bearing request because
+/// its registry entry declares no vision support.
 ///
-/// Image/multimodal content is rejected with a nicer 415 at the HTTP route
-/// (`routes/chat/mod.rs`) before payment, but that is a single gate. This
-/// backstop covers every provider-DISPATCH entry point — the HTTP fallback
-/// variants plus the A2A dispatch leg (which funnels through
-/// `chat_with_model_fallback`) — so image content cannot be serialized to an
-/// upstream provider via any dispatch path. The A2A request-INTAKE leg
-/// (cost estimation in `handle_new_request`) does NOT pass through this module;
-/// it is safe separately because it builds `Text` content from a plain string,
-/// not from client image parts. Native image-block translation, capability
-/// gating, and image cost accounting are a tracked follow-up PR. Returns the
-/// module's `ProviderError` so the caller surfaces a failure rather than
-/// silently dropping (or billing for) image parts.
-fn reject_image_content(req: &ChatRequest) -> Result<(), ProviderError> {
-    if req.messages.iter().any(|m| m.content.has_image_parts()) {
-        tracing::error!(
-            model = %req.model,
-            "image/multimodal content reached provider dispatch — rejecting \
-             (backstop; should have been blocked upstream)"
-        );
-        return Err("image/multimodal content is not yet supported".into());
+/// The chat route gates the PRIMARY model on `supports_vision` (415 before
+/// payment), but failover/chain dispatch can re-target a DIFFERENT model after
+/// payment. Without this re-check, an image request whose primary is
+/// vision-capable could fail over to a non-vision model and be dispatched
+/// (agent paid; image silently dropped or a paid upstream 4xx). We therefore
+/// skip any candidate whose `(provider/model_id)` registry entry is non-vision.
+///
+/// Lookup mirrors the primary gate: the registry is keyed by the canonical
+/// `provider/model_id`. A candidate the registry does not know is treated as
+/// ineligible for images (fail-closed) — we will not dispatch an image to a
+/// model whose capability we cannot confirm.
+///
+/// The `format!("{provider}/{model_id}")`-then-bare-`model_id` lookup order
+/// mirrors `model_fallback_chain`'s key format (canonical `provider/model_id`
+/// first, bare id as a fallback), and is fail-closed: an unknown key → reject.
+fn candidate_rejects_images(registry: &ModelRegistry, provider: &str, model_id: &str) -> bool {
+    let key = format!("{provider}/{model_id}");
+    match registry.get(&key).or_else(|| registry.get(model_id)) {
+        Some(entry) => !entry.supports_vision,
+        None => true,
     }
-    Ok(())
 }
 
 /// Result from a fallback-aware request. Tracks whether the response
@@ -59,12 +68,13 @@ pub struct FallbackResult<T> {
 pub async fn chat_with_model_fallback(
     providers: &ProviderRegistry,
     health: &ProviderHealthTracker,
+    registry: &ModelRegistry,
     primary_provider: &str,
     primary_model: &str,
     req: ChatRequest,
 ) -> Result<FallbackResult<ChatResponse>, ProviderError> {
-    reject_image_content(&req)?;
     let chain = model_fallback_chain(primary_provider, primary_model);
+    let request_has_images = req.messages.iter().any(|m| m.content.has_image_parts());
     let mut last_error: Option<ProviderError> = None;
 
     for (prov, model_id) in &chain {
@@ -73,6 +83,13 @@ pub async fn chat_with_model_fallback(
             Some(p) => p,
             None => continue,
         };
+
+        // Skip a non-vision model for an image-bearing request (post-payment
+        // failover must not dispatch an image to a model that can't see it).
+        if request_has_images && candidate_rejects_images(registry, prov, model_id) {
+            warn!(provider = %prov, model = %model_id, "skipping non-vision model for image request");
+            continue;
+        }
 
         // Skip if model circuit is open
         if !health.is_model_available(prov, model_id).await {
@@ -130,7 +147,13 @@ pub async fn chat_with_model_fallback(
         }
     }
 
-    Err(last_error.unwrap_or_else(|| "no available models in fallback chain".into()))
+    Err(last_error.unwrap_or_else(|| {
+        if request_has_images {
+            "no vision-capable model available in fallback chain for image request".into()
+        } else {
+            "no available models in fallback chain".into()
+        }
+    }))
 }
 
 /// Execute a streaming chat completion with model-aware fallback.
@@ -140,12 +163,13 @@ pub async fn chat_with_model_fallback(
 pub async fn stream_with_model_fallback(
     providers: &ProviderRegistry,
     health: &ProviderHealthTracker,
+    registry: &ModelRegistry,
     primary_provider: &str,
     primary_model: &str,
     req: ChatRequest,
 ) -> Result<FallbackResult<ChatStream>, ProviderError> {
-    reject_image_content(&req)?;
     let chain = model_fallback_chain(primary_provider, primary_model);
+    let request_has_images = req.messages.iter().any(|m| m.content.has_image_parts());
     let mut last_error: Option<ProviderError> = None;
 
     for (prov, model_id) in &chain {
@@ -153,6 +177,11 @@ pub async fn stream_with_model_fallback(
             Some(p) => p,
             None => continue,
         };
+
+        if request_has_images && candidate_rejects_images(registry, prov, model_id) {
+            warn!(provider = %prov, model = %model_id, "skipping non-vision model for image stream");
+            continue;
+        }
 
         if !health.is_model_available(prov, model_id).await {
             info!(provider = %prov, model = %model_id, "skipping model for streaming (circuit open)");
@@ -206,20 +235,34 @@ pub async fn stream_with_model_fallback(
         }
     }
 
-    Err(last_error.unwrap_or_else(|| "no available models for streaming in fallback chain".into()))
+    Err(last_error.unwrap_or_else(|| {
+        if request_has_images {
+            "no vision-capable model available in fallback chain for image stream".into()
+        } else {
+            "no available models for streaming in fallback chain".into()
+        }
+    }))
 }
 
 /// Execute a chat completion with fallback.
 ///
 /// Tries providers in the given order, skipping any whose circuit is open.
 /// Records success/failure metrics for circuit breaker evaluation.
+///
+// NOTE: this provider-NAME dispatch path does NOT perform `supports_vision`
+// gating — it routes by provider name and has no per-model capability info. An
+// image request is therefore rejected here fail-closed (never silently
+// dispatched to an un-capability-checked provider). Use the model-aware
+// `*_with_model_fallback` / `*_with_chain` paths for vision.
 pub async fn chat_with_fallback(
     providers: &ProviderRegistry,
     health: &ProviderHealthTracker,
     provider_names: &[String],
     req: ChatRequest,
 ) -> Result<ChatResponse, ProviderError> {
-    reject_image_content(&req)?;
+    if req.messages.iter().any(|m| m.content.has_image_parts()) {
+        return Err(IMAGE_ON_PROVIDER_NAME_PATH_ERR.into());
+    }
     let mut last_error: Option<ProviderError> = None;
 
     for name in provider_names {
@@ -265,13 +308,19 @@ pub async fn chat_with_fallback(
 }
 
 /// Execute a streaming chat completion with fallback.
+///
+// NOTE: like `chat_with_fallback`, this provider-NAME dispatch path does NOT do
+// `supports_vision` gating, so image content is rejected here by design. Use the
+// model-aware `*_with_model_fallback` / `*_with_chain` paths for vision.
 pub async fn stream_with_fallback(
     providers: &ProviderRegistry,
     health: &ProviderHealthTracker,
     provider_names: &[String],
     req: ChatRequest,
 ) -> Result<ChatStream, ProviderError> {
-    reject_image_content(&req)?;
+    if req.messages.iter().any(|m| m.content.has_image_parts()) {
+        return Err(IMAGE_ON_PROVIDER_NAME_PATH_ERR.into());
+    }
     let mut last_error: Option<ProviderError> = None;
 
     for name in provider_names {
@@ -308,11 +357,12 @@ pub async fn stream_with_fallback(
 pub async fn chat_with_chain(
     providers: &ProviderRegistry,
     health: &ProviderHealthTracker,
+    registry: &ModelRegistry,
     chain: &[(String, String)],
     original_model: &str,
     req: ChatRequest,
 ) -> Result<FallbackResult<ChatResponse>, ProviderError> {
-    reject_image_content(&req)?;
+    let request_has_images = req.messages.iter().any(|m| m.content.has_image_parts());
     let mut last_error: Option<ProviderError> = None;
 
     for (prov, model_id) in chain {
@@ -320,6 +370,11 @@ pub async fn chat_with_chain(
             Some(p) => p,
             None => continue,
         };
+
+        if request_has_images && candidate_rejects_images(registry, prov, model_id) {
+            warn!(provider = %prov, model = %model_id, "skipping non-vision model for image request (chain)");
+            continue;
+        }
 
         if !health.is_model_available(prov, model_id).await {
             info!(provider = %prov, model = %model_id, "skipping model (circuit open)");
@@ -372,18 +427,25 @@ pub async fn chat_with_chain(
         }
     }
 
-    Err(last_error.unwrap_or_else(|| "no available models in chain".into()))
+    Err(last_error.unwrap_or_else(|| {
+        if request_has_images {
+            "no vision-capable model available in chain for image request".into()
+        } else {
+            "no available models in chain".into()
+        }
+    }))
 }
 
 /// Execute a streaming chat completion using an explicit model chain.
 pub async fn stream_with_chain(
     providers: &ProviderRegistry,
     health: &ProviderHealthTracker,
+    registry: &ModelRegistry,
     chain: &[(String, String)],
     original_model: &str,
     req: ChatRequest,
 ) -> Result<FallbackResult<ChatStream>, ProviderError> {
-    reject_image_content(&req)?;
+    let request_has_images = req.messages.iter().any(|m| m.content.has_image_parts());
     let mut last_error: Option<ProviderError> = None;
 
     for (prov, model_id) in chain {
@@ -391,6 +453,11 @@ pub async fn stream_with_chain(
             Some(p) => p,
             None => continue,
         };
+
+        if request_has_images && candidate_rejects_images(registry, prov, model_id) {
+            warn!(provider = %prov, model = %model_id, "skipping non-vision model for image stream (chain)");
+            continue;
+        }
 
         if !health.is_model_available(prov, model_id).await {
             info!(provider = %prov, model = %model_id, "skipping model for streaming (circuit open)");
@@ -438,7 +505,13 @@ pub async fn stream_with_chain(
         }
     }
 
-    Err(last_error.unwrap_or_else(|| "no available models for streaming in chain".into()))
+    Err(last_error.unwrap_or_else(|| {
+        if request_has_images {
+            "no vision-capable model available in chain for image stream".into()
+        } else {
+            "no available models for streaming in chain".into()
+        }
+    }))
 }
 
 /// Get the ordered fallback list for a provider.
@@ -567,9 +640,76 @@ pub fn model_fallback_chain<'a>(provider: &'a str, model: &'a str) -> Vec<(&'a s
 mod tests {
     use super::*;
 
-    use solvela_protocol::{ChatMessage, ContentPart, ImageUrl, MessageContent, Role};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use solvela_protocol::{
+        ChatMessage, ContentPart, ImageUrl, MessageContent, ModelRegistration, Role,
+    };
+    use solvela_router::models::ModelRegistry;
 
     use crate::providers::health::{CircuitBreakerConfig, ProviderHealthTracker};
+    use crate::providers::{ChatStream, LLMProvider, ProviderError, ProviderRegistry};
+
+    /// A provider that records every model id it is dispatched, and always
+    /// fails the call (so the loop advances to the next chain entry). Lets a
+    /// test assert that a non-vision model is NEVER dispatched for an image
+    /// request.
+    struct RecordingProvider {
+        name: String,
+        dispatched: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl LLMProvider for RecordingProvider {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn supported_models(&self) -> Vec<ModelRegistration> {
+            vec![]
+        }
+        async fn chat_completion(&self, req: ChatRequest) -> Result<ChatResponse, ProviderError> {
+            self.dispatched.lock().unwrap().push(req.model.clone());
+            Err("simulated provider failure".into())
+        }
+        async fn chat_completion_stream(
+            &self,
+            req: ChatRequest,
+        ) -> Result<ChatStream, ProviderError> {
+            self.dispatched.lock().unwrap().push(req.model.clone());
+            Err("simulated provider failure".into())
+        }
+    }
+
+    /// Registry with a vision-capable and a non-vision model under the same
+    /// provider, so a chain can mix them.
+    fn vision_mixed_registry() -> ModelRegistry {
+        ModelRegistry::from_toml(
+            r#"
+[models.vision-model]
+provider = "openai"
+model_id = "vis"
+display_name = "Vision"
+input_cost_per_million = 1.0
+output_cost_per_million = 1.0
+context_window = 128000
+supports_streaming = true
+supports_vision = true
+
+[models.text-model]
+provider = "openai"
+model_id = "txt"
+display_name = "Text"
+input_cost_per_million = 1.0
+output_cost_per_million = 1.0
+context_window = 128000
+supports_streaming = true
+"#,
+        )
+        .unwrap()
+    }
 
     /// Build a request whose single message carries an image content part.
     fn image_request() -> ChatRequest {
@@ -601,54 +741,293 @@ mod tests {
         }
     }
 
-    /// FIX 1 backstop: an image-bearing request passed directly to the shared
-    /// dispatch chokepoint must be rejected and never reach a provider. The
-    /// registry is empty, so if the guard did NOT fire we'd see the
-    /// "no available models" exhaustion error instead — asserting the guard's
-    /// own message proves the rejection happens *before* dispatch.
+    /// FIX 1 (PR #2 round-1 review): post-payment failover must NOT dispatch an
+    /// image request to a non-vision model. The chain's first entry is
+    /// vision-capable (and is dispatched, then fails); the second entry is
+    /// non-vision and must be SKIPPED — never dispatched — and the call must
+    /// surface a clear vision-exhaustion error rather than silently dropping
+    /// the image at a text-only model that the agent already paid for.
     #[tokio::test]
-    async fn image_content_rejected_before_provider_dispatch() {
-        let providers = ProviderRegistry::from_env(reqwest::Client::new());
+    async fn image_request_never_dispatches_to_non_vision_fallback() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
+        let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
+        let registry = vision_mixed_registry();
+
+        // vision model first (dispatched, fails), then NON-vision model.
+        let chain = vec![
+            ("openai".to_string(), "vis".to_string()),
+            ("openai".to_string(), "txt".to_string()),
+        ];
+        let err = chat_with_chain(
+            &providers,
+            &health,
+            &registry,
+            &chain,
+            "vis",
+            image_request(),
+        )
+        .await
+        .expect_err("must error: only the non-vision fallback remained");
+
+        let calls = dispatched.lock().unwrap().clone();
+        assert!(
+            calls.contains(&"vis".to_string()),
+            "the vision-capable model should have been dispatched, got {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"txt".to_string()),
+            "the non-vision fallback model must NEVER be dispatched for an image \
+             request, got {calls:?}"
+        );
+        // The surfaced error is the vision model's own provider failure (it WAS
+        // dispatched and failed). The point of this test is the skip, asserted
+        // above. The all-non-vision case below pins the vision-exhaustion error.
+        assert!(
+            err.to_string().contains("simulated provider failure"),
+            "{err}"
+        );
+    }
+
+    /// When EVERY candidate is non-vision, an image request must surface a clear
+    /// vision-exhaustion error and dispatch to NONE of them.
+    #[tokio::test]
+    async fn image_request_all_non_vision_surfaces_vision_error() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
+        let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
+        let registry = vision_mixed_registry();
+
+        let chain = vec![("openai".to_string(), "txt".to_string())];
+        let err = chat_with_chain(
+            &providers,
+            &health,
+            &registry,
+            &chain,
+            "txt",
+            image_request(),
+        )
+        .await
+        .expect_err("an all-non-vision chain must error for an image request");
+
+        assert!(
+            dispatched.lock().unwrap().is_empty(),
+            "no non-vision model may be dispatched for an image request"
+        );
+        assert!(
+            err.to_string().contains("vision-capable"),
+            "error must name the vision-capability exhaustion, got: {err}"
+        );
+    }
+
+    /// A TEXT request must still be free to fall back to the non-vision model —
+    /// the vision skip is scoped to image-bearing requests only.
+    #[tokio::test]
+    async fn text_request_may_dispatch_to_non_vision_fallback() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
+        let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
+        let registry = vision_mixed_registry();
+
+        let chain = vec![
+            ("openai".to_string(), "vis".to_string()),
+            ("openai".to_string(), "txt".to_string()),
+        ];
+        let mut text_req = image_request();
+        text_req.messages = vec![ChatMessage {
+            role: Role::User,
+            content: "hello".into(),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }];
+        let _ = chat_with_chain(&providers, &health, &registry, &chain, "vis", text_req).await;
+
+        let calls = dispatched.lock().unwrap().clone();
+        assert!(
+            calls.contains(&"txt".to_string()),
+            "a text request must be allowed to fall back to the non-vision model, got {calls:?}"
+        );
+    }
+
+    /// The streaming chain path applies the same vision skip.
+    #[tokio::test]
+    async fn image_stream_never_dispatches_to_non_vision_fallback() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
+        let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
+        let registry = vision_mixed_registry();
+
+        let chain = vec![
+            ("openai".to_string(), "vis".to_string()),
+            ("openai".to_string(), "txt".to_string()),
+        ];
+        let err = stream_with_chain(
+            &providers,
+            &health,
+            &registry,
+            &chain,
+            "vis",
+            image_request(),
+        )
+        .await
+        .map(|_| ())
+        .expect_err("must error: only the non-vision fallback remained");
+
+        let calls = dispatched.lock().unwrap().clone();
+        assert!(!calls.contains(&"txt".to_string()), "got {calls:?}");
+        // Surfaced error is the vision model's dispatch failure; the skip is the
+        // asserted invariant.
+        assert!(
+            err.to_string().contains("simulated provider failure"),
+            "got: {err}"
+        );
+    }
+
+    /// FIX 1 (PR #2 round-2 review): the provider-NAME dispatch path
+    /// `chat_with_fallback` does NO `supports_vision` gating (it has no
+    /// per-model capability info — it dispatches by provider name only). An
+    /// image-bearing request must therefore be rejected at the top, fail-closed,
+    /// and NEVER dispatched to any provider. Round-1 removed the old
+    /// `reject_image_content` backstop here without a replacement; this restores
+    /// it as a hard error.
+    #[tokio::test]
+    async fn chat_with_fallback_rejects_image_request_without_dispatch() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
         let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
 
-        let err =
-            chat_with_model_fallback(&providers, &health, "openai", "gpt-4o", image_request())
-                .await
-                .expect_err("image content must be rejected by the backstop");
+        let err = chat_with_fallback(
+            &providers,
+            &health,
+            &["openai".to_string()],
+            image_request(),
+        )
+        .await
+        .expect_err("provider-name dispatch must reject image content");
+
         assert!(
-            err.to_string()
-                .contains("image/multimodal content is not yet supported"),
-            "must fail via the image backstop, not provider exhaustion: {err}"
+            dispatched.lock().unwrap().is_empty(),
+            "no provider may be dispatched an image via the un-capability-checked \
+             provider-name path"
         );
+        assert!(
+            err.to_string().contains("vision"),
+            "error must name the vision-unsupported reason, got: {err}"
+        );
+    }
 
-        // The same guard protects the streaming, provider-name, and chain
-        // variants — the four dispatch paths the HTTP route can take. The
-        // streaming `Ok` payload (`FallbackResult<ChatStream>`) is not `Debug`,
-        // so map it to `()` before unwrapping the error.
-        let err =
-            stream_with_model_fallback(&providers, &health, "openai", "gpt-4o", image_request())
-                .await
-                .map(|_| ())
-                .expect_err("streaming dispatch must also reject image content");
-        assert!(err
-            .to_string()
-            .contains("image/multimodal content is not yet supported"));
+    /// Streaming twin of the above: `stream_with_fallback` must also reject image
+    /// content fail-closed without dispatching.
+    #[tokio::test]
+    async fn stream_with_fallback_rejects_image_request_without_dispatch() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
+        let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
 
-        let chain = vec![("openai".to_string(), "gpt-4o".to_string())];
-        let err = chat_with_chain(&providers, &health, &chain, "gpt-4o", image_request())
-            .await
-            .expect_err("chain dispatch must also reject image content");
-        assert!(err
-            .to_string()
-            .contains("image/multimodal content is not yet supported"));
+        let err = stream_with_fallback(
+            &providers,
+            &health,
+            &["openai".to_string()],
+            image_request(),
+        )
+        .await
+        .map(|_| ())
+        .expect_err("provider-name stream dispatch must reject image content");
 
-        let names = vec!["openai".to_string()];
-        let err = chat_with_fallback(&providers, &health, &names, image_request())
-            .await
-            .expect_err("provider-name dispatch must also reject image content");
-        assert!(err
-            .to_string()
-            .contains("image/multimodal content is not yet supported"));
+        assert!(
+            dispatched.lock().unwrap().is_empty(),
+            "no provider may be dispatched an image via the un-capability-checked \
+             provider-name stream path"
+        );
+        assert!(
+            err.to_string().contains("vision"),
+            "error must name the vision-unsupported reason, got: {err}"
+        );
+    }
+
+    /// A TEXT request through the provider-name path must still dispatch normally
+    /// (the rejection is scoped to image-bearing requests only).
+    #[tokio::test]
+    async fn chat_with_fallback_dispatches_text_request() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
+        let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
+
+        let mut text_req = image_request();
+        text_req.messages = vec![ChatMessage {
+            role: Role::User,
+            content: "hello".into(),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }];
+        // Provider always fails, but the point is that it WAS dispatched (the
+        // image guard did not short-circuit a text request).
+        let _ = chat_with_fallback(&providers, &health, &["openai".to_string()], text_req).await;
+        assert!(
+            dispatched
+                .lock()
+                .unwrap()
+                .contains(&"openai/gpt-4o".to_string()),
+            "a text request must be dispatched through the provider-name path"
+        );
     }
 
     #[test]

--- a/crates/gateway/src/providers/fallback.rs
+++ b/crates/gateway/src/providers/fallback.rs
@@ -741,6 +741,41 @@ supports_streaming = true
         }
     }
 
+    /// Registry mirroring a real `model_fallback_chain` arm so the
+    /// `*_with_model_fallback` paths (which build the chain INTERNALLY from
+    /// `model_fallback_chain`, unlike the `*_with_chain` paths that take an
+    /// explicit chain) can be exercised. For `("openai", "gpt-4o")` the chain is
+    /// `[gpt-4o, claude-sonnet-4-6, gemini-3.1-pro, grok-3]`; here the primary
+    /// `openai/gpt-4o` is vision-capable and the next-in-chain
+    /// `anthropic/claude-sonnet-4-6` is declared NON-vision, so a correct
+    /// implementation must dispatch the primary (then fail) and SKIP the
+    /// non-vision fallback rather than dispatch an image to it post-payment.
+    fn gpt4o_chain_mixed_registry() -> ModelRegistry {
+        ModelRegistry::from_toml(
+            r#"
+[models.gpt-4o]
+provider = "openai"
+model_id = "gpt-4o"
+display_name = "GPT-4o"
+input_cost_per_million = 1.0
+output_cost_per_million = 1.0
+context_window = 128000
+supports_streaming = true
+supports_vision = true
+
+[models.claude-sonnet]
+provider = "anthropic"
+model_id = "claude-sonnet-4-6"
+display_name = "Claude Sonnet"
+input_cost_per_million = 1.0
+output_cost_per_million = 1.0
+context_window = 128000
+supports_streaming = true
+"#,
+        )
+        .unwrap()
+    }
+
     /// FIX 1 (PR #2 round-1 review): post-payment failover must NOT dispatch an
     /// image request to a non-vision model. The chain's first entry is
     /// vision-capable (and is dispatched, then fails); the second entry is
@@ -791,6 +826,123 @@ supports_streaming = true
         // The surfaced error is the vision model's own provider failure (it WAS
         // dispatched and failed). The point of this test is the skip, asserted
         // above. The all-non-vision case below pins the vision-exhaustion error.
+        assert!(
+            err.to_string().contains("simulated provider failure"),
+            "{err}"
+        );
+    }
+
+    /// FIX 1 (test-coverage review): the `*_with_chain` paths are tested above,
+    /// but `chat_with_model_fallback` — which `routes/chat/provider.rs` and the
+    /// A2A handler actually call — builds its chain INTERNALLY via
+    /// `model_fallback_chain` and had no direct vision-skip test. A regression
+    /// that reverted the `candidate_rejects_images` check inside THIS function
+    /// would slip past CI. This pins it: the generated chain for
+    /// `("openai","gpt-4o")` is `[gpt-4o, claude-sonnet-4-6, ...]`; with a
+    /// registry where the primary is vision-capable and the next entry is
+    /// non-vision, the primary is dispatched (and fails) but the non-vision
+    /// fallback must NEVER be dispatched.
+    #[tokio::test]
+    async fn model_fallback_image_request_never_dispatches_to_non_vision() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        // The non-vision fallback's provider IS configured — so if the skip were
+        // broken, the image WOULD be dispatched to it. That is what makes the
+        // negative assertion meaningful.
+        map.insert(
+            "anthropic".to_string(),
+            Arc::new(RecordingProvider {
+                name: "anthropic".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
+        let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
+        let registry = gpt4o_chain_mixed_registry();
+
+        // primary openai/gpt-4o (vision) is dispatched then fails; the chain's
+        // next entry anthropic/claude-sonnet-4-6 (non-vision) must be skipped.
+        let err = chat_with_model_fallback(
+            &providers,
+            &health,
+            &registry,
+            "openai",
+            "gpt-4o",
+            image_request(),
+        )
+        .await
+        .expect_err("must error once the vision primary fails and only non-vision remains");
+
+        let calls = dispatched.lock().unwrap().clone();
+        assert!(
+            calls.contains(&"gpt-4o".to_string()),
+            "the vision-capable primary should have been dispatched, got {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"claude-sonnet-4-6".to_string()),
+            "the non-vision fallback must NEVER be dispatched for an image request \
+             via chat_with_model_fallback, got {calls:?}"
+        );
+        assert!(
+            err.to_string().contains("simulated provider failure"),
+            "{err}"
+        );
+    }
+
+    /// Streaming twin: `stream_with_model_fallback` must apply the same vision
+    /// skip on its internally-built chain. Same coverage-gap rationale as the
+    /// non-streaming test above.
+    #[tokio::test]
+    async fn model_fallback_image_stream_never_dispatches_to_non_vision() {
+        let dispatched = Arc::new(Mutex::new(Vec::<String>::new()));
+        let mut map: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        map.insert(
+            "openai".to_string(),
+            Arc::new(RecordingProvider {
+                name: "openai".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        map.insert(
+            "anthropic".to_string(),
+            Arc::new(RecordingProvider {
+                name: "anthropic".to_string(),
+                dispatched: dispatched.clone(),
+            }),
+        );
+        let providers = ProviderRegistry::from_providers(map);
+        let health = ProviderHealthTracker::new(CircuitBreakerConfig::default());
+        let registry = gpt4o_chain_mixed_registry();
+
+        let err = stream_with_model_fallback(
+            &providers,
+            &health,
+            &registry,
+            "openai",
+            "gpt-4o",
+            image_request(),
+        )
+        .await
+        .map(|_| ())
+        .expect_err("must error once the vision primary fails and only non-vision remains");
+
+        let calls = dispatched.lock().unwrap().clone();
+        assert!(
+            calls.contains(&"gpt-4o".to_string()),
+            "the vision-capable primary should have been dispatched, got {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"claude-sonnet-4-6".to_string()),
+            "the non-vision fallback must NEVER be dispatched for an image stream \
+             via stream_with_model_fallback, got {calls:?}"
+        );
         assert!(
             err.to_string().contains("simulated provider failure"),
             "{err}"

--- a/crates/gateway/src/providers/google.rs
+++ b/crates/gateway/src/providers/google.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 use solvela_protocol::{
-    ChatChoice, ChatMessage, ChatRequest, ChatResponse, ModelRegistration, Role, Usage,
+    ChatChoice, ChatMessage, ChatRequest, ChatResponse, ContentPart, MessageContent,
+    ModelRegistration, ParseImageError, ParsedImage, Role, Usage,
 };
 
 use super::LLMProvider;
@@ -48,12 +49,79 @@ struct GeminiContent {
     parts: Vec<GeminiPart>,
 }
 
+/// A single Gemini content part.
+///
+/// A part carries exactly ONE payload kind. We model that as an UNTAGGED enum
+/// so an empty part or a multi-field part is unrepresentable by construction:
+/// a text part serializes to `{"text":...}`, an inline image to
+/// `{"inlineData":{...}}`, and a remote image to `{"fileData":{...}}`.
+///
+/// On the RESPONSE side `serde(untagged)` tries each variant in declaration
+/// order; an unrecognized part kind (`thought`, `executableCode`, …) falls
+/// through to [`GeminiPart::Other`] (forward-compat) and is dropped by the
+/// response reader's `match` rather than failing the whole deserialization.
+///
+/// Wire schema verified against the Gemini API docs (ai.google.dev, fetched
+/// 2026-06-03):
+///   text:        {"text":"..."}
+///   inline image:{"inlineData":{"mimeType":"image/png","data":"<b64>"}}
+///   remote image:{"fileData":{"mimeType":"image/png","fileUri":"https://..."}}
+/// Field names are camelCase on the wire (`inlineData`, `mimeType`, `fileUri`).
+///
+/// VARIANT ORDER IS LOAD-BEARING. `untagged` takes the first variant that
+/// deserializes; `Other` (a permissive catch-all) MUST stay last so the typed
+/// variants are tried first.
 #[derive(Debug, Serialize, Deserialize)]
-struct GeminiPart {
-    #[serde(default)]
-    text: String,
-    // Newer Gemini models may return `thought`, `executableCode`, etc.
-    // These are silently ignored via default serde behavior.
+#[serde(untagged)]
+enum GeminiPart {
+    Text {
+        text: String,
+    },
+    // NOTE: for an UNTAGGED enum, an enum-level `rename_all` does NOT rename the
+    // fields inside struct variants — each variant needs its own `rename_all`,
+    // or the wire field is the raw snake_case name (`inline_data`) which Gemini
+    // rejects. The per-variant `rename_all = "camelCase"` is load-bearing.
+    #[serde(rename_all = "camelCase")]
+    InlineData {
+        inline_data: GeminiInlineData,
+    },
+    #[serde(rename_all = "camelCase")]
+    FileData {
+        file_data: GeminiFileData,
+    },
+    /// Forward-compat catch-all for response part kinds we don't model
+    /// (`thought`, `executableCode`, …). Never constructed for requests; the
+    /// response reader skips it. The captured value is intentionally unread —
+    /// the variant exists only so untagged deserialization of an unknown part
+    /// kind succeeds instead of failing the whole response.
+    #[serde(skip_serializing)]
+    Other(#[allow(dead_code)] serde_json::Value),
+}
+
+impl GeminiPart {
+    fn text(s: String) -> Self {
+        GeminiPart::Text { text: s }
+    }
+}
+
+/// Outbound-only when constructed for a request; also read back on responses,
+/// so it keeps `Deserialize`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiInlineData {
+    mime_type: String,
+    data: String,
+}
+
+/// Constructed only for requests, but `Deserialize` is REQUIRED: it is a
+/// payload of the untagged [`GeminiPart`] enum, whose derived `Deserialize`
+/// (used to read responses) needs every variant payload to be `Deserialize`.
+/// Removing it does not compile.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiFileData {
+    mime_type: String,
+    file_uri: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -115,46 +183,127 @@ fn validate_gemini_model_name(model: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn to_gemini_request(req: &ChatRequest) -> GeminiRequest {
-    // Extract system instruction
+/// Infer a concrete image MIME type for Gemini's `fileData.mimeType` from a
+/// remote URL's path extension.
+///
+/// `fileData` requires a real MIME type; `image/*` is rejected by the API. The
+/// OpenAI `image_url.url` contract carries no type, so we sniff the path
+/// extension (ignoring any query string), restricted to the formats Gemini
+/// decodes (png/jpeg/webp). Anything unrecognized falls back to `image/jpeg` —
+/// the most common web format — rather than a wildcard. The type is advisory;
+/// Gemini ultimately sniffs the fetched bytes, but it must be a valid value.
+fn mime_type_from_url(url: &str) -> String {
+    // Strip query/fragment so `?v=2` / `#frag` don't defeat the extension match.
+    let path = url
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(url)
+        .trim_end_matches('/');
+    let ext = path.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+    match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        // Gemini does not support gif; fall back to jpeg (advisory only).
+        _ => "image/jpeg",
+    }
+    .to_string()
+}
+
+/// Translate one OpenAI [`MessageContent`] into Gemini parts.
+///
+/// Text-only content becomes a single text part. Multimodal content preserves
+/// part ORDER and translates each image via [`ImageUrl::parse`]: a `data:` URI
+/// → `inlineData` (base64), an http(s) URL → `fileData` (`fileUri`). A
+/// malformed image URL returns `Err` so the image is never silently dropped.
+fn content_to_gemini_parts(content: &MessageContent) -> Result<Vec<GeminiPart>, String> {
+    match content {
+        MessageContent::Text(s) => Ok(vec![GeminiPart::text(s.clone())]),
+        MessageContent::Parts(parts) => {
+            let mut out = Vec::with_capacity(parts.len());
+            for part in parts {
+                match part {
+                    ContentPart::Text { text } => out.push(GeminiPart::text(text.clone())),
+                    ContentPart::ImageUrl { image_url } => {
+                        let p = match image_url
+                            .parse()
+                            .map_err(|e: ParseImageError| e.to_string())?
+                        {
+                            ParsedImage::Base64 { media_type, data } => GeminiPart::InlineData {
+                                inline_data: GeminiInlineData {
+                                    mime_type: media_type,
+                                    data,
+                                },
+                            },
+                            ParsedImage::Url { url } => GeminiPart::FileData {
+                                file_data: GeminiFileData {
+                                    // Gemini's `fileData` requires a concrete
+                                    // MIME type — `image/*` is NOT a valid value
+                                    // and the API rejects it. OpenAI image_url
+                                    // URLs don't carry a type, so infer it from
+                                    // the URL path extension, defaulting to JPEG.
+                                    mime_type: mime_type_from_url(&url),
+                                    file_uri: url,
+                                },
+                            },
+                        };
+                        out.push(p);
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+}
+
+fn to_gemini_request(req: &ChatRequest) -> Result<GeminiRequest, String> {
+    // Extract system instruction. An image in a system/developer message would
+    // be silently dropped by `as_text()` while the vision gate still accepts the
+    // request — the agent pays, the model never sees it. Reject it explicitly.
     let system_instruction: Option<GeminiContent> = {
-        let system_text: Vec<String> = req
+        let mut system_text: Vec<String> = Vec::new();
+        for m in req
             .messages
             .iter()
             .filter(|m| m.role == Role::System || m.role == Role::Developer)
-            .map(|m| m.content.as_text().into_owned())
-            .collect();
+        {
+            if m.content.has_image_parts() {
+                return Err(
+                    "image content is not supported in system/developer messages; \
+                     place images in a user message"
+                        .to_string(),
+                );
+            }
+            system_text.push(m.content.as_text().into_owned());
+        }
 
         if system_text.is_empty() {
             None
         } else {
             Some(GeminiContent {
                 role: None,
-                parts: vec![GeminiPart {
-                    text: system_text.join("\n\n"),
-                }],
+                parts: vec![GeminiPart::text(system_text.join("\n\n"))],
             })
         }
     };
 
     // Convert messages (excluding system) to Gemini contents
-    let contents: Vec<GeminiContent> = req
+    let mut contents: Vec<GeminiContent> = Vec::new();
+    for m in req
         .messages
         .iter()
         .filter(|m| m.role != Role::System && m.role != Role::Developer && m.role != Role::Unknown)
-        .map(|m| GeminiContent {
-            role: Some(match m.role {
-                Role::User => "user".to_string(),
-                Role::Assistant => "model".to_string(),
-                Role::System | Role::Developer => "user".to_string(), // filtered above, but safe fallback
-                Role::Tool => "user".to_string(), // Gemini uses "user" for tool results
-                Role::Unknown => "user".to_string(), // filtered above; safe fallback for forward-compat
-            }),
-            parts: vec![GeminiPart {
-                text: m.content.as_text().into_owned(),
-            }],
-        })
-        .collect();
+    {
+        let role = Some(match m.role {
+            Role::User => "user".to_string(),
+            Role::Assistant => "model".to_string(),
+            Role::System | Role::Developer => "user".to_string(), // filtered above, but safe fallback
+            Role::Tool => "user".to_string(), // Gemini uses "user" for tool results
+            Role::Unknown => "user".to_string(), // filtered above; safe fallback for forward-compat
+        });
+        let parts = content_to_gemini_parts(&m.content)?;
+        contents.push(GeminiContent { role, parts });
+    }
 
     let generation_config =
         if req.max_tokens.is_some() || req.temperature.is_some() || req.top_p.is_some() {
@@ -167,11 +316,11 @@ fn to_gemini_request(req: &ChatRequest) -> GeminiRequest {
             None
         };
 
-    GeminiRequest {
+    Ok(GeminiRequest {
         contents,
         system_instruction,
         generation_config,
-    }
+    })
 }
 
 fn from_gemini_response(resp: GeminiResponse, original_model: &str) -> ChatResponse {
@@ -181,7 +330,15 @@ fn from_gemini_response(resp: GeminiResponse, original_model: &str) -> ChatRespo
                 .content
                 .parts
                 .iter()
-                .map(|p| p.text.as_str())
+                .filter_map(|p| match p {
+                    GeminiPart::Text { text } => Some(text.as_str()),
+                    // Non-text response parts (inline/file data, or any
+                    // forward-compat `Other` kind like `thought`) contribute no
+                    // assistant text and are skipped.
+                    GeminiPart::InlineData { .. }
+                    | GeminiPart::FileData { .. }
+                    | GeminiPart::Other(_) => None,
+                })
                 .collect::<Vec<_>>()
                 .join("");
             let reason = c.finish_reason.as_ref().map(|r| match r.as_str() {
@@ -281,7 +438,8 @@ impl LLMProvider for GoogleProvider {
             model_name
         );
 
-        let gemini_req = to_gemini_request(&req);
+        let gemini_req = to_gemini_request(&req)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
         let req_body = serde_json::to_value(&gemini_req)?;
         let response = super::retry_with_backoff(2, || {
@@ -324,8 +482,16 @@ impl LLMProvider for GoogleProvider {
 mod tests {
     use super::*;
 
+    /// Text of a `GeminiPart::Text`, else `None`.
+    fn part_text(p: &GeminiPart) -> Option<&str> {
+        match p {
+            GeminiPart::Text { text } => Some(text.as_str()),
+            _ => None,
+        }
+    }
+
     #[test]
-    fn test_gemini_user_text_parts_flattened_to_space_joined_string() {
+    fn test_gemini_user_text_parts_become_separate_parts() {
         use solvela_protocol::vision::{ContentPart, MessageContent};
         let req = ChatRequest {
             model: "google/gemini-2.5-flash".to_string(),
@@ -351,10 +517,226 @@ mod tests {
             tool_choice: None,
         };
 
-        let gemini_req = to_gemini_request(&req);
+        let gemini_req = to_gemini_request(&req).unwrap();
         assert_eq!(gemini_req.contents.len(), 1);
-        // String-based adapter flattens text parts with a single space.
-        assert_eq!(gemini_req.contents[0].parts[0].text, "first second");
+        // Each text part maps to its own text part, preserving order.
+        assert_eq!(gemini_req.contents[0].parts.len(), 2);
+        assert_eq!(part_text(&gemini_req.contents[0].parts[0]), Some("first"));
+        assert_eq!(part_text(&gemini_req.contents[0].parts[1]), Some("second"));
+    }
+
+    #[test]
+    fn test_gemini_image_data_uri_becomes_inline_data() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let req = ChatRequest {
+            model: "google/gemini-3.1-pro".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![
+                    ContentPart::Text {
+                        text: "what is this?".to_string(),
+                    },
+                    ContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+                            detail: None,
+                        },
+                    },
+                ]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        let gemini_req = to_gemini_request(&req).unwrap();
+        // Exact wire shape per Gemini API (verified 2026-06-03): camelCase
+        // inlineData/mimeType.
+        let v = serde_json::to_value(&gemini_req.contents[0]).unwrap();
+        assert_eq!(
+            v["parts"],
+            serde_json::json!([
+                {"text":"what is this?"},
+                {"inlineData":{"mimeType":"image/png","data":"iVBORw0KGgo="}}
+            ])
+        );
+    }
+
+    #[test]
+    fn test_gemini_image_http_url_becomes_file_data() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let req = ChatRequest {
+            model: "google/gemini-3.1-pro".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "https://example.com/cat.png".to_string(),
+                        detail: None,
+                    },
+                }]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        let gemini_req = to_gemini_request(&req).unwrap();
+        let v = serde_json::to_value(&gemini_req.contents[0]).unwrap();
+        // MIME inferred from the `.png` path extension (never the invalid
+        // `image/*` wildcard).
+        assert_eq!(
+            v["parts"],
+            serde_json::json!([
+                {"fileData":{"mimeType":"image/png","fileUri":"https://example.com/cat.png"}}
+            ])
+        );
+    }
+
+    #[test]
+    fn test_mime_type_from_url_infers_extension() {
+        assert_eq!(mime_type_from_url("https://x/a.png"), "image/png");
+        assert_eq!(mime_type_from_url("https://x/a.PNG"), "image/png");
+        assert_eq!(mime_type_from_url("https://x/a.jpg"), "image/jpeg");
+        assert_eq!(mime_type_from_url("https://x/a.jpeg"), "image/jpeg");
+        assert_eq!(mime_type_from_url("https://x/a.webp"), "image/webp");
+        // Query string is ignored when sniffing the extension.
+        assert_eq!(mime_type_from_url("https://x/a.png?v=2"), "image/png");
+        // Unknown / no extension → jpeg fallback, never a wildcard.
+        assert_eq!(mime_type_from_url("https://x/image"), "image/jpeg");
+        assert_eq!(mime_type_from_url("https://x/a.gif"), "image/jpeg");
+        assert!(!mime_type_from_url("https://x/a.png").contains('*'));
+    }
+
+    #[test]
+    fn test_gemini_image_in_system_message_rejected() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let req = ChatRequest {
+            model: "google/gemini-3.1-pro".to_string(),
+            messages: vec![
+                ChatMessage {
+                    role: Role::System,
+                    content: MessageContent::Parts(vec![ContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+                            detail: None,
+                        },
+                    }]),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                ChatMessage {
+                    role: Role::User,
+                    content: "hi".into(),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+            ],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        assert!(
+            to_gemini_request(&req).is_err(),
+            "an image in a system message must reject, not be silently dropped"
+        );
+    }
+
+    #[test]
+    fn test_gemini_data_uri_without_base64_rejected_at_adapter() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let req = ChatRequest {
+            model: "google/gemini-3.1-pro".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "data:image/png,rawnotbase64".to_string(),
+                        detail: None,
+                    },
+                }]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        assert!(
+            to_gemini_request(&req).is_err(),
+            "a non-base64 data URI must be rejected at the adapter"
+        );
+    }
+
+    #[test]
+    fn test_gemini_response_skips_non_text_parts() {
+        // A response with an unknown part kind (`thought`) plus a text part must
+        // deserialize (untagged `Other` catch-all) and yield only the text.
+        let raw = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {"thought": true},
+                        {"text": "hello"},
+                        {"inlineData": {"mimeType": "image/png", "data": "AAAA"}}
+                    ]
+                },
+                "finishReason": "STOP"
+            }]
+        });
+        let resp: GeminiResponse = serde_json::from_value(raw).unwrap();
+        let out = from_gemini_response(resp, "google/gemini-3.1-pro");
+        assert_eq!(out.choices[0].message.content.as_text(), "hello");
+    }
+
+    #[test]
+    fn test_gemini_malformed_image_is_rejected_not_dropped() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let req = ChatRequest {
+            model: "google/gemini-3.1-pro".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Parts(vec![ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "ftp://bad/scheme.png".to_string(),
+                        detail: None,
+                    },
+                }]),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            max_tokens: Some(100),
+            temperature: None,
+            top_p: None,
+            stream: false,
+            tools: None,
+            tool_choice: None,
+        };
+        assert!(
+            to_gemini_request(&req).is_err(),
+            "a malformed image URL must reject the request, not silently drop the image"
+        );
     }
 
     #[test]
@@ -385,12 +767,12 @@ mod tests {
             tool_choice: None,
         };
 
-        let gemini_req = to_gemini_request(&req);
+        let gemini_req = to_gemini_request(&req).unwrap();
 
         assert!(gemini_req.system_instruction.is_some());
         assert_eq!(
-            gemini_req.system_instruction.unwrap().parts[0].text,
-            "Be concise."
+            part_text(&gemini_req.system_instruction.unwrap().parts[0]),
+            Some("Be concise.")
         );
         assert_eq!(gemini_req.contents.len(), 1);
         assert_eq!(gemini_req.contents[0].role.as_deref(), Some("user"));
@@ -432,13 +814,13 @@ mod tests {
             tool_choice: None,
         };
 
-        let gemini_req = to_gemini_request(&req);
+        let gemini_req = to_gemini_request(&req).unwrap();
 
         // Developer message should be extracted as system_instruction
         assert!(gemini_req.system_instruction.is_some());
         assert_eq!(
-            gemini_req.system_instruction.unwrap().parts[0].text,
-            "Always respond in JSON."
+            part_text(&gemini_req.system_instruction.unwrap().parts[0]),
+            Some("Always respond in JSON.")
         );
         // Only the User message should remain in contents
         assert_eq!(gemini_req.contents.len(), 1);
@@ -451,9 +833,7 @@ mod tests {
             candidates: Some(vec![GeminiCandidate {
                 content: GeminiContent {
                     role: Some("model".to_string()),
-                    parts: vec![GeminiPart {
-                        text: "Hi there!".to_string(),
-                    }],
+                    parts: vec![GeminiPart::text("Hi there!".to_string())],
                 },
                 finish_reason: Some("STOP".to_string()),
             }]),

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -170,6 +170,39 @@ mod tests {
     }
 
     #[test]
+    fn build_chat_body_passes_image_parts_through_as_array() {
+        use solvela_protocol::vision::{ContentPart, ImageUrl, MessageContent};
+        let mut req = sample_request("openai/gpt-4o");
+        req.messages[0].content = MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "what is this?".to_string(),
+            },
+            ContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: "https://example.com/cat.png".to_string(),
+                    detail: Some("high".to_string()),
+                },
+            },
+        ]);
+        let body = build_chat_body(&req).expect("body must serialize");
+        // The OpenAI passthrough must serialize `content` as a JSON ARRAY (not
+        // a stringified/dropped value) so the image reaches the upstream API.
+        assert!(
+            body["messages"][0]["content"].is_array(),
+            "image content must serialize as a JSON array, not stringified/dropped"
+        );
+        assert_eq!(body["messages"][0]["content"][1]["type"], "image_url");
+        assert_eq!(
+            body["messages"][0]["content"][1]["image_url"]["url"],
+            "https://example.com/cat.png"
+        );
+        assert_eq!(
+            body["messages"][0]["content"][1]["image_url"]["detail"],
+            "high"
+        );
+    }
+
+    #[test]
     fn build_stream_body_injects_stream_true() {
         let req = sample_request("openai/gpt-4o");
         let body = build_stream_body(&req).expect("body must serialize");

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -124,18 +124,72 @@ const IMAGE_TOKENS_LOW_DETAIL: u32 = 85;
 /// worst-case.
 const IMAGE_TOKENS_HIGH_DETAIL: u32 = 765;
 
+/// Internal, parse-only classification of the OpenAI `detail` hint for the
+/// purpose of the UPFRONT 402 quote ONLY.
+///
+/// This is deliberately NOT the wire type: `ImageUrl.detail` stays
+/// `Option<String>` in `crates/protocol/src/vision.rs` and is serialized
+/// verbatim to OpenAI-format passthrough providers (openai/xai/deepseek). This
+/// enum is constructed transiently from that string solely to drive the
+/// token-estimate branch; it never round-trips back onto the wire, so it cannot
+/// emit a normalized/"unknown" value upstream (which would risk a provider 400)
+/// or drift the cross-repo SDK wire contract.
+///
+/// The point of making this a typed enum (rather than matching the raw string
+/// inline) is to make the FAIL-SAFE-LARGE direction structural: the only
+/// variant that maps to the cheap 85-token estimate is `Low`; every other
+/// input — including unknown/typo strings and an absent detail — resolves to a
+/// variant that prices at the conservative high figure. A future reader cannot
+/// mistake the coercion of `"loow"` (a typo) to high as accidental.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImageDetail {
+    Low,
+    High,
+    Auto,
+}
+
+impl ImageDetail {
+    /// Classify the raw `detail` hint for the upfront quote.
+    ///
+    /// Mapping: `"low"` → [`Low`], `"high"` → [`High`], `"auto"` → [`Auto`].
+    /// EVERYTHING ELSE — any unknown/typo string (e.g. `"loow"`, `"HIGH"`) AND
+    /// the absent (`None`) case — resolves to [`High`]. This is the DELIBERATE
+    /// fail-safe-large direction for the quote: an under-classified image must
+    /// reserve the larger token figure so the upfront 402 reservation isn't
+    /// under-funded. It never over-bills — the final charge is reconciled to
+    /// provider-reported `Usage` at settlement (see [`image_tokens_for_detail`]
+    /// and `compute_actual_atomic_cost`). The estimate only needs to be
+    /// conservative enough not to under-fund the reservation.
+    ///
+    /// [`Low`]: ImageDetail::Low
+    /// [`High`]: ImageDetail::High
+    /// [`Auto`]: ImageDetail::Auto
+    fn from_opt(detail: Option<&str>) -> ImageDetail {
+        match detail {
+            Some("low") => ImageDetail::Low,
+            Some("high") => ImageDetail::High,
+            Some("auto") => ImageDetail::Auto,
+            // Unknown/typo string OR absent → conservative high (fail-safe-large).
+            _ => ImageDetail::High,
+        }
+    }
+}
+
 /// Conservative upfront-quote token contribution for one image, keyed on the
-/// OpenAI `detail` hint. Unknown/absent detail is treated as high (the
-/// fail-safe-large direction for a quote).
+/// typed [`ImageDetail`] classification of the OpenAI `detail` hint. Only
+/// `Low` is cheap; `High` and `Auto` both price at the conservative high
+/// figure. Unknown/absent detail is classified as `High` by
+/// [`ImageDetail::from_opt`] (the fail-safe-large direction for a quote), so it
+/// lands here as the high figure without a catch-all string arm.
 fn image_tokens_for_detail(detail: Option<&str>) -> u32 {
-    match detail {
-        Some("low") => IMAGE_TOKENS_LOW_DETAIL,
-        // "high", "auto", anything else, or unspecified → conservative high.
-        // NOTE: mapping "auto" (and unknown values) to high(765) is INTENTIONAL
-        // conservative over-estimation for the UPFRONT QUOTE ONLY — it never
-        // over-bills, because the final charge is reconciled to provider-reported
-        // usage at settlement; it only ensures the reservation isn't under-funded.
-        _ => IMAGE_TOKENS_HIGH_DETAIL,
+    match ImageDetail::from_opt(detail) {
+        ImageDetail::Low => IMAGE_TOKENS_LOW_DETAIL,
+        // "high"/"auto" — and, via from_opt, every unknown/typo/absent value —
+        // map to the conservative high figure. This is over-estimation for the
+        // UPFRONT QUOTE ONLY; it never over-bills, because the final charge is
+        // reconciled to provider-reported usage at settlement. It only ensures
+        // the reservation isn't under-funded.
+        ImageDetail::High | ImageDetail::Auto => IMAGE_TOKENS_HIGH_DETAIL,
     }
 }
 
@@ -677,6 +731,52 @@ mod tests {
         assert_eq!(
             estimate_input_tokens(&unknown),
             estimate_input_tokens(&high)
+        );
+    }
+
+    #[test]
+    fn image_detail_from_opt_maps_known_and_fails_safe_high() {
+        // Known hints map to their explicit variant.
+        assert_eq!(ImageDetail::from_opt(Some("low")), ImageDetail::Low);
+        assert_eq!(ImageDetail::from_opt(Some("high")), ImageDetail::High);
+        assert_eq!(ImageDetail::from_opt(Some("auto")), ImageDetail::Auto);
+
+        // Absent detail → High (fail-safe-large for the upfront quote).
+        assert_eq!(ImageDetail::from_opt(None), ImageDetail::High);
+
+        // Unknown / typo / wrong-case strings ALL → High, never Low. This is the
+        // structural guarantee: the only path to the cheap estimate is an exact
+        // "low"; an under-classified image always reserves the larger figure.
+        for bad in ["loow", "LOW", "Low", "hi", "ultra-mega", "", "  low  "] {
+            assert_eq!(
+                ImageDetail::from_opt(Some(bad)),
+                ImageDetail::High,
+                "unknown/typo detail {bad:?} must fail safe to High, never Low"
+            );
+        }
+    }
+
+    #[test]
+    fn image_tokens_for_detail_only_low_is_cheap() {
+        // Pins the enum→constant mapping: Low is the only cheap classification;
+        // high/auto/unknown/absent all resolve to the conservative high figure.
+        assert_eq!(
+            image_tokens_for_detail(Some("low")),
+            IMAGE_TOKENS_LOW_DETAIL
+        );
+        assert_eq!(
+            image_tokens_for_detail(Some("high")),
+            IMAGE_TOKENS_HIGH_DETAIL
+        );
+        assert_eq!(
+            image_tokens_for_detail(Some("auto")),
+            IMAGE_TOKENS_HIGH_DETAIL
+        );
+        assert_eq!(image_tokens_for_detail(None), IMAGE_TOKENS_HIGH_DETAIL);
+        assert_eq!(
+            image_tokens_for_detail(Some("loow")),
+            IMAGE_TOKENS_HIGH_DETAIL,
+            "a typo must price at the conservative high figure"
         );
     }
 

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -116,10 +116,12 @@ const IMAGE_TOKENS_LOW_DETAIL: u32 = 85;
 
 /// Per-image token contribution for the upfront quote at `detail: "high"`,
 /// `"auto"`, or unspecified. A high-detail image tiles into multiple 512px
-/// crops; OpenAI's worst-case for a large image is ~765+ tokens (85 base +
-/// 170 per tile). We use 765 as a single conservative per-image figure so the
-/// quote over-, never under-, estimates a typical vision request. Still
-/// reconciled to provider-reported usage at settlement.
+/// crops; OpenAI's typical cost for a large (≤2048×2048) image is ~765 tokens
+/// (85 base + 170 per tile × 4 tiles). Images larger than 4 tiles cost more,
+/// but we use 765 as a single per-image figure so the quote covers a typical
+/// vision request without under-estimating it. Any overage is still reconciled
+/// to provider-reported usage at settlement, so the figure need not be a hard
+/// worst-case.
 const IMAGE_TOKENS_HIGH_DETAIL: u32 = 765;
 
 /// Conservative upfront-quote token contribution for one image, keyed on the

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -3,7 +3,7 @@
 //! All financial calculations use integer arithmetic to avoid f64 precision
 //! loss on monetary amounts. USDC has 6 decimal places (atomic units).
 
-use tracing::{error, warn};
+use tracing::warn;
 
 use solvela_protocol::{ChatRequest, ModelRegistration, Usage};
 
@@ -101,36 +101,64 @@ pub(crate) fn cap_usage_to_request_limits(
     }
 }
 
-/// Rough token estimate: ~4 chars per token.
-pub(crate) fn estimate_input_tokens(req: &ChatRequest) -> u32 {
-    // `as_text()` flattens only text parts — image parts contribute zero chars,
-    // so this estimate silently undercounts vision input (an image message would
-    // be priced as ~1 token, i.e. near-zero charge). Images are rejected upstream
-    // today (route + fallback backstop return 415), so this branch is unreachable
-    // for normal traffic; this is a defense-in-depth observability guard.
-    //
-    // The `debug_assert!` documents the invariant and fires it in debug/test
-    // builds, but it is COMPILED OUT in `--release` (which is what the gateway
-    // ships), so it cannot be relied on as a production signal. The
-    // `tracing::error!` below is the production-visible guard: it survives
-    // release builds and fires on a real (money-path) cost path if image
-    // content ever reaches estimation despite the upstream rejection.
-    let has_image = req.messages.iter().any(|m| m.content.has_image_parts());
-    debug_assert!(
-        !has_image,
-        "estimate_input_tokens does not account for image tokens — image content \
-         must be rejected upstream; revisit when vision lands (PR #2)"
-    );
-    if has_image {
-        error!(
-            messages = req.messages.len(),
-            "image content reached estimate_input_tokens — input tokens will be \
-             undercounted (image parts contribute zero chars), producing a near-zero \
-             cost estimate; should be unreachable given upstream 415 rejection"
-        );
+/// Per-image token contribution for the UPFRONT 402 quote when an image is
+/// sent at OpenAI `detail: "low"`. OpenAI prices a low-detail image at a flat
+/// 85 tokens; we mirror that for the estimate.
+///
+/// MONEY-PATH NOTE: this constant governs the upfront 402 quote / budget
+/// reservation ONLY. The FINAL bill is computed from provider-reported
+/// `Usage` (which already counts the real vision tokens) via
+/// `compute_actual_atomic_cost` in the settlement path — see
+/// `image_tokens_for_detail` docs and the `chat/mod.rs` settlement arm. The
+/// estimate only needs to be conservative enough that the reservation isn't
+/// under-funded; it is reconciled to the actual usage afterward.
+const IMAGE_TOKENS_LOW_DETAIL: u32 = 85;
+
+/// Per-image token contribution for the upfront quote at `detail: "high"`,
+/// `"auto"`, or unspecified. A high-detail image tiles into multiple 512px
+/// crops; OpenAI's worst-case for a large image is ~765+ tokens (85 base +
+/// 170 per tile). We use 765 as a single conservative per-image figure so the
+/// quote over-, never under-, estimates a typical vision request. Still
+/// reconciled to provider-reported usage at settlement.
+const IMAGE_TOKENS_HIGH_DETAIL: u32 = 765;
+
+/// Conservative upfront-quote token contribution for one image, keyed on the
+/// OpenAI `detail` hint. Unknown/absent detail is treated as high (the
+/// fail-safe-large direction for a quote).
+fn image_tokens_for_detail(detail: Option<&str>) -> u32 {
+    match detail {
+        Some("low") => IMAGE_TOKENS_LOW_DETAIL,
+        // "high", "auto", anything else, or unspecified → conservative high.
+        // NOTE: mapping "auto" (and unknown values) to high(765) is INTENTIONAL
+        // conservative over-estimation for the UPFRONT QUOTE ONLY — it never
+        // over-bills, because the final charge is reconciled to provider-reported
+        // usage at settlement; it only ensures the reservation isn't under-funded.
+        _ => IMAGE_TOKENS_HIGH_DETAIL,
     }
-    let chars: usize = req.messages.iter().map(|m| m.content.as_text().len()).sum();
-    (chars / 4).max(1) as u32
+}
+
+/// Rough input-token estimate for the upfront 402 quote / budget reservation.
+///
+/// Text is estimated at ~4 chars per token. Each image part adds a flat,
+/// detail-based contribution (see [`image_tokens_for_detail`]) so a vision
+/// request is not quoted as near-zero (text-only) and the reservation isn't
+/// under-funded. This drives ONLY the quote/reservation; the final bill comes
+/// from provider-reported `Usage` at settlement (`compute_actual_atomic_cost`),
+/// which counts the provider's real vision-token accounting.
+pub(crate) fn estimate_input_tokens(req: &ChatRequest) -> u32 {
+    let text_chars: usize = req.messages.iter().map(|m| m.content.as_text().len()).sum();
+    let text_tokens = (text_chars / 4) as u32;
+
+    let image_tokens: u32 = req
+        .messages
+        .iter()
+        .flat_map(|m| m.content.image_urls())
+        .map(|img| image_tokens_for_detail(img.detail.as_deref()))
+        .fold(0u32, |acc, t| acc.saturating_add(t));
+
+    // Floor at 1 so a (degenerate) empty request still quotes a non-zero token
+    // count, matching the prior behavior for text-only requests.
+    text_tokens.saturating_add(image_tokens).max(1)
 }
 
 /// Compute the actual cost in atomic USDC units from token usage.
@@ -590,6 +618,128 @@ mod tests {
     fn test_estimate_input_tokens_empty_message_returns_at_least_one() {
         let req = make_request("m", vec![user_msg("")]);
         assert_eq!(estimate_input_tokens(&req), 1, "minimum should be 1 token");
+    }
+
+    fn image_msg(text: &str, detail: Option<&str>) -> ChatMessage {
+        use solvela_protocol::{ContentPart, ImageUrl, MessageContent};
+        ChatMessage {
+            role: Role::User,
+            content: MessageContent::Parts(vec![
+                ContentPart::Text {
+                    text: text.to_string(),
+                },
+                ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "https://example.com/img.png".to_string(),
+                        detail: detail.map(str::to_string),
+                    },
+                },
+            ]),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+
+    #[test]
+    fn test_estimate_input_tokens_image_adds_tokens_over_text_only() {
+        // An image request must quote MORE tokens than the same text alone, so
+        // the upfront 402 quote / budget reservation isn't under-funded.
+        let text_only = make_request("m", vec![user_msg("describe this")]);
+        let with_image = make_request("m", vec![image_msg("describe this", Some("high"))]);
+        assert!(
+            estimate_input_tokens(&with_image) > estimate_input_tokens(&text_only),
+            "image request must estimate strictly more tokens than text-only"
+        );
+        // Text "describe this" = 13 chars → 3 tokens; + 765 high-detail image.
+        assert_eq!(estimate_input_tokens(&with_image), 3 + 765);
+    }
+
+    #[test]
+    fn test_estimate_input_tokens_detail_low_cheaper_than_high() {
+        let low = make_request("m", vec![image_msg("x", Some("low"))]);
+        let high = make_request("m", vec![image_msg("x", Some("high"))]);
+        let auto = make_request("m", vec![image_msg("x", Some("auto"))]);
+        let unspecified = make_request("m", vec![image_msg("x", None)]);
+        assert!(estimate_input_tokens(&low) < estimate_input_tokens(&high));
+        // auto + unspecified are treated as the conservative high figure.
+        assert_eq!(estimate_input_tokens(&auto), estimate_input_tokens(&high));
+        assert_eq!(
+            estimate_input_tokens(&unspecified),
+            estimate_input_tokens(&high)
+        );
+
+        // An arbitrary UNKNOWN detail string also maps to the conservative high
+        // figure (fail-safe-large for the quote), never low or zero.
+        let unknown = make_request("m", vec![image_msg("x", Some("ultra-mega"))]);
+        assert_eq!(
+            estimate_input_tokens(&unknown),
+            estimate_input_tokens(&high)
+        );
+    }
+
+    #[test]
+    fn test_estimate_input_tokens_multiple_images_sum() {
+        use solvela_protocol::{ContentPart, ImageUrl, MessageContent};
+        let two_images = ChatMessage {
+            role: Role::User,
+            content: MessageContent::Parts(vec![
+                ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "https://example.com/a.png".to_string(),
+                        detail: Some("low".to_string()),
+                    },
+                },
+                ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "https://example.com/b.png".to_string(),
+                        detail: Some("low".to_string()),
+                    },
+                },
+            ]),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        };
+        let req = make_request("m", vec![two_images]);
+        // Two low-detail images → 85 + 85 = 170 (text is empty → 0 text tokens).
+        assert_eq!(estimate_input_tokens(&req), 170);
+    }
+
+    /// SETTLEMENT CONFIRMATION (money-path): the final bill must come from
+    /// provider-reported `Usage`, NOT from `estimate_input_tokens`. The
+    /// provider counts the real vision tokens; `compute_actual_atomic_cost`
+    /// prices those. This test pins that the actual-cost path is usage-driven
+    /// and entirely independent of the upfront image estimate — so the
+    /// conservative estimate above can never become the thing the agent is
+    /// finally billed. (The chat route's settlement arm feeds the
+    /// provider-reported, then capped, `Usage` into `compute_actual_atomic_cost`;
+    /// see `crates/gateway/src/routes/chat/mod.rs`.)
+    #[test]
+    fn test_actual_cost_is_usage_driven_not_image_estimate() {
+        let model_info = ModelRegistration {
+            id: "openai/gpt-4o".to_string(),
+            provider: "openai".to_string(),
+            model_id: "gpt-4o".to_string(),
+            display_name: "GPT-4o".to_string(),
+            input_cost_per_million: 2.50,
+            output_cost_per_million: 10.00,
+            context_window: 128_000,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_vision: true,
+            reasoning: false,
+            supports_structured_output: false,
+            supports_batch: false,
+            max_output_tokens: None,
+        };
+        // Provider reports 1200 prompt tokens (image tokens already folded in by
+        // the provider) and 500 completion. The bill is a pure function of those
+        // numbers — the upfront 85/765 estimate plays no role here.
+        let billed = compute_actual_atomic_cost(1200, 500, &model_info);
+        // 1200 * 2.50/M = 3000 atomic; 500 * 10/M = 5000 atomic; sum 8000;
+        // ×1.05 fee = 8400.
+        assert_eq!(billed, Some(8400));
     }
 
     // =========================================================================

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -219,9 +219,14 @@ pub async fn chat_completions(
     // images in system/developer messages here (the provider `system` channels
     // are text-only and would otherwise silently drop the image after payment).
     //
-    // Image parts in user/assistant/tool roles are INTENTIONALLY allowed (a
-    // valid multi-turn vision conversation can carry images in any of those
-    // roles); only system/developer-role images are rejected below.
+    // Image parts in user/assistant messages are always allowed (a valid
+    // multi-turn vision conversation carries images in those roles). Tool-role
+    // images are accepted here at the protocol layer — Gemini forwards them as
+    // user-role parts — but provider support varies: the Anthropic adapter
+    // rejects tool-role images (with a clear error) rather than silently
+    // dropping them, since it does not yet translate tool results to
+    // `tool_result` blocks. Only system/developer-role images are rejected
+    // unconditionally below.
     //
     // Per-image bytes are bounded by `MAX_DATA_URI_BYTES` inside `parse()`;
     // total image bytes across the whole request are additionally bounded by the

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -53,6 +53,18 @@ const MAX_MESSAGES: usize = 256;
 /// array forces excessive per-part work on the hot path).
 const MAX_CONTENT_PARTS: usize = 64;
 
+/// Maximum number of image parts allowed across an ENTIRE request.
+///
+/// `MAX_MESSAGES` (256) × `MAX_CONTENT_PARTS` (64) otherwise admits up to ~16K
+/// image parts, and URL images are ~30 bytes each so thousands fit inside the
+/// 10MB body limit. Each image also adds a per-image token contribution to the
+/// upfront 402 estimate, so an unbounded count inflates the quote and forces
+/// per-image work on the hot path. 100 is the tightest hard limit across the
+/// supported vision providers (Anthropic's API caps a request at 100 images),
+/// so an accepted count never settles payment then gets rejected upstream for
+/// image-count. Enforced BEFORE payment.
+const MAX_IMAGES_PER_REQUEST: usize = 100;
+
 /// Platform-wide upper bound for `max_tokens` to prevent unbounded cost exposure.
 const MAX_TOKENS_LIMIT: u32 = 128_000;
 
@@ -101,6 +113,21 @@ pub async fn chat_completions(
                 )));
             }
         }
+    }
+
+    // Aggregate image-count cap — runs BEFORE payment and model resolution so a
+    // request carrying more images than any provider accepts is a client 4xx,
+    // never billed-then-rejected upstream. Bounds the abuse case where thousands
+    // of small URL images fit inside the body limit (see MAX_IMAGES_PER_REQUEST).
+    let total_images: usize = req
+        .messages
+        .iter()
+        .map(|msg| msg.content.image_urls().count())
+        .sum();
+    if total_images > MAX_IMAGES_PER_REQUEST {
+        return Err(GatewayError::BadRequest(format!(
+            "too many images: {total_images} exceeds maximum of {MAX_IMAGES_PER_REQUEST}"
+        )));
     }
 
     // Empty-prompt rejection — runs BEFORE payment so an empty request is never

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -81,25 +81,17 @@ pub async fn chat_completions(
         )));
     }
 
-    // Content validation — runs BEFORE payment, guard, and provider dispatch.
+    // Content-shape validation — runs BEFORE payment, guard, and provider
+    // dispatch. Caps the per-message parts array to bound hot-path work.
     //
-    // PR #1 accepts `content` as a string OR an array of OpenAI text parts.
-    // Image/multimodal content is NOT yet processed (native image blocks,
-    // capability gating, and image cost accounting are a tracked follow-up
-    // PR). Reject it explicitly with a 415 so it is never silently dropped,
-    // mis-costed, or cached — rather than half-supported. Also cap the
-    // per-message parts array to bound hot-path work.
+    // The IMAGE capability gate is deliberately NOT here: it needs the
+    // resolved model's `supports_vision` flag, which is only known after model
+    // resolution + registry lookup below. Image content for a non-vision model
+    // is rejected there (415); for a vision model it is translated to the
+    // provider's native multimodal format. Note: the empty-prompt check below
+    // still requires at least one non-empty User *text* message, so an
+    // image-only request with no text is rejected as an empty prompt.
     for msg in &req.messages {
-        if msg.content.has_image_parts() {
-            warn!("rejected request with image/multimodal content (not yet supported)");
-            return Err(GatewayError::UnsupportedMediaType(
-                "image/multimodal content is not yet supported; \
-                 send text content (string or text parts)"
-                    .to_string(),
-            ));
-        }
-        // Same `Parts` arm as the image check above (image check first, then
-        // length cap — order/errors unchanged) so the variant is matched once.
         if let MessageContent::Parts(parts) = &msg.content {
             if parts.len() > MAX_CONTENT_PARTS {
                 return Err(GatewayError::BadRequest(format!(
@@ -199,6 +191,59 @@ pub async fn chat_completions(
         .model_registry
         .get(&req.model)
         .ok_or_else(|| GatewayError::ModelNotFound(req.model.clone()))?;
+
+    // Step 2a: Vision capability gate. Image content is only accepted for a
+    // model whose registry entry declares `supports_vision`. A non-vision model
+    // must reject (415) rather than silently strip the image (which would
+    // change the prompt's meaning while still billing the agent) or forward it
+    // to a provider that doesn't accept it (a paid 5xx after settlement). Runs
+    // BEFORE payment so an unsupported request is never billed.
+    let request_has_images = req.messages.iter().any(|m| m.content.has_image_parts());
+    if request_has_images && !model_info.supports_vision {
+        warn!(
+            model = %req.model,
+            "rejected image content for a non-vision model"
+        );
+        return Err(GatewayError::UnsupportedMediaType(format!(
+            "model '{}' does not support image input; \
+             use a vision-capable model or send text-only content",
+            req.model
+        )));
+    }
+
+    // Step 2a': Validate every image part at the route BEFORE payment, so a
+    // malformed image (bad scheme, non-base64 data URI, oversize, unsupported
+    // media type) is a client 4xx and the agent is never billed for it — rather
+    // than surfacing as a post-payment provider 5xx. This is the single route
+    // chokepoint; the adapters re-validate as defense-in-depth. Also reject
+    // images in system/developer messages here (the provider `system` channels
+    // are text-only and would otherwise silently drop the image after payment).
+    //
+    // Image parts in user/assistant/tool roles are INTENTIONALLY allowed (a
+    // valid multi-turn vision conversation can carry images in any of those
+    // roles); only system/developer-role images are rejected below.
+    //
+    // Per-image bytes are bounded by `MAX_DATA_URI_BYTES` inside `parse()`;
+    // total image bytes across the whole request are additionally bounded by the
+    // 10 MB `RequestBodyLimitLayer` on the HTTP body (see lib.rs `build_router`),
+    // so no separate aggregate image-byte cap is needed here.
+    if request_has_images {
+        for msg in &req.messages {
+            let is_system = matches!(msg.role, Role::System | Role::Developer);
+            if is_system && msg.content.has_image_parts() {
+                return Err(GatewayError::BadRequest(
+                    "image content is not supported in system/developer messages; \
+                     place images in a user message"
+                        .to_string(),
+                ));
+            }
+            for image_url in msg.content.image_urls() {
+                if let Err(e) = image_url.parse() {
+                    return Err(GatewayError::BadRequest(format!("invalid image: {e}")));
+                }
+            }
+        }
+    }
 
     // Step 2b: Clamp max_tokens to model/platform limit to prevent unbounded cost
     if let Some(requested_max) = req.max_tokens {

--- a/crates/gateway/src/routes/chat/provider.rs
+++ b/crates/gateway/src/routes/chat/provider.rs
@@ -334,6 +334,7 @@ async fn execute_streaming_call(
             fallback::stream_with_chain(
                 &ctx.state.providers,
                 &ctx.state.provider_health,
+                &ctx.state.model_registry,
                 &chain,
                 &ctx.req.model,
                 ctx.req.clone(),
@@ -343,6 +344,7 @@ async fn execute_streaming_call(
             fallback::stream_with_model_fallback(
                 &ctx.state.providers,
                 &ctx.state.provider_health,
+                &ctx.state.model_registry,
                 provider_name,
                 &ctx.req.model,
                 ctx.req.clone(),
@@ -446,6 +448,7 @@ async fn execute_non_streaming_call(
             fallback::chat_with_chain(
                 &ctx.state.providers,
                 &ctx.state.provider_health,
+                &ctx.state.model_registry,
                 &chain,
                 &ctx.req.model,
                 ctx.req.clone(),
@@ -455,6 +458,7 @@ async fn execute_non_streaming_call(
             fallback::chat_with_model_fallback(
                 &ctx.state.providers,
                 &ctx.state.provider_health,
+                &ctx.state.model_registry,
                 provider_name,
                 &ctx.req.model,
                 ctx.req.clone(),

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -2220,6 +2220,62 @@ async fn test_chat_content_parts_over_cap_returns_400() {
     );
 }
 
+/// MAX_IMAGES_PER_REQUEST (over edge): >100 images spread across messages must
+/// be rejected with 400 BadRequest, naming the cap. Runs before payment and
+/// model resolution so an over-large vision request is never billed. Uses two
+/// user messages of 60 image parts each (120 total > 100), each within the
+/// 64-part-per-message cap so the aggregate image cap is what fires.
+#[tokio::test]
+async fn test_chat_image_count_over_cap_returns_400() {
+    let app = test_app();
+
+    let image_parts = |n: usize| -> Vec<serde_json::Value> {
+        (0..n)
+            .map(|i| {
+                serde_json::json!({
+                    "type": "image_url",
+                    "image_url": {"url": format!("https://example.com/{i}.png")}
+                })
+            })
+            .collect()
+    };
+    let mut first = vec![serde_json::json!({"type": "text", "text": "describe these"})];
+    first.extend(image_parts(60));
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [
+            {"role": "user", "content": first},
+            {"role": "user", "content": image_parts(60)},
+        ],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "120 images exceeds the cap of 100 and must be rejected with 400"
+    );
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let msg = json["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("too many images") && msg.contains("100"),
+        "400 error must name the image cap, got: {msg}"
+    );
+}
+
 /// Image rejection runs BEFORE the 402, not after. The same image body that is
 /// rejected with 415 when a payment header IS present
 /// (`test_chat_image_content_rejected_for_non_vision_model_415`) must also be

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -1893,14 +1893,18 @@ async fn test_chat_text_content_array_returns_mock_response() {
     assert_eq!(json["choices"][0]["message"]["content"], "[mock response]");
 }
 
-/// Image/multimodal content is not yet supported in PR #1 — it must be
-/// rejected with a clear 4xx (415), not silently dropped (which would mis-cost
-/// and mis-cache) and not 500. Rejection runs BEFORE payment/provider.
+/// PR #2 capability gating: image content sent to a NON-vision model must be
+/// rejected with a clear 415 — not silently dropped (which would change the
+/// prompt's meaning while still billing) and not 500. `deepseek/deepseek-chat`
+/// has `supports_vision` unset in the test registry. (The blanket PR-#1 415 is
+/// replaced by this model-aware gate.)
 #[tokio::test]
-async fn test_chat_image_content_rejected_with_415() {
+async fn test_chat_image_content_rejected_for_non_vision_model_415() {
     let app = test_app_with_mock_provider();
 
-    let body = r#"{"model":"openai/gpt-4o","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://x/y.png"}}]}]}"#;
+    // Include a text part so the empty-prompt check passes — we want to reach
+    // the vision gate, not be rejected as an empty prompt.
+    let body = r#"{"model":"deepseek/deepseek-chat","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"https://x/y.png"}}]}]}"#;
 
     let response = app
         .oneshot(
@@ -1921,12 +1925,187 @@ async fn test_chat_image_content_rejected_with_415() {
     assert_eq!(
         response.status(),
         StatusCode::UNSUPPORTED_MEDIA_TYPE,
-        "image content must be rejected with 415, not 200 and not 500"
+        "image content for a non-vision model must be rejected with 415, not 200/500"
     );
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["error"]["type"], "unsupported_media_type");
+}
+
+/// PR #2 capability gating: image content sent to a VISION-capable model
+/// (`openai/gpt-4o`, `supports_vision = true`) must be ACCEPTED and reach the
+/// (mock) provider, returning 200 — not the PR-#1 blanket 415.
+#[tokio::test]
+async fn test_chat_image_content_accepted_for_vision_model_200() {
+    let app = test_app_with_mock_provider();
+
+    let body = r#"{"model":"openai/gpt-4o","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}]}]}"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "image content for a vision model must be accepted (200), not rejected"
+    );
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["object"], "chat.completion");
+}
+
+/// 402 path: a vision model + image with NO payment header must return 402
+/// whose cost breakdown reflects the image-token contribution (the estimate
+/// must not silently zero out the image). The same prompt WITHOUT the image
+/// must quote strictly less, proving the image added to the upfront quote.
+#[tokio::test]
+async fn test_chat_image_402_cost_breakdown_includes_image_tokens() {
+    async fn quote_total(body: &'static str) -> f64 {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let info: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        info["cost_breakdown"]["total"]
+            .as_str()
+            .expect("total must be a string")
+            .parse()
+            .expect("total must parse")
+    }
+
+    let with_image = r#"{"model":"openai/gpt-4o","messages":[{"role":"user","content":[{"type":"text","text":"describe this"},{"type":"image_url","image_url":{"url":"https://example.com/cat.png","detail":"high"}}]}]}"#;
+    let text_only = r#"{"model":"openai/gpt-4o","messages":[{"role":"user","content":[{"type":"text","text":"describe this"}]}]}"#;
+
+    let image_total = quote_total(with_image).await;
+    let text_total = quote_total(text_only).await;
+    assert!(
+        image_total > text_total,
+        "image 402 quote ({image_total}) must exceed the text-only quote ({text_total}) — \
+         the image-token contribution must not be silently zeroed"
+    );
+}
+
+/// Unknown model + image → 404 (model-not-found), NOT 415/500. The model lookup
+/// precedes the vision gate, so an unknown model is a clean 404 even with an
+/// image present.
+#[tokio::test]
+async fn test_chat_unknown_model_with_image_returns_404() {
+    let app = test_app();
+    let body = r#"{"model":"nonexistent/model","messages":[{"role":"user","content":[{"type":"text","text":"hi"},{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}]}]}"#;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "unknown model with an image must be 404, not 415/500"
+    );
+}
+
+/// Image-only message (no text part) on a vision model → rejected as empty
+/// prompt (the route requires at least one non-empty User text message).
+#[tokio::test]
+async fn test_chat_image_only_no_text_rejected_as_empty_prompt() {
+    let app = test_app();
+    let body = r#"{"model":"openai/gpt-4o","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}]}]}"#;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "an image-only message with no text must be rejected as an empty prompt (400)"
+    );
+}
+
+/// A `data:` URI missing `;base64` must be rejected at the ROUTE as a 4xx
+/// (client error) pre-payment — not a post-payment 5xx. Vision model so the
+/// vision gate passes and we reach the image-validation chokepoint.
+#[tokio::test]
+async fn test_chat_data_uri_without_base64_rejected_at_route_4xx() {
+    let app = test_app();
+    let body = r#"{"model":"openai/gpt-4o","messages":[{"role":"user","content":[{"type":"text","text":"look"},{"type":"image_url","image_url":{"url":"data:image/png,rawnotbase64"}}]}]}"#;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "a non-base64 data URI must be a 4xx at the route, pre-payment"
+    );
+}
+
+/// Image in a system message (vision model) → rejected at the route as a 4xx,
+/// never silently dropped after payment.
+#[tokio::test]
+async fn test_chat_image_in_system_message_rejected_at_route() {
+    let app = test_app();
+    let body = r#"{"model":"openai/gpt-4o","messages":[{"role":"system","content":[{"type":"text","text":"ctx"},{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}]},{"role":"user","content":"hi"}]}"#;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "an image in a system message must be rejected at the route, not silently dropped"
+    );
 }
 
 /// A JSON number for `content` (`42`) is not a valid content shape. It must be
@@ -2043,15 +2222,18 @@ async fn test_chat_content_parts_over_cap_returns_400() {
 
 /// Image rejection runs BEFORE the 402, not after. The same image body that is
 /// rejected with 415 when a payment header IS present
-/// (`test_chat_image_content_rejected_with_415`) must also be rejected with
-/// 415 when NO payment header is present — proving the image guard precedes the
-/// payment check and an unpaid image request never leaks a 402 cost quote.
+/// (`test_chat_image_content_rejected_for_non_vision_model_415`) must also be
+/// rejected with 415 when NO payment header is present — proving the vision
+/// gate precedes the payment check and an unpaid image request to a non-vision
+/// model never leaks a 402 cost quote.
 #[tokio::test]
-async fn test_chat_image_content_rejected_with_415_without_payment() {
+async fn test_chat_image_content_rejected_for_non_vision_model_without_payment() {
     let app = test_app();
 
     // Raw JSON so we exercise the real wire deserialization of an image part.
-    let body = r#"{"model":"openai/gpt-4o","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://x/y.png"}}]}]}"#;
+    // Non-vision model + a text part (so we reach the vision gate, not the
+    // empty-prompt check).
+    let body = r#"{"model":"deepseek/deepseek-chat","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"https://x/y.png"}}]}]}"#;
 
     let response = app
         .oneshot(

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -14,3 +14,4 @@ categories = ["api-bindings"]
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror = { workspace = true }

--- a/crates/protocol/src/vision.rs
+++ b/crates/protocol/src/vision.rs
@@ -1,7 +1,7 @@
 //! Multimodal content wire-format types.
 //!
-//! **Status: wired in.** [`MessageContent`] is now the type of
-//! `ChatMessage::content`. It accepts both OpenAI shapes for message
+//! **Status: wired in (vision supported).** [`MessageContent`] is the type
+//! of `ChatMessage::content`. It accepts both OpenAI shapes for message
 //! content: a plain JSON string (`"hello"`) deserializes to
 //! [`MessageContent::Text`], and an array of content parts
 //! (`[{"type":"text","text":"hello"}]`) deserializes to
@@ -10,25 +10,77 @@
 //! round-trips as a JSON string, preserving backward compatibility for
 //! existing string-only clients.
 //!
-//! Image parts are NOT silently dropped here. They are rejected upstream:
-//! the chat route returns `415 Unsupported Media Type` for any request
-//! carrying image content, and `reject_image_content` is a backstop at
-//! provider dispatch. Because image content never reaches this layer in
-//! practice, [`MessageContent::as_text`] simply ignores any image parts it
-//! sees rather than treating that case as an error.
+//! Image parts are NOT silently dropped. As of PR #2, vision is supported
+//! and gated on the resolved model's `supports_vision` capability: a request
+//! carrying image content for a non-vision model is rejected with
+//! `415 Unsupported Media Type` in the chat route. For vision-capable models
+//! the image parts are translated to each provider's native multimodal wire
+//! format (Anthropic image content blocks, Gemini `inlineData`/`fileData`
+//! parts) or passed through natively for OpenAI-format providers.
 //!
 //! For the string-based provider adapters (Anthropic / Google), text
-//! parts are flattened to a single string via
-//! [`MessageContent::as_text`]. For OpenAI-format providers (OpenAI / xAI
-//! / DeepSeek), the request is serialized through directly, so array
-//! content passes through natively to the upstream API.
+//! parts are flattened to a single string via [`MessageContent::as_text`]
+//! when no images are present, and translated to native image blocks when
+//! they are. For OpenAI-format providers (OpenAI / xAI / DeepSeek), the
+//! request is serialized through directly, so array content (text + images)
+//! passes through natively to the upstream API.
 //!
-//! Native image-block translation for Anthropic / Google, model
-//! capability gating in `models.toml`, and image cost accounting are not
-//! yet implemented; image content is rejected at the boundary until they
-//! are.
+//! [`ImageUrl::parse`] decodes an `image_url.url` into a [`ParsedImage`]:
+//! either an inline base64 payload (from a `data:` URI) or a remote
+//! `http(s)` URL. Malformed inputs return a clear error and never panic.
 
 use serde::{Deserialize, Serialize};
+
+/// Maximum accepted size of an `image_url.url` field (bytes of the raw string).
+///
+/// This is the single chokepoint that bounds the cost of decoding/splitting a
+/// `data:` URI and of folding image bytes into the cache key. A multi-megabyte
+/// base64 blob is rejected here before any per-byte work, covering every caller
+/// (the Anthropic/Gemini adapters and both cache layers) at once. 10 MiB of
+/// base64 decodes to ~7.5 MB of image bytes — comfortably inside both
+/// providers' inline-image budgets (Anthropic 32 MB request, Gemini 20 MB
+/// request) while keeping a single hostile request from pinning a worker.
+pub const MAX_DATA_URI_BYTES: usize = 10 * 1024 * 1024;
+
+/// Errors from [`ImageUrl::parse`]. Typed so the chat route can map a malformed
+/// client image to a 4xx (client error) rather than a 500.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseImageError {
+    /// The `url` field was empty (or all whitespace).
+    #[error("image_url.url is empty")]
+    Empty,
+    /// A `data:` URI with no `,` separating metadata from payload.
+    #[error("malformed data URI: missing ',' separator")]
+    MissingComma,
+    /// A `data:` URI lacking the `;base64` token (non-base64/URL-encoded data).
+    #[error("unsupported data URI: only base64-encoded image data URIs are supported (expected ';base64' before the comma)")]
+    NotBase64,
+    /// A `data:` URI whose base64 payload was empty.
+    #[error("malformed data URI: empty base64 payload")]
+    EmptyPayload,
+    /// The `url` field exceeded [`MAX_DATA_URI_BYTES`].
+    #[error("image_url.url too large: {0} bytes exceeds the {1}-byte limit")]
+    TooLarge(usize, usize),
+    /// The scheme was neither a `data:` URI nor an `http(s)` URL, OR the
+    /// declared media type is not in the supported image allowlist. The
+    /// payload is the offending value (URL scheme or media type), already
+    /// length-bounded so it is safe to surface.
+    #[error("unsupported image_url: {0}")]
+    UnsupportedScheme(String),
+}
+
+/// The image media types accepted by [`ImageUrl::parse`].
+///
+/// Restricted to the formats the downstream providers actually decode. Verified
+/// 2026-06-03 against the live Anthropic vision docs
+/// (platform.claude.com/docs/en/build-with-claude/vision — jpeg/png/gif/webp)
+/// and the Gemini image-understanding docs
+/// (ai.google.dev/gemini-api/docs/image-understanding — png/jpeg/webp/heic/heif).
+/// We accept the Anthropic set (which is also the OpenAI-documented set); `gif`
+/// is Anthropic-only and `heic/heif` are Gemini-only, so callers that route a
+/// `gif` to Gemini may still see a provider-side rejection — but no UNSUPPORTED
+/// type is ever forwarded blindly.
+const SUPPORTED_MEDIA_TYPES: [&str; 4] = ["image/png", "image/jpeg", "image/gif", "image/webp"];
 
 /// An image URL with optional detail level.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -36,6 +88,119 @@ pub struct ImageUrl {
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub detail: Option<String>,
+}
+
+/// The decoded form of an [`ImageUrl::url`] field.
+///
+/// OpenAI's `image_url.url` is overloaded: it is either a `data:` URI
+/// carrying inline base64 bytes, or an `http(s)` URL pointing at a remote
+/// image. Providers need these split apart — Anthropic uses
+/// `source.type = "base64"` vs `"url"`, Gemini uses `inlineData` vs
+/// `fileData` — so this enum is the single normalized representation both
+/// adapters translate from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedImage {
+    /// Inline base64 image decoded from a `data:` URI. `media_type` is the
+    /// MIME type (e.g. `image/png`); `data` is the raw base64 payload (the
+    /// substring AFTER the `,`), passed through verbatim — not re-decoded.
+    Base64 { media_type: String, data: String },
+    /// A remote `http(s)` image URL, passed through verbatim.
+    Url { url: String },
+}
+
+impl ImageUrl {
+    /// Parse [`Self::url`] into a [`ParsedImage`].
+    ///
+    /// Accepts two shapes (mirroring the OpenAI `image_url.url` contract):
+    /// - `data:[<media-type>][;base64],<data>` → [`ParsedImage::Base64`].
+    ///   The media-type defaults to `image/jpeg` when omitted (matching the
+    ///   `data:` URI spec's default of `text/plain` being inappropriate for
+    ///   image content; image providers require an image MIME type). Only
+    ///   base64-encoded data URIs are accepted — a `data:` URI WITHOUT the
+    ///   `;base64` token (i.e. percent/URL-encoded inline text) is rejected,
+    ///   because the downstream provider image fields require base64 bytes
+    ///   and silently forwarding URL-encoded text would corrupt the image.
+    ///   The declared media type must be in the supported allowlist
+    ///   ([`SUPPORTED_MEDIA_TYPES`]); an unsupported type is rejected rather
+    ///   than forwarded to a provider that cannot decode it.
+    /// - `http://...` / `https://...` → [`ParsedImage::Url`].
+    ///
+    /// Returns a typed [`ParseImageError`] for any other shape (empty, oversize,
+    /// missing comma in a `data:` URI, non-base64, empty payload, unsupported
+    /// scheme/media-type). Never panics: every slice is bounds-checked via
+    /// `split_once` / `strip_prefix`.
+    ///
+    /// Size: the raw `url` is rejected up front if it exceeds
+    /// [`MAX_DATA_URI_BYTES`], BEFORE any decode/split, so this method bounds
+    /// the work a single request can trigger across every caller.
+    pub fn parse(&self) -> Result<ParsedImage, ParseImageError> {
+        // Size cap FIRST — before any trim/split/decode — so an oversize blob
+        // never reaches per-byte work. Measured on the raw, untrimmed string.
+        if self.url.len() > MAX_DATA_URI_BYTES {
+            return Err(ParseImageError::TooLarge(
+                self.url.len(),
+                MAX_DATA_URI_BYTES,
+            ));
+        }
+
+        let url = self.url.trim();
+        if url.is_empty() {
+            return Err(ParseImageError::Empty);
+        }
+
+        if let Some(rest) = url.strip_prefix("data:") {
+            // `data:[<media-type>][;base64],<data>`. Split on the FIRST comma:
+            // the metadata (media-type + encoding flags) precedes it, the
+            // payload follows. A data URI without a comma is malformed.
+            let (meta, data) = rest.split_once(',').ok_or(ParseImageError::MissingComma)?;
+
+            // The metadata is `<media-type>;base64` (media-type optional).
+            // We require the `;base64` token; URL-encoded (non-base64) data
+            // URIs are rejected rather than forwarded as corrupt image bytes.
+            let base64_meta = meta
+                .strip_suffix(";base64")
+                .ok_or(ParseImageError::NotBase64)?;
+
+            let media_type = if base64_meta.is_empty() {
+                // No media-type segment (`data:;base64,...`) → default. Image
+                // providers require an image MIME type, so default to JPEG
+                // rather than the `data:` spec's text/plain default.
+                "image/jpeg".to_string()
+            } else {
+                base64_meta.to_string()
+            };
+
+            // Reject media types no downstream provider can decode.
+            if !SUPPORTED_MEDIA_TYPES.contains(&media_type.as_str()) {
+                return Err(ParseImageError::UnsupportedScheme(media_type));
+            }
+
+            // NOTE: we do NOT trim the payload. base64 contains no internal
+            // whitespace in well-formed input, and trimming would silently
+            // "repair" a malformed payload (masking a client bug); the payload
+            // is passed through verbatim for the provider to validate/decode.
+            if data.is_empty() {
+                return Err(ParseImageError::EmptyPayload);
+            }
+
+            return Ok(ParsedImage::Base64 {
+                media_type,
+                data: data.to_string(),
+            });
+        }
+
+        if url.starts_with("http://") || url.starts_with("https://") {
+            return Ok(ParsedImage::Url {
+                url: url.to_string(),
+            });
+        }
+
+        // Surface only the scheme prefix (length-bounded), never the full URL.
+        let prefix: String = url.chars().take(16).collect();
+        Err(ParseImageError::UnsupportedScheme(format!(
+            "expected a 'data:' URI or an http(s) URL, got {prefix:?}"
+        )))
+    }
 }
 
 /// A single part of multi-modal content (text or image).
@@ -109,10 +274,10 @@ impl MessageContent {
     /// borrows that part's string (zero-copy), and it only allocates when
     /// joining 2+ text parts (separated by a single space `" "`). An empty
     /// `Parts` list, or one with no text parts, yields a borrowed empty
-    /// string. Any image parts are ignored here because image content is
-    /// rejected upstream (415 on the chat route + `reject_image_content`
-    /// backstop) and so never reaches this method in practice; see module
-    /// docs.
+    /// string. Image parts contribute no text here — callers that need the
+    /// images (the provider adapters) iterate the parts directly via the
+    /// `Parts` variant; `as_text` is the text-only flattening used for prompt
+    /// guards, system-message extraction, and routing/scoring.
     ///
     /// The join separator is a single space so the flattened text reads
     /// naturally for guard scanning and string-based provider adapters.
@@ -155,10 +320,10 @@ impl MessageContent {
     /// True when the flattened TEXT content is empty.
     ///
     /// Reflects text emptiness only: a `Parts` value whose only members are
-    /// image parts is considered empty here. That is acceptable because image
-    /// content is rejected upstream (415 on the chat route; see the chat
-    /// route validation), so `is_empty()` callers never observe an
-    /// image-only message in practice. Computed without allocating.
+    /// image parts is considered empty here (it has no text). The chat route's
+    /// empty-prompt check requires at least one non-empty User *text*
+    /// message, so an image-only User turn still needs accompanying text to be
+    /// accepted. Computed without allocating.
     pub fn is_empty(&self) -> bool {
         match self {
             MessageContent::Text(s) => s.is_empty(),
@@ -171,10 +336,9 @@ impl MessageContent {
 
     /// True if any [`ContentPart::ImageUrl`] is present.
     ///
-    /// Used by the chat route to reject image/multimodal content (415):
-    /// native image-block translation, capability gating, and image cost
-    /// accounting are not yet implemented, so image content is rejected at
-    /// the boundary until they are.
+    /// Used by the chat route's capability gate (reject image content for a
+    /// non-vision model), by the image cost-estimate path, and by the cache
+    /// layers to decide whether to flatten content for the key.
     pub fn has_image_parts(&self) -> bool {
         match self {
             MessageContent::Text(_) => false,
@@ -182,6 +346,22 @@ impl MessageContent {
                 .iter()
                 .any(|p| matches!(p, ContentPart::ImageUrl { .. })),
         }
+    }
+
+    /// Iterate the [`ImageUrl`] of every image part, in order.
+    ///
+    /// Empty for [`MessageContent::Text`] and for any `Parts` list with no
+    /// image parts. Used by the cost-estimate path (per-image token
+    /// contribution keyed on `detail`) and by the cache image-rep folding.
+    pub fn image_urls(&self) -> impl Iterator<Item = &ImageUrl> {
+        let slice: &[ContentPart] = match self {
+            MessageContent::Text(_) => &[],
+            MessageContent::Parts(parts) => parts.as_slice(),
+        };
+        slice.iter().filter_map(|p| match p {
+            ContentPart::ImageUrl { image_url } => Some(image_url),
+            ContentPart::Text { .. } => None,
+        })
     }
 }
 
@@ -405,6 +585,194 @@ mod tests {
             },
         }]);
         assert!(only_image.is_empty());
+    }
+
+    // =========================================================================
+    // ImageUrl::parse — data-URI / http(s) decoding (PR #2)
+    // =========================================================================
+
+    fn img(url: &str) -> ImageUrl {
+        ImageUrl {
+            url: url.to_string(),
+            detail: None,
+        }
+    }
+
+    #[test]
+    fn parse_data_uri_base64_with_media_type() {
+        let got = img("data:image/png;base64,iVBORw0KGgo=").parse().unwrap();
+        assert_eq!(
+            got,
+            ParsedImage::Base64 {
+                media_type: "image/png".to_string(),
+                data: "iVBORw0KGgo=".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_data_uri_base64_defaults_media_type_when_omitted() {
+        // `data:;base64,...` — no media-type segment → default to image/jpeg.
+        let got = img("data:;base64,QUJD").parse().unwrap();
+        assert_eq!(
+            got,
+            ParsedImage::Base64 {
+                media_type: "image/jpeg".to_string(),
+                data: "QUJD".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_http_and_https_urls_pass_through() {
+        assert_eq!(
+            img("https://example.com/cat.png").parse().unwrap(),
+            ParsedImage::Url {
+                url: "https://example.com/cat.png".to_string()
+            }
+        );
+        assert_eq!(
+            img("http://example.com/dog.jpg").parse().unwrap(),
+            ParsedImage::Url {
+                url: "http://example.com/dog.jpg".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rejects_malformed_inputs() {
+        // Empty → typed Empty.
+        assert_eq!(img("").parse(), Err(ParseImageError::Empty));
+        assert_eq!(img("   ").parse(), Err(ParseImageError::Empty));
+        // data: URI without a comma separator → MissingComma.
+        assert_eq!(
+            img("data:image/png;base64").parse(),
+            Err(ParseImageError::MissingComma)
+        );
+        // data: URI that is not base64-encoded (URL-encoded inline text) →
+        // NotBase64.
+        assert_eq!(
+            img("data:text/plain,hello%20world").parse(),
+            Err(ParseImageError::NotBase64)
+        );
+        assert_eq!(
+            img("data:image/png,rawbytes").parse(),
+            Err(ParseImageError::NotBase64)
+        );
+        // data: URI with empty base64 payload → EmptyPayload.
+        assert_eq!(
+            img("data:image/png;base64,").parse(),
+            Err(ParseImageError::EmptyPayload)
+        );
+        // Non-http(s) scheme → UnsupportedScheme.
+        assert!(matches!(
+            img("ftp://example.com/x.png").parse(),
+            Err(ParseImageError::UnsupportedScheme(_))
+        ));
+        assert!(matches!(
+            img("file:///etc/passwd").parse(),
+            Err(ParseImageError::UnsupportedScheme(_))
+        ));
+        assert!(matches!(
+            img("javascript:alert(1)").parse(),
+            Err(ParseImageError::UnsupportedScheme(_))
+        ));
+        // Bare string, no scheme.
+        assert!(matches!(
+            img("just-some-text").parse(),
+            Err(ParseImageError::UnsupportedScheme(_))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_oversize_data_uri_before_decoding() {
+        // A url longer than the cap is rejected with TooLarge, regardless of
+        // whether the rest of the shape is valid — and BEFORE any split/decode.
+        let huge = "data:image/png;base64,".to_string() + &"A".repeat(MAX_DATA_URI_BYTES);
+        let err = img(&huge).parse().unwrap_err();
+        match err {
+            ParseImageError::TooLarge(len, cap) => {
+                assert!(len > cap);
+                assert_eq!(cap, MAX_DATA_URI_BYTES);
+            }
+            other => panic!("expected TooLarge, got {other:?}"),
+        }
+
+        // A url exactly at the cap is NOT rejected for size (it parses on shape;
+        // here the payload makes it a valid base64 data URI).
+        let at_cap_payload_len = MAX_DATA_URI_BYTES - "data:image/png;base64,".len();
+        let at_cap = "data:image/png;base64,".to_string() + &"A".repeat(at_cap_payload_len);
+        assert_eq!(at_cap.len(), MAX_DATA_URI_BYTES);
+        assert!(img(&at_cap).parse().is_ok());
+    }
+
+    #[test]
+    fn parse_rejects_unsupported_media_type() {
+        // image/svg+xml is not in the provider allowlist → UnsupportedScheme.
+        assert!(matches!(
+            img("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=").parse(),
+            Err(ParseImageError::UnsupportedScheme(_))
+        ));
+        // image/bmp likewise rejected.
+        assert!(matches!(
+            img("data:image/bmp;base64,Qk0=").parse(),
+            Err(ParseImageError::UnsupportedScheme(_))
+        ));
+        // Each allowlisted type is accepted.
+        for mt in ["image/png", "image/jpeg", "image/gif", "image/webp"] {
+            let uri = format!("data:{mt};base64,QUJD");
+            let parsed = img(&uri).parse().expect("allowlisted type must parse");
+            assert_eq!(
+                parsed,
+                ParsedImage::Base64 {
+                    media_type: mt.to_string(),
+                    data: "QUJD".to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn parse_does_not_re_decode_payload() {
+        // The base64 payload is passed through verbatim (providers re-decode).
+        // Even an invalid-base64 string is forwarded as-is; validation is the
+        // provider's job, and `parse` must not panic or alter the bytes.
+        let got = img("data:image/webp;base64,!!!not-valid-b64!!!")
+            .parse()
+            .unwrap();
+        assert_eq!(
+            got,
+            ParsedImage::Base64 {
+                media_type: "image/webp".to_string(),
+                data: "!!!not-valid-b64!!!".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn image_urls_iterates_only_image_parts_in_order() {
+        let mc = MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "look".to_string(),
+            },
+            ContentPart::ImageUrl {
+                image_url: img("https://example.com/a.png"),
+            },
+            ContentPart::ImageUrl {
+                image_url: img("https://example.com/b.png"),
+            },
+        ]);
+        let urls: Vec<&str> = mc.image_urls().map(|u| u.url.as_str()).collect();
+        assert_eq!(
+            urls,
+            vec!["https://example.com/a.png", "https://example.com/b.png"]
+        );
+
+        // Text content and text-only parts yield no images.
+        assert_eq!(
+            MessageContent::Text("hi".to_string()).image_urls().count(),
+            0
+        );
     }
 
     #[test]

--- a/crates/protocol/src/vision.rs
+++ b/crates/protocol/src/vision.rs
@@ -71,16 +71,23 @@ pub enum ParseImageError {
 
 /// The image media types accepted by [`ImageUrl::parse`].
 ///
-/// Restricted to the formats the downstream providers actually decode. Verified
-/// 2026-06-03 against the live Anthropic vision docs
+/// Restricted to the INTERSECTION of formats every vision provider the gateway
+/// routes to can decode, so an allowed `data:` URI never settles payment and
+/// then gets rejected by the upstream provider. Verified 2026-06-03 against the
+/// live Anthropic vision docs
 /// (platform.claude.com/docs/en/build-with-claude/vision — jpeg/png/gif/webp)
 /// and the Gemini image-understanding docs
 /// (ai.google.dev/gemini-api/docs/image-understanding — png/jpeg/webp/heic/heif).
-/// We accept the Anthropic set (which is also the OpenAI-documented set); `gif`
-/// is Anthropic-only and `heic/heif` are Gemini-only, so callers that route a
-/// `gif` to Gemini may still see a provider-side rejection — but no UNSUPPORTED
-/// type is ever forwarded blindly.
-const SUPPORTED_MEDIA_TYPES: [&str; 4] = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+/// `gif` is deliberately EXCLUDED: it is Anthropic-only (Gemini cannot decode
+/// it), so accepting a `data:image/gif` would let an agent pay for a request a
+/// Gemini-routed model can never serve. `heic/heif` are likewise excluded
+/// (Gemini-only). The kept set (png/jpeg/webp) is the common subset that
+/// decodes on every provider — no type is ever billed-then-rejected for being
+/// undecodable. (Remote `http(s)` image URLs carry no declared media type and
+/// so bypass this allowlist; a `.gif` URL routed to Gemini remains a residual
+/// pay-then-fail edge the gateway cannot detect without fetching — see
+/// `providers/google.rs::mime_type_from_url`.)
+const SUPPORTED_MEDIA_TYPES: [&str; 3] = ["image/png", "image/jpeg", "image/webp"];
 
 /// An image URL with optional detail level.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -718,8 +725,15 @@ mod tests {
             img("data:image/bmp;base64,Qk0=").parse(),
             Err(ParseImageError::UnsupportedScheme(_))
         ));
+        // image/gif is deliberately rejected: it is Anthropic-only and Gemini
+        // cannot decode it, so accepting it would let an agent pay for a request
+        // a Gemini-routed model can never serve. Excluded from the common subset.
+        assert!(matches!(
+            img("data:image/gif;base64,R0lGODdh").parse(),
+            Err(ParseImageError::UnsupportedScheme(_))
+        ));
         // Each allowlisted type is accepted.
-        for mt in ["image/png", "image/jpeg", "image/gif", "image/webp"] {
+        for mt in ["image/png", "image/jpeg", "image/webp"] {
             let uri = format!("data:{mt};base64,QUJD");
             let parsed = img(&uri).parse().expect("allowlisted type must parse");
             assert_eq!(


### PR DESCRIPTION
## Summary

PR 2 of 2 for OpenAI-spec multimodal content. PR #1 (#457) made `content` accept a string **or** an array of parts and **rejected** image parts with a 415 stopgap. This PR lifts that stopgap and adds real, **capability-gated** image support across every provider.

## What's included

- **Anthropic** — native image content blocks (`{"type":"image","source":{base64|url}}`); system stays the separate `system` param.
- **Google Gemini** — `inlineData` (base64) + `fileData` (remote URL, MIME inferred from extension) parts; correct camelCase wire shape.
- **OpenAI / xAI / DeepSeek** — text+image part arrays pass through natively.
- **Capability gating** — the previously declared-but-unenforced `supports_vision` flag is now enforced at the chat route (after model resolution, before payment) **and across the fallback chain**, so an image request can never be billed then dispatched to a non-vision model. System/developer-role images are rejected, never silently dropped.
- **Shared `ImageUrl::parse()`** (solvela-protocol) — data-URI vs http(s) discriminator with a typed `thiserror` error, a **10 MiB per-image cap**, and a **media-type allowlist** (png/jpeg/gif/webp). (Total image bytes are additionally bounded by the existing 10 MB request-body limit.)
- **Cost** — per-image token contribution added to the **upfront 402 estimate** (detail-based: low≈85, high/auto≈765). **Final settlement still bills provider-reported usage** (`compute_actual_atomic_cost`), so the real charge self-corrects.
- **Semantic cache** — folds a 128-bit content hash of each image into the embedding text so distinct images don't collide (wrong-cached-answer prevention); skips caching entirely on an unparseable image rather than building a divergent key. Exact cache already keys on full image content.

## Review

Two independent money-path review rounds (rust-reviewer, security-reviewer, type-design-analyzer, silent-failure-hunter, pr-test-analyzer), per the money-path 2-round convention. Round 1 surfaced 6 blocking findings (incl. a real Gemini camelCase wire bug a round-trip test caught); round 2 converged on closing the dead-but-`pub` ungated fallback dispatch functions. Confirmed safe: no gateway-side SSRF (URLs are only forwarded), A2A cannot carry image parts, settlement is usage-driven.

## Testing

`cargo fmt`/`clippy -D warnings` clean. **54 protocol + 673 gateway lib + 157 integration** passing. Provider wire shapes pinned with exact-JSON round-trip tests; capability gating tested end-to-end through `test_app` (vision→200, non-vision→415); cost, cache-distinctness, and data-URI parse (happy + malformed) covered. Only the pre-existing `#[sqlx::test]` no-Postgres failures remain.