### PR TITLE
fix(gateway): drop discontinued Gemini 2.0 models (shut down 2026-06-01)

### DIFF
--- a/config/models.toml
+++ b/config/models.toml
@@ -242,28 +242,6 @@ supports_tools = true
 supports_vision = true
 max_output_tokens = 16384
 
-# --- Additional Google ---
-
-[models.google-gemini-2-0-flash]
-provider = "google"
-model_id = "gemini-2.0-flash"
-display_name = "Gemini 2.0 Flash"
-input_cost_per_million = 0.10
-output_cost_per_million = 0.40
-context_window = 1000000
-supports_streaming = true
-supports_tools = true
-max_output_tokens = 8192
-
-[models.google-gemini-2-0-flash-lite]
-provider = "google"
-model_id = "gemini-2.0-flash-lite"
-display_name = "Gemini 2.0 Flash Lite"
-input_cost_per_million = 0.075
-output_cost_per_million = 0.30
-context_window = 1000000
-supports_streaming = true
-
 # --- Additional DeepSeek ---
 
 [models.deepseek-coder]

--- a/crates/gateway/src/providers/fallback.rs
+++ b/crates/gateway/src/providers/fallback.rs
@@ -593,7 +593,6 @@ pub fn model_fallback_chain<'a>(provider: &'a str, model: &'a str) -> Vec<(&'a s
         ("openai", "gpt-4.1-nano") => vec![
             ("openai", "gpt-4.1-nano"),
             ("google", "gemini-2.5-flash-lite"),
-            ("google", "gemini-2.0-flash-lite"),
         ],
         ("anthropic", "claude-haiku-4-5-20251001") => vec![
             ("anthropic", "claude-haiku-4-5-20251001"),

--- a/sdks/ai-sdk-provider/src/generated/models.ts
+++ b/sdks/ai-sdk-provider/src/generated/models.ts
@@ -9,8 +9,6 @@ export type SolvelaModelId =
   | "deepseek-chat"
   | "deepseek-coder"
   | "deepseek-reasoner"
-  | "google-gemini-2-0-flash"
-  | "google-gemini-2-0-flash-lite"
   | "google-gemini-2-5-flash"
   | "google-gemini-2-5-flash-lite"
   | "google-gemini-3-1-pro"
@@ -128,35 +126,6 @@ export const MODELS = [
     supportsTools: false,
     supportsVision: false,
     reasoning: true,
-    supportsStructuredOutput: false,
-  },
-  {
-    id: "google-gemini-2-0-flash",
-    provider: "google",
-    modelId: "gemini-2.0-flash",
-    displayName: "Gemini 2.0 Flash",
-    inputCostPerMillion: 0.1,
-    outputCostPerMillion: 0.4,
-    contextWindow: 1000000,
-    supportsStreaming: true,
-    supportsTools: true,
-    supportsVision: false,
-    reasoning: false,
-    supportsStructuredOutput: false,
-    maxOutputTokens: 8192,
-  },
-  {
-    id: "google-gemini-2-0-flash-lite",
-    provider: "google",
-    modelId: "gemini-2.0-flash-lite",
-    displayName: "Gemini 2.0 Flash Lite",
-    inputCostPerMillion: 0.075,
-    outputCostPerMillion: 0.3,
-    contextWindow: 1000000,
-    supportsStreaming: true,
-    supportsTools: false,
-    supportsVision: false,
-    reasoning: false,
     supportsStructuredOutput: false,
   },
   {

--- a/sdks/ai-sdk-provider/tests/unit/codegen.test.ts
+++ b/sdks/ai-sdk-provider/tests/unit/codegen.test.ts
@@ -63,8 +63,6 @@ const KNOWN_MODEL_IDS: readonly string[] = [
   "deepseek-chat",
   "deepseek-coder",
   "deepseek-reasoner",
-  "google-gemini-2-0-flash",
-  "google-gemini-2-0-flash-lite",
   "google-gemini-2-5-flash",
   "google-gemini-2-5-flash-lite",
   "google-gemini-3-1-pro",
@@ -84,7 +82,7 @@ const KNOWN_MODEL_IDS: readonly string[] = [
   "xai-grok-code-fast-1",
 ] as const;
 
-const EXPECTED_COUNT = 26;
+const EXPECTED_COUNT = 24;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/sdks/openclaw-provider/src/models.generated.ts
+++ b/sdks/openclaw-provider/src/models.generated.ts
@@ -324,34 +324,6 @@ export const SOLVELA_MODELS: SolvelaModel[] = [
     "reasoning": false
   },
   {
-    "id": "solvela/gemini-2.0-flash",
-    "name": "Gemini 2.0 Flash",
-    "provider": "google",
-    "contextWindow": 1000000,
-    "maxTokens": 8192,
-    "inputCostPerMillion": 0.1,
-    "outputCostPerMillion": 0.4,
-    "supportsStreaming": true,
-    "supportsTools": true,
-    "supportsVision": false,
-    "supportsStructuredOutput": false,
-    "reasoning": false
-  },
-  {
-    "id": "solvela/gemini-2.0-flash-lite",
-    "name": "Gemini 2.0 Flash Lite",
-    "provider": "google",
-    "contextWindow": 1000000,
-    "maxTokens": 32768,
-    "inputCostPerMillion": 0.075,
-    "outputCostPerMillion": 0.3,
-    "supportsStreaming": true,
-    "supportsTools": false,
-    "supportsVision": false,
-    "supportsStructuredOutput": false,
-    "reasoning": false
-  },
-  {
     "id": "solvela/deepseek-coder",
     "name": "DeepSeek Coder V3",
     "provider": "deepseek",
@@ -395,4 +367,4 @@ export const SOLVELA_MODELS: SolvelaModel[] = [
   }
 ];
 
-export const MODEL_COUNT = 26;
+export const MODEL_COUNT = 24;


### PR DESCRIPTION
## What

Removes `google/gemini-2.0-flash` and `google/gemini-2.0-flash-lite` from the model registry and the fallback chain. Google **discontinued both on 2026-06-01** (https://ai.google.dev/gemini-api/docs/deprecations), so the gateway was advertising, pricing, and routing to dead model IDs.

## Why

A real-money escrow E2E test of the TS SDK surfaced that paid requests for these models **pass payment verification, take the customer's money on-chain, then 500** when Google's API returns 404 and no fallback survives:

```
WARN providers::fallback: model-aware request failed ... model=google/gemini-2.0-flash-lite
     error=HTTP status client error (404 Not Found) for url
     (.../models/gemini-2.0-flash-lite:generateContent)
ERROR all providers failed for model 'google/gemini-2.0-flash-lite'.
```

Control: the same escrow path with `openai/gpt-4o` returns **200 + completion**, isolating the failure to these discontinued IDs. (Full incident in #485.)

## Changes

- `config/models.toml` — remove both `google-gemini-2-0-*` entries.
- `crates/gateway/src/providers/fallback.rs` — drop the dead `gemini-2.0-flash-lite` fallback target from the `gpt-4.1-nano` chain; the live `gemini-2.5-flash-lite` remains ahead of it.
- Regenerated `sdks/ai-sdk-provider/src/generated/models.ts` and `sdks/openclaw-provider/src/models.generated.ts` via their codegen scripts; updated the ai-sdk-provider codegen count fixture (26 → 24).

## Verification

- `cargo check -p gateway` ✅, `cargo fmt --check` ✅
- `ai-sdk-provider`: regenerate + build + lint (`tsc --noEmit`) + tests ✅
- `openclaw-provider`: regenerate + build ✅
- `grep gemini-2.0` across config/crates/sdks → none remaining (except an unrelated format-validator test string `gemini-2.0-flash-exp`).

## Scope / follow-ups

- Does **not** address the deeper money-path defect (charge before confirming the provider can deliver) — tracked in #486.
- Follow-up: audit remaining Google IDs (`gemini-2.5-*`, `gemini-3.1-pro`) against live availability; Google now steers toward 3.x.

Refs #485.