### PR TITLE
feat(sdk-go): native x402 escrow deposit signing

### DIFF
--- a/sdks/go/CLAUDE.md
+++ b/sdks/go/CLAUDE.md
@@ -32,7 +32,8 @@ Single-package Go SDK (`package solvela`) — no sub-packages. Module: `github.c
 | `client.go` | `SolvelaClient` — main entry point. `Chat()`, `ChatStream()`, `Models()`. Orchestrates payment, caching, sessions, quality checking. |
 | `transport.go` | `Transport` — HTTP layer. `SendChat()`, `SendChatStream()` (SSE), `FetchModels()`. Handles 200/402/error responses. |
 | `wallet.go` | `Wallet` — ed25519 keypair. `CreateWallet()`, `WalletFromKeypairB58()`, `WalletFromEnv()`. Uses `mr-tron/base58`. |
-| `signer.go` | `Signer` interface + `KeypairSigner` stub. Pluggable payment transaction signing. |
+| `signer.go` | `Signer` interface + `KeypairSigner`. Builds escrow `deposit` transactions (`escrow` scheme); `exact` scheme returns a clear not-implemented error (no silent fallback). Pluggable. |
+| `escrow.go` | `buildDepositTx` + PDA/ATA derivation + legacy-message serializer. Byte-exact port of `crates/escrow-tx`; pinned to `GoldenVectorB64`. |
 | `cache.go` | `ResponseCache` — thread-safe LRU with TTL and dedup window. Default: 100 entries, 5m TTL, 2s dedup. |
 | `session.go` | `SessionStore` — conversation tracking with three-strike model escalation. |
 | `quality.go` | `CheckDegraded()` — detects empty, error-phrase, repetitive, or truncated responses. |

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -56,10 +56,17 @@ func main() {
 
 The core SDK (transport, caching, sessions, quality checking, streaming, balance monitoring) is fully implemented and tested.
 
-**`UnimplementedSigner` is the bundled placeholder.** It exists so the SDK compiles and the rest of the surface area (transport, caching, sessions, streaming) can be exercised, but `SignPayment` returns an error — it is **not** a working signer. To make real payments you have two options:
+**`KeypairSigner` is the bundled signer.** It builds real Solana transactions, branching on the x402 payment scheme:
 
-1. **Use a different SDK** — the [Python SDK](https://github.com/solvela-ai/solvela/tree/main/sdks/python) and [TypeScript SDK](https://github.com/solvela-ai/solvela/tree/main/sdks/typescript) include working `KeypairSigner` implementations backed by their respective Solana libraries.
-2. **Implement a custom `Signer`** — the `Signer` interface is pluggable. Provide your own implementation using `crypto/ed25519` (already in the Go standard library) and a Solana JSON-RPC client of your choice.
+- **`escrow`** — fully implemented. `SignPayment` builds a byte-exact escrow `deposit` transaction (golden-vector-pinned against the canonical Rust builder `crates/escrow-tx`), generating a per-request CSPRNG `service_id`, computing the expiry slot from `getSlot`, and fetching a recent blockhash. This is the trustless overpayment-protection path for a single metered request.
+- **`exact`** — not yet implemented in the Go SDK. `SignPayment` returns a clear error (it never silently substitutes another scheme). The byte layout has no pinned golden vector, so it is intentionally left unimplemented rather than guessed at on the money path.
+
+When the gateway advertises both `exact` and `escrow` (the default), `KeypairSigner` reports — via the optional `SchemeCapable` interface — that it can only sign `escrow`, so scheme selection prefers `escrow` rather than auto-selecting the unsignable first-listed `exact`. There is no silent substitution: if no compatible, signable scheme is offered, the client surfaces a `PaymentRequiredError`.
+
+To make `exact`-scheme payments today you have two options:
+
+1. **Use the Rust SDK** — the [Rust SDK](https://github.com/solvela-ai/solvela/tree/main/sdks/rust) is the canonical reference implementation and includes a working exact-scheme signer.
+2. **Implement a custom `Signer`** — the `Signer` interface is pluggable. Provide your own implementation using `crypto/ed25519` (already in the Go standard library) and a Solana JSON-RPC client of your choice. Optionally implement `SchemeCapable` so scheme selection knows which schemes your signer supports.
 
 ```go
 type MySigner struct{ wallet *solvela.Wallet }

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -383,13 +383,13 @@ func (c *SolvelaClient) sendWithPayment(ctx context.Context, request *ChatReques
 // gateway requires payment for the given request, and signs the payment if so.
 // Returns:
 //   - sig:        the encoded Payment-Signature header value, or "" if no
-//                 payment is needed (or the probe already returned a fully
-//                 resolved 200 response).
+//     payment is needed (or the probe already returned a fully
+//     resolved 200 response).
 //   - probeResp:  non-nil when the probe returned 200 with a complete
-//                 ChatResponse. Callers (ChatStream) MUST reuse this body
-//                 instead of issuing a second request — opening a streaming
-//                 follow-up would charge the caller twice and discard the
-//                 already-paid completion.
+//     ChatResponse. Callers (ChatStream) MUST reuse this body
+//     instead of issuing a second request — opening a streaming
+//     follow-up would charge the caller twice and discard the
+//     already-paid completion.
 //   - err:        any error encountered.
 //
 // The probe shares the same handshake logic as non-streaming Chat — the
@@ -495,15 +495,45 @@ func isCompatibleAccept(a PaymentAccept, scheme Scheme) bool {
 	return a.Scheme == scheme && a.Network == SolanaNetwork && a.Asset == USDCMint
 }
 
-func (c *SolvelaClient) findCompatibleScheme(pr *PaymentRequired) *PaymentAccept {
-	for i := range pr.Accepts {
-		if isCompatibleAccept(pr.Accepts[i], SchemeExact) {
-			return &pr.Accepts[i]
-		}
+// canSignerSign reports whether the configured signer is able to sign the given
+// scheme. A signer that implements [SchemeCapable] is asked directly; one that
+// does not is treated as scheme-agnostic (legacy custom-signer behavior). A nil
+// signer can sign nothing — the caller handles that earlier by returning a
+// PaymentRequiredError, but this stays safe regardless.
+func (c *SolvelaClient) canSignerSign(scheme Scheme) bool {
+	if c.signer == nil {
+		return false
 	}
-	for i := range pr.Accepts {
-		if isCompatibleAccept(pr.Accepts[i], SchemeEscrow) {
-			return &pr.Accepts[i]
+	if sc, ok := c.signer.(SchemeCapable); ok {
+		return sc.CanSignScheme(scheme)
+	}
+	return true
+}
+
+// findCompatibleScheme selects an accepted-scheme entry to pay against.
+//
+// An entry is only eligible if it is BOTH wire-compatible (right scheme,
+// network, and asset — see isCompatibleAccept) AND signable by the configured
+// signer (see canSignerSign). The gateway advertises `exact` first and `escrow`
+// second; we honor that preference order, but ONLY among schemes the signer can
+// actually fulfill. This is critical: KeypairSigner implements `escrow` only,
+// so without the signability filter the client would auto-select the
+// first-listed `exact` and every payment would fail (dead on arrival).
+//
+// There is NO silent substitution: we never sign a scheme the signer cannot
+// fulfill, and if no compatible+signable scheme exists we return nil so the
+// caller surfaces a clear PaymentRequiredError rather than guessing.
+func (c *SolvelaClient) findCompatibleScheme(pr *PaymentRequired) *PaymentAccept {
+	// Preference order matches the gateway's advertised order (exact, then
+	// escrow); each candidate must additionally be signable by the signer.
+	for _, scheme := range []Scheme{SchemeExact, SchemeEscrow} {
+		if !c.canSignerSign(scheme) {
+			continue
+		}
+		for i := range pr.Accepts {
+			if isCompatibleAccept(pr.Accepts[i], scheme) {
+				return &pr.Accepts[i]
+			}
 		}
 	}
 	return nil

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -201,6 +201,61 @@ func TestClientChat402WithoutSigner(t *testing.T) {
 	}
 }
 
+// TestClientChat402EscrowSignerExactOnlyFailsClosed pins the fail-closed core
+// of the T1.2 scheme-selection fix: with a real KeypairSigner (which signs
+// `escrow` only — see CanSignScheme) configured, a gateway that advertises ONLY
+// the `exact` scheme has no compatible+signable entry. The client MUST surface a
+// PaymentRequiredError (no scheme it can fulfill) — NOT a SignerError (that would
+// mean it tried to sign anyway) and NOT a silent substitution to escrow.
+//
+// This guards against a future regression where CanSignScheme accidentally
+// returns true for `exact`, or findCompatibleScheme drops the signability filter
+// and routes an exact offer into the escrow signer.
+func TestClientChat402EscrowSignerExactOnlyFailsClosed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version: X402Version,
+			Error:       "payment required",
+			CostBreakdown: CostBreakdown{
+				Total:    "1000",
+				Currency: "USDC",
+			},
+			// Gateway advertises ONLY exact — the KeypairSigner cannot sign it.
+			Accepts: []PaymentAccept{
+				{Scheme: SchemeExact, Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "recipient123"},
+			},
+		}
+		w.WriteHeader(402)
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, err := CreateWallet()
+	if err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+	// Real escrow-only signer. RPC URL is irrelevant: selection must fail closed
+	// BEFORE any signing / RPC is attempted.
+	signer := NewKeypairSigner(wallet, server.URL)
+	client, err := NewClient(wallet, signer, WithGatewayURL(server.URL))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when only the unsignable `exact` scheme is offered")
+	}
+	if _, ok := err.(*PaymentRequiredError); !ok {
+		// A SignerError here would mean the client tried to sign exact — the exact
+		// scheme-mismatch money-path bug this test exists to prevent.
+		t.Fatalf("expected PaymentRequiredError (fail closed), got %T: %v", err, err)
+	}
+}
+
 func TestClientLastKnownBalance(t *testing.T) {
 	wallet, _, _ := CreateWallet()
 	client, err := NewClient(wallet, nil)
@@ -566,7 +621,9 @@ func TestClientRecipientMismatch(t *testing.T) {
 			X402Version:   2,
 			CostBreakdown: CostBreakdown{Total: "1000"},
 			Accepts: []PaymentAccept{
-				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "wrong-recipient"},
+				// Offer escrow (signable by KeypairSigner) so selection reaches
+				// the scheme-independent recipient guard under test.
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "wrong-recipient", EscrowProgramID: ptr(testEscrowProgram)},
 			},
 		}
 		w.WriteHeader(402)
@@ -603,7 +660,8 @@ func TestClientAmountExceedsMax(t *testing.T) {
 			X402Version:   2,
 			CostBreakdown: CostBreakdown{Total: "999999"},
 			Accepts: []PaymentAccept{
-				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "999999", PayTo: "recipient"},
+				// Escrow so KeypairSigner can select it and reach the amount-cap guard.
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "999999", PayTo: "recipient", EscrowProgramID: ptr(testEscrowProgram)},
 			},
 		}
 		w.WriteHeader(402)
@@ -681,7 +739,8 @@ func TestClientRejectsZeroAmountAttack(t *testing.T) {
 			X402Version:   2,
 			CostBreakdown: CostBreakdown{Total: "0"},
 			Accepts: []PaymentAccept{
-				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "0", PayTo: "recipient"},
+				// Escrow so selection succeeds and the zero-amount guard fires.
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "0", PayTo: "recipient", EscrowProgramID: ptr(testEscrowProgram)},
 			},
 		}
 		w.WriteHeader(402)
@@ -724,7 +783,8 @@ func TestClientRejectsNonNumericAmount(t *testing.T) {
 			X402Version:   2,
 			CostBreakdown: CostBreakdown{Total: "junk"},
 			Accepts: []PaymentAccept{
-				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "notanumber", PayTo: "recipient"},
+				// Escrow so selection succeeds and the non-numeric-amount guard fires.
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "notanumber", PayTo: "recipient", EscrowProgramID: ptr(testEscrowProgram)},
 			},
 		}
 		w.WriteHeader(402)
@@ -765,7 +825,8 @@ func TestClientRejectsForeignResourceURL(t *testing.T) {
 			CostBreakdown: CostBreakdown{Total: "100"},
 			Resource:      Resource{URL: "https://attacker.example.com/v1/chat/completions", Method: "POST"},
 			Accepts: []PaymentAccept{
-				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
+				// Escrow so selection succeeds and the foreign-resource-URL guard fires.
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient", EscrowProgramID: ptr(testEscrowProgram)},
 			},
 		}
 		w.WriteHeader(402)

--- a/sdks/go/escrow.go
+++ b/sdks/go/escrow.go
@@ -1,0 +1,390 @@
+package solvela
+
+// Escrow deposit-transaction builder for the Go SDK.
+//
+// Byte-exact port of the canonical Rust builder crates/escrow-tx/src/deposit.rs
+// (+ pda.rs). The output MUST reproduce GOLDEN_VECTOR_B64 for the fixed
+// golden-vector input; the gateway verifier (crates/x402/src/escrow/)
+// independently re-derives the same layout, so any divergence here is a
+// fund-misdirection bug, not a style nit.
+//
+// Wire layout (single source of truth — see the Rust file and the solvela-x402
+// skill):
+//
+//   - Escrow PDA seeds: [b"escrow", agent_pubkey(32), service_id(32)].
+//   - Vault ATA: ATA(escrow_pda, usdc_mint).
+//   - Instruction data (56 bytes): anchorDiscriminator("deposit")[8] ||
+//     amount: u64 LE || service_id: [32] || expiry_slot: u64 LE.
+//   - Account list sorted by writability; program key appended last (index 9).
+//   - Instruction account-index order: [0, 4, 5, 1, 2, 3, 6, 7, 8].
+//   - Legacy message header [1, 0, 6]; length prefixes are single-byte
+//     compact-u16 (valid only for lengths <= 127 — reject larger rather than
+//     truncating).
+//   - Wire tx: compact-u16(1) || ed25519_signature(64) || message, then base64
+//     (standard alphabet).
+//
+// Derivation primitives (PDA/ATA find_program_address, the Anchor discriminator,
+// ed25519 signing) are computed with the Go standard library (crypto/ed25519,
+// crypto/sha256, filippo.io/edwards25519 for on-curve checks) plus mr-tron/base58
+// — the same dependency footprint as the rest of the SDK. We deliberately do NOT
+// pull in a full Solana SDK: the message must match the canonical
+// writability-sorted layout byte-for-byte, which a generic message builder would
+// re-derive differently.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"filippo.io/edwards25519"
+	"github.com/mr-tron/base58"
+)
+
+// Well-known program constants (match crates/escrow-tx/src/pda.rs).
+const (
+	ataProgramID    = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+	tokenProgramID  = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+	systemProgramID = "11111111111111111111111111111111"
+
+	// compactU16SingleByteMax is the largest length representable as a single
+	// compact-u16 byte. Lengths above this would require a continuation byte;
+	// emitting a bare byte there would corrupt the encoding, so we reject.
+	compactU16SingleByteMax = 127
+)
+
+// GoldenVectorB64 is the byte-exact base64 deposit transaction for the fixed
+// golden-vector input, copied verbatim from GOLDEN_VECTOR_B64 in
+// crates/escrow-tx/src/deposit.rs.
+//
+// DO NOT hand-edit. If this changes, the deposit-tx layout changed — the
+// on-chain/Rust value is ground truth. The drift-guard test
+// TestGoldenVectorMatchesRustSource pins this against the Rust source file.
+const GoldenVectorB64 = "Ad449R7ht12UKokgbDUYh29Ey/wDEwPioT/QtJOPKwSO4RHIaFRqS0DH+bPpEo2vCK78jbRLpP/6FV/5TY+qLw8BAAYKGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWFyvMLyv5o/k5XBGVxL9QMaEsQP6v01aK7nXazb0N/wMBS12eVticTdq8DzgM47jC/J8D1uNnFG6ZNqwpSU6GOelSnAbR4dY/56biCP6roeTxLQ8Q4TL7a2ArnBn2RW9HJ+jAiHYL/eHd3PMsF/IJuCQu5SqvEx+s2I0OosbQsG8sb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKmMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgo61GtoIM8r3akxjdsa2N5CEHZ8QBYuAbfwPDOL78eGrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urqwEJCQAEBQECAwYHCDjyI8aJUuHytkEKAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcuRQ8AAAAAAA=="
+
+// DepositParams holds the inputs required to build an escrow deposit
+// transaction.
+//
+// The service_id, expirySlot, and recentBlockhash are injected so the builder
+// is a pure, deterministic function (golden-vector testable). Production code
+// (the escrow signer) generates the CSPRNG service_id, computes expirySlot from
+// the current slot, and fetches the blockhash, then calls this builder.
+//
+// SECURITY: agentKeypair is raw ed25519 secret key material. It never crosses
+// the package boundary (the field is unexported) and is never logged. Callers
+// inside the package pass it from the wallet's private key.
+type DepositParams struct {
+	// agentKeypair is the 64-byte ed25519 private key (32-byte seed ||
+	// 32-byte public key), matching crypto/ed25519.PrivateKey.
+	agentKeypair ed25519.PrivateKey
+	// ProviderWalletB58 is the base58-encoded provider wallet pubkey.
+	ProviderWalletB58 string
+	// USDCMintB58 is the base58-encoded USDC mint pubkey.
+	USDCMintB58 string
+	// EscrowProgramIDB58 is the base58-encoded escrow program ID.
+	EscrowProgramIDB58 string
+	// Amount is the deposit amount in atomic USDC units (must be > 0).
+	Amount uint64
+	// ServiceID is the 32-byte service identifier that seeds the escrow PDA.
+	ServiceID [32]byte
+	// ExpirySlot is the slot at which the escrow deposit expires.
+	ExpirySlot uint64
+	// RecentBlockhash is the 32-byte recent blockhash from getLatestBlockhash.
+	RecentBlockhash [32]byte
+}
+
+// redactedDepositParams renders a DepositParams with the secret keypair
+// redacted. It mirrors the Rust `impl Debug for DepositParams`
+// (crates/escrow-tx/src/deposit.rs) and the Wallet.String() redaction: the raw
+// ed25519 secret material in agentKeypair must NEVER appear in a log line via
+// %v / %+v / %#v.
+func (p DepositParams) redactedDepositParams() string {
+	return fmt.Sprintf("DepositParams{agentKeypair:[REDACTED], ProviderWalletB58:%q, "+
+		"USDCMintB58:%q, EscrowProgramIDB58:%q, Amount:%d, ServiceID:[32]byte{...}, "+
+		"ExpirySlot:%d, RecentBlockhash:[32]byte{...}}",
+		p.ProviderWalletB58, p.USDCMintB58, p.EscrowProgramIDB58, p.Amount, p.ExpirySlot)
+}
+
+// String implements fmt.Stringer so plain %s / %v formatting redacts the
+// keypair.
+func (p DepositParams) String() string { return p.redactedDepositParams() }
+
+// GoString implements fmt.GoStringer so %#v formatting redacts the keypair
+// (the default %#v would otherwise dump the raw secret-key bytes).
+func (p DepositParams) GoString() string { return p.redactedDepositParams() }
+
+// Format implements fmt.Formatter so every verb (%v, %+v, %#v, %s) routes
+// through the redacted representation rather than reflecting over the struct
+// fields. fmt consults Formatter before Stringer/GoStringer, so this is the
+// authoritative guard against the keypair leaking. A pointer to DepositParams
+// also satisfies fmt.Formatter via this value receiver, so *DepositParams is
+// redacted too.
+func (p DepositParams) Format(f fmt.State, _ rune) {
+	_, _ = io.WriteString(f, p.redactedDepositParams())
+}
+
+// buildDepositTx builds a signed escrow deposit transaction, base64-encoded.
+//
+// Returns a base64 (standard alphabet) wire-format Solana legacy transaction
+// ready for the gateway / sendTransaction.
+//
+// Errors (all wrapped in *SignerError, never leaking the keypair):
+//   - zero amount
+//   - malformed provider/mint/program address
+//   - keypair of the wrong length
+//   - PDA or ATA derivation failure
+//   - message-too-long (a length field that would exceed the single-byte
+//     compact-u16 limit)
+func buildDepositTx(params *DepositParams) (string, error) {
+	// Step 1: fail-closed amount guard. The amount is a uint64 on the wire, so
+	// a negative/float amount is structurally impossible here (unlike the
+	// dynamically-typed Python port); we still reject zero before building
+	// anything — a zero-value escrow deposit is never legitimate.
+	if params.Amount == 0 {
+		return "", &SignerError{Message: "deposit amount must not be zero"}
+	}
+
+	// Step 2: recover the agent pubkey from the keypair. crypto/ed25519's
+	// PrivateKey is seed(32) || pubkey(32); the trailing 32 bytes are the
+	// public key, identical to Solana's keypair layout.
+	if len(params.agentKeypair) != ed25519.PrivateKeySize {
+		return "", &SignerError{Message: "invalid agent keypair: wrong length"}
+	}
+	// PrivateKey.Public() just copies the stored bytes [32:64]; it does NOT
+	// re-derive the pubkey from the seed. Re-derive it from the seed and
+	// require it to match the stored public half — mirroring the Rust guard
+	// (crates/escrow-tx/src/deposit.rs). A keypair with a corrupted public half
+	// would sign fine but seed the escrow PDA from the wrong agent identity,
+	// producing an un-claimable deposit on-chain. Fail closed instead.
+	storedPub := params.agentKeypair.Public().(ed25519.PublicKey)
+	derivedPriv := ed25519.NewKeyFromSeed(params.agentKeypair.Seed())
+	derivedPub := derivedPriv.Public().(ed25519.PublicKey)
+	if !bytes.Equal(storedPub, derivedPub) {
+		return "", &SignerError{Message: "invalid agent keypair: derived pubkey does not match stored pubkey"}
+	}
+	var agentPubkey [32]byte
+	copy(agentPubkey[:], storedPub)
+
+	// Step 3: parse all addresses.
+	provider, err := decodeBs58Pubkey(params.ProviderWalletB58)
+	if err != nil {
+		return "", &SignerError{Message: fmt.Sprintf("invalid address for provider_wallet: %v", err)}
+	}
+	usdcMint, err := decodeBs58Pubkey(params.USDCMintB58)
+	if err != nil {
+		return "", &SignerError{Message: fmt.Sprintf("invalid address for usdc_mint: %v", err)}
+	}
+	escrowProgram, err := decodeBs58Pubkey(params.EscrowProgramIDB58)
+	if err != nil {
+		return "", &SignerError{Message: fmt.Sprintf("invalid address for escrow_program_id: %v", err)}
+	}
+	tokenProgram, err := decodeBs58Pubkey(tokenProgramID)
+	if err != nil {
+		return "", &SignerError{Message: fmt.Sprintf("invalid address for token_program: %v", err)}
+	}
+	ataProgram, err := decodeBs58Pubkey(ataProgramID)
+	if err != nil {
+		return "", &SignerError{Message: fmt.Sprintf("invalid address for ata_program: %v", err)}
+	}
+	systemProgram, err := decodeBs58Pubkey(systemProgramID)
+	if err != nil {
+		return "", &SignerError{Message: fmt.Sprintf("invalid address for system_program: %v", err)}
+	}
+
+	// Step 4: derive escrow PDA.
+	escrowPDA, _, ok := findProgramAddress([][]byte{[]byte("escrow"), agentPubkey[:], params.ServiceID[:]}, escrowProgram)
+	if !ok {
+		return "", &SignerError{Message: "failed to derive escrow PDA"}
+	}
+
+	// Step 5: derive agent ATA and vault ATA.
+	agentATA, ok := deriveATAAddress(agentPubkey, usdcMint)
+	if !ok {
+		return "", &SignerError{Message: "failed to derive agent ATA"}
+	}
+	vaultATA, ok := deriveATAAddress(escrowPDA, usdcMint)
+	if !ok {
+		return "", &SignerError{Message: "failed to derive vault ATA"}
+	}
+
+	// Step 6: account list sorted by writability (writable signer, writable
+	// non-signers, readonly non-signers). The program key is appended last
+	// (index 9) inside the message serializer.
+	accounts := [][32]byte{
+		agentPubkey,   // 0: signer, writable
+		escrowPDA,     // 1: writable, non-signer
+		agentATA,      // 2: writable, non-signer
+		vaultATA,      // 3: writable, non-signer
+		provider,      // 4: readonly
+		usdcMint,      // 5: readonly
+		tokenProgram,  // 6: readonly
+		ataProgram,    // 7: readonly
+		systemProgram, // 8: readonly
+	}
+
+	// Step 7: instruction data = discriminator || amount(LE u64) || service_id
+	// || expiry_slot(LE u64) = 8 + 8 + 32 + 8 = 56 bytes.
+	ixData := make([]byte, 0, 56)
+	disc := anchorDiscriminator("deposit")
+	ixData = append(ixData, disc[:]...)
+	var amountLE [8]byte
+	binary.LittleEndian.PutUint64(amountLE[:], params.Amount)
+	ixData = append(ixData, amountLE[:]...)
+	ixData = append(ixData, params.ServiceID[:]...)
+	var expiryLE [8]byte
+	binary.LittleEndian.PutUint64(expiryLE[:], params.ExpirySlot)
+	ixData = append(ixData, expiryLE[:]...)
+	if len(ixData) != 56 {
+		return "", &SignerError{Message: fmt.Sprintf("deposit ix_data must be 56 bytes, got %d", len(ixData))}
+	}
+
+	// Anchor program account order remapped into the writability-sorted layout.
+	ixAccountIndices := []byte{0, 4, 5, 1, 2, 3, 6, 7, 8}
+
+	// Step 8: legacy message. Header [1, 0, 6]; program_id_index = 9 (last).
+	msg, err := buildLegacyMessage(
+		[3]byte{1, 0, 6},
+		accounts,
+		escrowProgram,
+		params.RecentBlockhash,
+		9, // program_id_index = 9 (last account)
+		ixAccountIndices,
+		ixData,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// Step 9: sign the raw message bytes with the agent keypair (ed25519).
+	signature := ed25519.Sign(params.agentKeypair, msg)
+	if len(signature) != ed25519.SignatureSize {
+		return "", &SignerError{Message: "unexpected ed25519 signature length"}
+	}
+
+	// Step 10: assemble wire tx: compact-u16(1) || signature(64) || message.
+	txBytes := make([]byte, 0, 1+ed25519.SignatureSize+len(msg))
+	txBytes = append(txBytes, 0x01) // compact-u16: 1 signature
+	txBytes = append(txBytes, signature...)
+	txBytes = append(txBytes, msg...)
+
+	return base64.StdEncoding.EncodeToString(txBytes), nil
+}
+
+// buildLegacyMessage serializes a Solana legacy transaction message.
+//
+// Layout: header(3) || acct_count(u8) || N*32 keys (+ program key) ||
+// blockhash(32) || ix_count(u8)=1 || program_id_index(u8) || ix_acct_count(u8)
+// || ix_acct_indices || data_len(u8) || data.
+//
+// Length prefixes are emitted as a single byte — the correct compact-u16
+// encoding only for lengths <= 127. Larger values are rejected (not truncated),
+// mirroring the Rust builder.
+func buildLegacyMessage(
+	header [3]byte,
+	accounts [][32]byte,
+	programID [32]byte,
+	recentBlockhash [32]byte,
+	programIDIndex byte,
+	ixAccountIndices []byte,
+	ixData []byte,
+) ([]byte, error) {
+	totalAccounts := len(accounts) + 1 // +1 for the appended program key
+	if totalAccounts > compactU16SingleByteMax {
+		return nil, &SignerError{Message: fmt.Sprintf("account count %d exceeds the 127-byte compact-u16 single-byte limit", totalAccounts)}
+	}
+	if len(ixAccountIndices) > compactU16SingleByteMax {
+		return nil, &SignerError{Message: fmt.Sprintf("instruction account count %d exceeds the 127-byte compact-u16 single-byte limit", len(ixAccountIndices))}
+	}
+	if len(ixData) > compactU16SingleByteMax {
+		return nil, &SignerError{Message: fmt.Sprintf("instruction data length %d exceeds the 127-byte compact-u16 single-byte limit", len(ixData))}
+	}
+
+	msg := make([]byte, 0, 3+1+totalAccounts*32+32+1+1+1+len(ixAccountIndices)+1+len(ixData))
+	msg = append(msg, header[:]...)
+	msg = append(msg, byte(totalAccounts))
+	for i := range accounts {
+		msg = append(msg, accounts[i][:]...)
+	}
+	msg = append(msg, programID[:]...) // program key is the last account
+	msg = append(msg, recentBlockhash[:]...)
+	msg = append(msg, 1) // instruction count
+	msg = append(msg, programIDIndex)
+	msg = append(msg, byte(len(ixAccountIndices)))
+	msg = append(msg, ixAccountIndices...)
+	msg = append(msg, byte(len(ixData)))
+	msg = append(msg, ixData...)
+	return msg, nil
+}
+
+// anchorDiscriminator computes the Anchor instruction discriminator:
+// sha256("global:<name>")[..8].
+func anchorDiscriminator(name string) [8]byte {
+	sum := sha256.Sum256([]byte("global:" + name))
+	var disc [8]byte
+	copy(disc[:], sum[:8])
+	return disc
+}
+
+// findProgramAddress derives a Program Derived Address using SHA-256 (same as
+// the Solana runtime). Returns (pubkey, bump, ok). ok is false if no valid
+// off-curve point is found across all 256 bumps.
+//
+// Hash input order matches solana_program::pubkey::Pubkey::create_program_address:
+// seeds || bump || program_id || "ProgramDerivedAddress" (the program id comes
+// BEFORE the PDA marker, not after).
+func findProgramAddress(seeds [][]byte, programID [32]byte) ([32]byte, uint8, bool) {
+	for nonce := 255; nonce >= 0; nonce-- {
+		h := sha256.New()
+		for _, seed := range seeds {
+			h.Write(seed)
+		}
+		h.Write([]byte{byte(nonce)})
+		h.Write(programID[:])
+		h.Write([]byte("ProgramDerivedAddress"))
+		var candidate [32]byte
+		copy(candidate[:], h.Sum(nil))
+		if !isOnEd25519Curve(candidate) {
+			return candidate, uint8(nonce), true
+		}
+	}
+	return [32]byte{}, 0, false
+}
+
+// isOnEd25519Curve reports whether 32 bytes decode to a valid compressed point
+// on the ed25519 curve. A PDA must be OFF the curve.
+func isOnEd25519Curve(b [32]byte) bool {
+	_, err := new(edwards25519.Point).SetBytes(b[:])
+	return err == nil
+}
+
+// deriveATAAddress derives the Associated Token Account address for a wallet
+// and mint: find_program_address([wallet, token_program, mint], ata_program).
+func deriveATAAddress(wallet, mint [32]byte) ([32]byte, bool) {
+	tokenProgram, err := decodeBs58Pubkey(tokenProgramID)
+	if err != nil {
+		return [32]byte{}, false
+	}
+	ataProgram, err := decodeBs58Pubkey(ataProgramID)
+	if err != nil {
+		return [32]byte{}, false
+	}
+	addr, _, ok := findProgramAddress([][]byte{wallet[:], tokenProgram[:], mint[:]}, ataProgram)
+	return addr, ok
+}
+
+// decodeBs58Pubkey decodes a base58-encoded pubkey into 32 bytes.
+func decodeBs58Pubkey(s string) ([32]byte, error) {
+	var out [32]byte
+	raw, err := base58.Decode(s)
+	if err != nil {
+		return out, fmt.Errorf("invalid base58: %w", err)
+	}
+	if len(raw) != 32 {
+		return out, fmt.Errorf("expected 32 bytes, got %d", len(raw))
+	}
+	copy(out[:], raw)
+	return out, nil
+}

--- a/sdks/go/escrow_test.go
+++ b/sdks/go/escrow_test.go
@@ -1,0 +1,340 @@
+package solvela
+
+// Unit tests for the escrow deposit-transaction builder.
+//
+// The golden-vector parity test is the contract: the Go deposit builder MUST
+// reproduce crates/escrow-tx/src/deposit.rs's GOLDEN_VECTOR_B64 byte-for-byte
+// for its fixed input. If it diverges, the on-chain layout disagreement is a
+// fund-misdirection bug — fix the Go builder, NEVER edit the expected golden
+// value (the Rust/on-chain value is ground truth).
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mr-tron/base58"
+)
+
+const (
+	goldenProvider      = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+	goldenUSDCMint      = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	goldenEscrowProgram = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+)
+
+// goldenKeypair builds the deterministic 64-byte agent keypair from seed
+// [42]*32 (matches the Rust golden fixture: SigningKey::from_bytes([42; 32])).
+func goldenKeypair() ed25519.PrivateKey {
+	seed := make([]byte, 32)
+	for i := range seed {
+		seed[i] = 42
+	}
+	return ed25519.NewKeyFromSeed(seed)
+}
+
+func goldenParams() *DepositParams {
+	var serviceID [32]byte
+	for i := range serviceID {
+		serviceID[i] = 7
+	}
+	var blockhash [32]byte
+	for i := range blockhash {
+		blockhash[i] = 0xAB
+	}
+	return &DepositParams{
+		agentKeypair:       goldenKeypair(),
+		ProviderWalletB58:  goldenProvider,
+		USDCMintB58:        goldenUSDCMint,
+		EscrowProgramIDB58: goldenEscrowProgram,
+		Amount:             2625,
+		ServiceID:          serviceID,
+		ExpirySlot:         1_000_750,
+		RecentBlockhash:    blockhash,
+	}
+}
+
+// TestDepositTxMatchesGoldenVector is the sole correctness bar for the wire
+// format: byte-for-byte parity with the canonical Rust builder.
+func TestDepositTxMatchesGoldenVector(t *testing.T) {
+	out, err := buildDepositTx(goldenParams())
+	if err != nil {
+		t.Fatalf("golden build should succeed: %v", err)
+	}
+	if out != GoldenVectorB64 {
+		t.Fatalf("Go deposit-tx does not match the Rust golden vector.\n"+
+			"The on-chain layout is ground truth — fix the Go builder, do NOT edit the expected value.\n"+
+			"got:  %s\nwant: %s", out, GoldenVectorB64)
+	}
+}
+
+// TestDepositTxDeterministic confirms the build is pure: same fixed input
+// always yields the same bytes (no nonce, no clock).
+func TestDepositTxDeterministic(t *testing.T) {
+	a, err := buildDepositTx(goldenParams())
+	if err != nil {
+		t.Fatalf("build a: %v", err)
+	}
+	b, err := buildDepositTx(goldenParams())
+	if err != nil {
+		t.Fatalf("build b: %v", err)
+	}
+	if a != b {
+		t.Fatal("deposit build is not deterministic")
+	}
+}
+
+func TestGoldenVectorDecodesToSignedTx(t *testing.T) {
+	raw, err := base64.StdEncoding.DecodeString(GoldenVectorB64)
+	if err != nil {
+		t.Fatalf("golden vector must be valid base64: %v", err)
+	}
+	// compact-u16(1) || sig(64) || message
+	if raw[0] != 0x01 {
+		t.Errorf("first byte should be 0x01 (1 signature), got 0x%02x", raw[0])
+	}
+	if len(raw) <= 1+ed25519.SignatureSize {
+		t.Errorf("tx too short: %d bytes", len(raw))
+	}
+}
+
+// TestGoldenVectorMatchesRustSource is the drift guard: the Go golden constant
+// MUST equal the Rust source of truth. If the Rust GOLDEN_VECTOR_B64 ever
+// changes, the on-chain wire layout changed and this test fails loudly, forcing
+// a resync of the Go constant and builder rather than letting the SDKs silently
+// diverge.
+func TestGoldenVectorMatchesRustSource(t *testing.T) {
+	// escrow_test.go -> sdks/go; worktree root is two levels up.
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve worktree root: %v", err)
+	}
+	rustSrc := filepath.Join(root, "crates", "escrow-tx", "src", "deposit.rs")
+	data, err := os.ReadFile(rustSrc)
+	if err != nil {
+		t.Fatalf("Rust deposit.rs not found at %s: %v", rustSrc, err)
+	}
+	re := regexp.MustCompile(`GOLDEN_VECTOR_B64:\s*&str\s*=\s*"([^"]+)"`)
+	m := re.FindSubmatch(data)
+	if m == nil {
+		t.Fatalf("could not locate GOLDEN_VECTOR_B64 in %s", rustSrc)
+	}
+	rustValue := string(m[1])
+	if rustValue != GoldenVectorB64 {
+		t.Fatalf("Go GoldenVectorB64 has drifted from the Rust source of truth " +
+			"(crates/escrow-tx/src/deposit.rs). The on-chain layout is ground truth: " +
+			"resync the Go constant AND re-verify buildDepositTx byte-parity — do NOT " +
+			"just paste the new value.")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Derivation parity (PDA seeds + vault ATA + discriminator).
+// ---------------------------------------------------------------------------
+
+func TestEscrowPDAExternalGroundTruth(t *testing.T) {
+	// Mirrors crates/escrow-tx/src/pda.rs ground-truth test:
+	// agent=[1]*32, service_id=[2]*32 -> BEAUsvsWvV4o6y7XkC1bkyTq4FtQnKErcV3dzTFPT5hX, bump 255.
+	program, err := decodeBs58Pubkey(goldenEscrowProgram)
+	if err != nil {
+		t.Fatalf("decode program: %v", err)
+	}
+	var agent, serviceID [32]byte
+	for i := range agent {
+		agent[i] = 1
+		serviceID[i] = 2
+	}
+	pda, bump, ok := findProgramAddress([][]byte{[]byte("escrow"), agent[:], serviceID[:]}, program)
+	if !ok {
+		t.Fatal("PDA derivation failed")
+	}
+	if got := base58.Encode(pda[:]); got != "BEAUsvsWvV4o6y7XkC1bkyTq4FtQnKErcV3dzTFPT5hX" {
+		t.Errorf("PDA mismatch: got %s", got)
+	}
+	if bump != 255 {
+		t.Errorf("bump mismatch: got %d, want 255", bump)
+	}
+}
+
+func TestVaultATAKnownValue(t *testing.T) {
+	// Mirrors crates/escrow-tx/src/pda.rs test_derive_ata_for_known_wallet.
+	wallet, err := decodeBs58Pubkey("4P8mSmvv3nfzUtoqhNKG1mfGrHMVbXvKBXR7fDivv6qp")
+	if err != nil {
+		t.Fatalf("decode wallet: %v", err)
+	}
+	mint, err := decodeBs58Pubkey(goldenUSDCMint)
+	if err != nil {
+		t.Fatalf("decode mint: %v", err)
+	}
+	ata, ok := deriveATAAddress(wallet, mint)
+	if !ok {
+		t.Fatal("ATA derivation failed")
+	}
+	if got := base58.Encode(ata[:]); got != "CYHVCkLwiEjMBdRiz5MsrrCbVL2YTZuv57TjV3ggxoSN" {
+		t.Errorf("ATA mismatch: got %s", got)
+	}
+}
+
+func TestAnchorDiscriminatorDeterministic(t *testing.T) {
+	d1 := anchorDiscriminator("deposit")
+	d2 := anchorDiscriminator("deposit")
+	if d1 != d2 {
+		t.Error("discriminator not deterministic")
+	}
+	if anchorDiscriminator("deposit") == anchorDiscriminator("claim") {
+		t.Error("distinct instruction names must give distinct discriminators")
+	}
+}
+
+func TestIsOnEd25519CurveDetectsOffCurvePDA(t *testing.T) {
+	// A derived PDA must be OFF the curve.
+	program, _ := decodeBs58Pubkey(goldenEscrowProgram)
+	var agent, serviceID [32]byte
+	for i := range agent {
+		agent[i] = 1
+		serviceID[i] = 2
+	}
+	pda, _, _ := findProgramAddress([][]byte{[]byte("escrow"), agent[:], serviceID[:]}, program)
+	if isOnEd25519Curve(pda) {
+		t.Error("PDA must be off the ed25519 curve")
+	}
+	// A normal wallet pubkey (the golden agent) is ON the curve.
+	var agentPub [32]byte
+	copy(agentPub[:], goldenKeypair().Public().(ed25519.PublicKey))
+	if !isOnEd25519Curve(agentPub) {
+		t.Error("a real ed25519 pubkey must be on the curve")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rejection / fail-closed behavior.
+// ---------------------------------------------------------------------------
+
+func TestDepositZeroAmountRejected(t *testing.T) {
+	p := goldenParams()
+	p.Amount = 0
+	_, err := buildDepositTx(p)
+	if err == nil {
+		t.Fatal("zero amount should be rejected")
+	}
+	if _, ok := err.(*SignerError); !ok {
+		t.Fatalf("expected *SignerError, got %T", err)
+	}
+}
+
+func TestDepositInvalidKeypairLengthRejected(t *testing.T) {
+	p := goldenParams()
+	p.agentKeypair = ed25519.PrivateKey([]byte{1, 2, 3})
+	_, err := buildDepositTx(p)
+	if err == nil {
+		t.Fatal("invalid keypair length should be rejected")
+	}
+}
+
+func TestDepositInvalidProviderRejected(t *testing.T) {
+	p := goldenParams()
+	p.ProviderWalletB58 = "not-base58-0OIl!!!"
+	_, err := buildDepositTx(p)
+	if err == nil {
+		t.Fatal("invalid provider address should be rejected")
+	}
+}
+
+func TestDepositInvalidMintRejected(t *testing.T) {
+	p := goldenParams()
+	p.USDCMintB58 = "not-base58-0OIl!!!"
+	_, err := buildDepositTx(p)
+	if err == nil {
+		t.Fatal("invalid mint address should be rejected")
+	}
+}
+
+func TestDepositKeypairNotLeakedInError(t *testing.T) {
+	// A malformed keypair must never echo secret bytes. We pass a wrong-length
+	// key; the error message must not contain any hex/base58 of the bytes.
+	p := goldenParams()
+	p.agentKeypair = ed25519.PrivateKey([]byte{9, 9, 9, 9})
+	_, err := buildDepositTx(p)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != "signer error: invalid agent keypair: wrong length" {
+		t.Errorf("error message leaked detail or changed: %q", got)
+	}
+}
+
+func TestBuildLegacyMessageRejectsTooManyAccounts(t *testing.T) {
+	// 127 data accounts + 1 program key = 128 total -> exceeds the limit.
+	accounts := make([][32]byte, 127)
+	_, err := buildLegacyMessage([3]byte{1, 0, 0}, accounts, [32]byte{}, [32]byte{}, 127, []byte{0}, []byte{0})
+	if err == nil {
+		t.Fatal("128 total accounts should be rejected")
+	}
+}
+
+func TestBuildLegacyMessageRejectsLongIxData(t *testing.T) {
+	_, err := buildLegacyMessage([3]byte{1, 0, 0}, [][32]byte{{}}, [32]byte{}, [32]byte{}, 1, []byte{0}, make([]byte, 128))
+	if err == nil {
+		t.Fatal("128 ix-data bytes should be rejected")
+	}
+}
+
+// TestDepositCorruptedPubkeyHalfRejected mirrors the Rust guard
+// (crates/escrow-tx/src/deposit.rs): ed25519.PrivateKey.Public() copies the
+// stored bytes [32:64] rather than re-deriving from the seed, so a keypair with
+// a corrupted public half would sign fine but seed the escrow PDA from the
+// wrong identity, producing an un-claimable on-chain deposit. The builder must
+// re-derive from the seed and reject the mismatch.
+func TestDepositCorruptedPubkeyHalfRejected(t *testing.T) {
+	p := goldenParams()
+	corrupted := make(ed25519.PrivateKey, len(p.agentKeypair))
+	copy(corrupted, p.agentKeypair)
+	// Flip a bit in the stored public half (bytes 32..64) WITHOUT touching the
+	// seed. The seed-derived pubkey will no longer match the stored one.
+	corrupted[40] ^= 0xFF
+	p.agentKeypair = corrupted
+
+	_, err := buildDepositTx(p)
+	if err == nil {
+		t.Fatal("a keypair whose stored pubkey half does not match its seed must be rejected")
+	}
+	if _, ok := err.(*SignerError); !ok {
+		t.Fatalf("expected *SignerError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "derived pubkey does not match stored pubkey") {
+		t.Errorf("unexpected error: %q", err.Error())
+	}
+}
+
+// TestDepositParamsRedactsKeypair verifies the secret keypair never appears in
+// any fmt rendering of DepositParams (%v, %+v, %#v, %s). A raw 64-byte secret
+// key landing in a log line is a key-disclosure bug.
+func TestDepositParamsRedactsKeypair(t *testing.T) {
+	// goldenParams() returns a *DepositParams; dereference so we can test both
+	// the value and pointer forms below.
+	pp := goldenParams()
+	p := *pp
+	// The first secret-seed byte of the golden keypair is 42 (0x2a). If the
+	// struct were reflected normally, %v / %#v would print the keypair slice as
+	// "[42 42 42 ...]" / "ed25519.PrivateKey{0x2a, ...}".
+	for _, verb := range []string{"%v", "%+v", "%#v", "%s"} {
+		// Test both the value and the *DepositParams pointer (production code
+		// holds a *DepositParams and would log it directly).
+		for _, arg := range []any{p, pp} {
+			out := fmt.Sprintf(verb, arg)
+			if !strings.Contains(out, "[REDACTED]") {
+				t.Errorf("%s rendering of %T missing [REDACTED] marker: %q", verb, arg, out)
+			}
+			// Guard against the secret bytes leaking in either base-10 (reflected
+			// slice) or 0x2a hex (%#v) form. "42 42 42" and "0x2a, 0x2a" are the
+			// tell-tale shapes of a dumped 64-byte key.
+			if strings.Contains(out, "42 42 42") || strings.Contains(out, "0x2a, 0x2a") {
+				t.Errorf("%s rendering of %T leaked raw keypair bytes: %q", verb, arg, out)
+			}
+		}
+	}
+}

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -3,3 +3,5 @@ module github.com/solvela-ai/solvela/sdks/go
 go 1.23.7
 
 require github.com/mr-tron/base58 v1.2.0
+
+require filippo.io/edwards25519 v1.1.0

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,2 +1,4 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=

--- a/sdks/go/signer.go
+++ b/sdks/go/signer.go
@@ -1,57 +1,430 @@
 package solvela
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/mr-tron/base58"
+)
 
 // Signer is a pluggable interface for signing payment transactions.
 type Signer interface {
 	SignPayment(ctx context.Context, amountAtomic uint64, recipient string, resource Resource, accepted PaymentAccept) (*PaymentPayload, error)
 }
 
-// Compile-time assertion that UnimplementedSigner satisfies Signer. If the
-// interface drifts (e.g., a method is renamed), the build fails here rather
-// than at first runtime call.
-var _ Signer = (*UnimplementedSigner)(nil)
+// SchemeCapable is an OPTIONAL interface a [Signer] may implement to declare
+// which x402 payment schemes it can actually fulfill. Scheme selection
+// ([SolvelaClient.findCompatibleScheme]) consults this so it never picks a
+// scheme the active signer cannot sign.
+//
+// This matters because the gateway advertises BOTH `exact` and `escrow` (with
+// `exact` listed first; see crates/gateway/src/routes/chat/mod.rs). A signer
+// that only implements `escrow` (like [KeypairSigner]) would otherwise have the
+// client auto-select `exact` and fail every payment — dead on arrival. Honoring
+// CanSignScheme lets selection prefer `escrow` for such a signer.
+//
+// A signer that does NOT implement this interface is treated as scheme-agnostic
+// (assumed able to sign any compatible scheme), preserving the legacy
+// "first compatible scheme wins" behavior for custom signers.
+type SchemeCapable interface {
+	// CanSignScheme reports whether this signer can produce a signed payload for
+	// the given scheme. It must not perform I/O.
+	CanSignScheme(scheme Scheme) bool
+}
 
-// UnimplementedSigner is a placeholder Signer for callers who do not yet
-// have a real Solana USDC-SPL signing implementation. Its SignPayment
-// method always returns an error. Construct your own Signer implementation
-// (or use a future built-in signer) before sending paid requests.
-type UnimplementedSigner struct {
+// Compile-time assertion that KeypairSigner satisfies Signer and SchemeCapable.
+// If either interface drifts (e.g., a method is renamed), the build fails here
+// rather than at first runtime call.
+var (
+	_ Signer        = (*KeypairSigner)(nil)
+	_ SchemeCapable = (*KeypairSigner)(nil)
+)
+
+// --- Escrow expiry-slot bounds (mirror the Rust/Python SDK signers) ---
+//
+// Solana slots are ~400 ms. These bounds are ported verbatim from
+// sdks/rust/crates/solvela-client/src/signer.rs and sdks/python/.../signer.py so
+// all SDKs choose compatible expiry slots and none is bounced by the gateway.
+const (
+	// maxEscrowExpirySlotsAhead is the upper bound on how far ahead an escrow
+	// may expire (~66 min). Rejects a malicious/misconfigured gateway from
+	// pushing expiry to "never".
+	maxEscrowExpirySlotsAhead = 10_000
+
+	// minEscrowExpirySlotsAhead is the lower bound on expiry distance. Mirrors
+	// AND exceeds the gateway's MIN_EXPIRY_BUFFER_SLOTS = 50
+	// (crates/x402/src/escrow/verifier.rs); the extra headroom (150 vs 50)
+	// absorbs slot-skew between the slot we read and the slot the gateway
+	// verifies against. ~150 slots ~= 60 s.
+	minEscrowExpirySlotsAhead = 150
+
+	// minPlausibleSlot is the floor below which a getSlot result is implausible
+	// and rejected. A stub/genesis/freshly-reset validator can answer getSlot
+	// with a near-zero slot; computing an escrow expiry from that base yields
+	// an already-expired (or trivially-near-expiry) deposit the gateway would
+	// bounce. Mainnet/devnet have been well past this for years. Fail closed
+	// rather than silently signing a dead-on-arrival escrow deposit.
+	minPlausibleSlot = 1_000_000
+
+	defaultRPCURL = "https://api.mainnet-beta.solana.com"
+
+	// maxRPCBodyBytes caps a successful (200 OK) JSON-RPC response body. The
+	// getSlot/getLatestBlockhash responses this signer reads are tiny (a few
+	// hundred bytes), but we still bound the read so a misbehaving/hostile RPC
+	// endpoint cannot stream an unbounded body into memory. This is the
+	// success-path cap; maxErrorBodyBytes (4 KB) is the tighter error-path cap.
+	maxRPCBodyBytes = 64 << 10 // 64 KB
+)
+
+// KeypairSigner is the default Signer. It builds real Solana transactions,
+// branching on the x402 payment scheme:
+//
+//	exact  -> NOT yet implemented in the Go SDK (returns a clear error; never
+//	          silently substitutes another scheme). For exact-scheme payments use
+//	          the Rust SDK (the canonical reference implementation) or supply a
+//	          custom Signer.
+//	escrow -> on-chain deposit into a per-request escrow PDA (returns an
+//	          EscrowPayload), byte-exact with the canonical builder. This is the
+//	          scheme the Go SDK signs; scheme selection prefers it (see
+//	          CanSignScheme / SchemeCapable).
+//
+// There is NO silent fallback: an escrow-selected payment always produces an
+// escrow deposit, never an exact transfer, and an unknown scheme is rejected.
+// Routing an escrow-selected payment as an exact transfer is the scheme-mismatch
+// money-path bug this guards against (per the solvela-x402 skill).
+type KeypairSigner struct {
 	wallet *Wallet
 	rpcURL string
+	client *http.Client
 }
 
-// NewUnimplementedSigner creates a stub [Signer] from a wallet and optional
-// Solana RPC URL. If rpcURL is empty, defaults to mainnet-beta. The returned
-// signer's SignPayment always returns an error; see [UnimplementedSigner].
-func NewUnimplementedSigner(wallet *Wallet, rpcURL string) *UnimplementedSigner {
+// NewKeypairSigner creates a [KeypairSigner] from a wallet and optional Solana
+// RPC URL. If rpcURL is empty, defaults to mainnet-beta.
+func NewKeypairSigner(wallet *Wallet, rpcURL string) *KeypairSigner {
 	if rpcURL == "" {
-		rpcURL = "https://api.mainnet-beta.solana.com"
+		rpcURL = defaultRPCURL
 	}
-	return &UnimplementedSigner{wallet: wallet, rpcURL: rpcURL}
+	return &KeypairSigner{
+		wallet: wallet,
+		rpcURL: rpcURL,
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
 }
 
-// SignPayment is not yet implemented in solvela-go.
-//
-// Use the Python SDK (solvela-python) or TypeScript SDK (solvela-ts) for
-// production payment signing, or implement a custom [Signer] using the
-// standard library's crypto/ed25519 package and a Solana JSON-RPC client
-// of your choice.
-func (s *UnimplementedSigner) SignPayment(_ context.Context, _ uint64, _ string, _ Resource, _ PaymentAccept) (*PaymentPayload, error) {
-	return nil, &SignerError{Message: "UnimplementedSigner.SignPayment is not yet implemented in solvela-go; use the Python or TS SDK, or implement a custom Signer"}
+// CanSignScheme reports which schemes this signer can fulfill. The Go
+// KeypairSigner implements `escrow` only; `exact` is intentionally
+// unimplemented (see signExactPayment), so it reports false for exact. This
+// keeps scheme selection from auto-picking the gateway's first-listed `exact`
+// offer and failing every payment.
+func (s *KeypairSigner) CanSignScheme(scheme Scheme) bool {
+	return scheme == SchemeEscrow
 }
 
-// KeypairSigner is a deprecated alias for [UnimplementedSigner].
-//
-// Deprecated: renamed to UnimplementedSigner because the original name
-// implied a working keypair-based signer; the type is in fact a stub. Use
-// [UnimplementedSigner] directly. This alias will be removed in a future
-// release.
-type KeypairSigner = UnimplementedSigner
+// SignPayment builds and signs a payment transaction, branching on the scheme.
+func (s *KeypairSigner) SignPayment(
+	ctx context.Context,
+	amountAtomic uint64,
+	recipient string,
+	resource Resource,
+	accepted PaymentAccept,
+) (*PaymentPayload, error) {
+	switch accepted.Scheme {
+	case SchemeExact:
+		return s.signExactPayment(ctx, amountAtomic, recipient, resource, accepted)
+	case SchemeEscrow:
+		return s.signEscrowPayment(ctx, amountAtomic, resource, accepted)
+	default:
+		// Scheme is a closed type; PaymentAccept.UnmarshalJSON already rejects
+		// unknown wire schemes. This branch fails closed if a new scheme is
+		// added to the enum without a financial branch here — never defaults to
+		// a transfer.
+		return nil, &SignerError{Message: fmt.Sprintf("unsupported payment scheme: %q", accepted.Scheme)}
+	}
+}
 
-// NewKeypairSigner is a deprecated alias for [NewUnimplementedSigner].
+// signExactPayment handles the exact (USDC-SPL transfer) scheme.
 //
-// Deprecated: see [KeypairSigner].
-func NewKeypairSigner(wallet *Wallet, rpcURL string) *UnimplementedSigner {
-	return NewUnimplementedSigner(wallet, rpcURL)
+// The Go SDK does not yet build exact-scheme transfers. Critically, it does NOT
+// silently fall back to an escrow deposit or any other scheme — it returns a
+// clear typed error so the caller knows exact signing is unavailable here. The
+// Rust SDK is the reference implementation for the exact path; the byte layout
+// has no pinned golden vector, so it is intentionally left unimplemented in Go
+// rather than guessed at on the money path.
+func (s *KeypairSigner) signExactPayment(
+	_ context.Context,
+	_ uint64,
+	_ string,
+	_ Resource,
+	_ PaymentAccept,
+) (*PaymentPayload, error) {
+	return nil, &SignerError{Message: "exact-scheme signing is not implemented in the Go SDK; " +
+		"use the Rust SDK, or supply a custom Signer (the Go SDK does build escrow-scheme deposits)"}
+}
+
+// signEscrowPayment builds and signs an escrow deposit transaction (escrow
+// scheme).
+//
+// Generates a fresh CSPRNG service_id, computes the expiry slot from the current
+// slot and accepted.MaxTimeoutSeconds (mirroring the Rust/Python SDKs), fetches a
+// recent blockhash, and delegates byte-exact transaction construction to the
+// shared, golden-vector-pinned buildDepositTx.
+func (s *KeypairSigner) signEscrowPayment(
+	ctx context.Context,
+	amountAtomic uint64,
+	resource Resource,
+	accepted PaymentAccept,
+) (*PaymentPayload, error) {
+	// Fail clearly if escrow was selected but no program ID was offered — never
+	// silently fall back to an exact transfer.
+	if accepted.EscrowProgramID == nil || *accepted.EscrowProgramID == "" {
+		return nil, &SignerError{Message: "escrow scheme selected but escrow_program_id is missing"}
+	}
+
+	// amountAtomic is a uint64: a negative/float amount is structurally
+	// impossible (unlike the dynamically-typed Python port). We still reject
+	// zero before issuing any RPC — a zero-value escrow deposit is never
+	// legitimate, and we must not burn an RPC round-trip on it.
+	if amountAtomic == 0 {
+		return nil, &SignerError{Message: "escrow deposit amount must be greater than zero"}
+	}
+
+	if s.wallet == nil {
+		return nil, &SignerError{Message: "signer has no wallet configured"}
+	}
+
+	// Per-request CSPRNG service_id (#118 invariant): two identical requests
+	// must never share a service_id -> escrow PDA -> vault ATA.
+	serviceID, err := generateServiceID()
+	if err != nil {
+		return nil, &SignerError{Message: fmt.Sprintf("failed to generate service_id: %v", err)}
+	}
+
+	currentSlot, err := s.fetchCurrentSlot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	expirySlot := escrowExpirySlot(currentSlot, accepted.MaxTimeoutSeconds)
+
+	blockhash, err := s.fetchLatestBlockhash(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	depositTx, err := buildDepositTx(&DepositParams{
+		agentKeypair:       s.wallet.privateKeyBytes(),
+		ProviderWalletB58:  accepted.PayTo,
+		USDCMintB58:        USDCMint,
+		EscrowProgramIDB58: *accepted.EscrowProgramID,
+		Amount:             amountAtomic,
+		ServiceID:          serviceID,
+		ExpirySlot:         expirySlot,
+		RecentBlockhash:    blockhash,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	payload := EscrowPayload{
+		DepositTx:   depositTx,
+		ServiceID:   base64.StdEncoding.EncodeToString(serviceID[:]),
+		AgentPubkey: s.wallet.Address(),
+	}
+	return &PaymentPayload{
+		X402Version: X402Version,
+		Resource:    resource,
+		Accepted:    accepted,
+		Payload:     payload,
+	}, nil
+}
+
+// escrowExpirySlot computes the slot at which a now-created escrow PDA should
+// expire. Ported from the Rust SDK's escrow_expiry_slot: ~2.5 slots/s
+// (1000 ms / 400 ms), clamped into
+// [minEscrowExpirySlotsAhead, maxEscrowExpirySlotsAhead]. The floor mirrors and
+// exceeds the gateway's MIN_EXPIRY_BUFFER_SLOTS so a too-near expiry is never
+// bounced; the cap rejects an unbounded-future expiry. A negative timeout is
+// floored to 0 (never pushes expiry backwards into a dead-on-arrival deposit).
+// Arithmetic saturates to avoid wrap-to-zero.
+func escrowExpirySlot(currentSlot uint64, maxTimeoutSeconds int) uint64 {
+	timeout := maxTimeoutSeconds
+	if timeout < 0 {
+		timeout = 0
+	}
+	// timeout * 1000 / 400, with saturation on the multiply.
+	timeoutSlots := satMul(uint64(timeout), 1000) / 400
+	effective := timeoutSlots
+	if effective < minEscrowExpirySlotsAhead {
+		effective = minEscrowExpirySlotsAhead
+	}
+	if effective > maxEscrowExpirySlotsAhead {
+		effective = maxEscrowExpirySlotsAhead
+	}
+	return satAdd(currentSlot, effective)
+}
+
+func satMul(a, b uint64) uint64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	if a > ^uint64(0)/b {
+		return ^uint64(0)
+	}
+	return a * b
+}
+
+func satAdd(a, b uint64) uint64 {
+	if a > ^uint64(0)-b {
+		return ^uint64(0)
+	}
+	return a + b
+}
+
+// generateServiceID returns a unique 32-byte service_id. Mirrors the Rust SDK:
+// hash 32 CSPRNG bytes so the result is distinct per call (#118 invariant — two
+// identical requests must never share a service_id).
+func generateServiceID() ([32]byte, error) {
+	var nonce [32]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return [32]byte{}, err
+	}
+	return sha256.Sum256(nonce[:]), nil
+}
+
+// rpcRequest is the minimal JSON-RPC envelope this signer sends.
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
+}
+
+// rpcError is the JSON-RPC error object; we surface only the numeric code,
+// never the message (which can echo node internals — GHSA-cgqx-mg48-949v).
+// Code is a pointer so we can distinguish an absent/unparseable code (nil) from
+// a real code of 0 — emitting "code: 0" for a code-less error is misleading.
+type rpcError struct {
+	Code *int `json:"code"`
+}
+
+// rpcErrorCodeSuffix renders a parenthesized, message-free description of a
+// JSON-RPC error object suitable for appending to a SignerError. It surfaces
+// only the numeric code (never the RPC message text — GHSA-cgqx-mg48-949v), and
+// clearly distinguishes an unparseable / code-less error from a real code.
+func rpcErrorCodeSuffix(rawErr json.RawMessage) string {
+	var e rpcError
+	if err := json.Unmarshal(rawErr, &e); err != nil || e.Code == nil {
+		return "(unparseable error object, no numeric code)"
+	}
+	return fmt.Sprintf("(code: %d)", *e.Code)
+}
+
+// postRPC issues a JSON-RPC POST and returns the decoded body. HTTP-level
+// failures, non-200 status, and malformed JSON are surfaced as *SignerError
+// before any field access — so a 429/5xx HTML body never leaks node internals
+// into a panic or error string.
+func (s *KeypairSigner) postRPC(ctx context.Context, method string, params []any, label string) (map[string]json.RawMessage, error) {
+	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: 1, Method: method, Params: params})
+	if err != nil {
+		return nil, &SignerError{Message: fmt.Sprintf("%s RPC: encode request: %v", label, err)}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.rpcURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, &SignerError{Message: fmt.Sprintf("%s RPC: build request: %v", label, err)}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, &SignerError{Message: fmt.Sprintf("%s RPC request failed", label)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// Check status BEFORE reading. A non-200 body is an error page (possibly an
+	// HTML 429/5xx) we only bound and discard — so the tight error-path cap
+	// applies. The status itself is the surfaced signal; the body text is never
+	// echoed (it can leak node internals — GHSA-cgqx-mg48-949v).
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return nil, &SignerError{Message: fmt.Sprintf("%s RPC HTTP %d", label, resp.StatusCode)}
+	}
+	// Success: read the JSON body under the generous success-path cap so we do
+	// not truncate a legitimate 200 result (the old code applied the 4 KB
+	// error-path cap here, which could corrupt a large result body).
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxRPCBodyBytes))
+	if err != nil {
+		return nil, &SignerError{Message: fmt.Sprintf("%s RPC: read body", label)}
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, &SignerError{Message: fmt.Sprintf("%s RPC: malformed JSON body", label)}
+	}
+	return decoded, nil
+}
+
+// fetchCurrentSlot fetches the current slot via getSlot (commitment confirmed).
+// Fails closed: any HTTP failure, malformed body, RPC error, or
+// missing/invalid result is a *SignerError — never a silent default slot, which
+// would let the escrow expiry be computed from a bogus base. Also rejects an
+// implausibly-low slot (stub/genesis node).
+func (s *KeypairSigner) fetchCurrentSlot(ctx context.Context) (uint64, error) {
+	decoded, err := s.postRPC(ctx, "getSlot", []any{map[string]string{"commitment": "confirmed"}}, "getSlot")
+	if err != nil {
+		return 0, err
+	}
+	if rawErr, ok := decoded["error"]; ok {
+		return 0, &SignerError{Message: fmt.Sprintf("getSlot RPC error %s", rpcErrorCodeSuffix(rawErr))}
+	}
+	rawResult, ok := decoded["result"]
+	if !ok {
+		return 0, &SignerError{Message: "getSlot RPC: missing result"}
+	}
+	var slot uint64
+	if err := json.Unmarshal(rawResult, &slot); err != nil {
+		return 0, &SignerError{Message: "getSlot RPC: missing or invalid result"}
+	}
+	if slot < minPlausibleSlot {
+		return 0, &SignerError{Message: fmt.Sprintf(
+			"getSlot RPC returned implausibly low slot %d (< %d); refusing to build an escrow deposit",
+			slot, minPlausibleSlot)}
+	}
+	return slot, nil
+}
+
+// fetchLatestBlockhash fetches a recent blockhash via getLatestBlockhash and
+// decodes it to 32 raw bytes. Fails closed on any HTTP/JSON/RPC failure or a
+// missing/malformed blockhash, never returning a default.
+func (s *KeypairSigner) fetchLatestBlockhash(ctx context.Context) ([32]byte, error) {
+	var out [32]byte
+	decoded, err := s.postRPC(ctx, "getLatestBlockhash", []any{map[string]string{"commitment": "finalized"}}, "Blockhash")
+	if err != nil {
+		return out, err
+	}
+	rawResult, ok := decoded["result"]
+	if !ok {
+		// Surface the RPC error code if present, else a generic miss.
+		if rawErr, hasErr := decoded["error"]; hasErr {
+			return out, &SignerError{Message: fmt.Sprintf("RPC did not return a blockhash %s", rpcErrorCodeSuffix(rawErr))}
+		}
+		return out, &SignerError{Message: "RPC did not return a blockhash"}
+	}
+	var result struct {
+		Value struct {
+			Blockhash string `json:"blockhash"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(rawResult, &result); err != nil || result.Value.Blockhash == "" {
+		return out, &SignerError{Message: "RPC did not return a blockhash"}
+	}
+	raw, err := base58.Decode(result.Value.Blockhash)
+	if err != nil || len(raw) != 32 {
+		return out, &SignerError{Message: "RPC returned a malformed blockhash"}
+	}
+	copy(out[:], raw)
+	return out, nil
 }

--- a/sdks/go/signer_test.go
+++ b/sdks/go/signer_test.go
@@ -2,53 +2,497 @@ package solvela
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-func TestNewKeypairSignerDefaultRPCURL(t *testing.T) {
+const testEscrowProgram = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+
+// A valid base58 32-byte hash usable as a canned blockhash (the system program
+// ID — 32 zero bytes encode to a valid 32-byte base58 string).
+const fakeBlockhash = "11111111111111111111111111111111"
+
+func newTestSigner(t *testing.T, rpcURL string) *KeypairSigner {
+	t.Helper()
 	wallet, _, err := CreateWallet()
 	if err != nil {
 		t.Fatalf("create wallet: %v", err)
 	}
-	signer := NewKeypairSigner(wallet, "")
-	if signer.rpcURL != "https://api.mainnet-beta.solana.com" {
+	return NewKeypairSigner(wallet, rpcURL)
+}
+
+func exactAccept() PaymentAccept {
+	return PaymentAccept{
+		Scheme:            SchemeExact,
+		Network:           SolanaNetwork,
+		Amount:            "1000000",
+		Asset:             USDCMint,
+		PayTo:             "11111111111111111111111111111112",
+		MaxTimeoutSeconds: 300,
+	}
+}
+
+func escrowAccept(programID *string) PaymentAccept {
+	return PaymentAccept{
+		Scheme:            SchemeEscrow,
+		Network:           SolanaNetwork,
+		Amount:            "2625",
+		Asset:             USDCMint,
+		PayTo:             goldenProvider,
+		MaxTimeoutSeconds: 300,
+		EscrowProgramID:   programID,
+	}
+}
+
+func testResource() Resource {
+	return Resource{URL: "https://rpc.test.local/v1/chat/completions", Method: "POST"}
+}
+
+func ptr(s string) *string { return &s }
+
+// rpcMock is a test JSON-RPC server that returns queued responses per method.
+type rpcMock struct {
+	server   *httptest.Server
+	requests int
+}
+
+// newRPCMock builds a server. getSlot and getLatestBlockhash routing is by the
+// "method" field in the request body. Responses are supplied as raw JSON.
+func newRPCMock(t *testing.T, getSlotJSON, getBlockhashJSON string, status int) *rpcMock {
+	t.Helper()
+	m := &rpcMock{}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.requests++
+		if status != 0 && status != http.StatusOK {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte("<html>error</html>"))
+			return
+		}
+		var req struct {
+			Method string `json:"method"`
+		}
+		body, _ := readAllBody(r)
+		_ = json.Unmarshal(body, &req)
+		switch req.Method {
+		case "getSlot":
+			_, _ = w.Write([]byte(getSlotJSON))
+		case "getLatestBlockhash":
+			_, _ = w.Write([]byte(getBlockhashJSON))
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+func readAllBody(r *http.Request) ([]byte, error) {
+	defer func() { _ = r.Body.Close() }()
+	// io.ReadAll drains the whole body; a single r.Body.Read can return a
+	// partial body, which would make method-routing (and thus RPC-error tests)
+	// assert against a truncated request.
+	return io.ReadAll(r.Body)
+}
+
+func goodSlotJSON(slot int) string {
+	return `{"jsonrpc":"2.0","id":1,"result":` + itoa(slot) + `}`
+}
+
+func goodBlockhashJSON() string {
+	return `{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1000000},"value":{"blockhash":"` + fakeBlockhash + `","lastValidBlockHeight":1000000}}}`
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+// --- Constructor ---
+
+func TestNewKeypairSignerDefaultRPCURL(t *testing.T) {
+	signer := newTestSigner(t, "")
+	if signer.rpcURL != defaultRPCURL {
 		t.Errorf("rpcURL: got %q, want default mainnet", signer.rpcURL)
 	}
 }
 
 func TestNewKeypairSignerCustomRPCURL(t *testing.T) {
-	wallet, _, err := CreateWallet()
-	if err != nil {
-		t.Fatalf("create wallet: %v", err)
-	}
-	signer := NewKeypairSigner(wallet, "https://api.devnet.solana.com")
+	signer := newTestSigner(t, "https://api.devnet.solana.com")
 	if signer.rpcURL != "https://api.devnet.solana.com" {
 		t.Errorf("rpcURL: got %q, want devnet", signer.rpcURL)
 	}
 }
 
-func TestKeypairSignerReturnsStubError(t *testing.T) {
+// --- Scheme branching (no silent fallback) ---
+
+func TestEscrowSchemeReturnsEscrowPayload(t *testing.T) {
+	m := newRPCMock(t, goodSlotJSON(1_000_000), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	payload, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err != nil {
+		t.Fatalf("escrow sign should succeed: %v", err)
+	}
+	if payload.Accepted.Scheme != SchemeEscrow {
+		t.Errorf("scheme: got %q, want escrow", payload.Accepted.Scheme)
+	}
+	ep, ok := payload.Payload.(EscrowPayload)
+	if !ok {
+		t.Fatalf("payload type: got %T, want EscrowPayload", payload.Payload)
+	}
+	txBytes, err := base64.StdEncoding.DecodeString(ep.DepositTx)
+	if err != nil {
+		t.Fatalf("deposit_tx not valid base64: %v", err)
+	}
+	if txBytes[0] != 0x01 {
+		t.Errorf("deposit_tx first byte: got 0x%02x, want 0x01 (1 sig)", txBytes[0])
+	}
+	sid, err := base64.StdEncoding.DecodeString(ep.ServiceID)
+	if err != nil || len(sid) != 32 {
+		t.Errorf("service_id must be base64 of 32 bytes, got len=%d err=%v", len(sid), err)
+	}
+	if ep.AgentPubkey != signer.wallet.Address() {
+		t.Errorf("agent_pubkey: got %q, want wallet address %q", ep.AgentPubkey, signer.wallet.Address())
+	}
+}
+
+func TestEscrowServiceIDUniquePerCall(t *testing.T) {
+	m := newRPCMock(t, goodSlotJSON(1_000_000), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	p1, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err != nil {
+		t.Fatalf("p1: %v", err)
+	}
+	p2, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err != nil {
+		t.Fatalf("p2: %v", err)
+	}
+	s1 := p1.Payload.(EscrowPayload).ServiceID
+	s2 := p2.Payload.(EscrowPayload).ServiceID
+	if s1 == s2 {
+		t.Error("service_id must differ across calls (front-running / confidentiality invariant)")
+	}
+}
+
+func TestExactSchemeNotImplementedNoSilentFallback(t *testing.T) {
+	// The Go SDK does not build exact transfers. It must return a clear error,
+	// NOT silently produce an escrow deposit or any other scheme. No RPC may be
+	// issued.
+	m := newRPCMock(t, goodSlotJSON(1_000_000), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 1_000_000, "11111111111111111111111111111112", testResource(), exactAccept())
+	if err == nil {
+		t.Fatal("exact scheme should return an error in the Go SDK")
+	}
+	if _, ok := err.(*SignerError); !ok {
+		t.Fatalf("expected *SignerError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "exact-scheme signing is not implemented") {
+		t.Errorf("unexpected error message: %q", err.Error())
+	}
+	if m.requests != 0 {
+		t.Errorf("no RPC should be issued for unimplemented exact path, got %d", m.requests)
+	}
+}
+
+func TestUnknownSchemeRejected(t *testing.T) {
+	m := newRPCMock(t, goodSlotJSON(1_000_000), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+	accept := exactAccept()
+	accept.Scheme = Scheme("upto") // force an out-of-domain scheme past the parser
+
+	_, err := signer.SignPayment(context.Background(), 1_000_000, "11111111111111111111111111111112", testResource(), accept)
+	if err == nil {
+		t.Fatal("unknown scheme must be rejected, never default-routed")
+	}
+	if !strings.Contains(err.Error(), "unsupported payment scheme") {
+		t.Errorf("unexpected error: %q", err.Error())
+	}
+	if m.requests != 0 {
+		t.Errorf("no RPC should be issued for an unknown scheme, got %d", m.requests)
+	}
+}
+
+// --- Scheme selection prefers a signable scheme (DOA regression) ---
+
+// TestFindCompatibleSchemePrefersEscrowForKeypairSigner pins the fix for the
+// dead-on-arrival bug: the gateway advertises ["exact","escrow"] (exact first),
+// but KeypairSigner can only sign escrow. Scheme selection must therefore pick
+// the escrow entry, never the unsignable first-listed exact.
+func TestFindCompatibleSchemePrefersEscrowForKeypairSigner(t *testing.T) {
+	signer := newTestSigner(t, "")
 	wallet, _, err := CreateWallet()
 	if err != nil {
-		t.Fatalf("create wallet: %v", err)
+		t.Fatalf("wallet: %v", err)
 	}
-	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer, WithGatewayURL("https://gw.test.local"))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
 
-	_, err = signer.SignPayment(
-		context.Background(),
-		1000,
-		"recipient",
-		Resource{URL: "/v1/chat/completions", Method: "POST"},
-		PaymentAccept{Scheme: "exact", Network: SolanaNetwork, Amount: "1000"},
+	pr := &PaymentRequired{
+		X402Version: X402Version,
+		Accepts: []PaymentAccept{
+			exactAccept(), // gateway lists exact FIRST
+			escrowAccept(ptr(testEscrowProgram)),
+		},
+	}
+	chosen := client.findCompatibleScheme(pr)
+	if chosen == nil {
+		t.Fatal("expected an escrow scheme to be selected, got nil")
+	}
+	if chosen.Scheme != SchemeEscrow {
+		t.Errorf("scheme: got %q, want escrow (must not auto-select unsignable exact)", chosen.Scheme)
+	}
+}
+
+// TestSignPaymentRequiredYieldsEscrowPayloadWhenBothOffered is the end-to-end
+// assertion: feeding a 402 that offers both schemes to a KeypairSigner produces
+// an escrow PaymentPayload, NOT a SignerError. Before the fix this errored
+// because exact was selected and KeypairSigner cannot sign exact.
+func TestSignPaymentRequiredYieldsEscrowPayloadWhenBothOffered(t *testing.T) {
+	m := newRPCMock(t, goodSlotJSON(1_000_000), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+	wallet := signer.wallet
+	maxAmt := uint64(1_000_000_000)
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL("https://rpc.test.local"),
+		WithMaxPaymentAmount(maxAmt),
 	)
-	if err == nil {
-		t.Fatal("expected error from stub signer")
+	if err != nil {
+		t.Fatalf("client: %v", err)
 	}
-	signerErr, ok := err.(*SignerError)
-	if !ok {
-		t.Fatalf("expected SignerError, got %T", err)
+
+	pr := &PaymentRequired{
+		X402Version: X402Version,
+		Resource:    testResource(),
+		Accepts: []PaymentAccept{
+			exactAccept(),
+			escrowAccept(ptr(testEscrowProgram)),
+		},
 	}
-	if signerErr.Message == "" {
-		t.Error("expected non-empty error message")
+	sigHeader, err := client.signPaymentRequired(context.Background(), pr)
+	if err != nil {
+		t.Fatalf("signPaymentRequired should succeed with an escrow-capable signer, got: %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(sigHeader)
+	if err != nil {
+		t.Fatalf("header not valid base64: %v", err)
+	}
+	var payload struct {
+		Accepted PaymentAccept `json:"accepted"`
+		Payload  struct {
+			DepositTx string `json:"deposit_tx"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		t.Fatalf("decode payment payload: %v", err)
+	}
+	if payload.Accepted.Scheme != SchemeEscrow {
+		t.Errorf("selected scheme: got %q, want escrow", payload.Accepted.Scheme)
+	}
+	if payload.Payload.DepositTx == "" {
+		t.Error("expected a non-empty escrow deposit_tx in the signed payload")
+	}
+}
+
+// TestCanSignSchemeKeypairSigner pins the capability declaration directly.
+func TestCanSignSchemeKeypairSigner(t *testing.T) {
+	signer := newTestSigner(t, "")
+	if !signer.CanSignScheme(SchemeEscrow) {
+		t.Error("KeypairSigner must report it can sign escrow")
+	}
+	if signer.CanSignScheme(SchemeExact) {
+		t.Error("KeypairSigner must report it cannot sign exact (unimplemented)")
+	}
+}
+
+// --- Escrow rejection / fail-closed paths ---
+
+func TestEscrowMissingProgramIDRejected(t *testing.T) {
+	m := newRPCMock(t, goodSlotJSON(1_000_000), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(nil))
+	if err == nil || !strings.Contains(err.Error(), "escrow_program_id is missing") {
+		t.Fatalf("expected escrow_program_id missing error, got %v", err)
+	}
+	if m.requests != 0 {
+		t.Errorf("rejection must occur before any RPC, got %d requests", m.requests)
+	}
+}
+
+func TestEscrowEmptyProgramIDRejected(t *testing.T) {
+	m := newRPCMock(t, goodSlotJSON(1_000_000), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr("")))
+	if err == nil || !strings.Contains(err.Error(), "escrow_program_id is missing") {
+		t.Fatalf("expected escrow_program_id missing error, got %v", err)
+	}
+	if m.requests != 0 {
+		t.Errorf("rejection must occur before any RPC, got %d requests", m.requests)
+	}
+}
+
+func TestEscrowZeroAmountRejected(t *testing.T) {
+	m := newRPCMock(t, goodSlotJSON(1_000_000), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 0, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err == nil || !strings.Contains(err.Error(), "greater than zero") {
+		t.Fatalf("expected greater-than-zero error, got %v", err)
+	}
+	if m.requests != 0 {
+		t.Errorf("no RPC for a zero amount we reject before building, got %d", m.requests)
+	}
+}
+
+func TestEscrowStubLowSlotRejected(t *testing.T) {
+	// A stub/genesis node returning a near-zero slot must be refused, not used
+	// to compute an instantly-expired escrow deposit.
+	m := newRPCMock(t, goodSlotJSON(0), goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err == nil || !strings.Contains(err.Error(), "implausibly low slot") {
+		t.Fatalf("expected implausibly-low-slot error, got %v", err)
+	}
+}
+
+func TestEscrowGetSlot429Rejected(t *testing.T) {
+	m := newRPCMock(t, "", "", http.StatusTooManyRequests)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err == nil || !strings.Contains(err.Error(), "getSlot RPC HTTP 429") {
+		t.Fatalf("expected getSlot HTTP 429 error, got %v", err)
+	}
+}
+
+func TestEscrowGetSlotMalformedJSONRejected(t *testing.T) {
+	m := newRPCMock(t, "not valid json", goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err == nil || !strings.Contains(err.Error(), "getSlot RPC: malformed JSON") {
+		t.Fatalf("expected getSlot malformed JSON error, got %v", err)
+	}
+}
+
+func TestEscrowGetSlotJSONRPCErrorRejected(t *testing.T) {
+	m := newRPCMock(t, `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"node behind"}}`, goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err == nil || !strings.Contains(err.Error(), "getSlot RPC error") {
+		t.Fatalf("expected getSlot RPC error, got %v", err)
+	}
+	// The numeric code may appear, but the message text must not leak.
+	if strings.Contains(err.Error(), "node behind") {
+		t.Errorf("RPC error message text leaked: %q", err.Error())
+	}
+}
+
+// TestEscrowGetSlotCodelessErrorNotMisleadingZero pins the LOW finding fix: a
+// JSON-RPC error object with no numeric code must NOT be reported as
+// "code: 0" (which looks like a real code). It should be flagged as
+// unparseable / code-less instead.
+func TestEscrowGetSlotCodelessErrorNotMisleadingZero(t *testing.T) {
+	// An error object with a message but no "code" field.
+	m := newRPCMock(t, `{"jsonrpc":"2.0","id":1,"error":{"message":"node behind"}}`, goodBlockhashJSON(), http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err == nil || !strings.Contains(err.Error(), "getSlot RPC error") {
+		t.Fatalf("expected getSlot RPC error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "code: 0") {
+		t.Errorf("code-less error must not be rendered as 'code: 0': %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "no numeric code") {
+		t.Errorf("expected a code-less marker in the error, got: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "node behind") {
+		t.Errorf("RPC error message text leaked: %q", err.Error())
+	}
+}
+
+func TestEscrowBlockhashMissingRejected(t *testing.T) {
+	m := newRPCMock(t, goodSlotJSON(1_000_000), `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"internal"}}`, http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err == nil || !strings.Contains(err.Error(), "did not return a blockhash") {
+		t.Fatalf("expected blockhash-missing error, got %v", err)
+	}
+}
+
+// TestEscrowBlockhashWrongLengthRejected pins the production guard at
+// fetchLatestBlockhash: a base58-VALID but non-32-byte blockhash must be
+// rejected as malformed, never copied into the 32-byte array (a short/long hash
+// would produce an unverifiable transaction). "1111" decodes to 4 zero bytes
+// under base58 — valid base58, wrong length.
+func TestEscrowBlockhashWrongLengthRejected(t *testing.T) {
+	shortHashJSON := `{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1000000},"value":{"blockhash":"1111","lastValidBlockHeight":1000000}}}`
+	m := newRPCMock(t, goodSlotJSON(1_000_000), shortHashJSON, http.StatusOK)
+	signer := newTestSigner(t, m.server.URL)
+
+	_, err := signer.SignPayment(context.Background(), 2625, goldenProvider, testResource(), escrowAccept(ptr(testEscrowProgram)))
+	if err == nil || !strings.Contains(err.Error(), "malformed blockhash") {
+		t.Fatalf("expected malformed-blockhash error for a wrong-length hash, got %v", err)
+	}
+}
+
+// --- escrowExpirySlot math (mirrors Rust/Python SDK tests) ---
+
+func TestEscrowExpirySlotTypical300s(t *testing.T) {
+	if got := escrowExpirySlot(1_000_000, 300); got != 1_000_750 {
+		t.Errorf("got %d, want 1_000_750", got)
+	}
+}
+
+func TestEscrowExpirySlotZeroSecondsAppliesMinFloor(t *testing.T) {
+	if got := escrowExpirySlot(1_000_000, 0); got != 1_000_150 {
+		t.Errorf("got %d, want 1_000_150", got)
+	}
+}
+
+func TestEscrowExpirySlotHugeTimeoutClampedToCap(t *testing.T) {
+	if got := escrowExpirySlot(1_000_000, 1<<40); got != 1_010_000 {
+		t.Errorf("got %d, want 1_010_000", got)
+	}
+}
+
+func TestEscrowExpirySlotNegativeTimeoutClampsToFloorNotBackwards(t *testing.T) {
+	if got := escrowExpirySlot(1_000_000, -1); got != 1_000_150 {
+		t.Errorf("got %d, want 1_000_150 (negative timeout must not push expiry backwards)", got)
+	}
+}
+
+func TestEscrowExpirySlotSaturatesCurrentSlotOverflow(t *testing.T) {
+	if got := escrowExpirySlot(^uint64(0)-100, 300); got != ^uint64(0) {
+		t.Errorf("got %d, want u64::MAX (saturating add)", got)
 	}
 }

--- a/sdks/go/wallet.go
+++ b/sdks/go/wallet.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/mr-tron/base58"
@@ -99,7 +100,33 @@ func (w *Wallet) ToKeypairB58() string {
 	return base58.Encode(w.privateKey)
 }
 
-// String returns a debug-safe representation that redacts the secret key.
-func (w *Wallet) String() string {
+// redactedWallet renders a Wallet with the secret key redacted. It is the
+// single source of truth for every fmt verb so the raw ed25519 private key in
+// privateKey can NEVER appear in a log line via %v / %+v / %#v / %s. Mirrors the
+// DepositParams redaction pattern (escrow.go).
+func (w Wallet) redactedWallet() string {
 	return fmt.Sprintf("Wallet(address=%s, secret=REDACTED)", w.Address())
+}
+
+// String implements fmt.Stringer so plain %s / %v / %+v formatting redacts the
+// secret key. A value receiver means both a Wallet value and a *Wallet pointer
+// are covered.
+func (w Wallet) String() string {
+	return w.redactedWallet()
+}
+
+// GoString implements fmt.GoStringer so %#v formatting redacts the secret key.
+// Without it, %#v would reflect over the struct fields and dump the raw
+// ed25519.PrivateKey bytes.
+func (w Wallet) GoString() string {
+	return w.redactedWallet()
+}
+
+// Format implements fmt.Formatter so every verb (%v, %+v, %#v, %s) routes
+// through the redacted representation rather than reflecting over the struct
+// fields. fmt consults Formatter before Stringer/GoStringer, so this is the
+// authoritative guard against the secret key leaking. The value receiver means
+// *Wallet satisfies fmt.Formatter too, so a pointer is redacted as well.
+func (w Wallet) Format(f fmt.State, _ rune) {
+	_, _ = io.WriteString(f, w.redactedWallet())
 }

--- a/sdks/go/wallet_test.go
+++ b/sdks/go/wallet_test.go
@@ -2,6 +2,7 @@ package solvela
 
 import (
 	"crypto/ed25519"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -131,6 +132,56 @@ func TestWalletStringRedacts(t *testing.T) {
 	b58 := w.ToKeypairB58()
 	if strings.Contains(s, b58) {
 		t.Error("String() should not contain the full private key")
+	}
+}
+
+// TestWalletFormatRedactsAllVerbs guards against the %#v secret leak: fmt's
+// default %#v reflects over struct fields and would dump the raw
+// ed25519.PrivateKey bytes. Wallet implements fmt.Formatter (plus Stringer /
+// GoStringer) so EVERY verb — %v, %+v, %#v, %s — on both a Wallet value and a
+// *Wallet pointer routes through the redacted form. The key is constructed from
+// an all-0x2a seed so the raw secret bytes render as "0x2a" / "42" sequences
+// under the default formatters; their absence proves redaction.
+func TestWalletFormatRedactsAllVerbs(t *testing.T) {
+	// Deterministic key: every private-key byte is 0x2a (== 42 decimal).
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = 0x2a
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	w, err := WalletFromKeypairBytes(priv)
+	if err != nil {
+		t.Fatalf("WalletFromKeypairBytes: %v", err)
+	}
+
+	// The first 32 bytes of an ed25519.PrivateKey are the seed (all 0x2a here),
+	// so a leaked raw key would surface these byte renderings.
+	leakMarkers := []string{"0x2a", "0x2A", ", 42,", "{42,", " 42,"}
+
+	verbs := []string{"%v", "%+v", "%#v", "%s"}
+	subjects := map[string]any{
+		"value":   *w,
+		"pointer": w,
+	}
+	for name, subj := range subjects {
+		for _, verb := range verbs {
+			out := fmt.Sprintf(verb, subj)
+			if !strings.Contains(out, "REDACTED") {
+				t.Errorf("%s %s: expected REDACTED, got %q", name, verb, out)
+			}
+			if !strings.Contains(out, w.Address()) {
+				t.Errorf("%s %s: expected address %q, got %q", name, verb, w.Address(), out)
+			}
+			for _, marker := range leakMarkers {
+				if strings.Contains(out, marker) {
+					t.Errorf("%s %s leaked raw key bytes (marker %q): %q", name, verb, marker, out)
+				}
+			}
+			// Also ensure the serialized secret never appears verbatim.
+			if strings.Contains(out, w.ToKeypairB58()) {
+				t.Errorf("%s %s leaked base58 secret: %q", name, verb, out)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Brings the **Go SDK** to escrow-signing parity with the landed Python SDK. Replaces the `UnimplementedSigner` stub (which could not pay at all) with a real `KeypairSigner` that builds and signs x402 **escrow deposit** transactions.

## Correctness contract

- **Golden-vector parity.** `escrow.go`'s deposit builder reproduces `GOLDEN_VECTOR_B64` (`crates/escrow-tx/src/deposit.rs`) **byte-for-byte** for the fixed input — `TestDepositTxMatchesGoldenVector`. A drift-guard test (`TestGoldenVectorMatchesRustSource`) reads the constant straight from the Rust source so the Go copy can't silently diverge.
- Anchor discriminator, escrow PDA + vault ATA derivation (incl. ed25519 off-curve check via `filippo.io/edwards25519`), legacy message serialization, and account ordering all match the canonical Rust builder.

## Money-path safety

- **No silent fallback.** `escrow` builds a deposit; `exact` returns a clear not-implemented error (never a silent exact-for-escrow substitution); unknown schemes error. A new `SchemeCapable` interface means scheme selection never picks a scheme the signer can't sign and **fails closed** (`PaymentRequiredError`) when only unsignable schemes are offered.
- **Fail-closed RPC** (`getSlot`/`getLatestBlockhash`) surfacing only numeric error codes (no RPC message text); per-request CSPRNG `service_id`; expiry clamp mirrors Rust/Python.
- **Secret hygiene.** Keypair never logged/echoed; `DepositParams` and `Wallet` redact under all `fmt` verbs incl `%#v`; seed↔pubkey consistency check rejects a corrupted keypair before it can produce an un-claimable vault.

## Scope

Escrow-only by design. The **exact** path (which requires `TransferChecked`/ix-12) is intentionally deferred and tracked separately. New dep: `filippo.io/edwards25519` (stdlib for ed25519/sha256; `mr-tron/base58` already present).

## Review & tests

Twice-reviewed before this PR: round 1 (`go-reviewer` + `silent-failure-hunter`) → fixes → round 2 (independent pass, approved). **165 tests pass, `go vet` clean, `gofmt` clean, golden vector intact.**