### PR TITLE
fix(sdk-rust-proxy): strip accept-encoding so 402 bodies stay parseable

### DIFF
--- a/sdks/rust/crates/solvela-client-proxy/src/proxy.rs
+++ b/sdks/rust/crates/solvela-client-proxy/src/proxy.rs
@@ -185,9 +185,16 @@ fn forward_headers(
 ) -> reqwest::RequestBuilder {
     for (name, value) in headers {
         let name_lower = name.as_str().to_lowercase();
+        // `accept-encoding` is stripped because this proxy's contract is to pipe
+        // bodies through unmodified (see `build_passthrough_response`) and its
+        // reqwest client is built without gzip/brotli/deflate support — so it
+        // cannot decompress a response it advertised it could accept. Forwarding
+        // the caller's `accept-encoding` lets the gateway (or a fronting edge
+        // proxy) compress the body, which then fails to parse as JSON. Treat it
+        // as hop-by-hop here.
         if matches!(
             name_lower.as_str(),
-            "host" | "connection" | "transfer-encoding" | "payment-signature"
+            "host" | "connection" | "transfer-encoding" | "payment-signature" | "accept-encoding"
         ) {
             if name_lower == "payment-signature" {
                 warn!("stripped PAYMENT-SIGNATURE header from caller (security)");

--- a/sdks/rust/crates/solvela-client-proxy/tests/integration.rs
+++ b/sdks/rust/crates/solvela-client-proxy/tests/integration.rs
@@ -256,6 +256,52 @@ async fn test_payment_signature_header_stripped_from_caller() {
     assert_eq!(resp.status(), StatusCode::OK);
 }
 
+/// Matcher asserting the forwarded request does NOT carry an `accept-encoding`
+/// header. The proxy must strip it: its reqwest client has no
+/// gzip/brotli/deflate support, so advertising encodings it cannot decompress
+/// yields a compressed body that fails to parse (e.g. a Brotli 402 body).
+struct NoAcceptEncoding;
+
+impl wiremock::Match for NoAcceptEncoding {
+    fn matches(&self, request: &wiremock::Request) -> bool {
+        !request.headers.contains_key("accept-encoding")
+    }
+}
+
+#[tokio::test]
+async fn test_accept_encoding_stripped_from_caller() {
+    let mock = MockServer::start().await;
+
+    // Only matches if the forwarded request has no accept-encoding header.
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(NoAcceptEncoding)
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let app = build_test_app(&mock.uri());
+
+    // Caller sends the header CowAgent's Python openai client always sends.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("accept-encoding", "gzip, deflate, br")
+                .body(Body::from(r"{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // If the proxy forwarded accept-encoding, the mock would not match and
+    // wiremock would return 404 (verified on drop via .expect(1)).
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
 #[tokio::test]
 async fn test_amount_exceeds_max_returns_error() {
     let mock = MockServer::start().await;


### PR DESCRIPTION
## Problem

The Rust client proxy (`solvela-client-proxy`) forwards the caller's `accept-encoding` header to the gateway, but its reqwest client is built **without** gzip/brotli/deflate support (workspace features: `json`/`stream`/`rustls`/`webpki-roots`). When a caller — e.g. CowAgent's Python `openai` client, which always sends `accept-encoding: gzip, deflate, br` — hits a 402, the gateway (or the fronting Fly.io edge) Brotli-compresses the 402 body. reqwest can't decompress it, so `resp_402.text()` lossily decodes the binary and `serde_json::from_str` fails with *"expected value at line 1 column 1"* → `invalid_402_body` (502). **Payment signing never proceeds.**

### Empirically reproduced against the live gateway

| Request | Status | Size | content-encoding | First bytes |
|---|---|---|---|---|
| no `Accept-Encoding` | 402 | 754 | (none) | `{"x402_version":` |
| `accept-encoding: gzip, deflate, br` | 402 | 495 | `br` | `8b 78 01 00…` (binary) |

This is **version-independent** and explains prior observations the version-skew theory couldn't:
- Direct `curl` works → curl sends no `Accept-Encoding`.
- Proxy v0.2.1 and v0.2.4 fail identically → it's the header path, not the version.
- Body looked "empty" → it was Brotli binary, not empty.

## Fix

Treat `accept-encoding` as hop-by-hop in `forward_headers` and strip it (one line + comment). The proxy's contract is to pipe bodies through unmodified (`build_passthrough_response` copies `content-encoding`/`content-length` verbatim) and it has no decompression compiled in, so it must not advertise encodings it cannot handle. With it stripped, the gateway returns uncompressed JSON end-to-end and the 402 parses.

**Why not enable reqwest's brotli/gzip feature instead?** That route would also require dropping the now-stale `content-encoding`/`content-length` headers in `build_passthrough_response` after reqwest decompresses — more invasive, and it breaks the unmodified-passthrough invariant.

## Test

Adds `test_accept_encoding_stripped_from_caller` with a custom wiremock matcher (`NoAcceptEncoding`) that asserts the forwarded request carries **no** `accept-encoding`. The existing `payment-signature` test only relies on `.expect(1)` and never asserts absence; this one does.

- Negative control: test **fails** without the strip, **passes** with it.
- Full proxy suite: 8/8 pass; `cargo fmt --check` + `cargo clippy -D warnings` clean.

## Note on root cause attribution

This repo's gateway crate has no compression layer (`tower-http` lacks the `compression` feature), so the `content-encoding: br` is added by the Fly.io edge / fronting proxy, not gateway code. The fix is robust regardless of *who* compresses — nothing can if the proxy never advertises it.

## Follow-up (not in this PR)

Deploy: `cargo build -p solvela-client-proxy --release`, reinstall, rebuild the cowagent-tenant image (or `flyctl machine update telsi-nikki-dix` with the new binary), re-test → USDC should drop below 4.999994.