### PR TITLE
feat(sdk-rust): add stats() helper to SolvelaClient

### DIFF
--- a/sdks/rust/crates/solvela-client/src/client.rs
+++ b/sdks/rust/crates/solvela-client/src/client.rs
@@ -20,6 +20,7 @@ use crate::error::ClientError;
 use crate::quality;
 use crate::session::SessionStore;
 use crate::signer;
+use crate::stats::StatsResponse;
 use crate::wallet::Wallet;
 
 /// Client for interacting with a `Solvela` gateway.
@@ -517,6 +518,93 @@ impl SolvelaClient {
         }
     }
 
+    /// Fetch per-wallet spend statistics from the gateway.
+    ///
+    /// Wraps `GET /v1/wallet/{wallet}/stats?days=N`. The endpoint is
+    /// authenticated: it requires a gateway-issued **session token** scoped to
+    /// `wallet`. The gateway returns this token in the `x-solvela-session`
+    /// response header after a successful paid chat, and it expires after ~1h.
+    /// This client does not retain that token (it is never read from chat
+    /// responses), so the caller must supply it explicitly via `session_token`.
+    /// A token issued for a different wallet yields a `403` from the gateway,
+    /// surfaced here as `ClientError::Gateway { status: 403, .. }`.
+    ///
+    /// `days` selects the reporting window:
+    /// - `Some(n)` — must be within `1..=365` (the gateway's accepted range);
+    ///   an out-of-range value is rejected client-side with
+    ///   `ClientError::InvalidArgument` rather than sent (which the gateway
+    ///   would reject with `400`). The `days` query parameter is sent only when
+    ///   `Some`.
+    /// - `None` — the parameter is omitted so the gateway's default window (30
+    ///   days) applies.
+    ///
+    /// All `*_cost_usdc` fields in the response are decimal-USDC strings,
+    /// mirrored verbatim from the gateway (never parsed to `f64`) to avoid float
+    /// drift.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ClientError::InvalidArgument` if `days` is out of range or
+    /// `session_token` is empty, `ClientError::Gateway` for any non-200 response
+    /// (including `401`/`403` auth failures), or `ClientError::ParseError` if
+    /// the response body is malformed.
+    pub async fn stats(
+        &self,
+        wallet: &str,
+        days: Option<u16>,
+        session_token: &str,
+    ) -> Result<StatsResponse, ClientError> {
+        // Validate `days` client-side against the gateway's accepted range
+        // (1..=365). Erroring here avoids a guaranteed-400 round trip and gives
+        // a clearer message than the gateway's. `u16` admits values up to
+        // 65_535, so an over-365 value is reachable and must be rejected.
+        if let Some(d) = days {
+            if !(1..=365).contains(&d) {
+                return Err(ClientError::InvalidArgument(format!(
+                    "days must be between 1 and 365, got {d}"
+                )));
+            }
+        }
+
+        // An empty session token can never authenticate; reject before sending.
+        if session_token.is_empty() {
+            return Err(ClientError::InvalidArgument(
+                "session_token must not be empty".to_string(),
+            ));
+        }
+
+        // Append `days` only when provided, so `None` lets the gateway's own
+        // default window apply. `d` is a validated `u16` (1..=365), so it is
+        // purely numeric and needs no percent-encoding. The wallet path segment
+        // is the caller-supplied address; the gateway re-validates its format
+        // and the base58 alphabet contains no URL-reserved characters.
+        let url = match days {
+            Some(d) => format!(
+                "{}/v1/wallet/{}/stats?days={}",
+                self.config.gateway_url, wallet, d
+            ),
+            None => format!("{}/v1/wallet/{}/stats", self.config.gateway_url, wallet),
+        };
+
+        let resp = self
+            .http
+            .get(&url)
+            .header("Authorization", format!("Bearer {session_token}"))
+            .send()
+            .await?;
+
+        let status = resp.status();
+        let body = resp.text().await?;
+
+        if status != StatusCode::OK {
+            return Err(ClientError::Gateway {
+                status: status.as_u16(),
+                message: body,
+            });
+        }
+        serde_json::from_str(&body).map_err(|e| ClientError::ParseError(e.to_string()))
+    }
+
     /// Sign a payment for a 402 response and return the encoded
     /// `PAYMENT-SIGNATURE` header value.
     ///
@@ -865,7 +953,7 @@ mod tests {
     use base64::Engine as _;
     use futures::StreamExt;
     use solvela_protocol::*;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_wallet() -> Wallet {
@@ -2039,5 +2127,310 @@ data: [DONE]\n\n";
 
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].choices[0].delta.content.as_deref(), Some("Free"));
+    }
+
+    // -------------------------------------------------------------------------
+    // stats()
+    // -------------------------------------------------------------------------
+
+    const TEST_STATS_WALLET: &str = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+
+    /// A representative, fully-populated stats body mirroring the gateway's
+    /// `StatsResponse` wire shape (see `crates/gateway/src/routes/stats.rs`).
+    fn sample_stats_body() -> serde_json::Value {
+        serde_json::json!({
+            "wallet": TEST_STATS_WALLET,
+            "period_days": 30,
+            "summary": {
+                "total_requests": 1247,
+                "total_cost_usdc": "3.847291",
+                "total_input_tokens": 892_400,
+                "total_output_tokens": 341_200,
+                "daily_cost_usdc": "0.142300",
+                "monthly_cost_usdc": "3.847291"
+            },
+            "by_model": [{
+                "model": "anthropic/claude-sonnet-4-20250514",
+                "requests": 412,
+                "cost_usdc": "1.923000",
+                "input_tokens": 310_000,
+                "output_tokens": 142_000
+            }],
+            "by_day": [{
+                "date": "2026-03-11",
+                "requests": 47,
+                "cost_usdc": "0.142300"
+            }]
+        })
+    }
+
+    #[tokio::test]
+    async fn test_stats_200_deserializes_all_fields() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/wallet/{TEST_STATS_WALLET}/stats")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_stats_body()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let stats = client
+            .stats(TEST_STATS_WALLET, Some(30), "session-token-abc")
+            .await
+            .unwrap();
+
+        // Top-level
+        assert_eq!(stats.wallet, TEST_STATS_WALLET);
+        assert_eq!(stats.period_days, 30);
+
+        // Summary — including daily/monthly, all decimal-USDC strings.
+        assert_eq!(stats.summary.total_requests, 1247);
+        assert_eq!(stats.summary.total_cost_usdc, "3.847291");
+        assert_eq!(stats.summary.total_input_tokens, 892_400);
+        assert_eq!(stats.summary.total_output_tokens, 341_200);
+        assert_eq!(stats.summary.daily_cost_usdc, "0.142300");
+        assert_eq!(stats.summary.monthly_cost_usdc, "3.847291");
+
+        // by_model
+        assert_eq!(stats.by_model.len(), 1);
+        assert_eq!(
+            stats.by_model[0].model,
+            "anthropic/claude-sonnet-4-20250514"
+        );
+        assert_eq!(stats.by_model[0].requests, 412);
+        assert_eq!(stats.by_model[0].cost_usdc, "1.923000");
+        assert_eq!(stats.by_model[0].input_tokens, 310_000);
+        assert_eq!(stats.by_model[0].output_tokens, 142_000);
+
+        // by_day
+        assert_eq!(stats.by_day.len(), 1);
+        assert_eq!(stats.by_day[0].date, "2026-03-11");
+        assert_eq!(stats.by_day[0].requests, 47);
+        assert_eq!(stats.by_day[0].cost_usdc, "0.142300");
+    }
+
+    #[tokio::test]
+    async fn test_stats_sends_days_query_param_when_provided() {
+        let mock_server = MockServer::start().await;
+
+        // The mock only matches when `days=7` is present in the query string;
+        // if the param were omitted (or wrong) this mock would not match and
+        // the request would 404, failing the test.
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/wallet/{TEST_STATS_WALLET}/stats")))
+            .and(wiremock::matchers::query_param("days", "7"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_stats_body()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let stats = client
+            .stats(TEST_STATS_WALLET, Some(7), "tok")
+            .await
+            .unwrap();
+        assert_eq!(stats.wallet, TEST_STATS_WALLET);
+    }
+
+    #[tokio::test]
+    async fn test_stats_omits_days_query_param_when_none() {
+        let mock_server = MockServer::start().await;
+
+        // Match only when `days` is absent, so the server default applies.
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/wallet/{TEST_STATS_WALLET}/stats")))
+            .and(wiremock::matchers::query_param_is_missing("days"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_stats_body()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let stats = client.stats(TEST_STATS_WALLET, None, "tok").await.unwrap();
+        assert_eq!(stats.wallet, TEST_STATS_WALLET);
+    }
+
+    #[tokio::test]
+    async fn test_stats_sets_bearer_auth_header() {
+        let mock_server = MockServer::start().await;
+
+        // Only matches when the exact Bearer header is present.
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/wallet/{TEST_STATS_WALLET}/stats")))
+            .and(header("authorization", "Bearer my-session-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_stats_body()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let stats = client
+            .stats(TEST_STATS_WALLET, None, "my-session-token")
+            .await
+            .unwrap();
+        assert_eq!(stats.wallet, TEST_STATS_WALLET);
+    }
+
+    #[tokio::test]
+    async fn test_stats_403_maps_to_gateway_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/wallet/{TEST_STATS_WALLET}/stats")))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "error": "token wallet does not match requested address"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let result = client
+            .stats(TEST_STATS_WALLET, Some(30), "wrong-wallet-token")
+            .await;
+        match result.unwrap_err() {
+            ClientError::Gateway { status, message } => {
+                assert_eq!(status, 403);
+                assert!(
+                    message.contains("does not match"),
+                    "403 body should be surfaced verbatim: {message}"
+                );
+            }
+            other => panic!("expected Gateway 403, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stats_500_maps_to_gateway_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/wallet/{TEST_STATS_WALLET}/stats")))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let result = client.stats(TEST_STATS_WALLET, None, "tok").await;
+        match result.unwrap_err() {
+            ClientError::Gateway { status, .. } => assert_eq!(status, 500),
+            other => panic!("expected Gateway 500, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stats_rejects_out_of_range_days_before_request() {
+        // days outside 1..=365 must be rejected client-side with a clear
+        // InvalidArgument error, never sent to the gateway (which would 400).
+        // The mock asserts zero requests reach it.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/wallet/{TEST_STATS_WALLET}/stats")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_stats_body()))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        // 0 is below the minimum.
+        let too_small = client.stats(TEST_STATS_WALLET, Some(0), "tok").await;
+        assert!(matches!(
+            too_small.unwrap_err(),
+            ClientError::InvalidArgument(_)
+        ));
+
+        // 366 is above the maximum.
+        let too_big = client.stats(TEST_STATS_WALLET, Some(366), "tok").await;
+        assert!(matches!(
+            too_big.unwrap_err(),
+            ClientError::InvalidArgument(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stats_rejects_empty_session_token() {
+        // An empty session token can never authenticate; reject it before
+        // sending rather than letting the gateway 401.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/wallet/{TEST_STATS_WALLET}/stats")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_stats_body()))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let client = SolvelaClient::new(
+            test_wallet(),
+            ClientConfig {
+                gateway_url: mock_server.uri(),
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+
+        let result = client.stats(TEST_STATS_WALLET, Some(30), "").await;
+        assert!(matches!(
+            result.unwrap_err(),
+            ClientError::InvalidArgument(_)
+        ));
     }
 }

--- a/sdks/rust/crates/solvela-client/src/error.rs
+++ b/sdks/rust/crates/solvela-client/src/error.rs
@@ -82,6 +82,9 @@ pub enum ClientError {
 
     #[error("balance check failed: {0}")]
     BalanceError(String),
+
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
 }
 
 #[cfg(test)]

--- a/sdks/rust/crates/solvela-client/src/lib.rs
+++ b/sdks/rust/crates/solvela-client/src/lib.rs
@@ -8,12 +8,14 @@ pub(crate) mod rpc_error;
 #[allow(dead_code)] // SessionInfo::escalated and cleanup_expired are reserved for future use
 pub(crate) mod session;
 pub(crate) mod signer;
+pub mod stats;
 pub mod wallet;
 
 pub use balance::BalanceMonitor;
 pub use client::SolvelaClient;
 pub use config::{ClientBuilder, ClientConfig, DEFAULT_MAX_PAYMENT_AMOUNT_ATOMIC};
 pub use error::{ClientError, SignerError, WalletError};
+pub use stats::{DayStats, ModelStats, StatsResponse, StatsSummary};
 // NOTE: `signer::EXACT_GOLDEN_VECTOR_B64` is intentionally NOT re-exported here.
 // It is a `pub(crate)` test-pinning artifact (the `exact`-scheme golden vector),
 // not a stable public API: nothing outside this crate imports it (the x402

--- a/sdks/rust/crates/solvela-client/src/stats.rs
+++ b/sdks/rust/crates/solvela-client/src/stats.rs
@@ -1,0 +1,69 @@
+//! Wallet spend-statistics response types.
+//!
+//! These deserialization structs mirror the gateway's `StatsResponse` shape
+//! defined in `crates/gateway/src/routes/stats.rs` (the `GET
+//! /v1/wallet/{address}/stats` endpoint). They are intentionally SDK-local
+//! rather than promoted into `solvela-protocol`: the gateway types derive only
+//! `Serialize` (they are response-only on the server), and promoting them would
+//! be a cross-crate refactor of the gateway money-path crate beyond the scope
+//! of adding this client helper.
+//!
+//! DRIFT WARNING: because these types are duplicated (gateway serializes, SDK
+//! deserializes) they MUST stay byte-compatible with the gateway's field names
+//! and types. If the gateway's `stats.rs` field set changes, update this file in
+//! lockstep. All `*_cost_usdc` fields are decimal-USDC STRINGS on the wire (never
+//! `f64`) — mirror them as `String` here to avoid float drift; do not parse them
+//! to `f64` in these deserialization types. Callers that need numeric values
+//! should parse the string explicitly with a checked decimal/atomic conversion.
+
+use serde::Deserialize;
+
+/// Top-level wallet spend-statistics response.
+///
+/// Mirrors `crates/gateway/src/routes/stats.rs::StatsResponse`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StatsResponse {
+    pub wallet: String,
+    pub period_days: i32,
+    pub summary: StatsSummary,
+    pub by_model: Vec<ModelStats>,
+    pub by_day: Vec<DayStats>,
+}
+
+/// Aggregated spend summary for the requested period.
+///
+/// Mirrors `crates/gateway/src/routes/stats.rs::StatsSummary`. All
+/// `*_cost_usdc` fields are decimal-USDC strings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StatsSummary {
+    pub total_requests: i64,
+    pub total_cost_usdc: String,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    /// Spend in the last 24h window (today, UTC) for this wallet, decimal USDC.
+    pub daily_cost_usdc: String,
+    /// Spend in the current calendar month (UTC) for this wallet, decimal USDC.
+    pub monthly_cost_usdc: String,
+}
+
+/// Per-model spend breakdown.
+///
+/// Mirrors `crates/gateway/src/routes/stats.rs::ModelStats`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelStats {
+    pub model: String,
+    pub requests: i64,
+    pub cost_usdc: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+}
+
+/// Per-day spend breakdown.
+///
+/// Mirrors `crates/gateway/src/routes/stats.rs::DayStats`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DayStats {
+    pub date: String,
+    pub requests: i64,
+    pub cost_usdc: String,
+}


### PR DESCRIPTION
## What

Adds a `stats()` helper to the Rust client so consumers can pull aggregate usage/cost without hand-rolling the HTTP call. Closes the gap noted after #488 (the client was chat-only; aggregate metering required a raw GET).

```rust
pub async fn stats(&self, wallet: &str, days: Option<u16>, session_token: &str)
    -> Result<StatsResponse, ClientError>
```

Wraps `GET /v1/wallet/{address}/stats`. **Read-only** — signs nothing, computes no costs.

## Design decisions

- **Session token is a required param.** The SDK does not retain the gateway-issued session token (returned in the `x-solvela-session` header on a paid chat), so it can't be defaulted. Sent as `Authorization: Bearer`.
- **`days` validated client-side to `1..=365`** via a new `ClientError::InvalidArgument` (avoids a guaranteed-400 round trip); omitted when `None` so the gateway default (30) applies.
- **Response types are SDK-local with a drift warning.** The gateway's `StatsResponse` structs (`routes/stats.rs`) are response-only (`Serialize`-only) and gateway-local; promoting them to `solvela-protocol` + adding `Deserialize` would be a cross-crate refactor of the gateway money-path crate, out of scope here. The SDK structs mirror the gateway shape byte-for-byte with a file-level drift note. `*_cost_usdc` stay `String` on the wire — never parsed to `f64`.

## Tests (8 new, TDD)

Full-shape deserialize (incl. `daily_cost_usdc`/`monthly_cost_usdc`, `by_model`, `by_day`); `days` param present/omitted; bearer header set; 403/500 → `ClientError::Gateway`; out-of-range `days` and empty token rejected before any request is sent. Follows the existing `models()` GET test pattern.

`cargo fmt --check`, `clippy -D warnings` clean; `solvela-client` suite **147 lib + 13 integration + 1 doctest, 0 failures**.

## Not included

Crate version bump / publish — separate operator release step.

## Follow-up (not blocking)

If wire-contract drift on the stats shape becomes a concern, promote the four structs to `solvela-protocol` as the single source of truth for both gateway and SDK.