### PR TITLE
release: solvela-protocol 0.3.0 + Rust SDK 0.2.4 (escrow signing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-protocol"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,4 +91,4 @@ dotenvy = "0.15"
 solvela-x402 = { path = "crates/x402", version = "0.2" }           # renamed from `x402` — that name is taken on crates.io
 solvela-escrow-tx = { path = "crates/escrow-tx", version = "0.2" } # no-deps escrow deposit-tx builder, shared with the Rust SDK
 solvela-router = { path = "crates/router", version = "0.2" }
-solvela-protocol = { path = "crates/protocol", version = "0.2" }
+solvela-protocol = { path = "crates/protocol", version = "0.3" }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solvela-protocol"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Shared wire-format types for the Solvela ecosystem (x402 payment protocol + OpenAI-compatible chat types)"
 license = "Apache-2.0"

--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "ahash",
  "base64",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "futures",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli-args"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bs58",
  "clap",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-proxy"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "axum",
  "clap",
@@ -3413,10 +3413,11 @@ dependencies = [
 
 [[package]]
 name = "solvela-protocol"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.91"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ keywords = ["solana", "x402", "usdc", "payments", "llm"]
 [workspace.dependencies]
 # Protocol — local path dep so wire-format drift between gateway and this SDK
 # fails CI in the same PR. Version pin matches the monorepo's crates/protocol.
-solvela-protocol = { path = "../../crates/protocol", version = "0.2" }
+solvela-protocol = { path = "../../crates/protocol", version = "0.3" }
 
 # Escrow deposit-tx builder — shared no-deps crate from the monorepo. Local path
 # dep so the on-chain-verified deposit byte layout stays in lockstep with the


### PR DESCRIPTION
## What

Version cascade to unblock the Rust SDK **v0.2.4** escrow-signing release.

| Crate | Change |
|---|---|
| `solvela-protocol` | `0.2.2 → 0.3.0` |
| root + SDK workspace protocol req | `"0.2" → "0.3"` |
| `sdks/rust` workspace (4 client crates) | `0.2.3 → 0.2.4` |
| `Cargo.lock` (root + sdks/rust) | regenerated |

## Why

SDK v0.2.4 ships x402 escrow-deposit signing, which depends on two `solvela-protocol` changes that were merged to `main` **but never published** (local `crates/protocol` drifted past the published `0.2.2` without a version bump):

- `MAINNET_ESCROW_PROGRAM_ID` constant
- `Message.content: String → MessageContent` enum (vision/image, #457 + #461)

A tag-publish of the SDK would have failed verification — when `cargo publish` resolves `solvela-protocol` from crates.io, the published `0.2.2` lacks both symbols. **Caught by the workspace publish dry-run before any tag was cut.**

## Why 0.3.0, not 0.2.3

`content: String → MessageContent` is a **breaking Rust API change**. Both already-published consumers — `solvela-client@0.2.3` and `solvela-x402@0.2.0` — pin `^0.2`. Publishing `0.2.3` into that range would break their fresh builds. `0.3.0` keeps existing `^0.2` pins from resolving it.

## Publish order (after merge)

1. `cargo publish -p solvela-protocol` (manual — no tag workflow for protocol; same as escrow-tx)
2. Tag `sdks/rust/v0.2.4` → `sdk-rust-publish.yml` publishes the four SDK crates against protocol `0.3.0`

`solvela-escrow-tx@0.2.0` is already live on crates.io.

## Follow-up (not in scope)

`solvela-x402` re-exports protocol wire types, so its next publish will need a protocol `"0.3"` pin and likely its own version bump.

## Verification

- `cargo check --workspace` green (root + sdks/rust)
- `cargo publish -p solvela-protocol --dry-run` ✅
- `cargo publish -p solvela-client -p solvela-client-cli-args -p solvela-client-cli -p solvela-client-proxy --dry-run --locked` — re-run after merge confirms the SDK builds against the published protocol `0.3.0`