### PR TITLE
fix(sdk-ts): exact payments must use TransferChecked (ix 12) + pin golden vector

### DIFF
--- a/sdks/typescript/src/signer.ts
+++ b/sdks/typescript/src/signer.ts
@@ -115,7 +115,8 @@ export class KeypairSigner implements Signer {
       );
     } catch (e) {
       if (e instanceof SignerError) throw e;
-      throw new SignerError(`Failed to sign payment: ${(e as Error).message}`);
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new SignerError(`Failed to sign payment: ${msg}`);
     }
   }
 
@@ -166,6 +167,14 @@ export class KeypairSigner implements Signer {
     recipient: string,
     blockhash: string,
   ): Promise<string> {
+    // Validate unconditionally at the lowest level so a direct external call to
+    // this public, barrel-exported builder cannot bypass the amount guard. A
+    // zero/negative/float/out-of-range amount would otherwise be silently
+    // mis-encoded into the u64 (e.g. a negative amount wraps to ~18.4
+    // quintillion atomic USDC). The duplicate call in signExactPayment is a
+    // harmless no-op once validation passes.
+    this.assertValidAmount(amountAtomic);
+
     const mint = new PublicKey(USDC_MINT);
     const sender = this.wallet.publicKey();
     const recipientPubkey = new PublicKey(recipient);
@@ -174,7 +183,7 @@ export class KeypairSigner implements Signer {
     const recipientAta = await getAssociatedTokenAddress(mint, recipientPubkey);
 
     // SPL Token TransferChecked: createTransferCheckedInstruction emits the
-    // canonical 4-account layout [source, mint, destination, owner] and the
+    // canonical 4-account layout [source, mint, destination, authority] and the
     // instruction data [12] || amount(u64 LE) || decimals(1). The mint + the
     // decimals byte are what let the gateway verify the USDC mint on-chain; the
     // live verifier rejects the plain Transfer (discriminator 3) the old code
@@ -218,11 +227,7 @@ export class KeypairSigner implements Signer {
     }
     // The agent is the sole signer; the signature count fits in a single
     // compact-u16 byte (1 <= 127). Mirrors the escrow wire-format assembly.
-    const wire = Buffer.concat([
-      Buffer.from([1]),
-      Buffer.from(signature),
-      Buffer.from(messageBytes),
-    ]);
+    const wire = Buffer.concat([Buffer.from([1]), signature, messageBytes]);
 
     return wire.toString('base64');
   }
@@ -300,7 +305,7 @@ function compileCanonicalMessage(
   const writableNonSigners = rest.filter((m) => !m.isSigner && m.isWritable).sort(byBytes);
   const readonlyNonSigners = rest.filter((m) => !m.isSigner && !m.isWritable).sort(byBytes);
 
-  const feePayerMeta = all.find((m) => m.pubkey.toBase58() === feePayerKey);
+  const feePayerMeta = metaByKey.get(feePayerKey);
   if (!feePayerMeta) {
     throw new SignerError('internal: fee payer missing from compiled account set');
   }

--- a/sdks/typescript/src/signer.ts
+++ b/sdks/typescript/src/signer.ts
@@ -1,10 +1,28 @@
-import { Connection, PublicKey, Transaction } from '@solana/web3.js';
-import { getAssociatedTokenAddress, createTransferInstruction } from '@solana/spl-token';
+import {
+  Connection,
+  Message,
+  PublicKey,
+  type CompiledInstruction,
+} from '@solana/web3.js';
+import {
+  getAssociatedTokenAddress,
+  createTransferCheckedInstruction,
+} from '@solana/spl-token';
+import bs58 from 'bs58';
 
 import { PaymentAccept, PaymentPayload, Resource, SolanaPayload } from './types.js';
 import { SignerError } from './errors.js';
 import { Wallet } from './wallet.js';
 import { USDC_MINT, X402_VERSION } from './constants.js';
+
+/**
+ * USDC has 6 decimals. The SPL `TransferChecked` instruction carries this byte
+ * so the gateway verifier can confirm the mint + decimals on-chain. Mirrors the
+ * Rust SDK's `const USDC_DECIMALS: u8 = 6`
+ * (`sdks/rust/crates/solvela-client/src/signer.rs`) and the Python SDK's
+ * `USDC_DECIMALS = 6` (`sdks/python/src/solvela/signer.py`).
+ */
+export const USDC_DECIMALS = 6;
 
 export interface Signer {
   signPayment(
@@ -21,29 +39,73 @@ export class KeypairSigner implements Signer {
     private readonly rpcUrl: string = 'https://api.mainnet-beta.solana.com',
   ) {}
 
+  /**
+   * Build and sign a payment transaction, branching on the selected scheme.
+   *
+   * `exact`  -> SPL-token `TransferChecked` to the gateway's pay_to ATA
+   *             (returns a `SolanaPayload`).
+   *
+   * There is NO silent fallback: an `escrow`-selected payment is rejected with
+   * a clear `SignerError` rather than being settled as an `exact` transfer.
+   * Silently routing an escrow-selected payment as an exact transfer is the
+   * scheme-mismatch money-path bug the `solvela-x402` skill warns against (it
+   * is the exact bug that existed in the Go/Python signers). The TS SDK does
+   * not yet implement the escrow deposit builder; until it does, the signer
+   * fails closed rather than producing a wrong-scheme transfer. An unknown
+   * scheme is likewise rejected, never default-routed.
+   */
   async signPayment(
     amountAtomic: number,
     recipient: string,
     resource: Resource,
     accepted: PaymentAccept,
   ): Promise<PaymentPayload> {
+    if (accepted.scheme === 'exact') {
+      return this.signExactPayment(amountAtomic, recipient, resource, accepted);
+    }
+    if (accepted.scheme === 'escrow') {
+      // No silent fallback: escrow was selected but the TS SDK cannot build an
+      // escrow deposit yet. Refuse rather than settle an exact transfer.
+      throw new SignerError(
+        'escrow payment scheme is not yet supported by the TypeScript SDK; ' +
+          'refusing to silently fall back to an exact transfer',
+      );
+    }
+    // `accepted.scheme` is a closed union (`PaymentAccept.fromJSON` rejects
+    // unknown wire schemes), so this is only reachable if the type is bypassed.
+    // Fail closed rather than default-route.
+    throw new SignerError(
+      `Unsupported payment scheme: ${JSON.stringify(accepted.scheme).slice(0, 64)}`,
+    );
+  }
+
+  /**
+   * Build and sign a USDC-SPL `TransferChecked` transaction (`exact` scheme).
+   *
+   * Fetches a recent blockhash via JSON-RPC, then delegates the byte-exact
+   * construction to {@link buildExactTransferTx}, which pins the canonical
+   * `TransferChecked` (instruction discriminator 12) wire layout the live
+   * gateway `exact` verifier accepts. The gateway rejects a plain SPL
+   * `Transfer` (discriminator 3) because it cannot verify the USDC mint
+   * on-chain from it; `TransferChecked` carries the mint + decimals so the
+   * verifier can (see `crates/x402/src/solana.rs`).
+   */
+  private async signExactPayment(
+    amountAtomic: number,
+    recipient: string,
+    resource: Resource,
+    accepted: PaymentAccept,
+  ): Promise<PaymentPayload> {
+    // Fail closed on a bad amount BEFORE any RPC/network call (mirrors the
+    // Python/Rust signers). Atomic USDC is an integer count; a float would be
+    // silently truncated into the on-chain u64 and mis-charge the agent.
+    this.assertValidAmount(amountAtomic);
+
     try {
       const connection = new Connection(this.rpcUrl);
-      const mint = new PublicKey(USDC_MINT);
-      const sender = this.wallet.publicKey();
-      const recipientPubkey = new PublicKey(recipient);
-
-      const senderAta = await getAssociatedTokenAddress(mint, sender);
-      const recipientAta = await getAssociatedTokenAddress(mint, recipientPubkey);
-
-      const ix = createTransferInstruction(senderAta, recipientAta, sender, amountAtomic);
       const { blockhash } = await connection.getLatestBlockhash('finalized');
 
-      const tx = new Transaction({ recentBlockhash: blockhash, feePayer: sender });
-      tx.add(ix);
-      this.wallet.signTransaction(tx);
-
-      const txB64 = tx.serialize().toString('base64');
+      const txB64 = await this.buildExactTransferTx(amountAtomic, recipient, blockhash);
 
       return new PaymentPayload(
         X402_VERSION,
@@ -56,4 +118,237 @@ export class KeypairSigner implements Signer {
       throw new SignerError(`Failed to sign payment: ${(e as Error).message}`);
     }
   }
+
+  /**
+   * Reject a non-integer, non-positive, or precision-unsafe atomic amount.
+   *
+   * JavaScript numbers are IEEE-754 doubles: only integers up to
+   * `Number.MAX_SAFE_INTEGER` (2^53 - 1) round-trip faithfully. An amount above
+   * that cannot be represented exactly as a `u64` and would silently mis-encode
+   * the transfer, so it is rejected here rather than producing a wrong on-chain
+   * amount. A non-integer (float) amount would be silently truncated by the
+   * instruction builder. Fail closed at the boundary — parity with the Python
+   * `_sign_exact_payment` guard and the Rust `build_exact_transfer_tx` zero check.
+   */
+  private assertValidAmount(amountAtomic: number): void {
+    if (!Number.isInteger(amountAtomic)) {
+      throw new SignerError(
+        'exact transfer amount must be an integer number of atomic USDC units',
+      );
+    }
+    if (amountAtomic <= 0) {
+      throw new SignerError('exact transfer amount must be greater than zero');
+    }
+    if (amountAtomic > Number.MAX_SAFE_INTEGER) {
+      throw new SignerError(
+        'exact transfer amount exceeds the safe-integer range (cannot encode as u64)',
+      );
+    }
+  }
+
+  /**
+   * Build and sign a USDC-SPL `TransferChecked` (discriminator 12) tx against a
+   * caller-supplied `recentBlockhash`.
+   *
+   * Pure with respect to the network (no I/O): for fixed inputs it always
+   * produces the same bytes, which is what lets `EXACT_GOLDEN_VECTOR_B64`
+   * (`sdks/rust/crates/solvela-client/src/signer.rs`) pin the wire layout. The
+   * agent wallet is the transaction fee payer (`account_keys[0]`) and the sole
+   * signer.
+   *
+   * Instruction accounts, in canonical SPL `TransferChecked` order:
+   * `[source_ata, mint, dest_ata, authority]` where
+   * `source_ata = ATA(agent, USDC_MINT)` and `dest_ata = ATA(recipient, USDC_MINT)`;
+   * instruction data is `[12] || amount(u64 LE) || decimals(=6)`.
+   */
+  async buildExactTransferTx(
+    amountAtomic: number,
+    recipient: string,
+    blockhash: string,
+  ): Promise<string> {
+    const mint = new PublicKey(USDC_MINT);
+    const sender = this.wallet.publicKey();
+    const recipientPubkey = new PublicKey(recipient);
+
+    const senderAta = await getAssociatedTokenAddress(mint, sender);
+    const recipientAta = await getAssociatedTokenAddress(mint, recipientPubkey);
+
+    // SPL Token TransferChecked: createTransferCheckedInstruction emits the
+    // canonical 4-account layout [source, mint, destination, owner] and the
+    // instruction data [12] || amount(u64 LE) || decimals(1). The mint + the
+    // decimals byte are what let the gateway verify the USDC mint on-chain; the
+    // live verifier rejects the plain Transfer (discriminator 3) the old code
+    // emitted (crates/x402/src/solana.rs).
+    const ix = createTransferCheckedInstruction(
+      senderAta,
+      mint,
+      recipientAta,
+      sender,
+      amountAtomic,
+      USDC_DECIMALS,
+    );
+
+    // Compile the message with the SAME account ordering the Solana Rust SDK's
+    // `Message::new` produces, so the bytes match the cross-SDK golden vector
+    // (EXACT_GOLDEN_VECTOR_B64 in sdks/rust/crates/solvela-client/src/signer.rs)
+    // and the Python SDK byte-for-byte. solana-web3.js's `Transaction.add(ix)`
+    // compiler preserves instruction-appearance order WITHIN each writability
+    // partition, whereas the Rust SDK's `CompiledKeys` sorts each partition by
+    // pubkey bytes. For TransferChecked that flips the two readonly accounts
+    // (token-program `06dd…` sorts before USDC mint `c6fa…`), producing a
+    // different — though semantically equivalent — wire layout the golden vector
+    // would reject. We replicate the Rust sort here. The agent wallet is the fee
+    // payer (account_keys[0]) and sole signer.
+    const message = compileCanonicalMessage(sender, blockhash, [
+      { programId: ix.programId, keys: ix.keys, data: ix.data },
+    ]);
+
+    // Assemble the wire transaction manually: `compact-u16(1) || sig(64) || msg`.
+    // We do NOT use `Transaction.sign()` / `Transaction.serialize()` here:
+    // solana-web3.js re-compiles (and re-orders) the message at sign/serialize
+    // time, which discards our canonical account ordering and breaks
+    // byte-for-byte parity with the cross-SDK golden vector. Instead we sign the
+    // canonical message bytes directly and prepend the single signature.
+    const messageBytes = message.serialize();
+    const signature = this.wallet.signMessage(messageBytes);
+    if (signature.length !== SIGNATURE_LENGTH) {
+      throw new SignerError(
+        `unexpected signature length ${signature.length} (want ${SIGNATURE_LENGTH})`,
+      );
+    }
+    // The agent is the sole signer; the signature count fits in a single
+    // compact-u16 byte (1 <= 127). Mirrors the escrow wire-format assembly.
+    const wire = Buffer.concat([
+      Buffer.from([1]),
+      Buffer.from(signature),
+      Buffer.from(messageBytes),
+    ]);
+
+    return wire.toString('base64');
+  }
+}
+
+const SIGNATURE_LENGTH = 64;
+
+interface CompilableInstruction {
+  programId: PublicKey;
+  keys: { pubkey: PublicKey; isSigner: boolean; isWritable: boolean }[];
+  data: Buffer;
+}
+
+/**
+ * Compile a legacy Solana `Message` with account ordering identical to the
+ * Solana Rust SDK's `Message::new` / `CompiledKeys` (the canonical layout the
+ * gateway verifier and the cross-SDK golden vectors are pinned against).
+ *
+ * Ordering rules (matching `CompiledKeys::try_into_message_components`):
+ *   1. The fee payer is always `account_keys[0]` (writable signer).
+ *   2. Remaining accounts are partitioned into:
+ *        writable-signers, readonly-signers, writable-non-signers,
+ *        readonly-non-signers
+ *      and, WITHIN each partition, sorted ascending by raw pubkey bytes.
+ *   3. Program IDs are folded in as readonly-non-signers.
+ *
+ * solana-web3.js's own `Transaction.compileMessage` does NOT sort within a
+ * partition (it preserves first-seen order), which is why we compile manually.
+ */
+function compileCanonicalMessage(
+  feePayer: PublicKey,
+  recentBlockhash: string,
+  instructions: CompilableInstruction[],
+): Message {
+  interface KeyMeta {
+    pubkey: PublicKey;
+    isSigner: boolean;
+    isWritable: boolean;
+  }
+
+  // Collect every account + program id, OR-ing the signer/writable flags.
+  const metaByKey = new Map<string, KeyMeta>();
+  const upsert = (pubkey: PublicKey, isSigner: boolean, isWritable: boolean): void => {
+    const k = pubkey.toBase58();
+    const existing = metaByKey.get(k);
+    if (existing) {
+      existing.isSigner = existing.isSigner || isSigner;
+      existing.isWritable = existing.isWritable || isWritable;
+    } else {
+      metaByKey.set(k, { pubkey, isSigner, isWritable });
+    }
+  };
+
+  // Fee payer first — forced writable signer.
+  upsert(feePayer, true, true);
+  for (const ix of instructions) {
+    for (const key of ix.keys) {
+      upsert(key.pubkey, key.isSigner, key.isWritable);
+    }
+    // Program ids are readonly, non-signer.
+    upsert(ix.programId, false, false);
+  }
+
+  const byBytes = (a: KeyMeta, b: KeyMeta): number =>
+    Buffer.compare(a.pubkey.toBuffer(), b.pubkey.toBuffer());
+
+  const all = [...metaByKey.values()];
+  // The fee payer stays pinned at index 0; everything else is partitioned and
+  // byte-sorted within its partition (matching the Rust SDK).
+  const feePayerKey = feePayer.toBase58();
+  const rest = all.filter((m) => m.pubkey.toBase58() !== feePayerKey);
+
+  const writableSigners = rest.filter((m) => m.isSigner && m.isWritable).sort(byBytes);
+  const readonlySigners = rest.filter((m) => m.isSigner && !m.isWritable).sort(byBytes);
+  const writableNonSigners = rest.filter((m) => !m.isSigner && m.isWritable).sort(byBytes);
+  const readonlyNonSigners = rest.filter((m) => !m.isSigner && !m.isWritable).sort(byBytes);
+
+  const feePayerMeta = all.find((m) => m.pubkey.toBase58() === feePayerKey);
+  if (!feePayerMeta) {
+    throw new SignerError('internal: fee payer missing from compiled account set');
+  }
+
+  const ordered: KeyMeta[] = [
+    feePayerMeta,
+    ...writableSigners,
+    ...readonlySigners,
+    ...writableNonSigners,
+    ...readonlyNonSigners,
+  ];
+
+  const accountKeys = ordered.map((m) => m.pubkey);
+  const indexOf = new Map<string, number>();
+  accountKeys.forEach((k, i) => indexOf.set(k.toBase58(), i));
+
+  const numRequiredSignatures = ordered.filter((m) => m.isSigner).length;
+  const numReadonlySignedAccounts = ordered.filter((m) => m.isSigner && !m.isWritable).length;
+  const numReadonlyUnsignedAccounts = ordered.filter((m) => !m.isSigner && !m.isWritable).length;
+
+  const compiledInstructions: CompiledInstruction[] = instructions.map((ix) => {
+    const programIdIndex = indexOf.get(ix.programId.toBase58());
+    if (programIdIndex === undefined) {
+      throw new SignerError('internal: program id missing from compiled account set');
+    }
+    const accounts = ix.keys.map((key) => {
+      const idx = indexOf.get(key.pubkey.toBase58());
+      if (idx === undefined) {
+        throw new SignerError('internal: instruction account missing from compiled set');
+      }
+      return idx;
+    });
+    return {
+      programIdIndex,
+      accounts,
+      // CompiledInstruction.data is base58-encoded in the legacy Message form.
+      data: bs58.encode(ix.data),
+    };
+  });
+
+  return new Message({
+    header: {
+      numRequiredSignatures,
+      numReadonlySignedAccounts,
+      numReadonlyUnsignedAccounts,
+    },
+    accountKeys: accountKeys.map((k) => k.toBase58()),
+    recentBlockhash,
+    instructions: compiledInstructions,
+  });
 }

--- a/sdks/typescript/src/wallet.ts
+++ b/sdks/typescript/src/wallet.ts
@@ -1,8 +1,14 @@
+import { createPrivateKey, sign as edSign } from 'node:crypto';
+
 import { Keypair, PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
 import * as bip39 from 'bip39';
 import bs58 from 'bs58';
 
 import { WalletError } from './errors.js';
+
+// DER prefix for a PKCS#8-wrapped Ed25519 private key (RFC 8410). The 32-byte
+// raw seed is appended to form a complete PKCS#8 key Node's crypto can import.
+const ED25519_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
 
 export class Wallet {
   private constructor(private readonly keypair: Keypair) {}
@@ -19,6 +25,25 @@ export class Wallet {
     }
     (tx as Transaction).sign(this.keypair);
     return tx;
+  }
+
+  /**
+   * Sign raw message bytes with the wallet's Ed25519 key, returning the 64-byte
+   * detached signature.
+   *
+   * This is needed by the `exact` payment signer, which compiles a legacy
+   * Solana message with the canonical (Rust-SDK-sorted) account ordering and
+   * then assembles the wire transaction manually — `Transaction.sign()` cannot
+   * be used because solana-web3.js re-compiles (and re-orders) the message at
+   * sign/serialize time, which would break byte-for-byte parity with the
+   * cross-SDK golden vector. The secret never leaves the Wallet boundary: it is
+   * imported into a Node `KeyObject` and used in-process for the signature only.
+   */
+  signMessage(message: Uint8Array): Uint8Array {
+    const seed = this.keypair.secretKey.slice(0, 32);
+    const pkcs8 = Buffer.concat([ED25519_PKCS8_PREFIX, Buffer.from(seed)]);
+    const keyObject = createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+    return edSign(null, Buffer.from(message), keyObject);
   }
 
   static create(): [Wallet, string] {

--- a/sdks/typescript/tests/unit/signer.test.ts
+++ b/sdks/typescript/tests/unit/signer.test.ts
@@ -1,6 +1,73 @@
-import { describe, it, expect } from 'vitest';
-import { KeypairSigner } from '../../src/signer.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { Keypair, Connection } from '@solana/web3.js';
+import bs58 from 'bs58';
+
+import { KeypairSigner, USDC_DECIMALS } from '../../src/signer.js';
 import { Wallet } from '../../src/wallet.js';
+import { PaymentAccept, Resource, SolanaPayload, EscrowPayload } from '../../src/types.js';
+import { SOLANA_NETWORK, USDC_MINT } from '../../src/constants.js';
+
+// ---------------------------------------------------------------------------
+// Exact-scheme golden vector — byte-exact match against the canonical Rust
+// source sdks/rust/crates/solvela-client/src/signer.rs (EXACT_GOLDEN_VECTOR_B64).
+// ---------------------------------------------------------------------------
+//
+// Copied verbatim from EXACT_GOLDEN_VECTOR_B64 in
+// sdks/rust/crates/solvela-client/src/signer.rs. DO NOT hand-edit. If this
+// changes, the on-chain/gateway-accepted `exact` wire layout drifted — the
+// canonical value is ground truth, never this file (mirrors the Python exact
+// golden vector contract in tests/unit/test_signer.py).
+const EXACT_GOLDEN_VECTOR_B64 =
+  'AbipfII25y2dIV7pTiOYf+qp9tAqiikKnoJqJnMsMNmGEMP1hDxqdcaeDIPxW3EJq5WUYR+V27kgDsjLvDsXDwEBAAIFGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWEUtdnlbYnE3avA84DOO4wvyfA9bjZxRumTasKUlOhjntPqjPWsrKjNBSB1EhdcQ871Sl3Znt4goWtVJTc485fcBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKnG+nrzvtutOj1l82qryXQxsbvkwtL24OR8pgIDRS9dYaurq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urAQMEAQQCAAoMQQoAAAAAAAAG';
+
+// Fixed golden inputs (sibling-consistent with the escrow vector and the
+// Rust/Python exact vectors).
+const GOLDEN_PROVIDER = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
+// recent_blockhash = [0xAB; 32], encoded base58, as web3.js Transaction expects
+// a base58 blockhash string. The Rust/Python vectors use the raw 32 bytes
+// [0xAB; 32]; bs58 of those bytes is the same blockhash.
+const GOLDEN_BLOCKHASH_BYTES = new Uint8Array(32).fill(0xab);
+
+const RPC_URL = 'https://rpc.test.local';
+
+/**
+ * Deterministic agent wallet from seed [42; 32] — identical to the escrow
+ * golden vector's agent keypair (pubkey 2iXtA8oeZqUU5pofxK971TCEvFGfems2AcDRaZHKD2pQ),
+ * for sibling consistency across the exact and escrow vectors and across SDKs.
+ */
+function goldenAgentWallet(): Wallet {
+  const kp = Keypair.fromSeed(new Uint8Array(32).fill(42));
+  return Wallet.fromKeypairBytes(kp.secretKey);
+}
+
+function goldenBlockhashBase58(): string {
+  // The Rust/Python vectors use the raw 32 bytes [0xAB; 32] as recent_blockhash;
+  // web3.js expects a base58 blockhash string, so encode those exact bytes.
+  return bs58.encode(GOLDEN_BLOCKHASH_BYTES);
+}
+
+function accept(scheme: 'exact' | 'escrow' = 'exact'): PaymentAccept {
+  return new PaymentAccept(
+    scheme,
+    SOLANA_NETWORK,
+    '2625',
+    USDC_MINT,
+    GOLDEN_PROVIDER,
+    300,
+    scheme === 'escrow' ? '9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU' : undefined,
+  );
+}
+
+function resource(): Resource {
+  return new Resource(`${RPC_URL}/v1/chat/completions`, 'POST');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('Signer', () => {
   it('KeypairSigner implements Signer interface', () => {
@@ -20,5 +87,172 @@ describe('Signer', () => {
     const [wallet] = Wallet.create();
     const signer = new KeypairSigner(wallet, 'https://custom-rpc.example.com');
     expect(signer).toBeDefined();
+  });
+
+  it('USDC_DECIMALS is 6', () => {
+    expect(USDC_DECIMALS).toBe(6);
+  });
+});
+
+describe('Exact golden vector (TransferChecked byte parity)', () => {
+  // This is the sole correctness bar for the `exact` wire format. The live
+  // gateway verifier (crates/x402/src/solana.rs) rejects a plain SPL Transfer
+  // (discriminator 3); it requires TransferChecked (discriminator 12) so the
+  // USDC mint is on-chain-verifiable. The fixed inputs are sibling-consistent
+  // with the escrow golden vector.
+  //
+  // NEVER edit EXACT_GOLDEN_VECTOR_B64 to match this output — the vector is the
+  // cross-SDK contract; if this drifts, the wire layout changed and the fix is
+  // in the builder, not the expected value.
+  it('reproduces the canonical golden vector byte-for-byte', async () => {
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const out = await signer.buildExactTransferTx(2625, GOLDEN_PROVIDER, goldenBlockhashBase58());
+    expect(out).toBe(EXACT_GOLDEN_VECTOR_B64);
+  });
+
+  it('is deterministic for identical fixed input', async () => {
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const a = await signer.buildExactTransferTx(2625, GOLDEN_PROVIDER, goldenBlockhashBase58());
+    const b = await signer.buildExactTransferTx(2625, GOLDEN_PROVIDER, goldenBlockhashBase58());
+    expect(a).toBe(b);
+  });
+
+  it('emits TransferChecked (disc 12 + decimals), not plain Transfer (disc 3)', async () => {
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const raw = Buffer.from(
+      await signer.buildExactTransferTx(2625, GOLDEN_PROVIDER, goldenBlockhashBase58()),
+      'base64',
+    );
+    // TransferChecked ix data = [12] || amount(u64 LE) || decimals(1).
+    const amountLE = Buffer.alloc(8);
+    amountLE.writeBigUInt64LE(2625n);
+    const expectedTransferChecked = Buffer.concat([Buffer.from([12]), amountLE, Buffer.from([6])]);
+    expect(raw.includes(expectedTransferChecked)).toBe(true);
+    // The old plain-Transfer ix data ([3] || amount) must NOT be present.
+    const plainTransfer = Buffer.concat([Buffer.from([3]), amountLE]);
+    expect(raw.includes(plainTransfer)).toBe(false);
+  });
+});
+
+describe('Exact golden vector drift guard', () => {
+  // The TS exact golden constant MUST equal the canonical Rust source. If
+  // EXACT_GOLDEN_VECTOR_B64 ever changes in
+  // sdks/rust/crates/solvela-client/src/signer.rs, the gateway-accepted `exact`
+  // wire layout changed; this test fails loudly, forcing a resync of the TS
+  // constant and builder rather than letting the SDKs silently diverge. Mirrors
+  // Python's test_python_exact_golden_matches_rust_source.
+  it('TS exact golden constant matches the Rust source of truth', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // tests/unit/signer.test.ts -> worktree root is ../../../../ from here.
+    const rustSrc = resolve(
+      here,
+      '../../../../sdks/rust/crates/solvela-client/src/signer.rs',
+    );
+    const text = readFileSync(rustSrc, 'utf-8');
+    const m = text.match(/EXACT_GOLDEN_VECTOR_B64:\s*&str\s*=\s*"([^"]+)"/);
+    expect(m, 'could not locate EXACT_GOLDEN_VECTOR_B64 in the Rust signer.rs').not.toBeNull();
+    const rustValue = m![1];
+    expect(rustValue).toBe(EXACT_GOLDEN_VECTOR_B64);
+  });
+});
+
+describe('Exact amount rejections (fail closed before any RPC)', () => {
+  // Mirrors Python's TestExactAmountRejections. A bad amount must be rejected
+  // at the boundary, before any network call — never producing a wrong-amount
+  // signed transfer.
+  function spyNoRpc(): ReturnType<typeof vi.spyOn> {
+    // If a rejection path leaks through, this spy would be invoked and the
+    // assertion below catches it. getLatestBlockhash is the first network call.
+    return vi
+      .spyOn(Connection.prototype, 'getLatestBlockhash')
+      .mockRejectedValue(new Error('network must not be called for a rejected amount'));
+  }
+
+  it('rejects zero amount with no RPC call', async () => {
+    const spy = spyNoRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(0, GOLDEN_PROVIDER, resource(), accept()),
+    ).rejects.toThrow(/greater than zero/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative amount with no RPC call', async () => {
+    const spy = spyNoRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(-1, GOLDEN_PROVIDER, resource(), accept()),
+    ).rejects.toThrow(/greater than zero/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-integer (float) amount with no RPC call', async () => {
+    const spy = spyNoRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625.5, GOLDEN_PROVIDER, resource(), accept()),
+    ).rejects.toThrow(/integer/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects NaN amount with no RPC call', async () => {
+    const spy = spyNoRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(Number.NaN, GOLDEN_PROVIDER, resource(), accept()),
+    ).rejects.toThrow(/integer/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects an amount above the safe-integer range with no RPC call', async () => {
+    const spy = spyNoRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(Number.MAX_SAFE_INTEGER + 2, GOLDEN_PROVIDER, resource(), accept()),
+    ).rejects.toThrow(/safe-integer|integer/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('a valid amount (2625) is unaffected by the guard and produces a SolanaPayload', async () => {
+    vi.spyOn(Connection.prototype, 'getLatestBlockhash').mockResolvedValue({
+      blockhash: goldenBlockhashBase58(),
+      lastValidBlockHeight: 1_000_000,
+    });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const payload = await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), accept());
+    expect(payload.x402Version).toBe(2);
+    expect(payload.accepted.scheme).toBe('exact');
+    expect(payload.payload).toBeInstanceOf(SolanaPayload);
+    expect((payload.payload as SolanaPayload).transaction).toBe(EXACT_GOLDEN_VECTOR_B64);
+  });
+});
+
+describe('Scheme branching (no silent fallback)', () => {
+  it('escrow scheme is rejected, never settled as an exact transfer', async () => {
+    const spy = vi
+      .spyOn(Connection.prototype, 'getLatestBlockhash')
+      .mockRejectedValue(new Error('network must not be called for an escrow rejection'));
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), accept('escrow')),
+    ).rejects.toThrow(/escrow/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('an unknown scheme bypassing the type system is rejected, not default-routed', async () => {
+    const spy = vi
+      .spyOn(Connection.prototype, 'getLatestBlockhash')
+      .mockRejectedValue(new Error('network must not be called for an unknown scheme'));
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const a = accept();
+    // Force an out-of-domain scheme past the type system to prove the signer
+    // fails closed rather than defaulting to a transfer.
+    (a as { scheme: string }).scheme = 'upto';
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), a),
+    ).rejects.toThrow(/Unsupported payment scheme/);
+    expect(spy).not.toHaveBeenCalled();
+    // Defensive: escrow payload must never be produced by the exact signer.
+    expect(EscrowPayload).toBeDefined();
   });
 });

--- a/sdks/typescript/tests/unit/signer.test.ts
+++ b/sdks/typescript/tests/unit/signer.test.ts
@@ -6,6 +6,7 @@ import { Keypair, Connection } from '@solana/web3.js';
 import bs58 from 'bs58';
 
 import { KeypairSigner, USDC_DECIMALS } from '../../src/signer.js';
+import { SignerError } from '../../src/errors.js';
 import { Wallet } from '../../src/wallet.js';
 import { PaymentAccept, Resource, SolanaPayload, EscrowPayload } from '../../src/types.js';
 import { SOLANA_NETWORK, USDC_MINT } from '../../src/constants.js';
@@ -224,6 +225,80 @@ describe('Exact amount rejections (fail closed before any RPC)', () => {
     expect(payload.accepted.scheme).toBe('exact');
     expect(payload.payload).toBeInstanceOf(SolanaPayload);
     expect((payload.payload as SolanaPayload).transaction).toBe(EXACT_GOLDEN_VECTOR_B64);
+  });
+});
+
+describe('buildExactTransferTx direct-call guard (fail closed before any RPC)', () => {
+  // buildExactTransferTx is public + barrel-exported, so external consumers can
+  // call it directly, bypassing signExactPayment. The amount guard MUST hold on
+  // this path too: a zero/negative/float amount would otherwise be silently
+  // mis-encoded into the on-chain u64 (a negative amount wraps to ~18.4
+  // quintillion atomic USDC). These pin the money-path Critical fix.
+  function spyNoRpc(): ReturnType<typeof vi.spyOn> {
+    return vi
+      .spyOn(Connection.prototype, 'getLatestBlockhash')
+      .mockRejectedValue(new Error('network must not be called for a rejected amount'));
+  }
+
+  it('rejects zero amount on a direct call with no RPC', async () => {
+    const spy = spyNoRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.buildExactTransferTx(0, GOLDEN_PROVIDER, goldenBlockhashBase58()),
+    ).rejects.toThrow(SignerError);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a negative amount on a direct call with no RPC', async () => {
+    const spy = spyNoRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.buildExactTransferTx(-1, GOLDEN_PROVIDER, goldenBlockhashBase58()),
+    ).rejects.toThrow(SignerError);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a float amount on a direct call with no RPC', async () => {
+    const spy = spyNoRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.buildExactTransferTx(2625.5, GOLDEN_PROVIDER, goldenBlockhashBase58()),
+    ).rejects.toThrow(SignerError);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('signPayment error wrapping (non-Error rejections)', () => {
+  // Pins SHOULD-FIX #1: a plain non-Error rejection from the RPC layer must not
+  // surface as "Failed to sign payment: undefined".
+  it('surfaces a SignerError whose message is NOT "...undefined" when RPC throws a string', async () => {
+    vi.spyOn(Connection.prototype, 'getLatestBlockhash').mockRejectedValue('boom-string-rejection');
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    let caught: unknown;
+    try {
+      await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), accept());
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SignerError);
+    const msg = (caught as Error).message;
+    expect(msg).not.toMatch(/undefined/);
+    expect(msg).toContain('boom-string-rejection');
+  });
+});
+
+describe('signPayment invalid recipient', () => {
+  // An un-decodable base58 recipient must surface a SignerError, not a raw
+  // throw from PublicKey construction.
+  it('surfaces a SignerError for an invalid recipient base58 string', async () => {
+    vi.spyOn(Connection.prototype, 'getLatestBlockhash').mockResolvedValue({
+      blockhash: goldenBlockhashBase58(),
+      lastValidBlockHeight: 1_000_000,
+    });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, 'not-a-valid-base58-pubkey!!!', resource(), accept()),
+    ).rejects.toThrow(SignerError);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #477. The TypeScript SDK (`@solvela/sdk` on npm) signed `exact` USDC payments with a plain SPL `Transfer` instruction (discriminator 3), which the **live gateway verifier deterministically rejects** — it has required `TransferChecked` (discriminator 12) since `e4f0db45` so the USDC mint is on-chain-verifiable. External npm consumers' `exact` payments were failing verification in production.

This is the TS counterpart to the Python/Rust `exact` fix in #475.

## What changed

- **`src/signer.ts`** — `createTransferInstruction` → `createTransferCheckedInstruction` (adds the mint account + `USDC_DECIMALS = 6`, exported constant). Canonical account-index order `[source_ata, mint, dest_ata, authority]`.
- **Byte-exact wire assembly** — web3.js's `Transaction` compiler orders accounts by instruction-appearance within a writability partition; the Solana Rust SDK byte-sorts within the partition, which flips token-program vs mint for TransferChecked. To reproduce the canonical golden vector we compile a legacy `Message` with explicit Rust-SDK partition + byte-sort ordering, sign the raw message bytes, and assemble `compact-u16(1) || sig(64) || msg`. (Using `Transaction.sign()/serialize()` re-orders at serialize time and breaks parity.)
- **`src/wallet.ts`** — adds in-boundary `signMessage(bytes)` via Node's built-in `crypto` ed25519 (no new dependency); secret seed never leaves the Wallet.
- **Fail closed on scheme mismatch** — an `escrow` `PaymentAccept` passed to `signPayment` (possible when `preferEscrow` is set) previously produced a **silent exact transfer**; it now throws `SignerError` before any RPC. TS escrow deposit signing remains a follow-up.

## Tests (`tests/unit/signer.test.ts`)

- Golden-vector parity — TS output decodes to the canonical `EXACT_GOLDEN_VECTOR_B64` (pinned in the Rust SDK) **byte-for-byte**
- Drift guard — reads the Rust source constant at runtime; fails loudly on divergence
- TransferChecked-not-Transfer assertion (discriminator 12, amount LE, decimals byte)
- Amount rejections — zero / negative / float / NaN / out-of-u64-range, all **before any network call** (RPC spy asserted uncalled)
- Escrow + unknown-scheme rejection (no silent fallback, pre-RPC)

`npm run lint` clean · `npm test` → 151 passed, 3 skipped (live), 0 failed.

## Review

Implemented and independently second-pass reviewed through the money-path agent + `solvela-x402` skill. Byte parity verified three ways (test, independent decode of the vector, cross-check against the gateway's `exact_golden_vector_accepted_as_usdc_transfer_checked` verifier test). No money-path defect found.

## Follow-up
TS escrow deposit signing (to match the Python/Rust/Go escrow branch) is still unimplemented — `escrow` now fails closed rather than mis-routing.