### PR TITLE
feat(gateway): per-tenant attribution tag on x402 spend path (PR1)

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -445,6 +445,9 @@ fn build_cors() -> CorsLayer {
             "x-session-id"
                 .parse()
                 .expect("'x-session-id' is a valid header name"),
+            "x-tenant"
+                .parse()
+                .expect("'x-tenant' is a valid header name"),
         ])
         .expose_headers([
             // New x-solvela-* headers

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -38,7 +38,7 @@ use cost::{
 };
 use payment::{decode_payment_from_header, extract_payment_info, fire_escrow_claim};
 use provider::{ProviderCallContext, ProviderCallError, ProviderCallResult};
-use response::{build_session_token, validate_session_id};
+use response::{build_session_token, validate_session_id, validate_tenant};
 
 // Re-export `uses_durable_nonce` for use by `crate::routes::proxy`
 pub(crate) use payment::uses_durable_nonce;
@@ -168,6 +168,15 @@ pub async fn chat_completions(
         .get("x-session-id")
         .and_then(|v| v.to_str().ok())
         .and_then(validate_session_id);
+
+    // Extract and validate the x-tenant attribution tag. Unauthenticated,
+    // free-form header set by a trusted upstream proxy; recorded on the spend
+    // row for reporting only. Attribution-only — it never gates the request, so
+    // an invalid value simply yields `None` (untagged) rather than an error.
+    let tenant: Option<String> = headers
+        .get("x-tenant")
+        .and_then(|v| v.to_str().ok())
+        .and_then(validate_tenant);
 
     // Step 1: Resolve model — handle aliases and smart routing profiles
     let original_model = req.model.clone();
@@ -1107,6 +1116,7 @@ pub async fn chat_completions(
                             tx_signature: tx_signature.clone(),
                             request_id: request_id.clone(),
                             session_id: session_id.clone(),
+                            tenant: tenant.clone(),
                             estimated_cost_usdc: Some(estimated_cost),
                         });
                     }
@@ -1154,6 +1164,7 @@ pub async fn chat_completions(
                     tx_signature: tx_signature.clone(),
                     request_id: request_id.clone(),
                     session_id: session_id.clone(),
+                    tenant: tenant.clone(),
                     estimated_cost_usdc: Some(estimated_cost),
                 });
             }

--- a/crates/gateway/src/routes/chat/response.rs
+++ b/crates/gateway/src/routes/chat/response.rs
@@ -8,6 +8,9 @@ use crate::routes::debug_headers::{CacheStatus, DebugInfo, PaymentStatus};
 /// Maximum length for a client-provided session ID.
 const MAX_SESSION_ID_LEN: usize = 128;
 
+/// Maximum length for a client-provided tenant attribution tag.
+const MAX_TENANT_LEN: usize = 64;
+
 /// Validate a session ID: max 128 chars, `[a-zA-Z0-9\-_]` only.
 pub(crate) fn validate_session_id(value: &str) -> Option<String> {
     if value.is_empty() || value.len() > MAX_SESSION_ID_LEN {
@@ -16,6 +19,27 @@ pub(crate) fn validate_session_id(value: &str) -> Option<String> {
     if value
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        Some(value.to_string())
+    } else {
+        None
+    }
+}
+
+/// Validate a tenant attribution tag: max 64 chars, `[a-zA-Z0-9._-]` only.
+///
+/// The tenant tag is an unauthenticated, free-form `x-tenant` header set by a
+/// trusted upstream proxy. It is recorded on the spend row for reporting and is
+/// **attribution only** — it never gates, blocks, or otherwise changes request
+/// behavior. Invalid input returns `None` so the request proceeds untagged
+/// rather than failing (a malformed tag must not be able to block a paid call).
+pub(crate) fn validate_tenant(value: &str) -> Option<String> {
+    if value.is_empty() || value.len() > MAX_TENANT_LEN {
+        return None;
+    }
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
     {
         Some(value.to_string())
     } else {
@@ -151,6 +175,72 @@ mod tests {
         );
         assert_eq!(
             validate_session_id("path/traversal"),
+            None,
+            "slashes should be rejected"
+        );
+    }
+
+    // =========================================================================
+    // validate_tenant
+    // =========================================================================
+
+    #[test]
+    fn test_validate_tenant_valid_alphanumeric() {
+        assert_eq!(
+            validate_tenant("acme123"),
+            Some("acme123".to_string()),
+            "alphanumeric tenant should be accepted"
+        );
+    }
+
+    #[test]
+    fn test_validate_tenant_valid_with_dot_dash_underscore() {
+        assert_eq!(
+            validate_tenant("acme.team-1_prod"),
+            Some("acme.team-1_prod".to_string()),
+            "dot, dash, and underscore should be accepted in a tenant tag"
+        );
+    }
+
+    #[test]
+    fn test_validate_tenant_empty_rejected() {
+        assert_eq!(validate_tenant(""), None, "empty tenant should be rejected");
+    }
+
+    #[test]
+    fn test_validate_tenant_oversized_rejected() {
+        let long = "a".repeat(65);
+        assert_eq!(
+            validate_tenant(&long),
+            None,
+            "tenant > 64 chars should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_validate_tenant_exactly_64_chars_accepted() {
+        let id = "a".repeat(64);
+        assert_eq!(
+            validate_tenant(&id),
+            Some(id),
+            "tenant of exactly 64 chars should be accepted"
+        );
+    }
+
+    #[test]
+    fn test_validate_tenant_invalid_chars_rejected() {
+        assert_eq!(
+            validate_tenant("has spaces"),
+            None,
+            "spaces should be rejected"
+        );
+        assert_eq!(
+            validate_tenant("has!special@chars"),
+            None,
+            "special characters should be rejected"
+        );
+        assert_eq!(
+            validate_tenant("path/traversal"),
             None,
             "slashes should be rejected"
         );

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -567,6 +567,10 @@ pub async fn proxy_service(
         tx_signature,
         request_id: request_id.clone(),
         session_id: None,
+        // PR1 keeps the service-marketplace proxy minimal: it does not read the
+        // x-tenant header. Per-tenant attribution for the proxy path can be
+        // added later; None leaves these rows untagged for now.
+        tenant: None,
         // Service-marketplace proxy doesn't go through `check_budget`
         // (it has flat per-request pricing, not per-wallet budgets), so no
         // reservation is committed and log_spend increments by the full

--- a/crates/gateway/src/routes/stats.rs
+++ b/crates/gateway/src/routes/stats.rs
@@ -12,7 +12,7 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use crate::session::verify_session_token;
-use crate::usage::{get_stats_by_day, get_stats_by_model, get_wallet_stats};
+use crate::usage::{get_stats_by_day, get_stats_by_model, get_stats_by_tenant, get_wallet_stats};
 use crate::AppState;
 
 /// Base58 character set for wallet address validation.
@@ -36,6 +36,10 @@ pub struct StatsResponse {
     pub period_days: i32,
     pub summary: StatsSummary,
     pub by_model: Vec<ModelStats>,
+    /// Per-tenant attribution breakdown for traffic tagged via the `x-tenant`
+    /// header. Empty when no tagged requests exist in the period. Additive,
+    /// backward-compatible field (clients that ignore it are unaffected).
+    pub by_tenant: Vec<TenantStats>,
     pub by_day: Vec<DayStats>,
 }
 
@@ -63,6 +67,16 @@ pub struct StatsSummary {
 #[derive(Debug, Serialize)]
 pub struct ModelStats {
     pub model: String,
+    pub requests: i64,
+    pub cost_usdc: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+}
+
+/// Per-tenant breakdown (attribution only).
+#[derive(Debug, Serialize)]
+pub struct TenantStats {
+    pub tenant: String,
     pub requests: i64,
     pub cost_usdc: String,
     pub input_tokens: i64,
@@ -166,10 +180,11 @@ pub async fn wallet_stats(
         }
     };
 
-    // Run the three queries concurrently
-    let (summary_result, by_model_result, by_day_result) = tokio::join!(
+    // Run the queries concurrently
+    let (summary_result, by_model_result, by_tenant_result, by_day_result) = tokio::join!(
         get_wallet_stats(pool, &address, params.days),
         get_stats_by_model(pool, &address, params.days),
+        get_stats_by_tenant(pool, &address, params.days),
         get_stats_by_day(pool, &address, params.days),
     );
 
@@ -184,6 +199,15 @@ pub async fn wallet_stats(
 
     let model_rows = by_model_result.map_err(|e| {
         tracing::error!(error = %e, wallet = %address, "failed to retrieve stats by model");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": "failed to retrieve stats" })),
+        )
+            .into_response()
+    })?;
+
+    let tenant_rows = by_tenant_result.map_err(|e| {
+        tracing::error!(error = %e, wallet = %address, "failed to retrieve stats by tenant");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": "failed to retrieve stats" })),
@@ -229,6 +253,17 @@ pub async fn wallet_stats(
         })
         .collect();
 
+    let by_tenant = tenant_rows
+        .into_iter()
+        .map(|r| TenantStats {
+            tenant: r.tenant,
+            requests: r.requests,
+            cost_usdc: format!("{:.6}", r.cost),
+            input_tokens: r.input_tokens,
+            output_tokens: r.output_tokens,
+        })
+        .collect();
+
     let by_day = day_rows
         .into_iter()
         .map(|r| DayStats {
@@ -243,6 +278,7 @@ pub async fn wallet_stats(
         period_days: params.days,
         summary,
         by_model,
+        by_tenant,
         by_day,
     })
     .into_response())
@@ -295,6 +331,7 @@ mod tests {
                 monthly_cost_usdc: "0.000000".to_string(),
             },
             by_model: vec![],
+            by_tenant: vec![],
             by_day: vec![],
         };
         let json = serde_json::to_string(&resp).expect("should serialize");
@@ -391,6 +428,13 @@ mod tests {
                 input_tokens: 310_000,
                 output_tokens: 142_000,
             }],
+            by_tenant: vec![TenantStats {
+                tenant: "acme.team-1".to_string(),
+                requests: 200,
+                cost_usdc: "0.500000".to_string(),
+                input_tokens: 100_000,
+                output_tokens: 50_000,
+            }],
             by_day: vec![DayStats {
                 date: "2026-03-11".to_string(),
                 requests: 47,
@@ -427,6 +471,14 @@ mod tests {
         assert_eq!(json["by_model"][0]["input_tokens"], 310_000);
         assert_eq!(json["by_model"][0]["output_tokens"], 142_000);
 
+        // by_tenant array (PR1 attribution breakdown)
+        assert_eq!(json["by_tenant"].as_array().unwrap().len(), 1);
+        assert_eq!(json["by_tenant"][0]["tenant"], "acme.team-1");
+        assert_eq!(json["by_tenant"][0]["requests"], 200);
+        assert_eq!(json["by_tenant"][0]["cost_usdc"], "0.500000");
+        assert_eq!(json["by_tenant"][0]["input_tokens"], 100_000);
+        assert_eq!(json["by_tenant"][0]["output_tokens"], 50_000);
+
         // by_day array
         assert_eq!(json["by_day"].as_array().unwrap().len(), 1);
         assert_eq!(json["by_day"][0]["date"], "2026-03-11");
@@ -450,6 +502,7 @@ mod tests {
                 monthly_cost_usdc: "0.000000".to_string(),
             },
             by_model: vec![],
+            by_tenant: vec![],
             by_day: vec![],
         };
 
@@ -463,6 +516,7 @@ mod tests {
         assert_eq!(json["summary"]["daily_cost_usdc"], "0.000000");
         assert_eq!(json["summary"]["monthly_cost_usdc"], "0.000000");
         assert!(json["by_model"].as_array().unwrap().is_empty());
+        assert!(json["by_tenant"].as_array().unwrap().is_empty());
         assert!(json["by_day"].as_array().unwrap().is_empty());
     }
 }

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -116,6 +116,11 @@ pub struct SpendLogEntry {
     pub tx_signature: Option<String>,
     pub request_id: Option<String>,
     pub session_id: Option<String>,
+    /// Optional per-tenant attribution tag from the `x-tenant` header.
+    ///
+    /// Attribution only — recorded on the spend row for reporting; it does not
+    /// gate or change billing. See `validate_tenant` for the accepted charset.
+    pub tenant: Option<String>,
     /// Cost that was tentatively committed to the Redis spend counters at
     /// `check_budget` time. When `Some`, `log_spend` increments the counters
     /// by `(cost_usdc - estimated_cost_usdc)` so the ledger settles to the
@@ -222,8 +227,8 @@ impl UsageTracker {
             let db_entry = entry.clone();
             tokio::spawn(async move {
                 let result = sqlx::query(
-                    r#"INSERT INTO spend_logs (id, wallet_address, model, provider, input_tokens, output_tokens, cost_usdc, tx_signature, request_id, session_id, created_at)
-                       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"#,
+                    r#"INSERT INTO spend_logs (id, wallet_address, model, provider, input_tokens, output_tokens, cost_usdc, tx_signature, request_id, session_id, tenant, created_at)
+                       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)"#,
                 )
                 .bind(id)
                 .bind(&db_entry.wallet_address)
@@ -235,6 +240,7 @@ impl UsageTracker {
                 .bind(&db_entry.tx_signature)
                 .bind(&db_entry.request_id)
                 .bind(&db_entry.session_id)
+                .bind(&db_entry.tenant)
                 .bind(created_at)
                 .execute(&pool)
                 .await;
@@ -1064,6 +1070,16 @@ pub struct StatsModelRow {
     pub output_tokens: i64,
 }
 
+/// Per-tenant row returned by [`get_stats_by_tenant`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsTenantRow {
+    pub tenant: String,
+    pub requests: i64,
+    pub cost: f64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+}
+
 /// Per-day row returned by [`get_stats_by_day`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatsDayRow {
@@ -1126,6 +1142,45 @@ pub async fn get_stats_by_model(
         .map(
             |(model, requests, cost, input_tokens, output_tokens)| StatsModelRow {
                 model,
+                requests,
+                cost,
+                input_tokens,
+                output_tokens,
+            },
+        )
+        .collect())
+}
+
+/// Fetch per-tenant spend breakdown for a wallet over the given number of days.
+///
+/// Rows with a NULL `tenant` (requests that carried no `x-tenant` tag) are
+/// excluded — this is the attribution breakdown for tagged traffic only.
+pub async fn get_stats_by_tenant(
+    pool: &sqlx::PgPool,
+    wallet: &str,
+    days: i32,
+) -> Result<Vec<StatsTenantRow>, sqlx::Error> {
+    let rows: Vec<(String, i64, f64, i64, i64)> = sqlx::query_as(
+        r#"SELECT tenant, COUNT(*) as requests,
+                  COALESCE(SUM(cost_usdc), 0)::DOUBLE PRECISION as cost,
+                  COALESCE(SUM(input_tokens), 0) as input_tokens,
+                  COALESCE(SUM(output_tokens), 0) as output_tokens
+           FROM spend_logs
+           WHERE wallet_address = $1
+             AND tenant IS NOT NULL
+             AND created_at >= NOW() - make_interval(days => $2)
+           GROUP BY tenant ORDER BY cost DESC"#,
+    )
+    .bind(wallet)
+    .bind(days)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(tenant, requests, cost, input_tokens, output_tokens)| StatsTenantRow {
+                tenant,
                 requests,
                 cost,
                 input_tokens,
@@ -1232,6 +1287,7 @@ mod tests {
             tx_signature: None,
             request_id: None,
             session_id: None,
+            tenant: None,
             estimated_cost_usdc: None,
         });
     }

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -2045,6 +2045,88 @@ async fn test_chat_with_payment_returns_mock_response() {
     assert!(json["usage"]["total_tokens"].is_number());
 }
 
+/// PR1 tenant-attribution: a paid request carrying an `x-tenant` header must be
+/// handled IDENTICALLY to one without it. The tag is attribution-only — it must
+/// never gate, block, or change request behavior. This exercises the real route
+/// (parse → guard → payment → provider) through `oneshot`, per CLAUDE.md rule 10.
+/// The persisted `tenant` value cannot be read back without a DB in this harness
+/// (log_spend is fire-and-forget into PostgreSQL), so the contract checked here
+/// is "header accepted, happy path unaffected"; the value's acceptance rules are
+/// pinned by the `validate_tenant` unit tests.
+#[tokio::test]
+async fn test_chat_with_tenant_header_unaffected() {
+    let app = test_app_with_mock_provider();
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("x-tenant", "acme.team-1")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Same outcome as test_chat_with_payment_returns_mock_response: 200 + body.
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["object"], "chat.completion");
+    assert_eq!(json["choices"][0]["message"]["content"], "[mock response]");
+    assert!(json["usage"]["total_tokens"].is_number());
+}
+
+/// PR1 tenant-attribution: a malformed / over-long `x-tenant` value must NOT
+/// fail the request — `validate_tenant` drops it to `None` and the request
+/// proceeds untagged. Attribution must never become a way to block a paid call.
+#[tokio::test]
+async fn test_chat_with_invalid_tenant_header_still_succeeds() {
+    let app = test_app_with_mock_provider();
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    // 65 chars (> MAX_TENANT_LEN) plus an illegal '/': rejected by validate_tenant.
+    let bad_tenant = format!("{}/path", "a".repeat(65));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("x-tenant", bad_tenant)
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "an invalid x-tenant tag must not block a paid request — it is dropped to None"
+    );
+}
+
 /// CowAgent scenario: `content` arrives as an array of OpenAI text parts.
 /// This MUST flow through the real route (parse → guard → payment → provider)
 /// and return 200, exactly like a string-content request.

--- a/crates/gateway/tests/migrations.rs
+++ b/crates/gateway/tests/migrations.rs
@@ -32,6 +32,7 @@ const EXPECTED_TABLES: &[&str] = &[
 const EXPECTED_COLUMNS: &[(&str, &str)] = &[
     ("spend_logs", "request_id"),            // migration 003
     ("spend_logs", "session_id"),            // migration 003
+    ("spend_logs", "tenant"),                // migration 010
     ("escrow_claim_queue", "next_retry_at"), // migration 004
     ("wallet_budgets", "updated_at"),        // migration 001
     ("wallet_budgets", "hourly_limit_usdc"), // migration 007

--- a/crates/gateway/tests/usage_integration.rs
+++ b/crates/gateway/tests/usage_integration.rs
@@ -180,6 +180,7 @@ async fn log_spend_persists_row_when_db_configured(pool: PgPool) {
         tx_signature: Some("tx-test-sig".to_string()),
         request_id: Some("req-abc".to_string()),
         session_id: None,
+        tenant: None,
         estimated_cost_usdc: None,
     });
 
@@ -244,6 +245,7 @@ async fn log_spend_with_no_backends_does_not_panic() {
         tx_signature: None,
         request_id: None,
         session_id: None,
+        tenant: None,
         estimated_cost_usdc: None,
     });
 }

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -76,6 +76,7 @@ async fn log_spend_writes_redis_hourly_daily_monthly_counters(pool: PgPool) {
         tx_signature: None,
         request_id: None,
         session_id: None,
+        tenant: None,
         estimated_cost_usdc: None,
     });
 
@@ -124,6 +125,7 @@ async fn log_spend_accumulates_across_calls(pool: PgPool) {
         tx_signature: None,
         request_id: None,
         session_id: None,
+        tenant: None,
         estimated_cost_usdc: None,
     };
     tracker.log_spend(entry.clone());
@@ -499,6 +501,7 @@ async fn log_spend_writes_team_counters_when_wallet_in_team(pool: PgPool) {
         tx_signature: None,
         request_id: None,
         session_id: None,
+        tenant: None,
         estimated_cost_usdc: None,
     });
 

--- a/migrations/010_spend_tenant.sql
+++ b/migrations/010_spend_tenant.sql
@@ -1,0 +1,7 @@
+-- Per-tenant attribution: tag spend rows with an optional, free-form tenant
+-- identifier supplied by a trusted upstream proxy (x-tenant header). Attribution
+-- only in this migration — no budget/enforcement table or flag (those land in a
+-- later migration). Additive, mirrors migration 003's ALTER + partial-index
+-- pattern.
+ALTER TABLE spend_logs ADD COLUMN IF NOT EXISTS tenant TEXT;
+CREATE INDEX IF NOT EXISTS idx_spend_tenant ON spend_logs(wallet_address, tenant) WHERE tenant IS NOT NULL;


### PR DESCRIPTION
## What

PR1 of per-tenant billing. Adds an optional, validated `x-tenant` header that records a per-tenant attribution tag on each paid request, so spend on a single payer wallet can be allocated across the sub-tenants of a trusted upstream proxy (e.g. a router fronting many customers on one wallet).

**Attribution only.** The tag never gates, blocks, or changes billing. An invalid/oversized value yields `None` (request proceeds untagged) so a malformed tag can never fail a paid call. Per-`(wallet, tenant)` budget **enforcement** lands in PR2.

## Changes

- **migration `010_spend_tenant.sql`** — additive `spend_logs.tenant TEXT` + partial index `idx_spend_tenant(wallet_address, tenant) WHERE tenant IS NOT NULL` (mirrors migration 003).
- **`validate_tenant`** — 64-char cap, `[a-zA-Z0-9._-]`, mirroring `validate_session_id` (adds `.`); invalid → `None`.
- **ingest** — read/validate `x-tenant` alongside `x-request-id`/`x-session-id`; thread `tenant` through `SpendLogEntry` and the `spend_logs` INSERT (now 12 cols / `$12`).
- **CORS** — `x-tenant` added to allow-headers.
- **reporting** — `by_tenant` breakdown on the wallet stats endpoint (tagged traffic only; untagged spend still appears in `summary`/`by_model`/`by_day`).

## Design notes

- The tag is an **unauthenticated** header. That is sound here because the only entity that can set it is the trusted proxy whose own budget is being allocated — there is nothing to spoof. It is a cost-allocation primitive, **not a security boundary**.
- `proxy.rs` (service marketplace) passes `tenant: None` — not wired in PR1.

## Tests

- 6 unit tests for `validate_tenant` (valid / dot-dash-underscore / empty / 65-char / exactly-64 / bad-charset), written before the impl.
- 2 integration tests via `oneshot` + `test_app`: paid request with `x-tenant` behaves identically to one without; a malformed tag still succeeds (proves attribution can't block a paid call).
- `cargo fmt` clean, `cargo clippy --all-targets --all-features -D warnings` clean, `cargo test -p gateway` lib 699 + integration 165 pass. (DB-backed `#[sqlx::test]` suites are pre-existing infra-gated failures, unchanged by this PR.)