### PR TITLE
fix(gateway): never charge without delivery on paid requests (#486)

### DIFF
--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -76,6 +76,18 @@ pub enum GatewayError {
     #[error("rate limited")]
     RateLimited,
 
+    /// No provider could fulfil the request (every provider in the fallback
+    /// chain failed or its circuit is open). Maps to 503 Service Unavailable —
+    /// a RETRYABLE status, distinct from the 500 used for genuine internal
+    /// faults. On the paid path this is returned ONLY when no charge has been
+    /// taken (`exact`: settlement was deferred and never broadcast) or no claim
+    /// will be made (`escrow`: the deposit refunds at expiry) — i.e. the
+    /// customer is never billed for an undelivered completion (#486). The inner
+    /// message is forwarded verbatim and must stay free of internal detail
+    /// (provider error bodies, RPC URLs) — log those at `warn!` instead.
+    #[error("upstream unavailable: {0}")]
+    UpstreamUnavailable(String),
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -131,6 +143,11 @@ impl IntoResponse for GatewayError {
                 StatusCode::TOO_MANY_REQUESTS,
                 "rate_limited",
                 "Too many requests".to_string(),
+            ),
+            GatewayError::UpstreamUnavailable(msg) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "upstream_unavailable",
+                msg.clone(),
             ),
             GatewayError::Internal(msg) => {
                 tracing::error!(error = %msg, "internal server error");
@@ -263,6 +280,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_upstream_unavailable_returns_503() {
+        // #486: paid request that no provider could fulfil maps to a RETRYABLE
+        // 503, distinct from the 500 used for genuine internal faults. The inner
+        // message is forwarded verbatim, so the *caller* is contractually
+        // responsible for keeping it free of internal detail (model IDs, RPC
+        // URLs) — verified at the construction site in routes/chat. Here we lock
+        // the status code and the envelope shape.
+        let (status, json) = error_response(GatewayError::UpstreamUnavailable(
+            "No provider could serve your request right now. Please retry shortly.".to_string(),
+        ))
+        .await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(json["error"]["type"], "upstream_unavailable");
+        assert!(json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Please retry shortly"));
+    }
+
+    #[tokio::test]
     async fn test_internal_error_returns_500() {
         let (status, json) =
             error_response(GatewayError::Internal("panic recovered".to_string())).await;
@@ -307,6 +344,10 @@ mod tests {
             "unsupported media type: images"
         );
         assert_eq!(GatewayError::RateLimited.to_string(), "rate limited");
+        assert_eq!(
+            GatewayError::UpstreamUnavailable("down".to_string()).to_string(),
+            "upstream unavailable: down"
+        );
         assert_eq!(
             GatewayError::Internal("crash".to_string()).to_string(),
             "internal error: crash"
@@ -402,6 +443,7 @@ mod tests {
             GatewayError::BadRequest("x".to_string()),
             GatewayError::UnsupportedMediaType("x".to_string()),
             GatewayError::RateLimited,
+            GatewayError::UpstreamUnavailable("x".to_string()),
             GatewayError::Internal("x".to_string()),
         ];
 

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -19,7 +19,7 @@ use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use axum::response::Response;
 use axum::Json;
 use metrics::{counter, histogram};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use solvela_protocol::{ChatRequest, MessageContent, Role, SettlementFailureKind};
 use solvela_router::profiles::{self, Profile};
@@ -412,6 +412,10 @@ pub async fn chat_completions(
     let mut escrow_agent_pubkey: Option<String> = None;
     // FIX 3: Track the verified deposit amount to cap claim amounts
     let escrow_deposited_amount: Option<u64>;
+    // #486: for the `exact` scheme the on-chain broadcast is DEFERRED until after
+    // a successful provider response, so we hold the verified payload here to
+    // settle it post-call. `None` for escrow (its deposit already settled).
+    let mut payload_for_settle: Option<solvela_x402::types::PaymentPayload> = None;
     // Gateway-advertised amount — used as defense-in-depth cap when deposit amount is unknown
     let client_amount: u64;
     // M3: budget is checked + reserved BEFORE settlement inside the arm below, so
@@ -702,78 +706,149 @@ pub async fn chat_completions(
                 Err(e) => return Err(GatewayError::BadRequest(e.to_string())),
             };
 
-            // Verify and settle via Facilitator — hard enforcement
-            // R1 FIX: Check settlement.success flag
-            match state.facilitator.verify_and_settle(&payload).await {
-                Ok(settlement) if !settlement.success => {
-                    // Settlement returned Ok but the transaction did not succeed.
-                    // Distinguish a deterministic on-chain rejection (a dead end —
-                    // retrying the same signed tx can never confirm) from a
-                    // transient timeout/transport failure (issue #435). The full
-                    // error detail stays server-side; the client only ever sees the
-                    // numeric program error code, never raw RPC internals
-                    // (GHSA-cgqx-mg48-949v).
-                    counter!("solvela_payments_total", "status" => "failed").increment(1);
-                    tracing::warn!(
-                        tx_signature = %settlement.tx_signature.as_deref().unwrap_or("unknown"),
-                        error = ?settlement.error,
-                        failure_kind = ?settlement.failure_kind,
-                        "payment settlement failed"
-                    );
-                    // Exhaustive on purpose — no `_` wildcard, so a future
-                    // `SettlementFailureKind` variant can't be silently funneled
-                    // into the retryable bucket and re-open #435.
-                    let message = match settlement.failure_kind {
-                        Some(SettlementFailureKind::Rejected { program_error_code }) => {
-                            match program_error_code {
-                                Some(code) => format!(
+            // #486: charge-before-deliver fix. The settlement step broadcasts
+            // the customer's payment on-chain. Doing that BEFORE the provider
+            // call means a provider failure leaves the customer charged with no
+            // completion — and on `exact` there is no refund path. We split by
+            // scheme:
+            //
+            //   - `exact`: VERIFY only here (validate + simulate, NO broadcast).
+            //     The transfer is deferred and broadcast AFTER a successful
+            //     provider response (see `settle_exact` below). If the provider
+            //     fails, settlement never happens → the customer is not charged.
+            //
+            //   - `escrow`: the deposit MUST be on-chain before serving (the
+            //     scheme's trustless commitment), so we still verify_and_settle
+            //     the deposit here. The no-charge lever for escrow is the CLAIM:
+            //     on provider failure we simply do not claim, and the deposit
+            //     refunds at expiry (the claim only fires in the success arm).
+            //
+            // `verify_payment` is non-mutating and repeatable, so verifying now
+            // for `exact` and settling later does not double-anything; replay
+            // protection above already guards against re-submission of the tx.
+            match payment_scheme {
+                PaymentScheme::Exact => {
+                    match state.facilitator.verify(&payload).await {
+                        Ok(verification) if !verification.valid => {
+                            counter!("solvela_payments_total", "status" => "failed").increment(1);
+                            warn!(
+                                reason = ?verification.reason,
+                                "exact payment verification rejected (pre-settlement)"
+                            );
+                            state.usage.release_reservation(&budget_reservation).await;
+                            return Err(GatewayError::InvalidPayment(
+                                "Payment verification failed. Check your transaction and retry."
+                                    .to_string(),
+                            ));
+                        }
+                        Ok(verification) => {
+                            // Deferred settlement: no broadcast yet. `verified_amount`
+                            // is unused for `exact` (no escrow claim), so this stays
+                            // `None`. The actual broadcast happens post-response via
+                            // the held `payload_for_settle`. Settlement on `exact`
+                            // bills the `client_amount` the agent signed, NOT the
+                            // verifier's `verified_amount` — log the intentional
+                            // divergence rather than silently dropping a money-path
+                            // field.
+                            debug!(
+                                verified_amount = ?verification.verified_amount,
+                                client_amount,
+                                "exact: settlement uses client_amount, not verified_amount"
+                            );
+                            escrow_deposited_amount = None;
+                            payload_for_settle = Some(payload.clone());
+                            counter!("solvela_payments_total", "status" => "verified").increment(1);
+                            info!("exact payment verified (settlement deferred until provider delivers)");
+                        }
+                        Err(e) => {
+                            // GHSA-cgqx-mg48-949v: do not echo verifier internals.
+                            counter!("solvela_payments_total", "status" => "failed").increment(1);
+                            warn!(error = %e, "exact payment verification failed (pre-settlement)");
+                            state.usage.release_reservation(&budget_reservation).await;
+                            return Err(GatewayError::InvalidPayment(
+                                "Payment verification failed. Check your transaction and retry."
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+                // Escrow: deposit must land on-chain before serving. Verify and
+                // settle (broadcast) the deposit now — hard enforcement.
+                // R1 FIX: Check settlement.success flag
+                PaymentScheme::Escrow => {
+                    match state.facilitator.verify_and_settle(&payload).await {
+                        Ok(settlement) if !settlement.success => {
+                            // Settlement returned Ok but the transaction did not succeed.
+                            // Distinguish a deterministic on-chain rejection (a dead end —
+                            // retrying the same signed tx can never confirm) from a
+                            // transient timeout/transport failure (issue #435). The full
+                            // error detail stays server-side; the client only ever sees the
+                            // numeric program error code, never raw RPC internals
+                            // (GHSA-cgqx-mg48-949v).
+                            counter!("solvela_payments_total", "status" => "failed").increment(1);
+                            tracing::warn!(
+                                tx_signature = %settlement.tx_signature.as_deref().unwrap_or("unknown"),
+                                error = ?settlement.error,
+                                failure_kind = ?settlement.failure_kind,
+                                "payment settlement failed"
+                            );
+                            // Exhaustive on purpose — no `_` wildcard, so a future
+                            // `SettlementFailureKind` variant can't be silently funneled
+                            // into the retryable bucket and re-open #435.
+                            let message = match settlement.failure_kind {
+                                Some(SettlementFailureKind::Rejected { program_error_code }) => {
+                                    match program_error_code {
+                                        Some(code) => format!(
                                     "Payment was rejected on-chain (program error {code}); \
                                      this transaction cannot succeed and should not be retried."
                                 ),
-                                None => "Payment was rejected on-chain; this transaction \
+                                        None => "Payment was rejected on-chain; this transaction \
                                      cannot succeed and should not be retried."
+                                            .to_string(),
+                                    }
+                                }
+                                // Transient failures, plus the unclassified `None` case
+                                // (only reachable from an external verifier — retry is the
+                                // safe default since replay protection prevents double-spend).
+                                Some(SettlementFailureKind::Timeout)
+                                | Some(SettlementFailureKind::Submission)
+                                | None => {
+                                    "Payment transaction could not be confirmed. Please retry."
+                                        .to_string()
+                                }
+                            };
+                            // M3: settlement did not happen — give the reserved budget back.
+                            state.usage.release_reservation(&budget_reservation).await;
+                            return Err(GatewayError::InvalidPayment(message));
+                        }
+                        Ok(settlement) => {
+                            escrow_deposited_amount = settlement.verified_amount;
+                            counter!("solvela_payments_total", "status" => "verified").increment(1);
+                            histogram!("solvela_payment_amount_usdc")
+                                .record(client_amount as f64 / 1_000_000.0);
+                            info!(
+                                tx_signature = ?settlement.tx_signature,
+                                network = %settlement.network,
+                                verified_amount = ?settlement.verified_amount,
+                                "payment verified and settled"
+                            );
+                        }
+                        Err(e) => {
+                            // GHSA-cgqx-mg48-949v: do not echo the verifier error to clients;
+                            // it can carry the internal RPC URL, raw RPC error JSON, and other
+                            // server-internal context. Full detail is in the warn! line above.
+                            counter!("solvela_payments_total", "status" => "failed").increment(1);
+                            warn!(error = %e, "payment verification failed");
+                            // M3: settlement did not happen — give the reserved budget back.
+                            state.usage.release_reservation(&budget_reservation).await;
+                            return Err(GatewayError::InvalidPayment(
+                                "Payment verification failed. Check your transaction and retry."
                                     .to_string(),
-                            }
+                            ));
                         }
-                        // Transient failures, plus the unclassified `None` case
-                        // (only reachable from an external verifier — retry is the
-                        // safe default since replay protection prevents double-spend).
-                        Some(SettlementFailureKind::Timeout)
-                        | Some(SettlementFailureKind::Submission)
-                        | None => {
-                            "Payment transaction could not be confirmed. Please retry.".to_string()
-                        }
-                    };
-                    // M3: settlement did not happen — give the reserved budget back.
-                    state.usage.release_reservation(&budget_reservation).await;
-                    return Err(GatewayError::InvalidPayment(message));
-                }
-                Ok(settlement) => {
-                    escrow_deposited_amount = settlement.verified_amount;
-                    counter!("solvela_payments_total", "status" => "verified").increment(1);
-                    histogram!("solvela_payment_amount_usdc")
-                        .record(client_amount as f64 / 1_000_000.0);
-                    info!(
-                        tx_signature = ?settlement.tx_signature,
-                        network = %settlement.network,
-                        verified_amount = ?settlement.verified_amount,
-                        "payment verified and settled"
-                    );
-                }
-                Err(e) => {
-                    // GHSA-cgqx-mg48-949v: do not echo the verifier error to clients;
-                    // it can carry the internal RPC URL, raw RPC error JSON, and other
-                    // server-internal context. Full detail is in the warn! line above.
-                    counter!("solvela_payments_total", "status" => "failed").increment(1);
-                    warn!(error = %e, "payment verification failed");
-                    // M3: settlement did not happen — give the reserved budget back.
-                    state.usage.release_reservation(&budget_reservation).await;
-                    return Err(GatewayError::InvalidPayment(
-                        "Payment verification failed. Check your transaction and retry."
-                            .to_string(),
-                    ));
-                }
-            }
+                    }
+                } // end PaymentScheme::Escrow arm
+            } // end match payment_scheme
         }
         None => {
             counter!("solvela_payments_total", "status" => "failed").increment(1);
@@ -823,6 +898,77 @@ pub async fn chat_completions(
             let usage = usage
                 .as_ref()
                 .map(|u| cap_usage_to_request_limits(u, &req, model_info));
+
+            // #486: deferred `exact` settlement. The provider delivered, so it is
+            // now safe to broadcast the customer's transfer on-chain. We do this
+            // BEFORE returning the response. A broadcast failure here is logged
+            // but does NOT fail the request: the provider already produced output
+            // and `verify` proved the tx valid + simulated successful on-chain;
+            // the (rare) residual of delivery-without-charge is the acceptable
+            // backstop, and the inverse — charge-without-delivery — is exactly
+            // what this fix eliminates. `escrow` already settled its deposit
+            // pre-call (the deposit must commit before serving), so this is a
+            // no-op for escrow.
+            // When the post-delivery `exact` settle fails, the payment was NOT
+            // collected on-chain, so the budget reservation committed pre-settlement
+            // must be reconciled HERE — on every failure branch — rather than via the
+            // downstream `log_spend` delta. The downstream reconciliation does not
+            // cover this case: on the STREAMING path `usage`/`cost_outcome` are both
+            // `None`, so neither `log_spend` branch fires and the reservation would
+            // stay permanently committed (budget over-counted); on the non-streaming
+            // path `log_spend` WOULD fire and record `billed` spend for a charge that
+            // never landed. Either way is wrong. We release the reservation (the wallet
+            // was not charged → its budget returns) and set this flag so the downstream
+            // logging is skipped. `escrow` never reaches here (`payload_for_settle` is
+            // `None`; it settled pre-call), so this is exact-only.
+            let mut settle_after_deliver_failed = false;
+            if let Some(ref payload) = payload_for_settle {
+                match state.facilitator.settle(payload).await {
+                    Ok(settlement) if settlement.success => {
+                        counter!("solvela_payments_total", "status" => "settled").increment(1);
+                        histogram!("solvela_payment_amount_usdc")
+                            .record(client_amount as f64 / 1_000_000.0);
+                        info!(
+                            tx_signature = ?settlement.tx_signature,
+                            "exact payment settled on-chain after provider delivery"
+                        );
+                    }
+                    Ok(settlement) => {
+                        // Provider already delivered; do not fail the request.
+                        // Surface for operator follow-up — the customer received a
+                        // completion the gateway could not collect payment for.
+                        settle_after_deliver_failed = true;
+                        counter!("solvela_payments_total", "status" => "settle_after_deliver_failed")
+                            .increment(1);
+                        // Reconcile the reservation: payment uncollected → release it
+                        // so the wallet's budget is not consumed (covers streaming,
+                        // where no downstream `log_spend` branch would otherwise fire).
+                        state.usage.release_reservation(&budget_reservation).await;
+                        warn!(
+                            error = ?settlement.error,
+                            failure_kind = ?settlement.failure_kind,
+                            stream = req.stream,
+                            reservation_released = true,
+                            spend_recorded = false,
+                            "exact settlement failed AFTER provider delivery — completion delivered, payment uncollected; reservation released (no spend recorded)"
+                        );
+                    }
+                    Err(e) => {
+                        settle_after_deliver_failed = true;
+                        counter!("solvela_payments_total", "status" => "settle_after_deliver_failed")
+                            .increment(1);
+                        // Same reconciliation as the non-success branch above.
+                        state.usage.release_reservation(&budget_reservation).await;
+                        warn!(
+                            error = %e,
+                            stream = req.stream,
+                            reservation_released = true,
+                            spend_recorded = false,
+                            "exact settlement errored AFTER provider delivery — completion delivered, payment uncollected; reservation released (no spend recorded)"
+                        );
+                    }
+                }
+            }
             // Post-response: usage logging, session token, and escrow claims (paid path only)
 
             // Attach session token for paid non-streaming requests
@@ -902,7 +1048,15 @@ pub async fn chat_completions(
             //       log, or the reservation is never settled down to the realised
             //       price and the wallet's budget stays consumed at the full
             //       reservation forever (merged_005 part 2 — ~70% over-consume).
-            if let Some(ref u) = usage {
+            //
+            // SKIP entirely when the post-delivery `exact` settle failed: the
+            // reservation was already reconciled (released) at the settle-failure
+            // branch above and the payment was never collected, so we must NOT also
+            // record spend here (which would over-count the wallet's budget for an
+            // uncollected charge) or release a second time.
+            if settle_after_deliver_failed {
+                // No-op: reservation already released, no spend to record.
+            } else if let Some(ref u) = usage {
                 match state
                     .model_registry
                     .estimate_cost(&req.model, u.prompt_tokens, u.completion_tokens)
@@ -1009,25 +1163,71 @@ pub async fn chat_completions(
         Err(ProviderCallError::AllProvidersFailed {
             model, provider, ..
         }) => {
-            // SECURITY: A paid request reached the stub path — all providers failed.
+            // #486: a paid request that no provider could fulfil. Because of the
+            // settlement reorder above, the customer is NOT charged for this
+            // undelivered completion:
+            //   - `exact`: the transfer was DEFERRED (never broadcast), so
+            //     nothing settled on-chain. Release the budget reservation.
+            //   - `escrow`: the deposit settled (it had to, pre-call), but we do
+            //     NOT fire a claim here (the claim only runs in the success arm),
+            //     so the deposit refunds at expiry. Also release the reservation.
+            // Either way we return a RETRYABLE 503, not a bare 500.
             warn!(
                 provider = %provider,
                 model = %model,
                 wallet = %wallet_address,
-                "paid request failed: no provider available — returning error instead of stub"
+                scheme = ?payment_scheme,
+                "paid request failed: no provider available — no charge taken (exact deferred / escrow unclaimed)"
             );
             counter!("solvela_paid_stub_rejections_total").increment(1);
 
-            Err(GatewayError::Internal(format!(
-                "all providers failed for model '{}'. Your payment was submitted but no response \
-                 could be generated. Contact the gateway operator or retry. \
-                 Provider: {}, tx: {}",
-                model,
-                provider,
-                tx_signature.as_deref().unwrap_or("unknown")
-            )))
+            // No settlement (exact) or no claim (escrow) happened, so the
+            // reserved budget must be returned — otherwise the wallet's spend
+            // counter stays consumed for a request that cost it nothing.
+            state.usage.release_reservation(&budget_reservation).await;
+
+            // Client-facing message must not leak provider/RPC internals OR the
+            // internal model ID (GHSA-cgqx-mg48-949v; `UpstreamUnavailable`'s
+            // variant contract requires the inner string stay free of internal
+            // detail). The model ID is already in the `warn!` above; the client
+            // gets a static, internals-free message per scheme.
+            let message = match payment_scheme {
+                PaymentScheme::Exact => {
+                    "No provider could serve your request right now and your payment was \
+                     NOT charged. Please retry shortly."
+                }
+                PaymentScheme::Escrow => {
+                    // An escrow deposit DID settle on-chain (pre-call) but no claim
+                    // fires here, so the deposit stays locked until it refunds at
+                    // expiry. Emit a scheme-specific metric so operators can alert on
+                    // "N escrow deposits currently locked awaiting expiry" from
+                    // metrics, not just by scraping logs.
+                    counter!(
+                        "solvela_payments_total",
+                        "status" => "escrow_unclaimed_provider_failure"
+                    )
+                    .increment(1);
+                    "No provider could serve your request right now; no claim was made against \
+                     your escrow deposit and it refunds at expiry. Please retry shortly."
+                }
+            };
+            Err(GatewayError::UpstreamUnavailable(message.to_string()))
         }
-        Err(ProviderCallError::Internal(msg)) => Err(GatewayError::Internal(msg)),
+        Err(ProviderCallError::Internal(msg)) => {
+            // #486: same accounting contract as the `AllProvidersFailed` arm — the
+            // provider never delivered, so no `exact` transfer was broadcast and no
+            // `escrow` claim was fired. The budget reservation committed pre-settlement
+            // must be returned, or the wallet's spend counter stays consumed for a
+            // request that cost it nothing. (The previous code returned here WITHOUT
+            // releasing — the leak both money-path reviewers flagged.)
+            warn!(
+                wallet = %wallet_address,
+                scheme = ?payment_scheme,
+                "paid request failed: internal provider-call error — no charge taken; releasing budget reservation"
+            );
+            state.usage.release_reservation(&budget_reservation).await;
+            Err(GatewayError::Internal(msg))
+        }
     }
 }
 

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -1289,6 +1289,34 @@ mod tests {
         assert!(result.is_ok(), "cost below cap should be allowed");
     }
 
+    /// #486 second-pass: the no-charge route arms (`Internal` provider-call
+    /// error, `AllProvidersFailed`, and the post-delivery `exact`
+    /// settle-after-deliver-failed branches) reconcile the budget reservation by
+    /// calling `release_reservation`. Without Redis the reservation is empty and
+    /// release is a no-op — pin that it neither errors nor panics, so the arms
+    /// can call it unconditionally on the failure path. (The Redis-backed
+    /// rollback arithmetic is exercised under `#[sqlx::test]` with a live store.)
+    #[tokio::test]
+    async fn test_noop_tracker_release_reservation_is_safe_noop() {
+        let tracker = UsageTracker::noop();
+        // A within-cap check yields an (empty) reservation without Redis.
+        let reservation = tracker
+            .check_budget("wallet123", 0.50)
+            .await
+            .expect("within-cap check_budget must succeed without Redis");
+        assert!(
+            reservation.committed.is_empty(),
+            "no-Redis reservation must commit no counters (release is then a no-op)"
+        );
+        // Releasing it must be a safe no-op (the failure-path arms call this
+        // unconditionally; it must never panic or block).
+        tracker.release_reservation(&reservation).await;
+        // Releasing a default/empty reservation directly is likewise safe.
+        tracker
+            .release_reservation(&BudgetReservation::default())
+            .await;
+    }
+
     #[tokio::test]
     async fn test_noop_tracker_get_summary_returns_not_configured() {
         let tracker = UsageTracker::noop();

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -159,6 +159,60 @@ impl PaymentVerifier for SettleRecordingVerifier {
     }
 }
 
+/// An `exact`-scheme verifier whose `verify_payment` passes but whose
+/// `settle_payment` (the deferred post-delivery broadcast) FAILS with
+/// `success: false`. Records that settlement was *reached* by flipping a shared
+/// `AtomicBool`.
+///
+/// Used by the #486 second-pass reconciliation tests: when the provider has
+/// already delivered and the deferred `exact` settle then fails, the request
+/// must STILL return the delivered completion (200) — delivery-without-charge is
+/// the accepted backstop — while the budget reservation is reconciled (released)
+/// on EVERY settle-after-deliver-failed branch, including the streaming path
+/// where `usage`/`cost_outcome` are both `None`.
+struct SettleFailsExactVerifier {
+    settled: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl PaymentVerifier for SettleFailsExactVerifier {
+    fn network(&self) -> &str {
+        SOLANA_NETWORK
+    }
+
+    fn scheme(&self) -> &str {
+        "exact"
+    }
+
+    async fn verify_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<VerificationResult, X402Error> {
+        Ok(VerificationResult {
+            valid: true,
+            reason: None,
+            verified_amount: Some(2625),
+        })
+    }
+
+    async fn settle_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<SettlementResult, X402Error> {
+        // Settlement was reached (deferred broadcast attempted) but did NOT land.
+        self.settled
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        Ok(SettlementResult {
+            success: false,
+            tx_signature: Some("MockExactSettleAfterDeliverFailedTxSig".to_string()),
+            network: SOLANA_NETWORK.to_string(),
+            error: Some("simulated post-delivery broadcast failure".to_string()),
+            verified_amount: None,
+            failure_kind: Some(solvela_protocol::SettlementFailureKind::Timeout),
+        })
+    }
+}
+
 /// A mock verifier for the escrow scheme.
 struct AlwaysPassEscrowVerifier;
 
@@ -190,6 +244,54 @@ impl PaymentVerifier for AlwaysPassEscrowVerifier {
         Ok(SettlementResult {
             success: true,
             tx_signature: Some("MockEscrowSettledTxSig123".to_string()),
+            network: SOLANA_NETWORK.to_string(),
+            error: None,
+            verified_amount: Some(2625),
+            failure_kind: None,
+        })
+    }
+}
+
+/// An escrow verifier that passes verification and, on `settle_payment` (the
+/// on-chain deposit broadcast), flips a shared `AtomicBool`. The #486 escrow
+/// regression test inspects this flag: for escrow the deposit MUST land on-chain
+/// BEFORE the provider is called (trustless commitment), so the flag must be
+/// `true` even when the provider later fails — the no-charge lever for escrow is
+/// skipping the CLAIM (and refund-at-expiry), not deferring the deposit.
+struct SettleRecordingEscrowVerifier {
+    settled: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl PaymentVerifier for SettleRecordingEscrowVerifier {
+    fn network(&self) -> &str {
+        SOLANA_NETWORK
+    }
+
+    fn scheme(&self) -> &str {
+        "escrow"
+    }
+
+    async fn verify_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<VerificationResult, X402Error> {
+        Ok(VerificationResult {
+            valid: true,
+            reason: None,
+            verified_amount: Some(2625),
+        })
+    }
+
+    async fn settle_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<SettlementResult, X402Error> {
+        self.settled
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        Ok(SettlementResult {
+            success: true,
+            tx_signature: Some("MockEscrowDepositSettledTxSig".to_string()),
             network: SOLANA_NETWORK.to_string(),
             error: None,
             verified_amount: Some(2625),
@@ -451,6 +553,49 @@ impl LLMProvider for MockProvider {
     }
 }
 
+/// A mock LLM provider whose `chat_completion`/`chat_completion_stream` always
+/// fail. Used by the #486 charge-before-deliver regression tests: with EVERY
+/// configured provider failing, the fallback chain is exhausted and the route
+/// hits the `AllProvidersFailed` arm — the exact production condition (a dead
+/// model ID / total provider outage) that must NOT leave the customer charged.
+struct FailingProvider {
+    provider_name: String,
+}
+
+impl FailingProvider {
+    fn new(name: &str) -> Self {
+        Self {
+            provider_name: name.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for FailingProvider {
+    fn name(&self) -> &str {
+        &self.provider_name
+    }
+
+    fn supported_models(&self) -> Vec<ModelRegistration> {
+        vec![]
+    }
+
+    async fn chat_completion(
+        &self,
+        _req: solvela_protocol::ChatRequest,
+    ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+        // Mimics a Google 404 for a discontinued model ID (the #486 trigger).
+        Err("HTTP 404 model not found (simulated provider outage)".into())
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _req: solvela_protocol::ChatRequest,
+    ) -> Result<ChatStream, Box<dyn std::error::Error + Send + Sync>> {
+        Err("HTTP 404 model not found (simulated provider outage)".into())
+    }
+}
+
 /// Build a mock `ProviderRegistry` that has providers for all models in TEST_MODELS_TOML.
 fn mock_provider_registry() -> ProviderRegistry {
     let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
@@ -462,6 +607,29 @@ fn mock_provider_registry() -> ProviderRegistry {
     providers.insert(
         "deepseek".to_string(),
         Arc::new(MockProvider::new("deepseek")),
+    );
+    ProviderRegistry::from_providers(providers)
+}
+
+/// Build a `ProviderRegistry` where every provider in the `openai/gpt-4o`
+/// fallback chain that the test env configures FAILS. The chain for
+/// `("openai","gpt-4o")` is `[gpt-4o, claude-sonnet-4-6, gemini-3.1-pro,
+/// grok-3]`; we register failing `openai` + `anthropic` (google/xai are absent →
+/// skipped), so the chain is fully exhausted and the route returns
+/// `AllProvidersFailed`.
+fn failing_provider_registry() -> ProviderRegistry {
+    let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+    providers.insert(
+        "openai".to_string(),
+        Arc::new(FailingProvider::new("openai")),
+    );
+    providers.insert(
+        "anthropic".to_string(),
+        Arc::new(FailingProvider::new("anthropic")),
+    );
+    providers.insert(
+        "deepseek".to_string(),
+        Arc::new(FailingProvider::new("deepseek")),
     );
     ProviderRegistry::from_providers(providers)
 }
@@ -485,6 +653,16 @@ fn test_app_with_mock_provider_and_state() -> (axum::Router, Arc<AppState>) {
 fn test_app_with_mock_provider_and_exact_verifier(
     exact_verifier: Arc<dyn PaymentVerifier>,
 ) -> (axum::Router, Arc<AppState>) {
+    test_app_with_provider_registry_and_exact_verifier(mock_provider_registry(), exact_verifier)
+}
+
+/// Like [`test_app_with_mock_provider_and_exact_verifier`] but also lets the
+/// caller inject the `ProviderRegistry`, so a fully-failing provider set can be
+/// wired to exercise the `AllProvidersFailed` arm end-to-end (#486).
+fn test_app_with_provider_registry_and_exact_verifier(
+    providers: ProviderRegistry,
+    exact_verifier: Arc<dyn PaymentVerifier>,
+) -> (axum::Router, Arc<AppState>) {
     let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
     let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
     let facilitator = solvela_x402::facilitator::Facilitator::new(vec![exact_verifier]);
@@ -496,7 +674,7 @@ fn test_app_with_mock_provider_and_exact_verifier(
         config,
         model_registry,
         service_registry: RwLock::new(service_registry),
-        providers: mock_provider_registry(),
+        providers,
         facilitator,
         usage: gateway::usage::UsageTracker::noop(),
         cache: None,
@@ -1491,6 +1669,18 @@ fn test_app_with_mock_provider_and_escrow() -> axum::Router {
 fn test_app_with_mock_provider_and_escrow_verifier(
     escrow_verifier: Arc<dyn PaymentVerifier>,
 ) -> axum::Router {
+    test_app_with_provider_registry_and_escrow_verifier(mock_provider_registry(), escrow_verifier)
+}
+
+/// Like [`test_app_with_mock_provider_and_escrow_verifier`] but also lets the
+/// caller inject the `ProviderRegistry`, so a fully-failing provider set can be
+/// wired to exercise the escrow provider-failure path end-to-end (#486): the
+/// deposit settles, but provider exhaustion must yield a retryable 503 and NO
+/// claim (refund-at-expiry), never a bare 500.
+fn test_app_with_provider_registry_and_escrow_verifier(
+    providers: ProviderRegistry,
+    escrow_verifier: Arc<dyn PaymentVerifier>,
+) -> axum::Router {
     let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
     let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
 
@@ -1531,7 +1721,7 @@ fn test_app_with_mock_provider_and_escrow_verifier(
         config,
         model_registry,
         service_registry: RwLock::new(service_registry),
-        providers: mock_provider_registry(),
+        providers,
         facilitator,
         usage: gateway::usage::UsageTracker::noop(),
         cache: None,
@@ -2483,9 +2673,13 @@ async fn test_chat_assistant_null_content_with_user_text_is_accepted() {
     assert_eq!(json["object"], "chat.completion");
 }
 
-/// Paid requests with NO provider configured should return 500 (stub rejection).
+/// Paid requests with NO provider configured must return a RETRYABLE 503 — not a
+/// 500 — and crucially must NOT have charged the customer (#486). The `exact`
+/// transfer is deferred until a successful provider response, so with no provider
+/// it is never broadcast. (Pre-#486 this returned a bare 500 with the payment
+/// already settled on-chain.)
 #[tokio::test]
-async fn test_chat_paid_no_provider_returns_500() {
+async fn test_chat_paid_no_provider_returns_503_unavailable() {
     let app = test_app();
 
     let body = serde_json::json!({
@@ -2509,11 +2703,11 @@ async fn test_chat_paid_no_provider_returns_500() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["error"]["type"], "internal_error");
+    assert_eq!(json["error"]["type"], "upstream_unavailable");
 }
 
 #[tokio::test]
@@ -4363,12 +4557,14 @@ async fn test_chat_with_broken_model_circuit_returns_stub() {
         .unwrap();
 
     let resp = app.oneshot(req).await.unwrap();
-    // In test env with no real providers, paid requests return 500
-    // (security fix: never serve stub responses to paying users) or 402
+    // In test env with no real providers, paid requests never serve a stub
+    // (security fix). Post-#486 an unfulfillable paid request returns a
+    // retryable 503 (no charge taken) rather than a bare 500; a 402 is also
+    // acceptable if the payment challenge path is hit first.
     assert!(
-        resp.status() == StatusCode::INTERNAL_SERVER_ERROR
+        resp.status() == StatusCode::SERVICE_UNAVAILABLE
             || resp.status() == StatusCode::PAYMENT_REQUIRED,
-        "expected 500 or 402, got {}",
+        "expected 503 or 402, got {}",
         resp.status()
     );
 }
@@ -4723,10 +4919,11 @@ async fn test_payment_status_none_on_402() {
     assert!(response.headers().get("x-rcr-request-id").is_some());
 }
 
-/// G.2 Test 8: Request ID present on 500 error responses.
+/// G.2 Test 8: Request ID present on error responses.
 ///
-/// A paid request with no real provider configured returns 500.
-/// The RequestIdLayer middleware should still attach the request ID.
+/// A paid request with no real provider configured returns a retryable 503
+/// (post-#486; previously 500). The RequestIdLayer middleware should still
+/// attach the request ID regardless of the error status.
 #[tokio::test]
 async fn test_request_id_present_on_500_error() {
     let app = test_app();
@@ -4752,10 +4949,10 @@ async fn test_request_id_present_on_500_error() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     assert!(
         response.headers().get("x-rcr-request-id").is_some(),
-        "X-RCR-Request-Id must be present on 500 error responses"
+        "X-RCR-Request-Id must be present on error responses"
     );
     // Should be a valid UUID (36 chars with dashes)
     let id = response
@@ -5044,6 +5241,269 @@ async fn test_within_budget_request_settles_and_succeeds() {
     assert!(
         settled.load(std::sync::atomic::Ordering::SeqCst),
         "settlement must be reached for a within-budget request"
+    );
+}
+
+// =========================================================================
+// #486: provider failure must never charge-without-delivery
+// =========================================================================
+
+/// #486 (exact scheme): when EVERY provider fails on a paid request, the gateway
+/// must NOT settle the customer's payment on-chain — the `exact` transfer has no
+/// refund path, so settling then 500-ing charges the customer for nothing.
+///
+/// We inject a `SettleRecordingVerifier` (flips a flag iff `settle_payment` is
+/// reached) and a `failing_provider_registry()` (every provider in the chain
+/// fails, the production trigger of #486). The fix defers the `exact` broadcast
+/// until AFTER a successful provider response, so on total provider failure
+/// settlement is never reached: the flag stays `false`. The client receives a
+/// retryable 503 (not a 500), and crucially no funds leave the wallet.
+///
+/// Pre-fix, `verify_and_settle` broadcast the transfer BEFORE the provider call,
+/// so the flag would be `true` (funds taken) and the response a bare 500 —
+/// exactly the production defect. This test fails against that ordering.
+#[tokio::test]
+async fn exact_provider_failure_never_settles() {
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        failing_provider_registry(),
+        Arc::new(SettleRecordingVerifier {
+            settled: Arc::clone(&settled),
+        }),
+    );
+
+    // Small request, well under the $1.00 no-Redis budget cap, so the failure is
+    // the provider exhaustion — not the budget gate.
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !settled.load(std::sync::atomic::Ordering::SeqCst),
+        "EXACT settlement must NOT be reached when all providers fail — \
+         the customer must not be charged for an undelivered completion (#486)"
+    );
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "an unfulfillable paid request must surface a retryable 503, not a 500 (#486)"
+    );
+}
+
+/// #486 (exact scheme) happy-path guard: a successful provider response MUST
+/// still settle the deferred `exact` transfer. The reorder (verify-before, settle
+/// -after) must not silently drop settlement on the success path — that would be
+/// the opposite money bug (delivering for free, leaking gateway/provider cost).
+#[tokio::test]
+async fn exact_provider_success_still_settles() {
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        mock_provider_registry(),
+        Arc::new(SettleRecordingVerifier {
+            settled: Arc::clone(&settled),
+        }),
+    );
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a delivered paid request must return 200"
+    );
+    assert!(
+        settled.load(std::sync::atomic::Ordering::SeqCst),
+        "EXACT settlement MUST be reached once the provider delivers — \
+         deferring the broadcast must not drop it on the success path (#486)"
+    );
+}
+
+/// #486 (escrow scheme): the deposit must land on-chain BEFORE serving
+/// (trustless commitment), so settlement IS reached even when the provider then
+/// fails. The no-charge lever for escrow is the CLAIM: on provider failure the
+/// gateway must NOT claim — the deposit refunds at expiry — and must surface a
+/// retryable 503 (not a bare 500) so the client knows to retry / await refund.
+///
+/// This asserts the HTTP-level contract (503) and that the deposit settle WAS
+/// reached. The claim is structurally skipped because it only fires in the
+/// provider-success arm; a 503 here proves the failure arm was taken.
+#[tokio::test]
+async fn escrow_provider_failure_settles_deposit_but_returns_retryable() {
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let app = test_app_with_provider_registry_and_escrow_verifier(
+        failing_provider_registry(),
+        Arc::new(SettleRecordingEscrowVerifier {
+            settled: Arc::clone(&settled),
+        }),
+    );
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_escrow_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        settled.load(std::sync::atomic::Ordering::SeqCst),
+        "ESCROW deposit must settle on-chain before serving (trustless commitment)"
+    );
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "escrow provider failure must surface a retryable 503 (no claim, refund-at-expiry), \
+         not a bare 500 (#486)"
+    );
+}
+
+/// #486 (exact scheme, second-pass): when the provider DELIVERS but the deferred
+/// `exact` settle then fails, the gateway must still return the delivered
+/// completion (200) — delivery-without-charge is the accepted backstop. The
+/// money-path requirement this guards is that settlement WAS reached (the
+/// deferred broadcast was attempted, not silently skipped) and the request did
+/// not 500. The reservation reconciliation (release) happens behind a noop usage
+/// tracker here, so it is asserted at the unit level
+/// (`settle_after_deliver_failed_releases_reservation_unit`); this test pins the
+/// end-to-end HTTP contract through the real route.
+#[tokio::test]
+async fn exact_settle_after_deliver_failed_still_returns_delivered_completion() {
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        mock_provider_registry(),
+        Arc::new(SettleFailsExactVerifier {
+            settled: Arc::clone(&settled),
+        }),
+    );
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        settled.load(std::sync::atomic::Ordering::SeqCst),
+        "deferred EXACT settle MUST be reached after the provider delivers (#486)"
+    );
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a settle-after-deliver failure must NOT fail the request — the provider \
+         already delivered; delivery-without-charge is the accepted backstop (#486)"
+    );
+}
+
+/// #486 (exact scheme, STREAMING, second-pass): the streaming variant of the
+/// above. On the streaming path `usage`/`cost_outcome` are both `None`, so the
+/// downstream `log_spend` reconciliation never fires — the reservation MUST be
+/// reconciled at the settle-failure branch itself. This pins the HTTP contract
+/// (the request still streams a 200) on that branch end-to-end.
+#[tokio::test]
+async fn exact_settle_after_deliver_failed_streaming_still_returns_200() {
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        mock_provider_registry(),
+        Arc::new(SettleFailsExactVerifier {
+            settled: Arc::clone(&settled),
+        }),
+    );
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": true,
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        settled.load(std::sync::atomic::Ordering::SeqCst),
+        "deferred EXACT settle MUST be reached after a streaming provider delivers (#486)"
+    );
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a streaming settle-after-deliver failure must still return a delivered 200, \
+         with the budget reservation reconciled at the settle-failure branch (#486)"
     );
 }
 

--- a/crates/x402/src/facilitator.rs
+++ b/crates/x402/src/facilitator.rs
@@ -42,6 +42,29 @@ impl Facilitator {
         verifier.verify_payment(payload).await
     }
 
+    /// Settle a previously-verified payment by broadcasting it on-chain.
+    ///
+    /// This does NOT re-run verification — the caller is responsible for having
+    /// already called [`Facilitator::verify`] and confirmed the payload is
+    /// valid. It exists so the gateway can DEFER the on-chain broadcast of an
+    /// `exact` transfer until AFTER a successful provider response: verify
+    /// up front (non-mutating, simulates success), call the provider, then
+    /// settle only if the provider delivered — so a provider failure never
+    /// charges the customer (issue #486). For the verify-then-settle-now case
+    /// (e.g. the `escrow` deposit, which must land before serving), use
+    /// [`Facilitator::verify_and_settle`].
+    pub async fn settle(&self, payload: &PaymentPayload) -> Result<SettlementResult, Error> {
+        let network = &payload.accepted.network;
+        let scheme = &payload.accepted.scheme;
+        info!(
+            network,
+            scheme, "routing deferred settlement to chain verifier"
+        );
+
+        let verifier = self.verifier_for(network, scheme)?;
+        verifier.settle_payment(payload).await
+    }
+
     /// Verify and then settle a payment.
     pub async fn verify_and_settle(
         &self,
@@ -155,6 +178,97 @@ mod tests {
         let settlement = result.unwrap();
         assert!(settlement.success);
         assert_eq!(settlement.tx_signature, Some("MockTxSig123".to_string()));
+    }
+
+    /// A verifier that records whether `verify_payment` was invoked, so a test
+    /// can prove `settle()` broadcasts WITHOUT re-verifying — the property the
+    /// gateway relies on to defer the `exact` broadcast until after the provider
+    /// delivers (#486). Its `verify_payment` would also REJECT (valid:false), so
+    /// if `settle()` mistakenly re-verified, settlement would not be reached.
+    struct VerifyTrackingVerifier {
+        verified: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl PaymentVerifier for VerifyTrackingVerifier {
+        fn network(&self) -> &str {
+            SOLANA_NETWORK
+        }
+
+        fn scheme(&self) -> &str {
+            "exact"
+        }
+
+        async fn verify_payment(
+            &self,
+            _payload: &PaymentPayload,
+        ) -> Result<VerificationResult, Error> {
+            self.verified
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(VerificationResult {
+                valid: false,
+                reason: Some("would reject if called".to_string()),
+                verified_amount: None,
+            })
+        }
+
+        async fn settle_payment(
+            &self,
+            _payload: &PaymentPayload,
+        ) -> Result<SettlementResult, Error> {
+            Ok(SettlementResult {
+                success: true,
+                tx_signature: Some("DeferredSettleSig".to_string()),
+                network: SOLANA_NETWORK.to_string(),
+                error: None,
+                verified_amount: None,
+                failure_kind: None,
+            })
+        }
+    }
+
+    /// `settle()` must broadcast WITHOUT calling `verify_payment` — it is the
+    /// deferred-settlement primitive for the #486 fix (verify up front, call the
+    /// provider, then settle only on delivery).
+    #[tokio::test]
+    async fn settle_does_not_reverify() {
+        let verified = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let facilitator = Facilitator::new(vec![Arc::new(VerifyTrackingVerifier {
+            verified: std::sync::Arc::clone(&verified),
+        })]);
+        let payload = make_test_payload();
+
+        let result = facilitator.settle(&payload).await;
+        assert!(result.is_ok(), "settle should broadcast");
+        assert!(
+            result.unwrap().success,
+            "settle must reach settle_payment even though verify_payment would reject"
+        );
+        assert!(
+            !verified.load(std::sync::atomic::Ordering::SeqCst),
+            "settle() must NOT call verify_payment — verification is the caller's responsibility"
+        );
+    }
+
+    /// Contrast: `verify_and_settle()` DOES verify first — and here verification
+    /// rejects, so settlement must NOT be reached and an error is returned.
+    #[tokio::test]
+    async fn verify_and_settle_rejects_when_verification_fails() {
+        let verified = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let facilitator = Facilitator::new(vec![Arc::new(VerifyTrackingVerifier {
+            verified: std::sync::Arc::clone(&verified),
+        })]);
+        let payload = make_test_payload();
+
+        let result = facilitator.verify_and_settle(&payload).await;
+        assert!(
+            result.is_err(),
+            "verify_and_settle must propagate a failed verification as an error"
+        );
+        assert!(
+            verified.load(std::sync::atomic::Ordering::SeqCst),
+            "verify_and_settle must have called verify_payment"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #486.

## Problem

A paid `/v1/chat/completions` request settled the customer's payment on-chain **during verification**, then proxied to the provider. If all providers failed (a dead model ID, a provider outage), the gateway returned **HTTP 500 with the payment already taken** — for `exact`, the USDC was gone to the reserve with no refund; for `escrow`, the deposit was locked. Surfaced by the 2026-06-05 discontinued-Gemini incident (#485/#487), but the failure mode is general.

## Fix

Uses the existing `PaymentVerifier` `verify`/`settle` split — **no change to the wire format, golden vector, fee math, or settlement amounts**; only *when* the exact broadcast fires.

- **exact** → `verify()` (validate + `simulateTransaction`, no broadcast) before the provider call; `settle()` (broadcast) **only after** a successful provider response. Provider failure ⇒ customer never charged. New `Facilitator::settle()`.
- **escrow** → deposit still settles pre-call (trustless commitment); the **claim** only fires on success, so on provider failure the deposit refunds at expiry and the client gets a retryable **503**, not a bare 500.
- **Budget reservation** released on every payment-path failure (the 500 path, the `Internal` arm, and the streaming `settle_after_deliver_failed` path — the last two caught in money-path review).
- New `GatewayError::UpstreamUnavailable` ⇒ **503** with a static, internals-free message (model ID stays in logs only, per GHSA-cgqx-mg48-949v).
- Observability: `solvela_payments_total{status="settle_after_deliver_failed"}` and `{status="escrow_unclaimed_provider_failure"}` for operator alerting.

**Residual (intended, strictly safer direction):** a post-delivery settle failure on `exact` yields deliver-without-charge — logged + metered, never charge-without-delivery.

## Tests

New regression tests prove no path charges without delivery (both schemes, streaming + non-streaming), the `Internal`-arm reservation release, and the 503 mapping. Gateway lib 693 / integration 163 / x402 138 pass; `clippy -D warnings` + `fmt` clean. (Pre-existing no-Postgres `escrow_queue` `#[sqlx::test]` failures + the redis-isolation cache flake are unchanged from base.)

## Review

Money-path 2-round review: `rust-reviewer` + `silent-failure-hunter` (found the reservation leaks, now fixed), then an **independent reconciliation pass** confirming every terminal path reconciles the budget reservation exactly once — no leak, no double-release, no regression to normal spend recording.