### PR TITLE
feat(sdk-ts): native x402 escrow deposit signing (#480 — four-language parity)

### DIFF
--- a/sdks/typescript/src/escrow.ts
+++ b/sdks/typescript/src/escrow.ts
@@ -1,0 +1,426 @@
+import { createHash } from 'node:crypto';
+
+import { PublicKey } from '@solana/web3.js';
+import {
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID as SPL_TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID as SPL_ATA_PROGRAM_ID,
+} from '@solana/spl-token';
+
+import { SignerError } from './errors.js';
+import { Wallet } from './wallet.js';
+
+/**
+ * Escrow deposit-transaction builder for the TypeScript SDK.
+ *
+ * Byte-exact port of the canonical Rust builder `crates/escrow-tx/src/deposit.rs`
+ * (+ `pda.rs`). The output MUST reproduce {@link GOLDEN_VECTOR_B64} for the fixed
+ * golden-vector input; the gateway verifier (`crates/x402/src/escrow/`)
+ * independently re-derives the same layout, so any divergence here is a
+ * fund-misdirection bug, not a style nit. Cross-SDK parity with
+ * `sdks/go/escrow.go` and `sdks/python/src/solvela/escrow.py` is a first-class
+ * concern.
+ *
+ * Wire layout (single source of truth — see the Rust file and the `solvela-x402`
+ * skill):
+ *
+ *   - Escrow PDA seeds: `[b"escrow", agent_pubkey(32), service_id(32)]`.
+ *   - Vault ATA: `ATA(escrow_pda, usdc_mint)` (escrow PDA is off-curve, so the
+ *     derivation must allow an off-curve owner).
+ *   - Instruction data (56 bytes): `anchorDiscriminator("deposit")[8]` ||
+ *     `amount: u64 LE` || `service_id: [32]` || `expiry_slot: u64 LE`.
+ *   - Account list sorted by writability; program key appended last (index 9).
+ *   - Instruction account-index order: `[0, 4, 5, 1, 2, 3, 6, 7, 8]`.
+ *   - Legacy message header `[1, 0, 6]`; length prefixes are single-byte
+ *     compact-u16 (valid only for lengths <= 127 — reject larger rather than
+ *     truncating).
+ *   - Wire tx: `compact-u16(1) || ed25519_signature(64) || message`, then base64
+ *     (standard alphabet).
+ *
+ * We deliberately do NOT use `@solana/web3.js`'s `Message` / `Transaction`
+ * compilation to assemble the escrow message: those re-derive their own account
+ * ordering and would not match the canonical writability-sorted layout
+ * byte-for-byte. We use web3.js / spl-token only for the primitives whose output
+ * is canonical and already pinned as ground truth: `PublicKey.findProgramAddressSync`
+ * (PDA + ATA derivation) — the golden vector is the arbiter that these agree —
+ * plus `Wallet.signMessage` for ed25519 signing. The Anchor discriminator and
+ * account ordering are computed locally with the Node `crypto` stdlib.
+ */
+
+// ---------------------------------------------------------------------------
+// Well-known program constants (match crates/escrow-tx/src/pda.rs).
+// ---------------------------------------------------------------------------
+
+const TOKEN_PROGRAM_ID = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+const ATA_PROGRAM_ID = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
+const SYSTEM_PROGRAM_ID = '11111111111111111111111111111111';
+
+/**
+ * Largest length representable as a single compact-u16 byte. Lengths above this
+ * would require a continuation byte; emitting a bare byte there would corrupt
+ * the encoding, so we reject (mirrors the Rust/Go/Python builders).
+ */
+const COMPACT_U16_SINGLE_BYTE_MAX = 127;
+
+const SIGNATURE_LENGTH = 64;
+const PUBKEY_LENGTH = 32;
+const IX_DATA_LENGTH = 56;
+
+/**
+ * Byte-exact base64 deposit transaction for the fixed golden-vector input,
+ * copied verbatim from `GOLDEN_VECTOR_B64` in `crates/escrow-tx/src/deposit.rs`
+ * (and `sdks/go/escrow.go`'s `GoldenVectorB64`).
+ *
+ * DO NOT hand-edit. If this changes, the deposit-tx layout changed — the
+ * on-chain/Rust value is ground truth. The drift-guard test in
+ * `tests/unit/escrow.test.ts` pins this against the Rust source file.
+ *
+ * Fixed input: agent keypair from seed `[42; 32]`, provider
+ * `9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM`, USDC mint
+ * `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`, program
+ * `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`, `service_id=[7; 32]`,
+ * `expiry_slot=1_000_750`, `recent_blockhash=[0xAB; 32]`, `amount=2625`.
+ */
+export const GOLDEN_VECTOR_B64 =
+  'Ad449R7ht12UKokgbDUYh29Ey/wDEwPioT/QtJOPKwSO4RHIaFRqS0DH+bPpEo2vCK78jbRLpP/6FV/5TY+qLw8BAAYKGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWFyvMLyv5o/k5XBGVxL9QMaEsQP6v01aK7nXazb0N/wMBS12eVticTdq8DzgM47jC/J8D1uNnFG6ZNqwpSU6GOelSnAbR4dY/56biCP6roeTxLQ8Q4TL7a2ArnBn2RW9HJ+jAiHYL/eHd3PMsF/IJuCQu5SqvEx+s2I0OosbQsG8sb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKmMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgo61GtoIM8r3akxjdsa2N5CEHZ8QBYuAbfwPDOL78eGrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urqwEJCQAEBQECAwYHCDjyI8aJUuHytkEKAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcuRQ8AAAAAAA==';
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+/**
+ * Inputs required to build an escrow deposit transaction.
+ *
+ * `serviceId`, `expirySlot`, and `recentBlockhash` are injected so the builder
+ * is a pure, deterministic function (golden-vector testable). Production code
+ * (the escrow signer) generates the CSPRNG `serviceId`, computes `expirySlot`
+ * from the current slot, and fetches the blockhash, then calls this builder.
+ *
+ * SECURITY: the agent secret key never crosses this interface in raw form — the
+ * caller passes a {@link Wallet}, and the builder reads only its public key and
+ * delegates signing to `wallet.signMessage`. The raw secret never leaves the
+ * Wallet boundary and is never logged.
+ */
+export interface DepositParams {
+  /** Agent wallet whose ed25519 key signs the deposit and seeds the escrow PDA. */
+  readonly wallet: Wallet;
+  /** Base58-encoded provider wallet pubkey. */
+  readonly providerWalletB58: string;
+  /** Base58-encoded USDC mint pubkey. */
+  readonly usdcMintB58: string;
+  /** Base58-encoded escrow program id. */
+  readonly escrowProgramIdB58: string;
+  /** Amount to deposit in atomic USDC units (must be a positive integer). */
+  readonly amount: number;
+  /** 32-byte service identifier that seeds the escrow PDA. */
+  readonly serviceId: Uint8Array;
+  /** Slot at which the escrow deposit expires (passed to the on-chain instruction). */
+  readonly expirySlot: number;
+  /** Recent blockhash (raw 32 bytes) from `getLatestBlockhash`. */
+  readonly recentBlockhash: Uint8Array;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the Anchor instruction discriminator: `sha256("global:<name>")[..8]`.
+ */
+export function anchorDiscriminator(name: string): Uint8Array {
+  return new Uint8Array(createHash('sha256').update(`global:${name}`).digest().subarray(0, 8));
+}
+
+/**
+ * Reject a non-integer, non-positive, or precision-unsafe atomic amount.
+ *
+ * JavaScript numbers are IEEE-754 doubles: only integers up to
+ * `Number.MAX_SAFE_INTEGER` (2^53 - 1) round-trip faithfully, and a u64 amount
+ * field above that cannot be represented exactly. A float would be silently
+ * truncated into the on-chain u64 and mis-charge the agent. Fail closed at the
+ * boundary — parity with the exact path's `assertValidAmount`, the Rust
+ * `ZeroAmount` check, and the Python `_is_strict_int` guard.
+ */
+function assertValidAmount(amount: number): void {
+  if (!Number.isInteger(amount)) {
+    throw new SignerError(
+      'deposit amount must be an integer number of atomic USDC units',
+    );
+  }
+  if (amount <= 0) {
+    throw new SignerError('deposit amount must be greater than zero');
+  }
+  if (amount > Number.MAX_SAFE_INTEGER) {
+    throw new SignerError(
+      'deposit amount exceeds the safe-integer range (cannot encode as u64)',
+    );
+  }
+}
+
+/**
+ * Reject a non-integer, non-finite, or non-positive expiry slot.
+ *
+ * `expiry_slot` is encoded directly into the on-chain `u64` via {@link u64LE}.
+ * An `expirySlot` of 0 silently encodes a dead-on-arrival deposit (it expires at
+ * genesis, so the gateway bounces it), and `NaN`/`Infinity`/`-1` make
+ * `BigInt(value)` in `u64LE` throw a raw untyped `RangeError`/`TypeError` rather
+ * than a `SignerError`. Fail closed here, parallel to {@link assertValidAmount},
+ * before any value reaches `u64LE`. The production path
+ * (`escrowExpirySlot` in `signer.ts`) always yields a valid positive slot, so the
+ * golden vector is unaffected.
+ */
+function assertValidExpirySlot(expirySlot: number): void {
+  if (!Number.isInteger(expirySlot)) {
+    throw new SignerError('expiry_slot must be a positive integer');
+  }
+  if (expirySlot <= 0) {
+    throw new SignerError('expiry_slot must be a positive integer');
+  }
+}
+
+/** Encode a non-negative safe-integer as 8 little-endian bytes (u64). */
+function u64LE(value: number): Uint8Array {
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64LE(BigInt(value));
+  return new Uint8Array(buf);
+}
+
+/**
+ * Decode a base58 pubkey into 32 raw bytes, wrapping any failure in a
+ * SignerError that names the offending field but never echoes secret material.
+ */
+function decodeBs58Pubkey(field: string, b58: string): Uint8Array {
+  let key: PublicKey;
+  try {
+    key = new PublicKey(b58);
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new SignerError(`invalid address for ${field}: ${reason}`);
+  }
+  const bytes = key.toBytes();
+  if (bytes.length !== PUBKEY_LENGTH) {
+    throw new SignerError(`invalid address for ${field}: expected 32 bytes, got ${bytes.length}`);
+  }
+  return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy message serializer (manual — must match the Rust byte layout exactly).
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a Solana legacy transaction message.
+ *
+ * Layout: `header(3) || acct_count(u8) || N*32 keys (+ program key) ||
+ * blockhash(32) || ix_count(u8)=1 || program_id_index(u8) || ix_acct_count(u8)
+ * || ix_acct_indices || data_len(u8) || data`.
+ *
+ * Length prefixes are emitted as a single byte — the correct compact-u16
+ * encoding only for lengths <= 127. Larger values are rejected (not truncated),
+ * mirroring the Rust/Go/Python builders.
+ */
+function buildLegacyMessage(
+  header: readonly [number, number, number],
+  accounts: readonly Uint8Array[],
+  programId: Uint8Array,
+  recentBlockhash: Uint8Array,
+  programIdIndex: number,
+  ixAccountIndices: Uint8Array,
+  ixData: Uint8Array,
+): Uint8Array {
+  const totalAccounts = accounts.length + 1; // +1 for the appended program key
+  if (totalAccounts > COMPACT_U16_SINGLE_BYTE_MAX) {
+    throw new SignerError(
+      `account count ${totalAccounts} exceeds the 127-byte compact-u16 single-byte limit`,
+    );
+  }
+  if (ixAccountIndices.length > COMPACT_U16_SINGLE_BYTE_MAX) {
+    throw new SignerError(
+      `instruction account count ${ixAccountIndices.length} exceeds the 127-byte compact-u16 single-byte limit`,
+    );
+  }
+  if (ixData.length > COMPACT_U16_SINGLE_BYTE_MAX) {
+    throw new SignerError(
+      `instruction data length ${ixData.length} exceeds the 127-byte compact-u16 single-byte limit`,
+    );
+  }
+
+  const parts: Uint8Array[] = [];
+  parts.push(Uint8Array.from(header));
+  parts.push(Uint8Array.from([totalAccounts]));
+  for (const acc of accounts) {
+    parts.push(acc);
+  }
+  parts.push(programId); // program key is the last account
+  parts.push(recentBlockhash);
+  parts.push(Uint8Array.from([1])); // instruction count
+  parts.push(Uint8Array.from([programIdIndex]));
+  parts.push(Uint8Array.from([ixAccountIndices.length]));
+  parts.push(ixAccountIndices);
+  parts.push(Uint8Array.from([ixData.length]));
+  parts.push(ixData);
+
+  return new Uint8Array(Buffer.concat(parts.map((p) => Buffer.from(p))));
+}
+
+// ---------------------------------------------------------------------------
+// Public builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a signed escrow `deposit` transaction, base64-encoded (standard
+ * alphabet).
+ *
+ * Returns a wire-format Solana legacy transaction ready for the gateway /
+ * `sendTransaction`. Pure with respect to the network (no I/O): for fixed
+ * inputs it always produces the same bytes, which is what lets
+ * {@link GOLDEN_VECTOR_B64} pin the wire layout.
+ *
+ * @throws SignerError on a zero/negative/float/out-of-range amount, a
+ *   non-positive/non-integer/non-finite expiry_slot, a malformed
+ *   provider/mint/program address, a wrong-length service_id/blockhash, a
+ *   PDA/ATA derivation failure, or a message-too-long length prefix. (A keypair
+ *   with an inconsistent public half is rejected earlier, at the {@link Wallet}
+ *   construction boundary, so it can never reach this builder.)
+ */
+export function buildDepositTx(params: DepositParams): string {
+  // Step 1: fail-closed amount + expiry-slot guards, BEFORE any derivation.
+  // expiry_slot is encoded into a u64 below; a 0/negative/NaN/Infinity value is
+  // either a dead-on-arrival deposit or makes `u64LE`'s `BigInt(...)` throw a raw
+  // untyped error. Reject at the boundary, parallel to the amount guard.
+  assertValidAmount(params.amount);
+  assertValidExpirySlot(params.expirySlot);
+
+  // Step 2: validate the injected fixed-size fields.
+  if (params.serviceId.length !== PUBKEY_LENGTH) {
+    throw new SignerError(`service_id must be 32 bytes, got ${params.serviceId.length}`);
+  }
+  if (params.recentBlockhash.length !== PUBKEY_LENGTH) {
+    throw new SignerError(
+      `recent_blockhash must be 32 bytes, got ${params.recentBlockhash.length}`,
+    );
+  }
+
+  // Step 3: obtain the agent pubkey that seeds the escrow PDA and signs the
+  // deposit. The `Wallet` was built via web3.js `Keypair.fromSecretKey`, which
+  // re-derives the public half from the seed at construction and rejects a
+  // keypair whose stored public half is inconsistent with its seed — so the
+  // seed-vs-stored-pubkey invariant is already enforced at the Wallet boundary,
+  // before any bytes can reach this builder. (The Go SDK re-checks here only
+  // because its `DepositParams` takes raw `ed25519.PrivateKey` bytes with no
+  // such construction-time validation; the TS `Wallet` type does not.) We
+  // therefore take the validated pubkey directly and do NOT pull raw secret-key
+  // material onto the per-call money path for a redundant re-derivation.
+  //
+  // SECRET: the raw secret key never leaves the `Wallet` boundary here. We use
+  // only the public key; all signing is delegated to `wallet.signMessage`
+  // (Step 9), which imports the seed into an in-process KeyObject and never
+  // exposes or logs it.
+  const agentPubkey = params.wallet.publicKey().toBytes();
+
+  // Step 4: parse all addresses.
+  const provider = decodeBs58Pubkey('provider_wallet', params.providerWalletB58);
+  const usdcMint = decodeBs58Pubkey('usdc_mint', params.usdcMintB58);
+  const escrowProgram = decodeBs58Pubkey('escrow_program_id', params.escrowProgramIdB58);
+  const tokenProgram = decodeBs58Pubkey('token_program', TOKEN_PROGRAM_ID);
+  const ataProgram = decodeBs58Pubkey('ata_program', ATA_PROGRAM_ID);
+  const systemProgram = decodeBs58Pubkey('system_program', SYSTEM_PROGRAM_ID);
+
+  // Step 5: derive escrow PDA, agent ATA, and vault ATA. We use the canonical
+  // web3.js / spl-token primitives; the golden vector is the arbiter that they
+  // reproduce the on-chain layout. NOTE: the vault ATA's owner is the escrow PDA
+  // (off-curve), so `allowOwnerOffCurve` must be true — otherwise spl-token
+  // throws `TokenOwnerOffCurveError`.
+  const escrowProgramKey = new PublicKey(escrowProgram);
+  const usdcMintKey = new PublicKey(usdcMint);
+  let escrowPda: PublicKey;
+  try {
+    [escrowPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from('escrow'), Buffer.from(agentPubkey), Buffer.from(params.serviceId)],
+      escrowProgramKey,
+    );
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new SignerError(`failed to derive escrow PDA: ${reason}`);
+  }
+
+  let agentAta: Uint8Array;
+  let vaultAta: Uint8Array;
+  try {
+    agentAta = getAssociatedTokenAddressSync(
+      usdcMintKey,
+      new PublicKey(agentPubkey),
+      false,
+      SPL_TOKEN_PROGRAM_ID,
+      SPL_ATA_PROGRAM_ID,
+    ).toBytes();
+    vaultAta = getAssociatedTokenAddressSync(
+      usdcMintKey,
+      escrowPda,
+      true, // escrow PDA owner is off-curve
+      SPL_TOKEN_PROGRAM_ID,
+      SPL_ATA_PROGRAM_ID,
+    ).toBytes();
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new SignerError(`failed to derive ATA: ${reason}`);
+  }
+
+  // Step 6: account list sorted by writability (writable signer, writable
+  // non-signers, readonly non-signers). The program key is appended last
+  // (index 9) inside the message serializer.
+  const accounts: Uint8Array[] = [
+    agentPubkey, // 0: signer, writable
+    escrowPda.toBytes(), // 1: writable, non-signer
+    agentAta, // 2: writable, non-signer
+    vaultAta, // 3: writable, non-signer
+    provider, // 4: readonly
+    usdcMint, // 5: readonly
+    tokenProgram, // 6: readonly
+    ataProgram, // 7: readonly
+    systemProgram, // 8: readonly
+  ];
+
+  // Step 7: instruction data = discriminator || amount(LE u64) || service_id ||
+  // expiry_slot(LE u64) = 8 + 8 + 32 + 8 = 56 bytes.
+  const ixData = new Uint8Array(
+    Buffer.concat([
+      Buffer.from(anchorDiscriminator('deposit')),
+      Buffer.from(u64LE(params.amount)),
+      Buffer.from(params.serviceId),
+      Buffer.from(u64LE(params.expirySlot)),
+    ]),
+  );
+  if (ixData.length !== IX_DATA_LENGTH) {
+    throw new SignerError(`deposit ix_data must be 56 bytes, got ${ixData.length}`);
+  }
+
+  // Anchor program account order remapped into the writability-sorted layout.
+  const ixAccountIndices = Uint8Array.from([0, 4, 5, 1, 2, 3, 6, 7, 8]);
+
+  // Step 8: legacy message. Header [1, 0, 6]; program_id_index = 9 (last).
+  const msg = buildLegacyMessage(
+    [1, 0, 6],
+    accounts,
+    escrowProgram,
+    params.recentBlockhash,
+    9, // program_id_index = 9 (last account)
+    ixAccountIndices,
+    ixData,
+  );
+
+  // Step 9: sign the raw message bytes with the agent keypair (ed25519). Reuse
+  // `wallet.signMessage` so the secret never leaves the Wallet boundary (same
+  // signing path the exact builder uses).
+  const signature = params.wallet.signMessage(msg);
+  if (signature.length !== SIGNATURE_LENGTH) {
+    throw new SignerError(
+      `unexpected ed25519 signature length ${signature.length} (want ${SIGNATURE_LENGTH})`,
+    );
+  }
+
+  // Step 10: assemble wire tx: compact-u16(1) || signature(64) || message.
+  const wire = Buffer.concat([Buffer.from([1]), Buffer.from(signature), Buffer.from(msg)]);
+
+  return wire.toString('base64');
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -3,6 +3,7 @@ export * from './types.js';
 export * from './errors.js';
 export * from './config.js';
 export * from './wallet.js';
+export * from './escrow.js';
 export * from './cache.js';
 export * from './session.js';
 export * from './quality.js';

--- a/sdks/typescript/src/signer.ts
+++ b/sdks/typescript/src/signer.ts
@@ -1,3 +1,5 @@
+import { randomBytes, createHash } from 'node:crypto';
+
 import {
   Connection,
   Message,
@@ -10,10 +12,17 @@ import {
 } from '@solana/spl-token';
 import bs58 from 'bs58';
 
-import { PaymentAccept, PaymentPayload, Resource, SolanaPayload } from './types.js';
+import {
+  PaymentAccept,
+  PaymentPayload,
+  Resource,
+  SolanaPayload,
+  EscrowPayload,
+} from './types.js';
 import { SignerError } from './errors.js';
 import { Wallet } from './wallet.js';
 import { USDC_MINT, X402_VERSION } from './constants.js';
+import { buildDepositTx } from './escrow.js';
 
 /**
  * USDC has 6 decimals. The SPL `TransferChecked` instruction carries this byte
@@ -23,6 +32,97 @@ import { USDC_MINT, X402_VERSION } from './constants.js';
  * `USDC_DECIMALS = 6` (`sdks/python/src/solvela/signer.py`).
  */
 export const USDC_DECIMALS = 6;
+
+// --- Escrow expiry-slot bounds (mirror the Rust/Go/Python SDK signers) ---
+//
+// Solana slots are ~400 ms. These bounds are ported verbatim from
+// sdks/rust/crates/solvela-client/src/signer.rs (and sdks/go/signer.go,
+// sdks/python/.../signer.py) so all SDKs choose compatible expiry slots and
+// none is bounced by the gateway.
+
+/**
+ * Upper bound on how far ahead an escrow may expire (~66 min). Rejects a
+ * malicious/misconfigured gateway from pushing expiry to "never".
+ */
+const MAX_ESCROW_EXPIRY_SLOTS_AHEAD = 10_000;
+
+/**
+ * Lower bound on expiry distance. Mirrors AND exceeds the gateway's
+ * MIN_EXPIRY_BUFFER_SLOTS = 50 (crates/x402/src/escrow/verifier.rs); the extra
+ * headroom (150 vs 50) absorbs slot-skew between the slot we read and the slot
+ * the gateway verifies against. ~150 slots ~= 60 s.
+ */
+const MIN_ESCROW_EXPIRY_SLOTS_AHEAD = 150;
+
+/**
+ * Floor below which a getSlot result is implausible and rejected. A stub /
+ * genesis / freshly-reset validator can answer getSlot with a near-zero slot;
+ * computing an escrow expiry from that base yields an already-expired (or
+ * trivially-near-expiry) deposit the gateway would bounce. Mainnet/devnet have
+ * been well past this for years. Fail closed rather than silently signing a
+ * dead-on-arrival escrow deposit.
+ */
+const MIN_PLAUSIBLE_SLOT = 1_000_000;
+
+const BLOCKHASH_LENGTH = 32;
+
+/**
+ * RPC request timeout (ms). A bare `fetch()` has no timeout, so a stalled RPC
+ * endpoint would hang the payment path forever. Both the Go SDK
+ * (`http.Client{Timeout: 30s}`) and the Python SDK (`httpx ... timeout=30`)
+ * enforce this; mirror it with an `AbortController` + `setTimeout`, the same
+ * pattern `src/transport.ts` uses.
+ */
+const RPC_TIMEOUT_MS = 30_000;
+
+/**
+ * Cap on a successful (200 OK) JSON-RPC response body, in bytes. The
+ * getSlot/getLatestBlockhash responses this signer reads are tiny (a few hundred
+ * bytes), but we still bound the read so a misbehaving/hostile RPC endpoint
+ * cannot stream an unbounded body into memory and OOM the agent. Mirrors the Go
+ * SDK's `maxRPCBodyBytes = 64 << 10` (`io.LimitReader`).
+ */
+const MAX_RPC_BODY_BYTES = 65_536;
+
+/**
+ * Render a parenthesized, message-free description of a JSON-RPC error object,
+ * suitable for appending to a `SignerError`. It surfaces only the numeric code
+ * (never the RPC message text — GHSA-cgqx-mg48-949v), and clearly distinguishes
+ * an unparseable / code-less error from a real code. Mirrors the Go SDK's
+ * `rpcErrorCodeSuffix`.
+ */
+function rpcErrorCodeSuffix(rawErr: unknown): string {
+  if (rawErr !== null && typeof rawErr === 'object' && 'code' in rawErr) {
+    const code = (rawErr as { code: unknown }).code;
+    if (typeof code === 'number' && Number.isInteger(code)) {
+      return `(code: ${code})`;
+    }
+  }
+  return '(unparseable error object, no numeric code)';
+}
+
+/**
+ * Compute the slot at which a now-created escrow PDA should expire.
+ *
+ * Ported from the Rust SDK's `escrow_expiry_slot`: ~2.5 slots/s (1000 ms /
+ * 400 ms), clamped into `[MIN_ESCROW_EXPIRY_SLOTS_AHEAD,
+ * MAX_ESCROW_EXPIRY_SLOTS_AHEAD]`. The floor mirrors and exceeds the gateway's
+ * MIN_EXPIRY_BUFFER_SLOTS so a too-near expiry is never bounced; the cap rejects
+ * an unbounded-future expiry. A negative timeout is floored to 0 (never pushes
+ * expiry backwards into a dead-on-arrival deposit). `currentSlot` and the
+ * effective offset stay within Number.MAX_SAFE_INTEGER for any plausible slot,
+ * so the add cannot lose precision. Exported for direct unit testing.
+ */
+export function escrowExpirySlot(currentSlot: number, maxTimeoutSeconds: number): number {
+  const timeout = Math.max(maxTimeoutSeconds, 0);
+  // timeout * 1000 / 400, floored to whole slots (matches the Rust integer math).
+  const timeoutSlots = Math.floor((timeout * 1000) / 400);
+  const effective = Math.max(
+    MIN_ESCROW_EXPIRY_SLOTS_AHEAD,
+    Math.min(timeoutSlots, MAX_ESCROW_EXPIRY_SLOTS_AHEAD),
+  );
+  return currentSlot + effective;
+}
 
 export interface Signer {
   signPayment(
@@ -44,15 +144,17 @@ export class KeypairSigner implements Signer {
    *
    * `exact`  -> SPL-token `TransferChecked` to the gateway's pay_to ATA
    *             (returns a `SolanaPayload`).
+   * `escrow` -> on-chain `deposit` into a per-request escrow PDA, byte-exact
+   *             with the canonical builder (returns an `EscrowPayload`).
    *
-   * There is NO silent fallback: an `escrow`-selected payment is rejected with
-   * a clear `SignerError` rather than being settled as an `exact` transfer.
-   * Silently routing an escrow-selected payment as an exact transfer is the
-   * scheme-mismatch money-path bug the `solvela-x402` skill warns against (it
-   * is the exact bug that existed in the Go/Python signers). The TS SDK does
-   * not yet implement the escrow deposit builder; until it does, the signer
-   * fails closed rather than producing a wrong-scheme transfer. An unknown
-   * scheme is likewise rejected, never default-routed.
+   * There is NO silent fallback: an `escrow`-selected payment always produces an
+   * escrow deposit, never an `exact` transfer, and an `exact`-selected payment
+   * never produces an escrow deposit. Silently routing an escrow-selected
+   * payment as an exact transfer is the scheme-mismatch money-path bug the
+   * `solvela-x402` skill warns against (it is the exact bug that previously
+   * existed in the Go/Python signers and in this TS signer before escrow
+   * support landed). An unknown scheme is likewise rejected, never
+   * default-routed.
    */
   async signPayment(
     amountAtomic: number,
@@ -64,12 +166,7 @@ export class KeypairSigner implements Signer {
       return this.signExactPayment(amountAtomic, recipient, resource, accepted);
     }
     if (accepted.scheme === 'escrow') {
-      // No silent fallback: escrow was selected but the TS SDK cannot build an
-      // escrow deposit yet. Refuse rather than settle an exact transfer.
-      throw new SignerError(
-        'escrow payment scheme is not yet supported by the TypeScript SDK; ' +
-          'refusing to silently fall back to an exact transfer',
-      );
+      return this.signEscrowPayment(amountAtomic, resource, accepted);
     }
     // `accepted.scheme` is a closed union (`PaymentAccept.fromJSON` rejects
     // unknown wire schemes), so this is only reachable if the type is bypassed.
@@ -117,6 +214,215 @@ export class KeypairSigner implements Signer {
       if (e instanceof SignerError) throw e;
       const msg = e instanceof Error ? e.message : String(e);
       throw new SignerError(`Failed to sign payment: ${msg}`);
+    }
+  }
+
+  /**
+   * Build and sign an escrow `deposit` transaction (`escrow` scheme).
+   *
+   * Generates a fresh CSPRNG `service_id`, computes the expiry slot from the
+   * current slot and `accepted.maxTimeoutSeconds` (mirroring the Rust/Go/Python
+   * SDKs), fetches a recent blockhash, and delegates the byte-exact transaction
+   * construction to the shared, golden-vector-pinned `buildDepositTx`. There is
+   * NO silent fallback to an exact transfer.
+   */
+  private async signEscrowPayment(
+    amountAtomic: number,
+    resource: Resource,
+    accepted: PaymentAccept,
+  ): Promise<PaymentPayload> {
+    // Fail clearly if escrow was selected but no program id was offered — never
+    // silently fall back to an exact transfer.
+    if (!accepted.escrowProgramId) {
+      throw new SignerError('escrow scheme selected but escrow_program_id is missing');
+    }
+
+    // Reject a bad amount BEFORE any RPC/network call (mirrors the exact path
+    // and the Go/Python signers). A zero/negative/float/out-of-range amount
+    // would otherwise be mis-encoded into the on-chain u64 and mis-charge the
+    // agent.
+    this.assertValidAmount(amountAtomic);
+
+    // Validate `maxTimeoutSeconds` BEFORE any RPC call. It comes straight from
+    // the untrusted gateway 402 with no parse-boundary validation; a
+    // NaN/Infinity/non-integer value propagates through `escrowExpirySlot`
+    // (`Math.max(NaN, 0) = NaN`) into `buildDepositTx` and surfaces as a
+    // confusing wrapped error. Reject only non-finite/non-integer values here —
+    // a *negative* finite integer is intentionally allowed, since
+    // `escrowExpirySlot` floors it to 0 then clamps to the 150-slot floor
+    // (parity with Go's `escrowExpirySlot`). This validation is scoped to the
+    // escrow path only — the exact path does not consume this field, so we must
+    // not start rejecting 402s over it (e.g. in `PaymentAccept.fromJSON`).
+    if (!Number.isInteger(accepted.maxTimeoutSeconds)) {
+      throw new SignerError(
+        'maxTimeoutSeconds must be a finite integer number of seconds',
+      );
+    }
+
+    try {
+      // Per-request CSPRNG service_id (#118 invariant): two identical requests
+      // must never share a service_id -> escrow PDA -> vault ATA. Hash 32 random
+      // bytes so the result is distinct per call (mirrors the Rust/Go SDKs).
+      const serviceId = new Uint8Array(createHash('sha256').update(randomBytes(32)).digest());
+
+      const currentSlot = await this.fetchCurrentSlot();
+      const expirySlot = escrowExpirySlot(currentSlot, accepted.maxTimeoutSeconds);
+
+      const recentBlockhash = await this.fetchLatestBlockhash();
+
+      const depositTx = buildDepositTx({
+        wallet: this.wallet,
+        providerWalletB58: accepted.payTo,
+        usdcMintB58: USDC_MINT,
+        escrowProgramIdB58: accepted.escrowProgramId,
+        amount: amountAtomic,
+        serviceId,
+        expirySlot,
+        recentBlockhash,
+      });
+
+      const payload = new EscrowPayload(
+        depositTx,
+        Buffer.from(serviceId).toString('base64'),
+        this.wallet.address(),
+      );
+      return new PaymentPayload(X402_VERSION, resource, accepted, payload);
+    } catch (e) {
+      if (e instanceof SignerError) throw e;
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new SignerError(`Failed to sign escrow deposit: ${msg}`);
+    }
+  }
+
+  /**
+   * Fetch the current slot via JSON-RPC `getSlot` (commitment confirmed).
+   *
+   * Fails closed: any HTTP failure, malformed body, RPC error, or
+   * missing/invalid result is a `SignerError` — never a silent default slot,
+   * which would let the escrow expiry be computed from a bogus base. Also
+   * rejects an implausibly-low slot (stub/genesis node). Mirrors the Go/Python
+   * `fetchCurrentSlot`. Only the numeric RPC error code is surfaced, never the
+   * message text (which can echo node internals — GHSA-cgqx-mg48-949v).
+   */
+  private async fetchCurrentSlot(): Promise<number> {
+    const data = await this.postRpc('getSlot', [{ commitment: 'confirmed' }], 'getSlot');
+    if (data.error !== undefined && data.error !== null) {
+      throw new SignerError(`getSlot RPC error ${rpcErrorCodeSuffix(data.error)}`);
+    }
+    const slot = data.result;
+    // Use Number.isSafeInteger (not Number.isInteger): a slot above
+    // Number.MAX_SAFE_INTEGER cannot be added to the expiry offset without
+    // precision loss, so reject it rather than computing a bogus expiry. The
+    // amount guard already uses the safe-integer bound; keep this consistent.
+    if (typeof slot !== 'number' || !Number.isSafeInteger(slot) || slot < 0) {
+      throw new SignerError('getSlot RPC: missing or invalid result');
+    }
+    if (slot < MIN_PLAUSIBLE_SLOT) {
+      throw new SignerError(
+        `getSlot RPC returned implausibly low slot ${slot} ` +
+          `(< ${MIN_PLAUSIBLE_SLOT}); refusing to build an escrow deposit`,
+      );
+    }
+    return slot;
+  }
+
+  /**
+   * Fetch a recent blockhash via JSON-RPC `getLatestBlockhash` and decode it to
+   * raw 32 bytes. Fails closed on any HTTP/JSON/RPC failure or a
+   * missing/malformed blockhash, never returning a default. Mirrors the
+   * Go/Python `fetchLatestBlockhash`. The builder needs the raw 32-byte
+   * blockhash (NOT the base58 string), so we bs58-decode it here.
+   */
+  private async fetchLatestBlockhash(): Promise<Uint8Array> {
+    const data = await this.postRpc(
+      'getLatestBlockhash',
+      [{ commitment: 'finalized' }],
+      'Blockhash',
+    );
+    const result = data.result as { value?: { blockhash?: unknown } } | undefined;
+    const blockhashStr = result?.value?.blockhash;
+    if (typeof blockhashStr !== 'string' || blockhashStr.length === 0) {
+      if (data.error !== undefined && data.error !== null) {
+        throw new SignerError(`RPC did not return a blockhash ${rpcErrorCodeSuffix(data.error)}`);
+      }
+      throw new SignerError('RPC did not return a blockhash');
+    }
+    let raw: Uint8Array;
+    try {
+      raw = bs58.decode(blockhashStr);
+    } catch {
+      throw new SignerError('RPC returned a malformed blockhash');
+    }
+    if (raw.length !== BLOCKHASH_LENGTH) {
+      throw new SignerError('RPC returned a malformed blockhash');
+    }
+    return raw;
+  }
+
+  /**
+   * Issue a JSON-RPC POST and return the decoded body. HTTP-level failures,
+   * non-200 status, and malformed JSON are surfaced as `SignerError` before any
+   * field access — so a 429/5xx HTML body never leaks node internals into the
+   * error string (only the status code is surfaced). Mirrors the Go SDK's
+   * `postRPC`.
+   *
+   * A bare `fetch()` has no timeout; a stalled RPC would hang the payment path
+   * forever, so we bound the request with an `AbortController` +
+   * {@link RPC_TIMEOUT_MS} (same pattern as `src/transport.ts`, and parity with
+   * the Go `http.Client{Timeout: 30s}` / Python `httpx ... timeout=30`). The
+   * 200-path body is read as text and rejected if it exceeds
+   * {@link MAX_RPC_BODY_BYTES} so a hostile RPC cannot OOM the agent (parity with
+   * the Go `io.LimitReader` cap), then `JSON.parse`d.
+   */
+  private async postRpc(
+    method: string,
+    params: unknown[],
+    label: string,
+  ): Promise<{ result?: unknown; error?: unknown }> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), RPC_TIMEOUT_MS);
+    try {
+      let resp: Response;
+      try {
+        resp = await fetch(this.rpcUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+          signal: controller.signal,
+        });
+      } catch (e) {
+        // An abort (timeout) and a transport failure both surface here; name the
+        // timeout case explicitly so a stalled RPC is diagnosable. Never echo the
+        // underlying error text (it can leak node URLs/internals).
+        if ((e as Error).name === 'AbortError') {
+          throw new SignerError(`${label} RPC request timed out after ${RPC_TIMEOUT_MS}ms`);
+        }
+        throw new SignerError(`${label} RPC request failed`);
+      }
+      if (resp.status !== 200) {
+        throw new SignerError(`${label} RPC HTTP ${resp.status}`);
+      }
+      // Read the success body as text under a size cap (Go's io.LimitReader
+      // equivalent) BEFORE parsing, so an unbounded/hostile body cannot OOM the
+      // agent. Only then JSON.parse, preserving the malformed-JSON handling.
+      let text: string;
+      try {
+        text = await resp.text();
+      } catch {
+        throw new SignerError(`${label} RPC: malformed JSON body`);
+      }
+      if (text.length > MAX_RPC_BODY_BYTES) {
+        throw new SignerError(
+          `${label} RPC: response body exceeds ${MAX_RPC_BODY_BYTES} bytes`,
+        );
+      }
+      try {
+        return JSON.parse(text) as { result?: unknown; error?: unknown };
+      } catch {
+        throw new SignerError(`${label} RPC: malformed JSON body`);
+      }
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/sdks/typescript/tests/unit/escrow.test.ts
+++ b/sdks/typescript/tests/unit/escrow.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { Keypair } from '@solana/web3.js';
+
+import {
+  buildDepositTx,
+  GOLDEN_VECTOR_B64,
+  anchorDiscriminator,
+  type DepositParams,
+} from '../../src/escrow.js';
+import { Wallet } from '../../src/wallet.js';
+import { SignerError } from '../../src/errors.js';
+
+// ---------------------------------------------------------------------------
+// Golden-vector parity is the contract: the TS deposit builder MUST reproduce
+// crates/escrow-tx/src/deposit.rs's GOLDEN_VECTOR_B64 byte-for-byte for its
+// fixed input. If it diverges, the on-chain layout disagreement is a
+// fund-misdirection bug — fix the TS builder, NEVER edit the expected golden
+// value (the Rust/on-chain value is ground truth). Mirrors Go escrow_test.go +
+// Python tests/unit/test_escrow.py.
+// ---------------------------------------------------------------------------
+
+const GOLDEN_PROVIDER = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
+const GOLDEN_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const GOLDEN_ESCROW_PROGRAM = '9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU';
+
+/**
+ * Deterministic agent wallet from seed [42; 32] — identical to the Rust/Go/
+ * Python golden fixture (`SigningKey::from_bytes([42; 32])`).
+ */
+function goldenWallet(): Wallet {
+  const kp = Keypair.fromSeed(new Uint8Array(32).fill(42));
+  return Wallet.fromKeypairBytes(kp.secretKey);
+}
+
+function goldenParams(): DepositParams {
+  return {
+    wallet: goldenWallet(),
+    providerWalletB58: GOLDEN_PROVIDER,
+    usdcMintB58: GOLDEN_USDC_MINT,
+    escrowProgramIdB58: GOLDEN_ESCROW_PROGRAM,
+    amount: 2625,
+    serviceId: new Uint8Array(32).fill(7),
+    expirySlot: 1_000_750,
+    recentBlockhash: new Uint8Array(32).fill(0xab),
+  };
+}
+
+describe('Escrow deposit golden vector (byte-exact parity)', () => {
+  it('reproduces the canonical Rust/Go golden vector byte-for-byte', () => {
+    const out = buildDepositTx(goldenParams());
+    // NEVER edit GOLDEN_VECTOR_B64 to match this output. The on-chain layout is
+    // ground truth — if this diverges, the fix is in the builder.
+    expect(out).toBe(GOLDEN_VECTOR_B64);
+  });
+
+  it('is deterministic for identical fixed input (no nonce, no clock)', () => {
+    const a = buildDepositTx(goldenParams());
+    const b = buildDepositTx(goldenParams());
+    expect(a).toBe(b);
+  });
+
+  it('golden vector decodes to 0x01 || sig(64) || message', () => {
+    const raw = Buffer.from(GOLDEN_VECTOR_B64, 'base64');
+    // compact-u16(1) || sig(64) || message
+    expect(raw[0]).toBe(0x01);
+    expect(raw.length).toBeGreaterThan(1 + 64);
+  });
+});
+
+describe('Escrow golden vector drift guard', () => {
+  // The TS escrow golden constant MUST equal the Rust source of truth. If the
+  // Rust GOLDEN_VECTOR_B64 ever changes, the on-chain wire layout changed and
+  // this test fails loudly, forcing a resync rather than silent divergence.
+  // Mirrors Go's TestGoldenVectorMatchesRustSource.
+  it('TS escrow golden constant matches the Rust source of truth', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // tests/unit/escrow.test.ts -> worktree root is ../../../../ from here.
+    const rustSrc = resolve(here, '../../../../crates/escrow-tx/src/deposit.rs');
+    const text = readFileSync(rustSrc, 'utf-8');
+    const m = text.match(/GOLDEN_VECTOR_B64:\s*&str\s*=\s*"([^"]+)"/);
+    expect(m, 'could not locate GOLDEN_VECTOR_B64 in crates/escrow-tx/src/deposit.rs').not.toBeNull();
+    const rustValue = m![1];
+    expect(rustValue).toBe(GOLDEN_VECTOR_B64);
+  });
+});
+
+describe('Escrow deposit derivation parity', () => {
+  it('anchorDiscriminator is deterministic and distinct per instruction', () => {
+    expect(anchorDiscriminator('deposit')).toEqual(anchorDiscriminator('deposit'));
+    expect(anchorDiscriminator('deposit')).not.toEqual(anchorDiscriminator('claim'));
+  });
+
+  it('the deposit tx embeds the deposit discriminator', () => {
+    const raw = Buffer.from(buildDepositTx(goldenParams()), 'base64');
+    const disc = Buffer.from(anchorDiscriminator('deposit'));
+    expect(raw.includes(disc)).toBe(true);
+  });
+
+  it('the deposit tx embeds the agent pubkey', () => {
+    const params = goldenParams();
+    const agentPubkey = Buffer.from(params.wallet.publicKey().toBytes());
+    const raw = Buffer.from(buildDepositTx(params), 'base64');
+    expect(raw.includes(agentPubkey)).toBe(true);
+  });
+});
+
+describe('Escrow deposit fail-closed amount guards', () => {
+  it('rejects zero amount', () => {
+    expect(() => buildDepositTx({ ...goldenParams(), amount: 0 })).toThrow(SignerError);
+  });
+
+  it('rejects a negative amount', () => {
+    expect(() => buildDepositTx({ ...goldenParams(), amount: -1 })).toThrow(/greater than zero|integer/);
+  });
+
+  it('rejects a non-integer (float) amount', () => {
+    expect(() => buildDepositTx({ ...goldenParams(), amount: 2625.5 })).toThrow(/integer/);
+  });
+
+  it('rejects a NaN amount', () => {
+    expect(() => buildDepositTx({ ...goldenParams(), amount: Number.NaN })).toThrow(/integer/);
+  });
+
+  it('rejects an amount above the safe-integer range', () => {
+    expect(() =>
+      buildDepositTx({ ...goldenParams(), amount: Number.MAX_SAFE_INTEGER + 2 }),
+    ).toThrow(/safe-integer|integer/);
+  });
+});
+
+describe('Escrow deposit fail-closed expiry-slot guards', () => {
+  // expiry_slot is encoded directly into the on-chain u64. A 0/negative value is
+  // a dead-on-arrival deposit; NaN/Infinity make u64LE's BigInt(...) throw a raw
+  // untyped error. All must fail closed with a typed SignerError, parallel to
+  // the amount guards. The production path always passes a valid positive slot,
+  // so the golden vector is unaffected.
+  it('rejects a zero expiry slot', () => {
+    expect(() => buildDepositTx({ ...goldenParams(), expirySlot: 0 })).toThrow(SignerError);
+  });
+
+  it('rejects a negative expiry slot', () => {
+    expect(() => buildDepositTx({ ...goldenParams(), expirySlot: -1 })).toThrow(
+      /expiry_slot must be a positive integer/,
+    );
+  });
+
+  it('rejects a non-integer (float) expiry slot', () => {
+    expect(() => buildDepositTx({ ...goldenParams(), expirySlot: 1_000_750.5 })).toThrow(
+      /expiry_slot must be a positive integer/,
+    );
+  });
+
+  it('rejects a NaN expiry slot', () => {
+    expect(() => buildDepositTx({ ...goldenParams(), expirySlot: Number.NaN })).toThrow(
+      /expiry_slot must be a positive integer/,
+    );
+  });
+
+  it('rejects an Infinity expiry slot', () => {
+    expect(() =>
+      buildDepositTx({ ...goldenParams(), expirySlot: Number.POSITIVE_INFINITY }),
+    ).toThrow(/expiry_slot must be a positive integer/);
+  });
+});
+
+describe('Escrow deposit fail-closed structural guards', () => {
+  it('rejects a malformed provider address', () => {
+    expect(() =>
+      buildDepositTx({ ...goldenParams(), providerWalletB58: 'not-base58-0OIl!!!' }),
+    ).toThrow(SignerError);
+  });
+
+  it('rejects a malformed mint address', () => {
+    expect(() =>
+      buildDepositTx({ ...goldenParams(), usdcMintB58: 'not-base58-0OIl!!!' }),
+    ).toThrow(SignerError);
+  });
+
+  it('rejects a malformed escrow program id', () => {
+    expect(() =>
+      buildDepositTx({ ...goldenParams(), escrowProgramIdB58: 'not-base58-0OIl!!!' }),
+    ).toThrow(SignerError);
+  });
+
+  it('rejects a service_id of the wrong length', () => {
+    expect(() =>
+      buildDepositTx({ ...goldenParams(), serviceId: new Uint8Array(31).fill(7) }),
+    ).toThrow(/service_id/);
+  });
+
+  it('rejects a recent_blockhash of the wrong length', () => {
+    expect(() =>
+      buildDepositTx({ ...goldenParams(), recentBlockhash: new Uint8Array(31).fill(0xab) }),
+    ).toThrow(/blockhash/);
+  });
+});
+
+describe('Escrow deposit corrupted-pubkey-half guard', () => {
+  // The canonical Rust/Go builders re-derive the pubkey from the seed and reject
+  // a keypair whose stored public half (bytes 32..64) does not match — a corrupt
+  // half would sign fine but seed the escrow PDA from the wrong identity,
+  // producing an un-claimable deposit. In the TS SDK this invariant lives at the
+  // layer that actually enforces it: `Wallet.fromKeypairBytes` -> web3.js
+  // `Keypair.fromSecretKey` validates the public half at construction and
+  // rejects a corrupted keypair before it can ever reach the builder. Because a
+  // `DepositParams.wallet` is, by type, an already-constructed `Wallet`, the
+  // builder cannot receive a public-half-inconsistent keypair and therefore no
+  // longer re-checks it (unlike Go, whose `DepositParams` takes raw
+  // `ed25519.PrivateKey` bytes with no construction-time validation, and unlike
+  // a builder-level guard that would have to pull raw secret-key material onto
+  // the per-call money path for zero marginal safety). We pin the protection at
+  // the Wallet construction boundary.
+  it('rejects a keypair whose stored pubkey half does not match its seed (at the Wallet boundary)', () => {
+    const kp = Keypair.fromSeed(new Uint8Array(32).fill(42));
+    const corrupted = Uint8Array.from(kp.secretKey);
+    // Flip a bit in the stored public half (bytes 32..64) WITHOUT touching the
+    // seed (bytes 0..32).
+    corrupted[40] ^= 0xff;
+    expect(() => Wallet.fromKeypairBytes(corrupted)).toThrow();
+  });
+});
+
+describe('Escrow deposit secret-redaction', () => {
+  // The agent secret key material must never appear in any error message. We
+  // force a builder error (malformed provider address) using the golden wallet
+  // whose seed bytes are all 42 (0x2a) and assert the raw seed bytes never leak
+  // into the thrown error.
+  it('never leaks raw keypair bytes in a builder error message', () => {
+    try {
+      buildDepositTx({ ...goldenParams(), providerWalletB58: 'not-base58-0OIl!!!' });
+      throw new Error('expected build to reject the malformed provider address');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      // 42 42 42 (decimal) / 2a,2a,2a (hex) are the tell-tale shapes of a dumped
+      // 32-byte seed. Neither may appear.
+      expect(msg).not.toMatch(/42, ?42, ?42/);
+      expect(msg).not.toMatch(/2a,? ?2a,? ?2a/i);
+    }
+  });
+});

--- a/sdks/typescript/tests/unit/signer.test.ts
+++ b/sdks/typescript/tests/unit/signer.test.ts
@@ -5,7 +5,7 @@ import { dirname, resolve } from 'node:path';
 import { Keypair, Connection } from '@solana/web3.js';
 import bs58 from 'bs58';
 
-import { KeypairSigner, USDC_DECIMALS } from '../../src/signer.js';
+import { KeypairSigner, USDC_DECIMALS, escrowExpirySlot } from '../../src/signer.js';
 import { SignerError } from '../../src/errors.js';
 import { Wallet } from '../../src/wallet.js';
 import { PaymentAccept, Resource, SolanaPayload, EscrowPayload } from '../../src/types.js';
@@ -68,6 +68,7 @@ function resource(): Resource {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('Signer', () => {
@@ -303,15 +304,15 @@ describe('signPayment invalid recipient', () => {
 });
 
 describe('Scheme branching (no silent fallback)', () => {
-  it('escrow scheme is rejected, never settled as an exact transfer', async () => {
-    const spy = vi
-      .spyOn(Connection.prototype, 'getLatestBlockhash')
-      .mockRejectedValue(new Error('network must not be called for an escrow rejection'));
+  it('an exact-selected payment never produces an escrow deposit', async () => {
+    vi.spyOn(Connection.prototype, 'getLatestBlockhash').mockResolvedValue({
+      blockhash: goldenBlockhashBase58(),
+      lastValidBlockHeight: 1_000_000,
+    });
     const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
-    await expect(
-      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), accept('escrow')),
-    ).rejects.toThrow(/escrow/i);
-    expect(spy).not.toHaveBeenCalled();
+    const payload = await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), accept('exact'));
+    expect(payload.payload).toBeInstanceOf(SolanaPayload);
+    expect(payload.payload).not.toBeInstanceOf(EscrowPayload);
   });
 
   it('an unknown scheme bypassing the type system is rejected, not default-routed', async () => {
@@ -329,5 +330,320 @@ describe('Scheme branching (no silent fallback)', () => {
     expect(spy).not.toHaveBeenCalled();
     // Defensive: escrow payload must never be produced by the exact signer.
     expect(EscrowPayload).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Escrow scheme signing. The escrow path uses raw JSON-RPC (global `fetch`) for
+// getSlot + getLatestBlockhash (mirroring the Go/Python signers), so these
+// tests mock `fetch` rather than web3.js `Connection`. Mirrors sdks/go's
+// signer_test.go escrow coverage.
+// ---------------------------------------------------------------------------
+
+const ESCROW_PROGRAM = '9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU';
+
+function escrowAccept(...programId: [] | [string | undefined]): PaymentAccept {
+  // Use a rest param so the caller distinguishes "default program id" (no arg)
+  // from "explicitly undefined / empty" — a defaulted positional param would
+  // turn an explicit `undefined` back into the default and mask the
+  // missing-program-id rejection path.
+  const pid = programId.length === 0 ? ESCROW_PROGRAM : programId[0];
+  return new PaymentAccept('escrow', SOLANA_NETWORK, '2625', USDC_MINT, GOLDEN_PROVIDER, 300, pid);
+}
+
+/** A JSON-RPC response body for a method, mirroring the real RPC shape. */
+function rpcOk(method: string): unknown {
+  if (method === 'getSlot') {
+    return { jsonrpc: '2.0', id: 1, result: 1_000_000 };
+  }
+  // getLatestBlockhash — blockhash is a base58 32-byte string. The system
+  // program id (32 zero bytes) base58-encodes to a valid 32-byte hash.
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      context: { slot: 1_000_000 },
+      value: { blockhash: '11111111111111111111111111111111', lastValidBlockHeight: 1_000_000 },
+    },
+  };
+}
+
+/**
+ * Install a `fetch` mock routing by JSON-RPC method. `overrides` lets a test
+ * substitute a custom { status, body } per method (body may be a non-JSON
+ * string to exercise the malformed-JSON path). Returns the vi mock for
+ * call-count assertions.
+ */
+function mockRpc(
+  overrides: Partial<Record<string, { status?: number; body?: unknown; raw?: string }>> = {},
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async (_url: string, init?: { body?: string }) => {
+    const parsed = JSON.parse(init?.body ?? '{}') as { method?: string };
+    const method = parsed.method ?? '';
+    const o = overrides[method];
+    if (o?.status !== undefined && o.status !== 200) {
+      return new Response('<html>error</html>', { status: o.status });
+    }
+    if (o?.raw !== undefined) {
+      return new Response(o.raw, { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    const body = o?.body ?? rpcOk(method);
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fn);
+  return fn as unknown as ReturnType<typeof vi.fn>;
+}
+
+describe('Escrow scheme signing (no silent fallback)', () => {
+  it('escrow scheme produces an EscrowPayload with a valid deposit_tx + base64 service_id', async () => {
+    mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const payload = await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept());
+    expect(payload.x402Version).toBe(2);
+    expect(payload.accepted.scheme).toBe('escrow');
+    expect(payload.payload).toBeInstanceOf(EscrowPayload);
+    const ep = payload.payload as EscrowPayload;
+    // deposit_tx is a base64 signed legacy tx: compact-u16(1) || sig(64) || msg.
+    const raw = Buffer.from(ep.depositTx, 'base64');
+    expect(raw[0]).toBe(0x01);
+    expect(raw.length).toBeGreaterThan(1 + 64);
+    // service_id is base64 of exactly 32 bytes.
+    expect(Buffer.from(ep.serviceId, 'base64').length).toBe(32);
+    expect(ep.agentPubkey).toBe(goldenAgentWallet().address());
+  });
+
+  it('generates a unique service_id per call (#118 CSPRNG invariant)', async () => {
+    mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const p1 = await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept());
+    const p2 = await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept());
+    const s1 = (p1.payload as EscrowPayload).serviceId;
+    const s2 = (p2.payload as EscrowPayload).serviceId;
+    expect(s1).not.toBe(s2);
+  });
+
+  it('rejects a missing escrow_program_id before any RPC', async () => {
+    const fn = mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept(undefined)),
+    ).rejects.toThrow(/escrow_program_id is missing/);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty escrow_program_id before any RPC', async () => {
+    const fn = mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept('')),
+    ).rejects.toThrow(/escrow_program_id is missing/);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a zero amount before any RPC', async () => {
+    const fn = mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(0, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/greater than zero/);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a float amount before any RPC', async () => {
+    const fn = mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625.5, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/integer/);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('rejects an implausibly low slot (stub/genesis node)', async () => {
+    mockRpc({ getSlot: { body: { jsonrpc: '2.0', id: 1, result: 0 } } });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/implausibly low slot/);
+  });
+
+  it('rejects a getSlot HTTP 429', async () => {
+    mockRpc({ getSlot: { status: 429 } });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/getSlot RPC HTTP 429/);
+  });
+
+  it('rejects a malformed getSlot JSON body', async () => {
+    mockRpc({ getSlot: { raw: 'not valid json' } });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/getSlot RPC: malformed JSON/);
+  });
+
+  it('surfaces a getSlot JSON-RPC error code without leaking the message text', async () => {
+    mockRpc({
+      getSlot: {
+        body: { jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'node behind' } },
+      },
+    });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    let caught: unknown;
+    try {
+      await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept());
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SignerError);
+    const msg = (caught as Error).message;
+    expect(msg).toMatch(/getSlot RPC error/);
+    expect(msg).toContain('-32000');
+    expect(msg).not.toContain('node behind');
+  });
+
+  it('does not render a code-less getSlot error as "code: 0"', async () => {
+    mockRpc({
+      getSlot: { body: { jsonrpc: '2.0', id: 1, error: { message: 'node behind' } } },
+    });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    let caught: unknown;
+    try {
+      await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept());
+    } catch (e) {
+      caught = e;
+    }
+    const msg = (caught as Error).message;
+    expect(msg).not.toContain('code: 0');
+    expect(msg).toMatch(/no numeric code/);
+    expect(msg).not.toContain('node behind');
+  });
+
+  it('rejects a missing blockhash', async () => {
+    mockRpc({
+      getLatestBlockhash: {
+        body: { jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'internal' } },
+      },
+    });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/did not return a blockhash/);
+  });
+
+  it('rejects a base58-valid but wrong-length blockhash', async () => {
+    mockRpc({
+      getLatestBlockhash: {
+        body: {
+          jsonrpc: '2.0',
+          id: 1,
+          result: { context: { slot: 1_000_000 }, value: { blockhash: '1111' } },
+        },
+      },
+    });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/malformed blockhash/);
+  });
+
+  it('produces a payload that is NOT a SolanaPayload (escrow scheme contract)', async () => {
+    // Converse of the exact-path scheme-contract assertion: an escrow-selected
+    // payment must never produce an exact-scheme `SolanaPayload`.
+    mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const payload = await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept());
+    expect(payload.payload).toBeInstanceOf(EscrowPayload);
+    expect(payload.payload).not.toBeInstanceOf(SolanaPayload);
+  });
+
+  it('rejects a NaN maxTimeoutSeconds before any RPC, naming the field', async () => {
+    // maxTimeoutSeconds comes straight from the untrusted gateway 402. A NaN
+    // value would flow through escrowExpirySlot (Math.max(NaN,0)=NaN) into the
+    // builder and surface as a confusing wrapped error. Reject at the boundary,
+    // before any RPC mock is hit.
+    const fn = mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const a = escrowAccept();
+    (a as { maxTimeoutSeconds: number }).maxTimeoutSeconds = Number.NaN;
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), a),
+    ).rejects.toThrow(/maxTimeoutSeconds/);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-integer (float) maxTimeoutSeconds before any RPC', async () => {
+    const fn = mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const a = escrowAccept();
+    (a as { maxTimeoutSeconds: number }).maxTimeoutSeconds = 300.5;
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), a),
+    ).rejects.toThrow(/maxTimeoutSeconds/);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('accepts a negative finite maxTimeoutSeconds and clamps (parity with Go)', async () => {
+    // A negative finite integer is NOT a hard error: escrowExpirySlot floors it
+    // to 0 then clamps to the 150-slot floor (mirrors Go's escrowExpirySlot). It
+    // must still produce a valid EscrowPayload.
+    mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const a = escrowAccept();
+    (a as { maxTimeoutSeconds: number }).maxTimeoutSeconds = -5;
+    const payload = await signer.signPayment(2625, GOLDEN_PROVIDER, resource(), a);
+    expect(payload.payload).toBeInstanceOf(EscrowPayload);
+  });
+
+  it('rejects an oversized (>64KB) getSlot RPC body', async () => {
+    // A misbehaving/hostile RPC must not be able to stream an unbounded 200 body
+    // into memory. The body cap (parity with Go's io.LimitReader) rejects it
+    // with a SignerError before JSON.parse.
+    const huge = `{"jsonrpc":"2.0","id":1,"result":1000000,"pad":"${'x'.repeat(70_000)}"}`;
+    mockRpc({ getSlot: { raw: huge } });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/exceeds 65536 bytes/);
+  });
+
+  it('the agent secret key never appears in an escrow error message', async () => {
+    // Drive a builder-level failure after RPC by handing a malformed provider in
+    // the accept's pay_to. The golden wallet seed is all 42 (0x2a); assert it
+    // never leaks.
+    mockRpc();
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    const bad = escrowAccept();
+    (bad as { payTo: string }).payTo = 'not-base58-0OIl!!!';
+    let caught: unknown;
+    try {
+      await signer.signPayment(2625, 'irrelevant', resource(), bad);
+    } catch (e) {
+      caught = e;
+    }
+    const msg = (caught as Error).message;
+    expect(msg).not.toMatch(/42, ?42, ?42/);
+    expect(msg).not.toMatch(/2a,? ?2a,? ?2a/i);
+  });
+});
+
+describe('escrowExpirySlot clamping math (mirrors Rust/Go/Python)', () => {
+  it('typical 300s timeout -> +750 slots', () => {
+    expect(escrowExpirySlot(1_000_000, 300)).toBe(1_000_750);
+  });
+
+  it('zero seconds applies the 150-slot floor', () => {
+    expect(escrowExpirySlot(1_000_000, 0)).toBe(1_000_150);
+  });
+
+  it('a huge timeout is clamped to the 10_000-slot cap', () => {
+    expect(escrowExpirySlot(1_000_000, 2 ** 40)).toBe(1_010_000);
+  });
+
+  it('a negative timeout clamps to the floor, never pushing expiry backwards', () => {
+    expect(escrowExpirySlot(1_000_000, -1)).toBe(1_000_150);
   });
 });


### PR DESCRIPTION
## What

Implements TypeScript SDK escrow deposit signing, the last of the four-language escrow parity set (Go #474, Rust v0.2.4, Python already shipped). The TS SDK previously **refused** the `escrow` scheme with a fail-closed `SignerError`; it now builds and signs USDC-SPL escrow deposit transactions.

Closes the TS half of #480.

## Byte-exact parity

`src/escrow.ts` `buildDepositTx` is a pure, deterministic, network-free port of the canonical Rust builder (`crates/escrow-tx/src/deposit.rs`) and `sdks/go/escrow.go`, pinned to the **same `GOLDEN_VECTOR_B64`**. The drift-guard test asserts byte-for-byte reproduction of the fixed golden input; the gateway verifier (`crates/x402/src/escrow/`) independently re-derives the same layout, so any divergence is a fund-misdirection bug, not a style nit.

Wire layout: escrow PDA seeds `[b"escrow", agent(32), service_id(32)]`, vault ATA `ATA(escrow_pda, mint)`, 56-byte instruction data (`sha256("global:deposit")[..8] || amount u64 LE || service_id || expiry_slot u64 LE`), writability-sorted 9-account list (program appended at index 9), ix-account order `[0,4,5,1,2,3,6,7,8]`, header `[1,0,6]`, single-byte compact-u16 length prefixes (rejects >127), `compactU16(1) || sig(64) || message` base64.

## Safety invariants

- **No silent fallback** — escrow-selected always builds an escrow deposit; exact never yields escrow; unknown scheme rejected. Tests pin both directions.
- **CSPRNG per-request `service_id`** (`sha256(randomBytes(32))`) — #118 invariant: two identical requests never share a service_id → PDA → vault ATA.
- **Expiry clamped** to `[150, 10_000]` slots — floor mirrors and exceeds the gateway `MIN_EXPIRY_BUFFER_SLOTS`; negative timeout floors to 0 (parity with Go).
- **Secret stays behind the `Wallet` boundary** — signing via `wallet.signMessage`; no raw secret-key extraction on the hot path; RPC errors surface numeric codes only (GHSA-cgqx-mg48-949v).

## Review hardening

Went through three independent reviewers (TypeScript / silent-failure / security) after implementation. Fixes folded in:

- `expirySlot` fail-closed guard in the public `buildDepositTx` (it had an `amount` guard but not an `expirySlot` one) — rejects `0`/negative/float/`NaN`/`Infinity` before u64 encoding.
- Validate `maxTimeoutSeconds` (non-finite/non-integer) before any RPC; negative finite still clamps (Go parity).
- 30s `AbortController` timeout on RPC calls — was bare `fetch` that could hang the payment path indefinitely; Go and Python both enforce 30s.
- `Number.isSafeInteger` slot guard; 64KB RPC response-body cap (Go parity).

Deferred (noted, not in scope): `SignerError` `cause`-chaining for richer RPC diagnostics — changes the shared error class, separate PR.

## Tests

- `tests/unit/escrow.test.ts` (new): golden-vector parity, determinism, decode shape, discriminator/pubkey embedding, amount + expiry-slot fail-closed guards, malformed-address/length guards, secret redaction.
- `tests/unit/signer.test.ts` (extended): EscrowPayload shape, service_id uniqueness, missing program id, NaN/float/negative timeout, low-slot, HTTP 429, oversized body, scheme-contract converse assertion.
- `npm run lint` (tsc --noEmit) clean, `npm run build` (tsc) succeeds, **full suite 203 passed / 3 skipped** (skipped = pre-existing live-gateway tests).