### PR TITLE
feat(gateway): surface daily/monthly wallet spend + team by-provider stats

### DIFF
--- a/crates/gateway/src/routes/orgs/analytics.rs
+++ b/crates/gateway/src/routes/orgs/analytics.rs
@@ -21,6 +21,7 @@ pub struct TeamStatsResponse {
     pub total_spend_usdc: f64,
     pub total_requests: i64,
     pub by_model: Vec<ModelBreakdown>,
+    pub by_provider: Vec<ProviderBreakdown>,
     pub by_wallet: Vec<WalletBreakdown>,
 }
 
@@ -28,6 +29,14 @@ pub struct TeamStatsResponse {
 #[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct ModelBreakdown {
     pub model: String,
+    pub request_count: i64,
+    pub total_cost_usdc: f64,
+}
+
+/// Per-provider breakdown for team analytics.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct ProviderBreakdown {
+    pub provider: String,
     pub request_count: i64,
     pub total_cost_usdc: f64,
 }
@@ -167,6 +176,35 @@ pub async fn get_team_stats(
         }
     };
 
+    // By-provider breakdown
+    let by_provider = sqlx::query_as::<_, ProviderBreakdown>(
+        r#"SELECT s.provider,
+                  COUNT(*) AS request_count,
+                  COALESCE(SUM(s.cost_usdc), 0.0)::DOUBLE PRECISION AS total_cost_usdc
+           FROM spend_logs s
+           JOIN team_wallets tw ON tw.wallet_address = s.wallet_address
+           WHERE tw.team_id = $1
+             AND s.created_at >= NOW() - make_interval(days => $2)
+           GROUP BY s.provider
+           ORDER BY total_cost_usdc DESC"#,
+    )
+    .bind(team_id)
+    .bind(days)
+    .fetch_all(pool)
+    .await;
+
+    let by_provider = match by_provider {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!(team_id = %team_id, error = %e, "failed to fetch team stats by provider");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to fetch team stats by provider" })),
+            )
+                .into_response();
+        }
+    };
+
     // By-wallet breakdown
     let by_wallet = sqlx::query_as::<_, WalletBreakdown>(
         r#"SELECT tw.wallet_address,
@@ -204,6 +242,7 @@ pub async fn get_team_stats(
             total_spend_usdc,
             total_requests,
             by_model,
+            by_provider,
             by_wallet,
         }),
     )

--- a/crates/gateway/src/routes/stats.rs
+++ b/crates/gateway/src/routes/stats.rs
@@ -46,6 +46,17 @@ pub struct StatsSummary {
     pub total_cost_usdc: String,
     pub total_input_tokens: i64,
     pub total_output_tokens: i64,
+    /// Spend in the last 24h window (today, UTC) for this wallet, decimal USDC.
+    ///
+    /// Read from the `spend:{wallet}:{%Y-%m-%d}` Redis counter the budget path
+    /// increments. Redis-optional (Architectural Rule #12): `0.0` when Redis is
+    /// absent or the counter is missing — never an error.
+    pub daily_cost_usdc: String,
+    /// Spend in the current calendar month (UTC) for this wallet, decimal USDC.
+    ///
+    /// Read from the `spend:{wallet}:{%Y-%m}` Redis counter. Same Redis-optional
+    /// `0.0` fallback as `daily_cost_usdc`.
+    pub monthly_cost_usdc: String,
 }
 
 /// Per-model breakdown.
@@ -189,11 +200,22 @@ pub async fn wallet_stats(
             .into_response()
     })?;
 
+    // Daily/monthly current-window spend come from the same Redis counters the
+    // budget path increments, via the shared `wallet_window_spend` helper (no
+    // copy-pasted key strings). Redis is OPTIONAL (Architectural Rule #12): when
+    // it is absent or a counter is missing, these are 0.0 and the endpoint still
+    // returns 200 with the DB-backed summary intact — it never hard-requires
+    // Redis. Formatted to 6 decimals to match the other `*_cost_usdc` fields.
+    let (daily_cost, monthly_cost) =
+        crate::usage::wallet_window_spend(state.usage.redis_client(), &address).await;
+
     let summary = StatsSummary {
         total_requests: summary_row.total_requests,
         total_cost_usdc: format!("{:.6}", summary_row.total_cost),
         total_input_tokens: summary_row.total_input,
         total_output_tokens: summary_row.total_output,
+        daily_cost_usdc: format!("{daily_cost:.6}"),
+        monthly_cost_usdc: format!("{monthly_cost:.6}"),
     };
 
     let by_model = model_rows
@@ -269,6 +291,8 @@ mod tests {
                 total_cost_usdc: "0.000000".to_string(),
                 total_input_tokens: 0,
                 total_output_tokens: 0,
+                daily_cost_usdc: "0.000000".to_string(),
+                monthly_cost_usdc: "0.000000".to_string(),
             },
             by_model: vec![],
             by_day: vec![],
@@ -357,6 +381,8 @@ mod tests {
                 total_cost_usdc: "3.847291".to_string(),
                 total_input_tokens: 892_400,
                 total_output_tokens: 341_200,
+                daily_cost_usdc: "0.142300".to_string(),
+                monthly_cost_usdc: "3.847291".to_string(),
             },
             by_model: vec![ModelStats {
                 model: "anthropic/claude-sonnet-4-20250514".to_string(),
@@ -387,6 +413,8 @@ mod tests {
         assert_eq!(json["summary"]["total_cost_usdc"], "3.847291");
         assert_eq!(json["summary"]["total_input_tokens"], 892_400);
         assert_eq!(json["summary"]["total_output_tokens"], 341_200);
+        assert_eq!(json["summary"]["daily_cost_usdc"], "0.142300");
+        assert_eq!(json["summary"]["monthly_cost_usdc"], "3.847291");
 
         // by_model array
         assert_eq!(json["by_model"].as_array().unwrap().len(), 1);
@@ -418,6 +446,8 @@ mod tests {
                 total_cost_usdc: "0.000000".to_string(),
                 total_input_tokens: 0,
                 total_output_tokens: 0,
+                daily_cost_usdc: "0.000000".to_string(),
+                monthly_cost_usdc: "0.000000".to_string(),
             },
             by_model: vec![],
             by_day: vec![],
@@ -430,6 +460,8 @@ mod tests {
         assert_eq!(json["summary"]["total_cost_usdc"], "0.000000");
         assert_eq!(json["summary"]["total_input_tokens"], 0);
         assert_eq!(json["summary"]["total_output_tokens"], 0);
+        assert_eq!(json["summary"]["daily_cost_usdc"], "0.000000");
+        assert_eq!(json["summary"]["monthly_cost_usdc"], "0.000000");
         assert!(json["by_model"].as_array().unwrap().is_empty());
         assert!(json["by_day"].as_array().unwrap().is_empty());
     }

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -572,16 +572,23 @@ impl UsageTracker {
             .await
             .map_err(|e| UsageError::Database(e.to_string()))?;
 
+            // Daily/monthly spend come from the same Redis counters the budget
+            // path increments (`spend:{wallet}:{period}`). Read via the shared
+            // `wallet_window_spend` helper so the stats HTTP endpoint and this
+            // summary path use one key derivation — no copy-pasted key strings.
+            // Redis-optional (Architectural Rule #12): absent Redis / missing /
+            // undecodable counters fall back to 0.0, never an error.
+            let (daily_cost_usdc, monthly_cost_usdc) =
+                wallet_window_spend(self.redis_client(), wallet_address).await;
+
             return Ok(SpendSummary {
                 wallet_address: wallet_address.to_string(),
                 total_requests: row.0 as u64,
                 total_input_tokens: row.1 as u64,
                 total_output_tokens: row.2 as u64,
                 total_cost_usdc: row.3,
-                // TODO: Query Redis daily/monthly spend counters to populate these fields.
-                // Currently returns 0.0 — see backend audit Q5.
-                daily_cost_usdc: 0.0,
-                monthly_cost_usdc: 0.0,
+                daily_cost_usdc,
+                monthly_cost_usdc,
             });
         }
 
@@ -1006,6 +1013,32 @@ pub async fn get_redis_spend(client: &redis::Client, key: &str) -> Result<f64, U
     redis_get_f64(&mut conn, key)
         .await
         .map_err(UsageError::Redis)
+}
+
+/// Read a wallet's current-window (today / this-month) spend from the
+/// `spend:{wallet}:{period}` Redis counters the budget path increments.
+///
+/// Single source of truth for the per-wallet daily/monthly key derivation,
+/// shared by [`UsageTracker::get_summary`] and the `GET /v1/wallet/:address/stats`
+/// HTTP handler so neither re-derives (or copy-pastes) the key format.
+///
+/// Redis is OPTIONAL (Architectural Rule #12): when `client` is `None` — or a
+/// counter is missing or fails to decode — the corresponding value falls back
+/// to `0.0` rather than erroring, matching the budget GET endpoint's
+/// `.unwrap_or(0.0)`. These are display counters; the authoritative ledger is
+/// Postgres `spend_logs`, so a `0.0` fallback under-reports a window at worst —
+/// it never bills. Returns `(daily, monthly)` decimal-USDC.
+pub async fn wallet_window_spend(client: Option<&redis::Client>, wallet: &str) -> (f64, f64) {
+    let Some(client) = client else {
+        return (0.0, 0.0);
+    };
+    let now = Utc::now();
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let month_key = format!("spend:{}:{}", wallet, now.format("%Y-%m"));
+    (
+        get_redis_spend(client, &day_key).await.unwrap_or(0.0),
+        get_redis_spend(client, &month_key).await.unwrap_or(0.0),
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -636,6 +636,93 @@ async fn audit_logs_endpoint_returns_json_array(pool: PgPool) {
     assert!(json.is_array(), "audit-logs response must be an array");
 }
 
+/// Gap 3: the team-stats response must include a `by_provider` breakdown,
+/// grouped on `spend_logs.provider` (joined through `team_wallets`), mirroring
+/// the existing `by_model` breakdown. Seed spend rows spanning two providers
+/// and assert the array aggregates correctly and is ordered by spend DESC.
+#[sqlx::test(migrations = "../../migrations")]
+async fn team_stats_includes_by_provider_breakdown(pool: PgPool) {
+    let app = router_with_pool(pool.clone());
+    let org_id = create_test_org(&app, "acme").await;
+
+    // Create a team via HTTP.
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams"),
+            r#"{"name":"Eng"}"#,
+        ))
+        .await
+        .expect("team");
+    let team_id = Uuid::parse_str(body_to_json(resp).await["id"].as_str().unwrap()).expect("uuid");
+
+    // Assign a wallet to the team via HTTP.
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/wallets"),
+            &format!(r#"{{"wallet_address":"{TEST_MEMBER_WALLET}"}}"#),
+        ))
+        .await
+        .expect("assign wallet");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // Seed spend rows spanning two providers for that wallet.
+    // anthropic: 0.30 + 0.20 = 0.50 over 2 requests; openai: 0.10 over 1.
+    for (model, provider, cost) in [
+        ("anthropic/claude-sonnet-4", "anthropic", 0.30_f64),
+        ("anthropic/claude-haiku", "anthropic", 0.20_f64),
+        ("openai/gpt-4o", "openai", 0.10_f64),
+    ] {
+        sqlx::query(
+            r#"INSERT INTO spend_logs
+                   (wallet_address, model, provider, input_tokens, output_tokens, cost_usdc)
+               VALUES ($1, $2, $3, 10, 20, $4)"#,
+        )
+        .bind(TEST_MEMBER_WALLET)
+        .bind(model)
+        .bind(provider)
+        .bind(cost)
+        .execute(&pool)
+        .await
+        .expect("seed spend_log");
+    }
+
+    let resp = app
+        .oneshot(bare_request(
+            "GET",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/stats?days=7"),
+        ))
+        .await
+        .expect("team stats");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+
+    let by_provider = json["by_provider"]
+        .as_array()
+        .expect("by_provider must be an array");
+    assert_eq!(by_provider.len(), 2, "two distinct providers seeded");
+
+    // Ordered by total_cost_usdc DESC: anthropic (0.50) before openai (0.10).
+    assert_eq!(by_provider[0]["provider"], "anthropic");
+    assert_eq!(by_provider[0]["request_count"], 2);
+    assert!(
+        (by_provider[0]["total_cost_usdc"].as_f64().unwrap() - 0.50).abs() < 1e-9,
+        "anthropic total must aggregate to 0.50, got {}",
+        by_provider[0]["total_cost_usdc"]
+    );
+
+    assert_eq!(by_provider[1]["provider"], "openai");
+    assert_eq!(by_provider[1]["request_count"], 1);
+    assert!(
+        (by_provider[1]["total_cost_usdc"].as_f64().unwrap() - 0.10).abs() < 1e-9,
+        "openai total must aggregate to 0.10, got {}",
+        by_provider[1]["total_cost_usdc"]
+    );
+}
+
 #[sqlx::test(migrations = "../../migrations")]
 async fn org_stats_endpoint_returns_200(pool: PgPool) {
     let app = router_with_pool(pool);

--- a/crates/gateway/tests/stats_http_redis.rs
+++ b/crates/gateway/tests/stats_http_redis.rs
@@ -1,0 +1,244 @@
+//! Real-path HTTP tests for the daily/monthly Redis-backed fields on
+//! `GET /v1/wallet/:address/stats`.
+//!
+//! These exercise the production handler through `build_router` + `oneshot`
+//! with a live Postgres pool AND a live Redis client, so
+//! `summary.daily_cost_usdc` / `summary.monthly_cost_usdc` are populated by the
+//! real route — not just asserted at the struct level (Architectural Rule #10,
+//! and `feedback_test_through_real_paths`).
+//!
+//! Deliberately a SEPARATE test binary from `integration.rs`: the `#[sqlx::test]`
+//! macro loads the repo `.env` (for `DATABASE_URL`) into the process
+//! environment, which carries provider API keys. In the `integration.rs` binary
+//! that would leak into `ProviderRegistry::from_env()` and flip the
+//! env-sensitive `/health` "no providers => error" tests. Isolating these tests
+//! in their own process keeps that env mutation contained.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use sqlx::PgPool;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+use gateway::config::AppConfig;
+use gateway::middleware::rate_limit::{RateLimitConfig, RateLimiter};
+use gateway::providers::health::{CircuitBreakerConfig, ProviderHealthTracker};
+use gateway::providers::ProviderRegistry;
+use gateway::services::ServiceRegistry;
+use gateway::usage::UsageTracker;
+use gateway::{build_router, AppState};
+use solvela_router::models::ModelRegistry;
+
+const REDIS_URL: &str = "redis://127.0.0.1:6379";
+const TEST_RECIPIENT_WALLET: &str = "GatewayRecipientWallet111111111111111111111111";
+const TEST_ADMIN_TOKEN: &str = "test-admin-token-for-stats-http-redis";
+const SESSION_SECRET: &[u8] = b"test-secret";
+
+const TEST_SERVICES_TOML: &str = r#"
+[services.llm-gateway]
+name = "LLM Intelligence"
+endpoint = "/v1/chat/completions"
+category = "intelligence"
+x402_enabled = true
+internal = true
+description = "OpenAI-compatible LLM inference"
+pricing_label = "per-token (see /pricing)"
+"#;
+
+const TEST_MODELS_TOML: &str = r#"
+[models.openai-gpt-4o]
+provider = "openai"
+model_id = "gpt-4o"
+display_name = "GPT-4o"
+input_cost_per_million = 2.50
+output_cost_per_million = 10.00
+context_window = 128000
+supports_streaming = true
+"#;
+
+/// Build a router whose `AppState` carries the supplied `UsageTracker` + pool.
+/// The stats route never touches the facilitator/providers, so an empty
+/// facilitator and env-derived (empty in CI) provider registry are fine.
+fn stats_router(usage: UsageTracker, db_pool: Option<PgPool>) -> axum::Router {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    let facilitator = solvela_x402::facilitator::Facilitator::new(vec![]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: ProviderRegistry::from_env(reqwest::Client::new()),
+        facilitator,
+        usage,
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool,
+        session_secret: SESSION_SECRET.to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: None,
+        dev_bypass_payment: false,
+    });
+    build_router(
+        Arc::clone(&state),
+        RateLimiter::new(RateLimitConfig::default()),
+    )
+}
+
+/// A randomly-generated, valid base58 Solana-style wallet (44 chars) so each
+/// test isolates its own `spend:{wallet}:{period}` Redis counters even under
+/// parallel execution. Must satisfy the handler's `is_valid_wallet_address`.
+fn random_valid_wallet() -> String {
+    const BASE58: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    let raw = uuid::Uuid::new_v4().simple().to_string();
+    let raw2 = uuid::Uuid::new_v4().simple().to_string();
+    format!("{raw}{raw2}")
+        .bytes()
+        .take(44)
+        .map(|b| BASE58[(b as usize) % BASE58.len()] as char)
+        .collect()
+}
+
+/// Build a valid (non-expired) session token bound to `wallet`, signed with the
+/// same secret the router uses.
+fn session_token_for(wallet: &str) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let claims = gateway::session::SessionClaims {
+        wallet: wallet.to_string(),
+        budget_remaining: 5_000_000,
+        issued_at: now,
+        expires_at: now + 3600,
+        allowed_models: vec![],
+    };
+    gateway::session::create_session_token(&claims, SESSION_SECRET).unwrap()
+}
+
+async fn redis_set_spend(client: &redis::Client, key: &str, val: &str) {
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("redis conn");
+    let _: () = redis::cmd("SET")
+        .arg(key)
+        .arg(val)
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed spend");
+}
+
+async fn redis_del_keys(client: &redis::Client, keys: &[&str]) {
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("redis conn");
+    for key in keys {
+        let _: Result<i64, _> = redis::cmd("DEL").arg(*key).query_async(&mut conn).await;
+    }
+}
+
+async fn get_stats_json(app: axum::Router, wallet: &str) -> (StatusCode, serde_json::Value) {
+    let token = session_token_for(wallet);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/wallet/{wallet}/stats"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&body).unwrap();
+    (status, json)
+}
+
+/// With both Postgres and Redis present, the stats response must surface the
+/// seeded daily/monthly counters formatted to 6 decimals.
+#[sqlx::test(migrations = "../../migrations")]
+async fn stats_endpoint_surfaces_daily_monthly_from_redis(pool: PgPool) {
+    let client = redis::Client::open(REDIS_URL).expect("redis client");
+    let wallet = random_valid_wallet();
+    let now = chrono::Utc::now();
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let month_key = format!("spend:{}:{}", wallet, now.format("%Y-%m"));
+
+    redis_set_spend(&client, &day_key, "0.250000").await;
+    redis_set_spend(&client, &month_key, "1.750000").await;
+
+    let usage = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    let app = stats_router(usage, Some(pool.clone()));
+
+    let (status, json) = get_stats_json(app, &wallet).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["summary"]["daily_cost_usdc"], "0.250000");
+    assert_eq!(json["summary"]["monthly_cost_usdc"], "1.750000");
+    // DB-backed summary is intact (no spend rows => zeros).
+    assert_eq!(json["summary"]["total_requests"], 0);
+    assert_eq!(json["summary"]["total_cost_usdc"], "0.000000");
+
+    redis_del_keys(&client, &[&day_key, &month_key]).await;
+}
+
+/// With Redis present but no counters seeded for the wallet, daily/monthly must
+/// be 0.0 (formatted "0.000000"), never an error — and the endpoint still 200s.
+#[sqlx::test(migrations = "../../migrations")]
+async fn stats_endpoint_daily_monthly_zero_when_counters_missing(pool: PgPool) {
+    let client = redis::Client::open(REDIS_URL).expect("redis client");
+    let wallet = random_valid_wallet(); // fresh => no spend keys
+
+    let usage = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    let app = stats_router(usage, Some(pool.clone()));
+
+    let (status, json) = get_stats_json(app, &wallet).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["summary"]["daily_cost_usdc"], "0.000000");
+    assert_eq!(json["summary"]["monthly_cost_usdc"], "0.000000");
+}
+
+/// Redis-OPTIONAL (Architectural Rule #12): with a DB but NO Redis client, the
+/// stats endpoint must still return 200 with the DB-backed summary intact and
+/// daily/monthly == "0.000000" — it must NOT start hard-requiring Redis.
+#[sqlx::test(migrations = "../../migrations")]
+async fn stats_endpoint_returns_200_with_redis_absent(pool: PgPool) {
+    // DB present, Redis absent.
+    let usage = UsageTracker::new(Some(pool.clone()), None);
+    let wallet = random_valid_wallet();
+    let app = stats_router(usage, Some(pool.clone()));
+
+    let (status, json) = get_stats_json(app, &wallet).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "endpoint must NOT hard-require Redis"
+    );
+    assert_eq!(json["summary"]["daily_cost_usdc"], "0.000000");
+    assert_eq!(json["summary"]["monthly_cost_usdc"], "0.000000");
+    assert_eq!(json["summary"]["total_requests"], 0);
+}

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -658,6 +658,102 @@ async fn check_budget_redis_get_failure_fails_closed(pool: PgPool) {
     .await;
 }
 
+/// Gap 2: `get_summary` must populate `daily_cost_usdc` / `monthly_cost_usdc`
+/// from the same `spend:{wallet}:{period}` Redis counters the budget path
+/// writes, parsed the same way (decimal USDC). Seed both windows, then assert
+/// the summary reflects them.
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_summary_populates_daily_and_monthly_from_redis(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let month_key = format!("spend:{}:{}", wallet, now.format("%Y-%m"));
+
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&day_key)
+        .arg("0.25")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed daily");
+    let _: () = redis::cmd("SET")
+        .arg(&month_key)
+        .arg("1.75")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed monthly");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    let summary = tracker
+        .get_summary(&wallet)
+        .await
+        .expect("summary with DB + Redis must succeed");
+
+    assert!(
+        (summary.daily_cost_usdc - 0.25).abs() < 1e-9,
+        "daily must reflect the seeded counter, got {}",
+        summary.daily_cost_usdc
+    );
+    assert!(
+        (summary.monthly_cost_usdc - 1.75).abs() < 1e-9,
+        "monthly must reflect the seeded counter, got {}",
+        summary.monthly_cost_usdc
+    );
+
+    redis_del(&client, &[&day_key, &month_key]).await;
+}
+
+/// Gap 2: a missing Redis counter (no spend yet this window) must fall back to
+/// 0.0 gracefully, never an error — matching the budget endpoint's
+/// `.unwrap_or(0.0)`.
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_summary_falls_back_to_zero_when_counters_missing(pool: PgPool) {
+    let client = redis_client();
+    // Fresh per-test wallet => no spend keys exist for it.
+    let wallet = unique_wallet();
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    let summary = tracker
+        .get_summary(&wallet)
+        .await
+        .expect("summary must succeed even with no Redis counters");
+
+    assert_eq!(
+        summary.daily_cost_usdc, 0.0,
+        "missing daily counter must fall back to 0.0"
+    );
+    assert_eq!(
+        summary.monthly_cost_usdc, 0.0,
+        "missing monthly counter must fall back to 0.0"
+    );
+}
+
+/// Gap 2: with a DB but NO Redis configured, daily/monthly must be 0.0 (not an
+/// error) — Redis is optional (Architectural Rule #12).
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_summary_zero_windows_when_redis_absent(pool: PgPool) {
+    let wallet = unique_wallet();
+
+    // DB present, Redis absent.
+    let tracker = UsageTracker::new(Some(pool.clone()), None);
+    let summary = tracker
+        .get_summary(&wallet)
+        .await
+        .expect("summary must succeed with DB only");
+
+    assert_eq!(summary.daily_cost_usdc, 0.0);
+    assert_eq!(summary.monthly_cost_usdc, 0.0);
+}
+
 #[tokio::test]
 async fn get_redis_spend_returns_zero_for_missing_key() {
     let client = redis_client();


### PR DESCRIPTION
## What

Two usage **read-path** additions, both display-only over the authoritative `spend_logs` ledger. No change to billing, the 5% fee, cost breakdowns, or settlement.

### Gap 2 — daily/monthly wallet spend on the live stats endpoint
`GET /v1/wallet/{address}/stats` now returns `daily_cost_usdc` and `monthly_cost_usdc`, read from the `spend:{wallet}:{period}` Redis counters the budget path already increments. Previously these windows were not surfaced on any endpoint at all (the `0.0`/TODO lived in an uncalled `UsageTracker::get_summary`).

- Factored the two-counter read into a shared `usage::wallet_window_spend` helper so the HTTP handler and `get_summary` share **one** key derivation — no copy-pasted `spend:{wallet}:{period}` strings.
- **Redis-optional (Architectural Rule #12):** absent Redis or a missing/undecodable counter falls back to `0.0`; the endpoint still returns 200 with the DB-backed summary intact and never hard-requires Redis.
- Fields are 6-decimal strings, matching the existing `*_cost_usdc` convention on `StatsSummary`.

### Gap 3 — team stats by-provider breakdown
`GET /v1/orgs/{id}/teams/{tid}/stats` now includes a `by_provider` array, mirroring the existing `by_model` query (JOIN through `team_wallets`, identical error handling, ordered by spend DESC). Brings team stats to parity with the by-provider breakdown admin stats already exposes.

## Why here (not enterprise)

The private v2 roadmap (`open-core` boundary) keeps spend **read endpoints / attribution** in the OSS gateway as the onboarding funnel; only the real-time WebSocket cost pump (F5) and hard kill-switch enforcement (F6) are enterprise. A plain HTTP read endpoint for rolled-up spend is squarely OSS.

## Tests

- `tests/stats_http_redis.rs` (new) — exercises the live endpoint through the real route (`oneshot`): populated counters, missing counter, and Redis-absent (still 200) cases.
- `tests/usage_redis.rs` — helper / `get_summary` populated + fallback coverage.
- `tests/orgs_routes.rs` — asserts the team `by_provider` aggregation over seeded multi-provider rows.

Full gateway suite green: lib 691, integration 158, orgs_routes 20, stats_http_redis 3, usage_redis 18, usage_integration 13 — **0 failures**. `cargo fmt --check` and `clippy -D warnings` clean.