### PR TITLE
fix(sdk): exact payments must use TransferChecked (ix 12) + pin exact golden vector

### DIFF
--- a/crates/x402/src/solana.rs
+++ b/crates/x402/src/solana.rs
@@ -1110,4 +1110,77 @@ mod tests {
         assert_eq!(result.failure_kind, Some(SettlementFailureKind::Submission));
         assert!(result.error.is_some());
     }
+
+    // -----------------------------------------------------------------------
+    // Exact-scheme golden vector — gateway-acceptance (pinning test b)
+    // -----------------------------------------------------------------------
+
+    /// Canonical `exact`-scheme golden vector. Re-pinned here from the Rust SDK
+    /// (`sdks/rust/crates/solvela-client/src/signer.rs::EXACT_GOLDEN_VECTOR_B64`),
+    /// mirroring how the escrow `GOLDEN_VECTOR_B64` is re-pinned across crates.
+    /// The two crates are separate dependency islands (the SDK uses solana-sdk;
+    /// x402 uses the hand-rolled parser), so the literal is duplicated and each
+    /// side independently proves its property. If the SDK constant changes, this
+    /// literal MUST change with it — they are the same cross-SDK contract.
+    const EXACT_GOLDEN_VECTOR_B64: &str = "AbipfII25y2dIV7pTiOYf+qp9tAqiikKnoJqJnMsMNmGEMP1hDxqdcaeDIPxW3EJq5WUYR+V27kgDsjLvDsXDwEBAAIFGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWEUtdnlbYnE3avA84DOO4wvyfA9bjZxRumTasKUlOhjntPqjPWsrKjNBSB1EhdcQ871Sl3Znt4goWtVJTc485fcBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKnG+nrzvtutOj1l82qryXQxsbvkwtL24OR8pgIDRS9dYaurq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urAQMEAQQCAAoMQQoAAAAAAAAG";
+
+    /// Fixed `pay_to`/recipient for the exact golden vector (sibling-consistent
+    /// with the escrow vector's provider).
+    const EXACT_GOLDEN_PAY_TO: &str = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+    /// Drive the canonical `exact` golden vector through the real verifier
+    /// parse/validate path — the same surface `verify_payment` uses before the
+    /// RPC `simulateTransaction` step (which needs a live node and is therefore
+    /// not exercised here, exactly as the existing extraction tests do).
+    ///
+    /// Asserts the gateway accepts it as a valid USDC `TransferChecked`
+    /// (discriminator 12) with the right mint, amount, and destination ATA, and
+    /// that the agent's signature verifies as `account_keys[0]` (fee payer).
+    #[test]
+    fn exact_golden_vector_accepted_as_usdc_transfer_checked() {
+        use crate::solana_types::derive_ata;
+
+        let usdc_mint = Pubkey::from_str(TEST_USDC_MINT).unwrap();
+        let pay_to = Pubkey::from_str(EXACT_GOLDEN_PAY_TO).unwrap();
+
+        // Verifier configured with the golden vector's recipient so the
+        // destination-ATA check (verify_payment Step 4) is meaningful.
+        let verifier = SolanaVerifier::new(
+            "https://api.mainnet-beta.solana.com",
+            EXACT_GOLDEN_PAY_TO,
+            TEST_USDC_MINT,
+            reqwest::Client::new(),
+        )
+        .expect("verifier");
+
+        // Step 1 (decode_and_validate): signature verifies against account_keys[0]
+        // (the agent / fee payer). This is the real cryptographic gate.
+        let tx = verifier
+            .decode_and_validate_transaction(EXACT_GOLDEN_VECTOR_B64)
+            .expect("golden exact tx must decode and signature-verify");
+
+        let message = tx.parse_message().expect("message must parse");
+
+        // Step 3 (extract_spl_transfer): must be a TransferChecked, not plain Transfer.
+        let transfer = extract_spl_transfer(&message).expect("must extract SPL transfer");
+
+        // Mint is present (TransferChecked) and is USDC — a plain Transfer would
+        // have mint == None and be rejected at verify_payment Step 5.
+        assert_eq!(
+            transfer.mint,
+            Some(usdc_mint),
+            "golden vector must be a USDC TransferChecked (discriminator 12), not plain Transfer"
+        );
+
+        // Amount matches the fixed input.
+        assert_eq!(transfer.amount, 2625, "golden vector amount drifted");
+
+        // Destination is the recipient's USDC ATA (verify_payment Step 4).
+        let expected_ata = derive_ata(&pay_to, &usdc_mint, &Pubkey::TOKEN_PROGRAM_ID)
+            .expect("derive recipient ATA");
+        assert_eq!(
+            transfer.destination, expected_ata,
+            "destination must be ATA(pay_to, USDC_MINT)"
+        );
+    }
 }

--- a/sdks/python/src/solvela/signer.py
+++ b/sdks/python/src/solvela/signer.py
@@ -22,6 +22,18 @@ from solvela.types import (
     SolanaPayload,
 )
 
+# USDC has 6 decimals; the SPL ``TransferChecked`` instruction carries this byte
+# so the gateway can verify the mint+decimals on-chain. Mirrors the Rust SDK's
+# ``const USDC_DECIMALS: u8 = 6`` (sdks/rust/crates/solvela-client/src/signer.rs).
+USDC_DECIMALS = 6
+
+# Maximum value of the on-chain ``u64`` amount field. An ``amount_atomic`` above
+# this cannot be encoded as ``to_bytes(8, "little")`` and would otherwise raise a
+# cryptic ``OverflowError`` from deep inside the builder. We reject it explicitly
+# at the boundary with a clear ``SignerError`` (mirrors the escrow path's
+# ``escrow._U64_MAX`` guard in ``DepositParams.__post_init__``).
+_U64_MAX = 0xFFFF_FFFF_FFFF_FFFF
+
 # --- Escrow expiry-slot bounds (mirror the Rust SDK's signer.rs) ---
 #
 # Solana slots are ~400 ms. These bounds are ported verbatim from
@@ -47,6 +59,7 @@ _MIN_ESCROW_EXPIRY_SLOTS_AHEAD = 150
 _MIN_PLAUSIBLE_SLOT = 1_000_000
 
 if TYPE_CHECKING:
+    from solders.hash import Hash as Blockhash
     from solders.pubkey import Pubkey
 
     from solvela.wallet import Wallet
@@ -124,51 +137,41 @@ class KeypairSigner(Signer):
         resource: Resource,
         accepted: PaymentAccept,
     ) -> PaymentPayload:
-        """Build and sign a USDC-SPL transfer transaction (``exact`` scheme)."""
+        """Build and sign a USDC-SPL ``TransferChecked`` transaction (``exact``).
+
+        Fetches a recent blockhash via JSON-RPC, then delegates the byte-exact
+        construction to the pure :meth:`_build_exact_transfer_tx`, which pins the
+        canonical ``TransferChecked`` (instruction discriminator 12) wire layout
+        the live gateway ``exact`` verifier accepts. The gateway rejects a plain
+        SPL ``Transfer`` (discriminator 3) because it cannot verify the USDC mint
+        on-chain from it; ``TransferChecked`` carries the mint + decimals so the
+        verifier can.
+        """
+        # Reject a non-integer (float/bool) amount BEFORE it reaches the on-chain
+        # u64 amount field. ``int(2.9)`` would silently truncate the transfer and
+        # mis-charge the agent; ``bool`` is an ``int`` subclass that would send 1
+        # atomic unit. Fail closed at the boundary (mirrors the escrow path).
+        if not (isinstance(amount_atomic, int) and not isinstance(amount_atomic, bool)):
+            raise SignerError(
+                "exact transfer amount must be an integer number of atomic USDC units"
+            )
+        if amount_atomic <= 0:
+            raise SignerError("exact transfer amount must be greater than zero")
+        # Reject an out-of-u64-range amount BEFORE the build, where it would
+        # otherwise surface as a cryptic ``OverflowError`` from ``to_bytes(8, ...)``
+        # (re-wrapped into a generic "Failed to sign payment" message). Fail
+        # closed with a clear error at the boundary (mirrors the escrow path).
+        if amount_atomic > _U64_MAX:
+            raise SignerError("exact transfer amount exceeds u64 maximum")
+
         try:
             from solders.hash import Hash as Blockhash
-            from solders.instruction import AccountMeta, Instruction
-            from solders.keypair import Keypair as SoldersKeypair
-            from solders.message import Message
-            from solders.pubkey import Pubkey
-            from solders.transaction import Transaction
-
-            sender = self._wallet.pubkey()
-            recipient_pubkey = Pubkey.from_string(recipient)
-            mint = Pubkey.from_string(USDC_MINT)
-
-            # SPL Token program
-            token_program = Pubkey.from_string("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
-
-            # Derive ATAs
-            sender_ata = self._derive_ata(sender, mint)
-            recipient_ata = self._derive_ata(recipient_pubkey, mint)
 
             # Get recent blockhash
             blockhash_str = await self._fetch_latest_blockhash()
             blockhash = Blockhash.from_string(blockhash_str)
 
-            # Build SPL Token transfer instruction
-            # Transfer instruction = index 3, data = amount as little-endian u64
-            transfer_data = bytes([3]) + amount_atomic.to_bytes(8, "little")
-            transfer_ix = Instruction(
-                program_id=token_program,
-                accounts=[
-                    AccountMeta(pubkey=sender_ata, is_signer=False, is_writable=True),
-                    AccountMeta(pubkey=recipient_ata, is_signer=False, is_writable=True),
-                    AccountMeta(pubkey=sender, is_signer=True, is_writable=False),
-                ],
-                data=transfer_data,
-            )
-
-            # Build and sign transaction
-            msg = Message.new_with_blockhash([transfer_ix], sender, blockhash)
-            kp_bytes = self._wallet.to_keypair_bytes()
-            solders_kp = SoldersKeypair.from_bytes(kp_bytes)
-            tx = Transaction.new_unsigned(msg)
-            tx.sign([solders_kp], blockhash)
-
-            tx_b64 = base64.b64encode(bytes(tx)).decode()
+            tx_b64 = self._build_exact_transfer_tx(int(amount_atomic), recipient, blockhash)
 
             return PaymentPayload(
                 x402_version=X402_VERSION,
@@ -184,6 +187,77 @@ class KeypairSigner(Signer):
             # off __cause__. The `{e}` text stays in the message (sufficient for
             # diagnostics) but the original exception object is not attached.
             raise SignerError(f"Failed to sign payment: {e}") from None
+
+    def _build_exact_transfer_tx(
+        self,
+        amount_atomic: int,
+        recipient: str,
+        blockhash: Blockhash,
+    ) -> str:
+        """Build and sign a USDC-SPL ``TransferChecked`` (discriminator 12) tx.
+
+        Pure (no I/O): for fixed inputs it always produces the same bytes, which
+        is what lets ``EXACT_GOLDEN_VECTOR_B64``
+        (``sdks/rust/crates/solvela-client/src/signer.rs``) pin the wire layout.
+        The agent wallet is the transaction fee payer (``account_keys[0]``) and
+        the sole signer.
+
+        Instruction accounts, in canonical SPL ``TransferChecked`` order:
+        ``[source_ata, mint, dest_ata, authority]`` where
+        ``source_ata = ATA(agent, USDC_MINT)`` and
+        ``dest_ata = ATA(recipient, USDC_MINT)``; instruction data is
+        ``[12] || amount(u64 LE) || decimals(=6)``.
+        """
+        from solders.instruction import AccountMeta, Instruction
+        from solders.keypair import Keypair as SoldersKeypair
+        from solders.message import Message
+        from solders.pubkey import Pubkey
+        from solders.transaction import Transaction
+
+        sender = self._wallet.pubkey()
+        recipient_pubkey = Pubkey.from_string(recipient)
+        mint = Pubkey.from_string(USDC_MINT)
+
+        # SPL Token program
+        token_program = Pubkey.from_string("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+
+        # Derive ATAs
+        sender_ata = self._derive_ata(sender, mint)
+        recipient_ata = self._derive_ata(recipient_pubkey, mint)
+
+        # Build SPL Token TransferChecked instruction.
+        # TransferChecked = discriminator 12, data = [12] || amount(u64 LE) ||
+        # decimals(1). The 4-account layout (with the mint) is what lets the
+        # gateway verify the USDC mint on-chain; the live verifier rejects the
+        # plain Transfer (discriminator 3) the old code emitted.
+        transfer_data = bytes([12]) + amount_atomic.to_bytes(8, "little") + bytes([USDC_DECIMALS])
+        transfer_ix = Instruction(
+            program_id=token_program,
+            accounts=[
+                AccountMeta(pubkey=sender_ata, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=mint, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=recipient_ata, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=sender, is_signer=True, is_writable=False),
+            ],
+            data=transfer_data,
+        )
+
+        # Build and sign transaction
+        msg = Message.new_with_blockhash([transfer_ix], sender, blockhash)
+        kp_bytes = self._wallet.to_keypair_bytes()
+        # Parse the keypair under a specific catch that raises a STATIC message:
+        # the input is secret key material, so we must not interpolate the
+        # underlying exception text (which could echo key-adjacent bytes) into the
+        # error. Mirrors build_deposit_tx's keypair-parse redaction (escrow.py)
+        # and keeps `from None` to drop the __cause__ chain.
+        try:
+            solders_kp = SoldersKeypair.from_bytes(kp_bytes)
+        except Exception:  # noqa: BLE001 — normalize to typed error, no secret leak
+            raise SignerError("keypair parse failed") from None
+        tx = Transaction.new_unsigned(msg)
+        tx.sign([solders_kp], blockhash)
+
+        return base64.b64encode(bytes(tx)).decode()
 
     async def _sign_escrow_payment(
         self,

--- a/sdks/python/tests/unit/test_signer.py
+++ b/sdks/python/tests/unit/test_signer.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import base64
+import re
+from pathlib import Path
 
 import pytest
+from solders.hash import Hash as Blockhash  # type: ignore[import-untyped]
+from solders.keypair import Keypair  # type: ignore[import-untyped]
 from solders.pubkey import Pubkey  # type: ignore[import-untyped]
 
 from solvela.constants import SOLANA_NETWORK, USDC_MINT
@@ -14,6 +18,32 @@ from solvela.types import EscrowPayload, PaymentAccept, Resource, SolanaPayload
 from solvela.wallet import Wallet
 
 ESCROW_PROGRAM = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+
+# ---------------------------------------------------------------------------
+# Exact-scheme golden vector — byte-exact match against the canonical Rust
+# source ``sdks/rust/crates/solvela-client/src/signer.rs`` (EXACT_GOLDEN_VECTOR_B64).
+# ---------------------------------------------------------------------------
+#
+# Copied verbatim from ``EXACT_GOLDEN_VECTOR_B64`` in
+# ``sdks/rust/crates/solvela-client/src/signer.rs``. DO NOT hand-edit. If this
+# changes, the on-chain/gateway-accepted ``exact`` wire layout drifted — the
+# canonical value is ground truth, never this file (mirrors the escrow golden
+# vector contract in test_escrow.py).
+EXACT_GOLDEN_VECTOR_B64 = "AbipfII25y2dIV7pTiOYf+qp9tAqiikKnoJqJnMsMNmGEMP1hDxqdcaeDIPxW3EJq5WUYR+V27kgDsjLvDsXDwEBAAIFGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWEUtdnlbYnE3avA84DOO4wvyfA9bjZxRumTasKUlOhjntPqjPWsrKjNBSB1EhdcQ871Sl3Znt4goWtVJTc485fcBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKnG+nrzvtutOj1l82qryXQxsbvkwtL24OR8pgIDRS9dYaurq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urAQMEAQQCAAoMQQoAAAAAAAAG"  # noqa: E501
+
+# Fixed golden inputs (sibling-consistent with the escrow vector).
+GOLDEN_PROVIDER = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+
+
+def _golden_agent_wallet() -> Wallet:
+    """Deterministic agent wallet from seed ``[42] * 32``.
+
+    Identical to the escrow golden vector's agent keypair
+    (pubkey ``2iXtA8oeZqUU5pofxK971TCEvFGfems2AcDRaZHKD2pQ``), for sibling
+    consistency across the exact and escrow vectors.
+    """
+    kp = Keypair.from_seed(bytes([42] * 32))
+    return Wallet.from_keypair_bytes(bytes(kp))
 
 
 class TestSignerInterface:
@@ -423,3 +453,187 @@ class TestEscrowExpirySlot:
         # result is current_slot + _MIN_ESCROW_EXPIRY_SLOTS_AHEAD (150).
         assert KeypairSigner._escrow_expiry_slot(1_000_000, -1) == 1_000_150
         assert KeypairSigner._escrow_expiry_slot(1_000_000, -(10**12)) == 1_000_150
+
+
+class TestExactGoldenVector:
+    """Byte-for-byte parity of the ``exact`` TransferChecked builder.
+
+    This is the sole correctness bar for the ``exact`` wire format. The live
+    gateway verifier (``crates/x402/src/solana.rs``) rejects a plain SPL
+    ``Transfer`` (discriminator 3); it requires ``TransferChecked``
+    (discriminator 12) so the USDC mint is on-chain-verifiable. The fixed inputs
+    are sibling-consistent with the escrow golden vector.
+
+    NEVER edit ``EXACT_GOLDEN_VECTOR_B64`` to match this output — the vector is
+    the cross-SDK contract; if this drifts, the wire layout changed and the fix
+    is in the builder, not the expected value.
+    """
+
+    def test_exact_tx_matches_golden_vector(self) -> None:
+        wallet = _golden_agent_wallet()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        blockhash = Blockhash.from_bytes(bytes([0xAB] * 32))
+        out = signer._build_exact_transfer_tx(2625, GOLDEN_PROVIDER, blockhash)
+        assert out == EXACT_GOLDEN_VECTOR_B64, (
+            "Python exact-tx does not match the canonical golden vector. "
+            "The gateway/on-chain layout is ground truth — fix the Python "
+            "builder, do NOT edit the expected value."
+        )
+
+    def test_exact_tx_is_deterministic(self) -> None:
+        # Pure: identical fixed input always yields identical bytes (no nonce, no
+        # clock — the blockhash is supplied).
+        wallet = _golden_agent_wallet()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        blockhash = Blockhash.from_bytes(bytes([0xAB] * 32))
+        a = signer._build_exact_transfer_tx(2625, GOLDEN_PROVIDER, blockhash)
+        b = signer._build_exact_transfer_tx(2625, GOLDEN_PROVIDER, blockhash)
+        assert a == b
+
+    def test_exact_tx_is_transfer_checked_not_transfer(self) -> None:
+        # The serialized instruction data must start with discriminator 12
+        # (TransferChecked) and carry the decimals byte (6), NOT discriminator 3
+        # (plain Transfer) which the live gateway rejects.
+        wallet = _golden_agent_wallet()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        blockhash = Blockhash.from_bytes(bytes([0xAB] * 32))
+        raw = base64.b64decode(signer._build_exact_transfer_tx(2625, GOLDEN_PROVIDER, blockhash))
+        # TransferChecked ix data = [12] || amount(u64 LE) || decimals(1).
+        expected_ix_data = bytes([12]) + (2625).to_bytes(8, "little") + bytes([6])
+        assert expected_ix_data in raw
+        # The old plain-Transfer ix data ([3] || amount) must NOT be present.
+        assert (bytes([3]) + (2625).to_bytes(8, "little")) not in raw
+
+
+class TestExactGoldenVectorDriftGuard:
+    """The Python exact golden constant MUST equal the canonical Rust source.
+
+    If ``EXACT_GOLDEN_VECTOR_B64`` ever changes in
+    ``sdks/rust/crates/solvela-client/src/signer.rs``, the gateway-accepted
+    ``exact`` wire layout changed; this test fails loudly, forcing a resync of
+    the Python constant and builder rather than letting the SDKs silently
+    diverge. Mirrors the escrow drift guard (test_escrow.py) and the Go escrow
+    drift guard.
+    """
+
+    def test_python_exact_golden_matches_rust_source(self) -> None:
+        # tests/unit/test_signer.py -> worktree root is parents[4].
+        worktree_root = Path(__file__).resolve().parents[4]
+        rust_src = (
+            worktree_root / "sdks" / "rust" / "crates" / "solvela-client" / "src" / "signer.rs"
+        )
+        assert rust_src.is_file(), f"Rust signer.rs not found at {rust_src}"
+        text = rust_src.read_text(encoding="utf-8")
+        m = re.search(r'EXACT_GOLDEN_VECTOR_B64:\s*&str\s*=\s*"([^"]+)"', text)
+        assert m is not None, (
+            "could not locate EXACT_GOLDEN_VECTOR_B64 in "
+            "sdks/rust/crates/solvela-client/src/signer.rs"
+        )
+        rust_value = m.group(1)
+        assert rust_value == EXACT_GOLDEN_VECTOR_B64, (
+            "Python EXACT_GOLDEN_VECTOR_B64 has drifted from the Rust source of "
+            "truth (sdks/rust/crates/solvela-client/src/signer.rs). The "
+            "gateway/on-chain layout is ground truth: resync the Python constant "
+            "AND re-verify _build_exact_transfer_tx byte-parity — do NOT just "
+            "paste the new value."
+        )
+
+
+class TestExactAmountRejections:
+    """The ``exact`` path must fail closed on a bad amount, like the escrow path."""
+
+    @pytest.mark.asyncio
+    async def test_exact_zero_amount_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        with pytest.raises(SignerError, match="greater than zero"):
+            await signer.sign_payment(
+                amount_atomic=0,
+                recipient="11111111111111111111111111111112",
+                resource=_resource(),
+                accepted=_accept(),
+            )
+        # No network call for an amount we reject before building.
+        assert len(httpx_mock.get_requests()) == 0
+
+    @pytest.mark.asyncio
+    async def test_exact_negative_amount_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        with pytest.raises(SignerError, match="greater than zero"):
+            await signer.sign_payment(
+                amount_atomic=-1,
+                recipient="11111111111111111111111111111112",
+                resource=_resource(),
+                accepted=_accept(),
+            )
+        assert len(httpx_mock.get_requests()) == 0
+
+    @pytest.mark.asyncio
+    async def test_exact_float_amount_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        # A float amount would be silently truncated into the on-chain u64.
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        with pytest.raises(SignerError, match="integer"):
+            await signer.sign_payment(
+                amount_atomic=1_000_000.0,  # type: ignore[arg-type]
+                recipient="11111111111111111111111111111112",
+                resource=_resource(),
+                accepted=_accept(),
+            )
+        assert len(httpx_mock.get_requests()) == 0
+
+    @pytest.mark.asyncio
+    async def test_exact_bool_amount_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        # ``bool`` is an ``int`` subclass: ``True`` would send 1 atomic unit and
+        # ``False`` 0. Both must be rejected as non-integer before any RPC call.
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        for bad in (True, False):
+            with pytest.raises(SignerError, match="integer"):
+                await signer.sign_payment(
+                    amount_atomic=bad,  # type: ignore[arg-type]
+                    recipient="11111111111111111111111111111112",
+                    resource=_resource(),
+                    accepted=_accept(),
+                )
+        assert len(httpx_mock.get_requests()) == 0
+
+    @pytest.mark.asyncio
+    async def test_exact_above_u64_max_rejected(self, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        # An amount above u64 max would raise a cryptic OverflowError from
+        # to_bytes(8, ...) deep in the builder. It must be rejected at the
+        # boundary with a clear SignerError and zero network calls.
+        wallet, _ = Wallet.create()
+        signer = KeypairSigner(wallet, rpc_url=_RPC_URL)
+        with pytest.raises(SignerError, match="exceeds u64 maximum"):
+            await signer.sign_payment(
+                amount_atomic=2**64,
+                recipient="11111111111111111111111111111112",
+                resource=_resource(),
+                accepted=_accept(),
+            )
+        assert len(httpx_mock.get_requests()) == 0
+
+    def test_exact_keypair_parse_failure_is_redacted(self) -> None:
+        # If the keypair bytes are malformed, the error must be a STATIC message
+        # with no interpolation of the underlying exception (which could echo
+        # key-adjacent bytes). Mirrors build_deposit_tx's keypair-parse redaction.
+        secret_marker = bytes([0xDE] * 33)  # wrong length -> from_bytes raises
+
+        class _BadKeypairWallet:
+            def pubkey(self) -> Pubkey:
+                return Pubkey.from_string(GOLDEN_PROVIDER)
+
+            def to_keypair_bytes(self) -> bytes:
+                return secret_marker
+
+        signer = KeypairSigner(_BadKeypairWallet(), rpc_url=_RPC_URL)  # type: ignore[arg-type]
+        blockhash = Blockhash.from_bytes(bytes([0xAB] * 32))
+        with pytest.raises(SignerError) as exc_info:
+            signer._build_exact_transfer_tx(2625, GOLDEN_PROVIDER, blockhash)
+        assert str(exc_info.value) == "keypair parse failed"
+        # The __cause__ chain is dropped so no inner exception can carry secrets.
+        assert exc_info.value.__cause__ is None
+        # No fragment of the secret bytes leaked into the message.
+        assert "de" not in str(exc_info.value).lower()

--- a/sdks/rust/crates/solvela-client/src/lib.rs
+++ b/sdks/rust/crates/solvela-client/src/lib.rs
@@ -14,4 +14,10 @@ pub use balance::BalanceMonitor;
 pub use client::SolvelaClient;
 pub use config::{ClientBuilder, ClientConfig, DEFAULT_MAX_PAYMENT_AMOUNT_ATOMIC};
 pub use error::{ClientError, SignerError, WalletError};
+// NOTE: `signer::EXACT_GOLDEN_VECTOR_B64` is intentionally NOT re-exported here.
+// It is a `pub(crate)` test-pinning artifact (the `exact`-scheme golden vector),
+// not a stable public API: nothing outside this crate imports it (the x402
+// gateway test duplicates the literal; the cross-SDK drift guards read it from
+// source text). Re-exporting it would semver-imply a stability guarantee it does
+// not carry.
 pub use wallet::Wallet;

--- a/sdks/rust/crates/solvela-client/src/signer.rs
+++ b/sdks/rust/crates/solvela-client/src/signer.rs
@@ -14,6 +14,46 @@ use crate::wallet::Wallet;
 
 const USDC_DECIMALS: u8 = 6;
 
+// ---------------------------------------------------------------------------
+// Exact-scheme golden vector (cross-SDK money-path contract)
+// ---------------------------------------------------------------------------
+
+/// Byte-exact base64 `exact`-scheme transaction for a fixed input. Pins the
+/// canonical SPL `TransferChecked` (instruction discriminator 12) wire layout
+/// every SDK signer must reproduce so the live gateway `exact` verifier
+/// (`crates/x402/src/solana.rs`, which rejects plain `Transfer` discriminator 3)
+/// accepts it. The escrow path has the sibling [`solvela_escrow_tx::deposit::GOLDEN_VECTOR_B64`];
+/// this is its `exact` counterpart. The same literal is re-pinned and driven
+/// through the real verifier parse/validate path in
+/// `crates/x402/src/solana.rs` (`exact_golden_vector_accepted_as_usdc_transfer_checked`).
+///
+/// Fixed input (sibling-consistent with the escrow vector):
+/// - agent keypair from seed `[42u8; 32]`
+///   (pubkey `2iXtA8oeZqUU5pofxK971TCEvFGfems2AcDRaZHKD2pQ`)
+/// - recipient / `pay_to` `9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM`
+/// - USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+/// - amount `2625` atomic USDC, `decimals = 6`
+/// - `recent_blockhash = [0xABu8; 32]`
+/// - instruction accounts `[source_ata, mint, dest_ata, authority]` where
+///   `source_ata = ATA(agent, mint)`, `dest_ata = ATA(pay_to, mint)`,
+///   `authority = agent`; agent is fee payer (`account_keys[0]`) and sole signer.
+///
+/// DO NOT hand-edit. If this changes, the `exact` wire layout drifted —
+/// recompute only after confirming the new layout is still accepted by the
+/// gateway verifier (the on-chain/gateway value is ground truth, never this file).
+///
+/// `#[cfg(test)]`, not `pub`: this is a test-pinning artifact, not a stable
+/// public API. No external crate imports it — the x402 gateway test duplicates
+/// the literal (separate dependency island) and the cross-SDK drift guards read
+/// it from this source file's text, so it exists only to drive this crate's own
+/// parity tests. Gating it to test builds keeps it off the public/non-test
+/// surface entirely (which would otherwise semver-imply a stability guarantee it
+/// does not carry). The escrow sibling
+/// (`solvela_escrow_tx::deposit::GOLDEN_VECTOR_B64`) is `pub` only because its
+/// golden-vector test lives in a *separate* crate and must import it.
+#[cfg(test)]
+const EXACT_GOLDEN_VECTOR_B64: &str = "AbipfII25y2dIV7pTiOYf+qp9tAqiikKnoJqJnMsMNmGEMP1hDxqdcaeDIPxW3EJq5WUYR+V27kgDsjLvDsXDwEBAAIFGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWEUtdnlbYnE3avA84DOO4wvyfA9bjZxRumTasKUlOhjntPqjPWsrKjNBSB1EhdcQ871Sl3Znt4goWtVJTc485fcBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKnG+nrzvtutOj1l82qryXQxsbvkwtL24OR8pgIDRS9dYaurq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urAQMEAQQCAAoMQQoAAAAAAAAG";
+
 /// Hard upper bound on how many Solana slots into the future an escrow's expiry
 /// may be set. Mirrors the CLI's `MAX_ESCROW_EXPIRY_SLOTS_AHEAD`
 /// (`crates/cli/src/commands/util.rs`). Solana slots are ~400 ms, so `10_000`
@@ -89,8 +129,8 @@ async fn get_latest_blockhash(rpc_url: &str, http: &reqwest::Client) -> Result<H
 
 /// Build and sign a USDC-SPL `TransferChecked` transaction for an exact payment.
 ///
-/// Fetches a recent blockhash via JSON-RPC, builds the SPL Token instruction,
-/// signs with the wallet's keypair, and returns a base64-encoded transaction.
+/// Fetches a recent blockhash via JSON-RPC, then delegates the byte-exact
+/// construction to [`build_exact_transfer_tx`].
 ///
 /// # Errors
 ///
@@ -104,6 +144,48 @@ pub(crate) async fn sign_exact_payment(
     recipient: &str,
     amount_atomic: u64,
 ) -> Result<String, SignerError> {
+    let blockhash = get_latest_blockhash(rpc_url, http).await?;
+    build_exact_transfer_tx(wallet, recipient, amount_atomic, blockhash)
+}
+
+/// Build and sign a USDC-SPL `TransferChecked` (instruction discriminator 12)
+/// transaction for an exact payment, against a caller-supplied `recent_blockhash`.
+///
+/// Pure (no I/O): for fixed inputs it always produces the same bytes, which is
+/// what lets the `EXACT_GOLDEN_VECTOR_B64` test vector pin the wire layout. The agent wallet is
+/// the transaction fee payer (`account_keys[0]`) and the sole signer — this is
+/// exactly the structure the gateway `exact` verifier accepts (it validates the
+/// first signature against `account_keys[0]` and requires `TransferChecked` so
+/// the USDC mint is on-chain-verifiable; see `crates/x402/src/solana.rs` Step 5).
+/// The gateway/facilitator is the SOL fee payer only at the settlement-broadcast
+/// layer, not in the signed payload the agent produces here.
+///
+/// Instruction accounts, in canonical SPL `TransferChecked` order:
+/// `[source_ata, mint, dest_ata, authority]` where
+/// `source_ata = ATA(agent, USDC_MINT)` and `dest_ata = ATA(recipient, USDC_MINT)`,
+/// and instruction data is `[12] || amount(u64 LE) || decimals(=6)`.
+///
+/// # Errors
+///
+/// Returns `SignerError::TransactionBuild` if the recipient address is invalid
+/// or the SPL instruction cannot be built.
+pub(crate) fn build_exact_transfer_tx(
+    wallet: &Wallet,
+    recipient: &str,
+    amount_atomic: u64,
+    blockhash: Hash,
+) -> Result<String, SignerError> {
+    // Reject a zero amount BEFORE building anything. A `0` would produce a
+    // perfectly valid `$0` `TransferChecked` that the gateway accepts as a
+    // signed payment, settling nothing while the request proceeds. Fail closed
+    // at the boundary — parity with the Python `_sign_exact_payment` guard and
+    // the escrow `DepositParams` amount check (money-path: reject zero amount).
+    if amount_atomic == 0 {
+        return Err(SignerError::TransactionBuild(
+            "exact transfer amount must be greater than zero".to_string(),
+        ));
+    }
+
     let mint: Pubkey = USDC_MINT
         .parse()
         .map_err(|e| SignerError::TransactionBuild(format!("invalid USDC mint: {e}")))?;
@@ -126,8 +208,6 @@ pub(crate) async fn sign_exact_payment(
         USDC_DECIMALS,
     )
     .map_err(|e| SignerError::TransactionBuild(format!("instruction build: {e}")))?;
-
-    let blockhash = get_latest_blockhash(rpc_url, http).await?;
 
     let message = Message::new(&[ix], Some(&wallet.pubkey()));
     // Bind the reconstructed `Keypair` to a local so the borrow lasts
@@ -360,6 +440,82 @@ mod tests {
     use super::*;
     use solana_sdk::signer::keypair::Keypair;
     use solana_sdk::signer::Signer;
+
+    const GOLDEN_PROVIDER: &str = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+    /// Deterministic agent wallet from seed `[42u8; 32]` — identical to the
+    /// escrow golden vector's agent keypair, for sibling consistency.
+    fn golden_agent_wallet() -> Wallet {
+        use ed25519_dalek::SigningKey;
+        let seed = [42u8; 32];
+        let sk = SigningKey::from_bytes(&seed);
+        let mut kp = [0u8; 64];
+        kp[..32].copy_from_slice(&sk.to_bytes());
+        kp[32..].copy_from_slice(sk.verifying_key().as_bytes());
+        Wallet::from_keypair_bytes(&kp).expect("valid golden keypair")
+    }
+
+    /// Pinning test (a): the reference `exact` construction reproduces the
+    /// canonical golden vector byte-for-byte. `sign_exact_payment` delegates to
+    /// `build_exact_transfer_tx` after fetching the blockhash, so proving the
+    /// pure builder reproduces the vector for the fixed blockhash proves
+    /// `sign_exact_payment` does too (task item 4 — Rust-SDK parity).
+    ///
+    /// NEVER edit `EXACT_GOLDEN_VECTOR_B64` to match this output — the vector is
+    /// the cross-SDK contract; if this drifts, the wire layout changed.
+    #[test]
+    fn exact_tx_matches_golden_vector() {
+        let wallet = golden_agent_wallet();
+        let blockhash = Hash::new_from_array([0xABu8; 32]);
+        let b64 = build_exact_transfer_tx(&wallet, GOLDEN_PROVIDER, 2625, blockhash)
+            .expect("golden exact build should succeed");
+        assert_eq!(
+            b64, EXACT_GOLDEN_VECTOR_B64,
+            "exact-tx byte layout drifted from the pinned golden vector"
+        );
+    }
+
+    /// The build is pure: identical fixed input always yields identical bytes
+    /// (no nonce, no clock — the blockhash is supplied).
+    #[test]
+    fn exact_tx_is_deterministic() {
+        let wallet = golden_agent_wallet();
+        let blockhash = Hash::new_from_array([0xABu8; 32]);
+        let a = build_exact_transfer_tx(&wallet, GOLDEN_PROVIDER, 2625, blockhash).unwrap();
+        let b = build_exact_transfer_tx(&wallet, GOLDEN_PROVIDER, 2625, blockhash).unwrap();
+        assert_eq!(a, b);
+    }
+
+    /// A zero amount must be rejected before any tx is built — parity with the
+    /// Python `_sign_exact_payment` guard. A `0` would otherwise produce a valid
+    /// signed `$0` `TransferChecked` (money-path: reject zero amount).
+    #[test]
+    fn exact_zero_amount_rejected() {
+        let wallet = golden_agent_wallet();
+        let blockhash = Hash::new_from_array([0xABu8; 32]);
+        let err = build_exact_transfer_tx(&wallet, GOLDEN_PROVIDER, 0, blockhash)
+            .expect_err("zero amount must be rejected");
+        match err {
+            SignerError::TransactionBuild(msg) => {
+                assert!(
+                    msg.contains("greater than zero"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected TransactionBuild, got {other:?}"),
+        }
+    }
+
+    /// A non-zero amount (e.g. the golden vector's 2625) is unaffected by the
+    /// zero guard — the builder still succeeds and reproduces the vector.
+    #[test]
+    fn exact_nonzero_amount_still_builds() {
+        let wallet = golden_agent_wallet();
+        let blockhash = Hash::new_from_array([0xABu8; 32]);
+        let b64 = build_exact_transfer_tx(&wallet, GOLDEN_PROVIDER, 2625, blockhash)
+            .expect("non-zero amount must build");
+        assert_eq!(b64, EXACT_GOLDEN_VECTOR_B64);
+    }
 
     #[test]
     fn test_associated_token_address_deterministic() {


### PR DESCRIPTION
## The bug (confirmed against the deployed gateway)

The **Python SDK** (and TS — fixed separately) signed `exact` USDC-SPL payments with plain SPL **`Transfer` (ix 3)**. The production gateway (`crates/x402/src/solana.rs`) **deterministically rejects** plain `Transfer` and requires **`TransferChecked` (ix 12)** so the USDC mint can be verified on-chain — the rejection fires *before* `simulateTransaction`, so it fails regardless of wallet funding. The Rust SDK already used ix 12 (correct); Go's `exact` is unimplemented.

The root cause it went unnoticed: the `exact` path had **no cross-SDK golden vector** (escrow has one; exact did not).

## What this PR does

- **Establishes the canonical `exact` golden vector** — `EXACT_GOLDEN_VECTOR_B64`, a fixed-input `TransferChecked` transaction (sibling to the escrow `GOLDEN_VECTOR_B64`: same agent seed, USDC mint, amount, blockhash, decimals=6). Pinned **two ways**:
  - a byte-for-byte parity test in the Rust reference signer, and
  - a **gateway-acceptance test** in `crates/x402` that drives the vector through the real verifier parse/validate path (`decode_and_validate_transaction` + `extract_spl_transfer` + mint/amount/destination checks).
- **Python `exact` → ix 12**, reproducing the vector byte-for-byte; fail-closed on zero/float/`bool`/`> u64::MAX` amounts before any RPC; keypair-parse errors redacted.
- **Rust reference:** extracts a pure, RPC-free `build_exact_transfer_tx` (so the vector is testable without a node) and adds a zero-amount guard for cross-SDK parity.

No gateway verification logic changed — only tests + a canonical constant. **TS** (exact + escrow) and **Go** (exact) follow in separate PRs.

## Review & tests

Reviewed by `python-reviewer` + `rust-reviewer` + `silent-failure-hunter` (fixes applied: Rust zero-amount guard, Python u64 bound + keypair redaction, test gaps, const visibility). **Rust 139+13+1, x402 136, Python 225 passing; escrow + exact golden vectors byte-identical; fmt/clippy/ruff/mypy clean.**