### PR TITLE
feat(sdks): opt-in escrow-program-id pinning for Go/Python/TS (#484)

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -570,6 +570,20 @@ func (c *SolvelaClient) validatePayment(accepted *PaymentAccept) error {
 	if c.config.ExpectedRecipient != "" && accepted.PayTo != c.config.ExpectedRecipient {
 		return &RecipientMismatchError{Expected: c.config.ExpectedRecipient, Actual: accepted.PayTo}
 	}
+	// Escrow-program pin: only the escrow scheme signs a deposit bound to a
+	// program ID. Reject before signing if the advertised program differs from
+	// the configured pin (prevents a malicious gateway redirecting the deposit
+	// to an attacker's program). Fail closed: a missing/empty advertised
+	// program against a non-empty pin is a mismatch. Mirrors ExpectedRecipient.
+	if accepted.Scheme == SchemeEscrow && c.config.ExpectedEscrowProgram != "" {
+		actual := ""
+		if accepted.EscrowProgramID != nil {
+			actual = *accepted.EscrowProgramID
+		}
+		if actual != c.config.ExpectedEscrowProgram {
+			return &EscrowProgramMismatchError{Expected: c.config.ExpectedEscrowProgram, Actual: actual}
+		}
+	}
 	// Defense-in-depth: re-verify network and asset here in case a caller bypassed
 	// findCompatibleScheme.
 	if accepted.Network != SolanaNetwork {

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -1290,3 +1290,164 @@ func TestChatPaymentRejectedAfterSign(t *testing.T) {
 		t.Error("PaymentRejectedError.Reason should be non-empty")
 	}
 }
+
+// TestClientEscrowProgramMismatch verifies the escrow-program pin rejects a 402
+// whose advertised escrow program differs from the configured pin, before any
+// deposit is signed. Mirrors TestClientRecipientMismatch for the escrow path.
+func TestClientEscrowProgramMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "1000"},
+			Accepts: []PaymentAccept{
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "recipient", EscrowProgramID: ptr("AttackerProgram1111111111111111111111111111")},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithExpectedEscrowProgram(testEscrowProgram),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	mismatch, ok := err.(*EscrowProgramMismatchError)
+	if !ok {
+		t.Fatalf("expected EscrowProgramMismatchError, got %T: %v", err, err)
+	}
+	if mismatch.Expected != testEscrowProgram || mismatch.Actual != "AttackerProgram1111111111111111111111111111" {
+		t.Fatalf("unexpected mismatch fields: %+v", mismatch)
+	}
+}
+
+// TestClientEscrowProgramMismatchMissingFailsClosed verifies that a non-empty
+// pin rejects a 402 that omits the escrow program ID entirely (fail closed).
+func TestClientEscrowProgramMismatchMissingFailsClosed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "1000"},
+			Accepts: []PaymentAccept{
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "recipient", EscrowProgramID: nil},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, "")
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithExpectedEscrowProgram(testEscrowProgram),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if _, ok := err.(*EscrowProgramMismatchError); !ok {
+		t.Fatalf("expected EscrowProgramMismatchError for missing program, got %T: %v", err, err)
+	}
+}
+
+// TestClientEscrowProgramMatchPassesPin verifies that a matching escrow program
+// passes the pin guard. The escrow signer then proceeds to issue Solana RPC,
+// which the test gateway does not serve, so the request fails AFTER the guard —
+// proving the pin did not reject a legitimate program (mirrors the Rust
+// recipient-match test that fails on unreachable RPC, not the guard).
+func TestClientEscrowProgramMatchPassesPin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "1000"},
+			Accepts: []PaymentAccept{
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "recipient", EscrowProgramID: ptr(testEscrowProgram), MaxTimeoutSeconds: 60},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	// Point the signer's RPC at the (non-RPC) test server so signing fails fast
+	// rather than hitting mainnet.
+	signer := NewKeypairSigner(wallet, server.URL)
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithRPCURL(server.URL),
+		WithExpectedEscrowProgram(testEscrowProgram),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error (RPC unavailable), got nil")
+	}
+	if _, ok := err.(*EscrowProgramMismatchError); ok {
+		t.Fatalf("pin must NOT reject a matching program; got EscrowProgramMismatchError: %v", err)
+	}
+}
+
+// TestClientEscrowProgramPinDisabledProceeds verifies that disabling the pin
+// lets any advertised escrow program through the guard (failing later at RPC).
+func TestClientEscrowProgramPinDisabledProceeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   2,
+			CostBreakdown: CostBreakdown{Total: "1000"},
+			Accepts: []PaymentAccept{
+				{Scheme: "escrow", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "recipient", EscrowProgramID: ptr("SomeOtherProgram111111111111111111111111111"), MaxTimeoutSeconds: 60},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	signer := NewKeypairSigner(wallet, server.URL)
+	client, err := NewClient(wallet, signer,
+		WithGatewayURL(server.URL),
+		WithRPCURL(server.URL),
+		DisableEscrowProgramPin(),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error (RPC unavailable), got nil")
+	}
+	if _, ok := err.(*EscrowProgramMismatchError); ok {
+		t.Fatalf("disabled pin must NOT reject any program; got EscrowProgramMismatchError: %v", err)
+	}
+}

--- a/sdks/go/config.go
+++ b/sdks/go/config.go
@@ -14,18 +14,26 @@ const DefaultMaxPaymentAmount uint64 = 10_000_000
 
 // ClientConfig holds all configuration for a Solvela client.
 type ClientConfig struct {
-	GatewayURL         string
-	RPCURL             string
-	PreferEscrow       bool
-	Timeout            time.Duration
-	ExpectedRecipient  string
-	MaxPaymentAmount   *uint64
-	EnableCache        bool
-	EnableSessions     bool
-	SessionTTL         time.Duration
-	EnableQualityCheck bool
-	MaxQualityRetries  int
-	FreeFallbackModel  string
+	GatewayURL        string
+	RPCURL            string
+	PreferEscrow      bool
+	Timeout           time.Duration
+	ExpectedRecipient string
+	// ExpectedEscrowProgram, when non-empty, pins the escrow program ID the
+	// client is willing to sign a deposit for. A 402 advertising an escrow
+	// scheme whose EscrowProgramID differs is rejected before signing,
+	// preventing a malicious gateway from redirecting the deposit to an
+	// attacker's program (mirrors ExpectedRecipient for the escrow path).
+	// [DefaultConfig] pins this to [MainnetEscrowProgramID]; an empty value
+	// disables the pin (see [DisableEscrowProgramPin]).
+	ExpectedEscrowProgram string
+	MaxPaymentAmount      *uint64
+	EnableCache           bool
+	EnableSessions        bool
+	SessionTTL            time.Duration
+	EnableQualityCheck    bool
+	MaxQualityRetries     int
+	FreeFallbackModel     string
 	// BalancePollInterval, when non-zero, instructs [NewClient] to start a
 	// background [BalanceMonitor] that periodically refreshes the client's
 	// last-known wallet balance. The free-fallback-model guard in
@@ -46,15 +54,19 @@ type ClientConfig struct {
 //   - GatewayURL points to the production HTTPS endpoint.
 //   - MaxPaymentAmount is set to [DefaultMaxPaymentAmount] (10 USDC atomic) to
 //     prevent wallet drains from a misconfigured or malicious gateway.
+//   - ExpectedEscrowProgram is pinned to [MainnetEscrowProgramID] so an escrow
+//     deposit is never signed for an unexpected program. Override with
+//     [WithExpectedEscrowProgram] or disable with [DisableEscrowProgramPin].
 func DefaultConfig() ClientConfig {
 	defaultMax := DefaultMaxPaymentAmount
 	return ClientConfig{
-		GatewayURL:        "https://api.solvela.ai",
-		RPCURL:            "https://api.mainnet-beta.solana.com",
-		Timeout:           180 * time.Second,
-		SessionTTL:        1800 * time.Second,
-		MaxQualityRetries: 1,
-		MaxPaymentAmount:  &defaultMax,
+		GatewayURL:            "https://api.solvela.ai",
+		RPCURL:                "https://api.mainnet-beta.solana.com",
+		Timeout:               180 * time.Second,
+		SessionTTL:            1800 * time.Second,
+		MaxQualityRetries:     1,
+		MaxPaymentAmount:      &defaultMax,
+		ExpectedEscrowProgram: MainnetEscrowProgramID,
 	}
 }
 
@@ -73,6 +85,22 @@ func WithTimeout(d time.Duration) Option { return func(c *ClientConfig) { c.Time
 // WithExpectedRecipient sets the expected payment recipient for verification.
 func WithExpectedRecipient(r string) Option {
 	return func(c *ClientConfig) { c.ExpectedRecipient = r }
+}
+
+// WithExpectedEscrowProgram pins the escrow program ID the client will sign a
+// deposit for. A 402 advertising an escrow scheme whose EscrowProgramID differs
+// is rejected before signing. By default the client pins
+// [MainnetEscrowProgramID] (see [DefaultConfig]); use this to point at a
+// different deployment.
+func WithExpectedEscrowProgram(id string) Option {
+	return func(c *ClientConfig) { c.ExpectedEscrowProgram = id }
+}
+
+// DisableEscrowProgramPin clears the escrow-program pin, allowing any advertised
+// escrow program. This removes a security guarantee; prefer
+// [WithExpectedEscrowProgram] to point at a non-default deployment instead.
+func DisableEscrowProgramPin() Option {
+	return func(c *ClientConfig) { c.ExpectedEscrowProgram = "" }
 }
 
 // WithMaxPaymentAmount sets the maximum payment amount in atomic units.

--- a/sdks/go/config_test.go
+++ b/sdks/go/config_test.go
@@ -165,3 +165,26 @@ func TestMultipleOptions(t *testing.T) {
 		t.Errorf("MaxPaymentAmount: got %v", cfg.MaxPaymentAmount)
 	}
 }
+
+func TestDefaultConfigPinsEscrowProgram(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.ExpectedEscrowProgram != MainnetEscrowProgramID {
+		t.Errorf("ExpectedEscrowProgram: got %q, want %q", cfg.ExpectedEscrowProgram, MainnetEscrowProgramID)
+	}
+}
+
+func TestWithExpectedEscrowProgram(t *testing.T) {
+	cfg := DefaultConfig()
+	WithExpectedEscrowProgram("EscRowOverride11111111111111111111111111111")(&cfg)
+	if cfg.ExpectedEscrowProgram != "EscRowOverride11111111111111111111111111111" {
+		t.Errorf("ExpectedEscrowProgram: got %q", cfg.ExpectedEscrowProgram)
+	}
+}
+
+func TestDisableEscrowProgramPin(t *testing.T) {
+	cfg := DefaultConfig()
+	DisableEscrowProgramPin()(&cfg)
+	if cfg.ExpectedEscrowProgram != "" {
+		t.Errorf("ExpectedEscrowProgram should be empty after disable, got %q", cfg.ExpectedEscrowProgram)
+	}
+}

--- a/sdks/go/constants.go
+++ b/sdks/go/constants.go
@@ -11,6 +11,13 @@ const (
 	// (Solana mainnet-beta, encoded as "solana:<genesis-hash-prefix>").
 	SolanaNetwork = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
 
+	// MainnetEscrowProgramID is the deployed Solvela escrow program on Solana
+	// mainnet-beta. [DefaultConfig] pins [ClientConfig].ExpectedEscrowProgram to
+	// this value so an escrow deposit is never signed for an unexpected program
+	// (mirrors the hardcoded [USDCMint] / [SolanaNetwork]). Matches the Rust
+	// SDK's MAINNET_ESCROW_PROGRAM_ID.
+	MainnetEscrowProgramID = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+
 	// MaxTimeoutSeconds is the upper bound (in seconds) enforced on
 	// [ClientConfig].Timeout when constructing a client.
 	MaxTimeoutSeconds = 300

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -69,6 +69,17 @@ func (e *RecipientMismatchError) Error() string {
 	return fmt.Sprintf("recipient mismatch: expected %s, got %s", e.Expected, e.Actual)
 }
 
+// EscrowProgramMismatchError indicates the 402's escrow program ID does not
+// match the configured pin (see [ClientConfig].ExpectedEscrowProgram). Returned
+// before any escrow deposit is signed.
+type EscrowProgramMismatchError struct {
+	Expected, Actual string
+}
+
+func (e *EscrowProgramMismatchError) Error() string {
+	return fmt.Sprintf("escrow program mismatch: expected %s, got %s", e.Expected, e.Actual)
+}
+
 // AmountExceedsMaxError indicates the payment amount exceeds the configured maximum.
 type AmountExceedsMaxError struct {
 	Amount, MaxAmount uint64

--- a/sdks/go/session_test.go
+++ b/sdks/go/session_test.go
@@ -191,4 +191,3 @@ func TestGetOrCreateDoesNotIncrementRequestCount(t *testing.T) {
 		t.Fatal("expected escalation after 3 RecordRequests with same hash")
 	}
 }
-

--- a/sdks/python/src/solvela/__init__.py
+++ b/sdks/python/src/solvela/__init__.py
@@ -6,6 +6,7 @@ from solvela.config import ClientBuilder, ClientConfig
 from solvela.errors import (
     AmountExceedsMaxError,
     ClientError,
+    EscrowProgramMismatchError,
     GatewayError,
     InsufficientBalanceError,
     PaymentRejectedError,
@@ -40,6 +41,7 @@ __all__ = [
     "ClientConfig",
     "AmountExceedsMaxError",
     "ClientError",
+    "EscrowProgramMismatchError",
     "GatewayError",
     "InsufficientBalanceError",
     "PaymentRejectedError",

--- a/sdks/python/src/solvela/client.py
+++ b/sdks/python/src/solvela/client.py
@@ -13,6 +13,7 @@ from solvela.constants import SOLANA_NETWORK, USDC_MINT
 from solvela.errors import (
     AmountExceedsMaxError,
     ClientError,
+    EscrowProgramMismatchError,
     PaymentRejectedError,
     PaymentRequiredError,
     RecipientMismatchError,
@@ -398,6 +399,19 @@ class SolvelaClient:
                 expected=self._config.expected_recipient,
                 actual=accept.pay_to,
             )
+        # Escrow-program pin: only the escrow scheme signs a deposit bound to a
+        # program ID. Reject before signing if the advertised program differs
+        # from the configured pin (prevents a malicious gateway redirecting the
+        # deposit to an attacker's program). Fail closed: a missing/None
+        # advertised program against a non-None pin is a mismatch. Mirrors the
+        # ``expected_recipient`` check above.
+        if accept.scheme == "escrow" and self._config.expected_escrow_program_id is not None:
+            actual_program = accept.escrow_program_id or ""
+            if actual_program != self._config.expected_escrow_program_id:
+                raise EscrowProgramMismatchError(
+                    expected=self._config.expected_escrow_program_id,
+                    actual=actual_program,
+                )
         # Wire amount is a string; cast at this single boundary so the rest of
         # the SDK only ever sees a typed AtomicUsdc. A malformed or negative
         # value must surface as ClientError, not bare ValueError/OverflowError,

--- a/sdks/python/src/solvela/config.py
+++ b/sdks/python/src/solvela/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
+from solvela.constants import MAINNET_ESCROW_PROGRAM_ID
 from solvela.errors import ClientError
 from solvela.types import AtomicUsdc
 
@@ -52,6 +53,11 @@ class ClientConfig:
         ``max_payment_amount`` defaults to 10 USDC (10_000_000 atomic units) so
         a hostile or buggy gateway cannot silently drain the wallet. Callers
         that genuinely need higher limits must set this explicitly.
+
+        ``expected_escrow_program_id`` is pinned to
+        ``MAINNET_ESCROW_PROGRAM_ID`` by default so an escrow deposit is never
+        signed for an unexpected program (mirrors ``expected_recipient`` for the
+        escrow path). Set to ``None`` to disable the pin.
     """
 
     gateway_url: str = "https://api.solvela.ai"
@@ -59,6 +65,7 @@ class ClientConfig:
     prefer_escrow: bool = False
     timeout: float = 180.0
     expected_recipient: str | None = None
+    expected_escrow_program_id: str | None = MAINNET_ESCROW_PROGRAM_ID
     max_payment_amount: AtomicUsdc | None = field(default=DEFAULT_MAX_PAYMENT_AMOUNT)
     enable_cache: bool = False
     enable_sessions: bool = False
@@ -98,6 +105,25 @@ class ClientBuilder:
 
     def expected_recipient(self, value: str | None) -> ClientBuilder:
         self._config.expected_recipient = value
+        return self
+
+    def expected_escrow_program_id(self, value: str | None) -> ClientBuilder:
+        """Pin the escrow program ID the client will sign a deposit for.
+
+        A 402 advertising an escrow scheme whose ``escrow_program_id`` differs is
+        rejected before signing. Defaults to ``MAINNET_ESCROW_PROGRAM_ID`` (see
+        ``ClientConfig``); use this to point at a different deployment.
+        """
+        self._config.expected_escrow_program_id = value
+        return self
+
+    def disable_escrow_program_pin(self) -> ClientBuilder:
+        """Clear the escrow-program pin, allowing any advertised escrow program.
+
+        This removes a security guarantee; prefer ``expected_escrow_program_id``
+        to point at a non-default deployment instead.
+        """
+        self._config.expected_escrow_program_id = None
         return self
 
     def max_payment_amount(self, value: AtomicUsdc | None) -> ClientBuilder:

--- a/sdks/python/src/solvela/constants.py
+++ b/sdks/python/src/solvela/constants.py
@@ -5,5 +5,10 @@ from __future__ import annotations
 X402_VERSION: int = 2
 USDC_MINT: str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 SOLANA_NETWORK: str = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+# Deployed Solvela escrow program on Solana mainnet-beta. ``ClientConfig`` pins
+# ``expected_escrow_program_id`` to this by default so an escrow deposit is never
+# signed for an unexpected program (mirrors the hardcoded ``USDC_MINT`` /
+# ``SOLANA_NETWORK``). Matches the Rust SDK's ``MAINNET_ESCROW_PROGRAM_ID``.
+MAINNET_ESCROW_PROGRAM_ID: str = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
 MAX_TIMEOUT_SECONDS: int = 300
 PLATFORM_FEE_PERCENT: int = 5

--- a/sdks/python/src/solvela/errors.py
+++ b/sdks/python/src/solvela/errors.py
@@ -82,6 +82,20 @@ class RecipientMismatchError(ClientError):
         super().__init__(f"Recipient mismatch: expected {expected}, got {actual}")
 
 
+class EscrowProgramMismatchError(ClientError):
+    """Raised when the 402's escrow program ID does not match the configured pin.
+
+    Surfaced before any escrow deposit is signed, preventing a malicious gateway
+    from redirecting the deposit to an attacker's program. Mirrors
+    ``RecipientMismatchError`` for the escrow path.
+    """
+
+    def __init__(self, expected: str, actual: str) -> None:
+        self.expected = expected
+        self.actual = actual
+        super().__init__(f"Escrow program mismatch: expected {expected}, got {actual}")
+
+
 class AmountExceedsMaxError(ClientError):
     """Raised when a payment amount exceeds the configured maximum.
 

--- a/sdks/python/tests/unit/test_client.py
+++ b/sdks/python/tests/unit/test_client.py
@@ -122,6 +122,70 @@ class TestValidatePayment:
             client._validate_payment(_accept(amount="-1"))
 
 
+class TestEscrowProgramPin:
+    """`_validate_payment` must reject an escrow 402 whose program ID differs
+    from the configured pin, before any deposit is signed. Mirrors the
+    recipient guard for the escrow path."""
+
+    MAINNET = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+
+    def _escrow_accept(self, *, program_id: str | None) -> PaymentAccept:
+        return PaymentAccept(
+            scheme="escrow",
+            network=SOLANA_NETWORK,
+            amount="1000",
+            asset=USDC_MINT,
+            pay_to="RecipientPubkey111111111111111111111111111",
+            max_timeout_seconds=300,
+            escrow_program_id=program_id,
+        )
+
+    def test_default_config_pins_mainnet_escrow_program(self) -> None:
+        assert ClientConfig().expected_escrow_program_id == self.MAINNET
+
+    def test_mismatch_rejected(self) -> None:
+        from solvela.errors import EscrowProgramMismatchError
+
+        client = SolvelaClient(config=ClientConfig(max_payment_amount=None))
+        attacker = "AttackerProgram1111111111111111111111111111"
+        with pytest.raises(EscrowProgramMismatchError) as exc:
+            client._validate_payment(self._escrow_accept(program_id=attacker))
+        assert exc.value.expected == self.MAINNET
+        assert exc.value.actual == attacker
+
+    def test_missing_program_fails_closed(self) -> None:
+        from solvela.errors import EscrowProgramMismatchError
+
+        client = SolvelaClient(config=ClientConfig(max_payment_amount=None))
+        with pytest.raises(EscrowProgramMismatchError):
+            client._validate_payment(self._escrow_accept(program_id=None))
+
+    def test_match_proceeds(self) -> None:
+        # A matching program passes the guard; _validate_payment returns the
+        # parsed amount (signing/RPC happens later, not here).
+        client = SolvelaClient(config=ClientConfig(max_payment_amount=None))
+        amount = client._validate_payment(self._escrow_accept(program_id=self.MAINNET))
+        assert amount == 1000
+
+    def test_disabled_pin_proceeds_for_any_program(self) -> None:
+        # Back-compat / escape hatch: with the pin disabled (None), any
+        # advertised escrow program passes the guard.
+        client = SolvelaClient(
+            config=ClientConfig(max_payment_amount=None, expected_escrow_program_id=None)
+        )
+        amount = client._validate_payment(
+            self._escrow_accept(program_id="SomeOtherProgram111111111111111111111111111")
+        )
+        assert amount == 1000
+
+    def test_exact_scheme_unaffected_by_pin(self) -> None:
+        # The escrow pin must NOT apply to an exact-scheme accept (no program ID
+        # field is relevant there) — existing exact callers are unaffected.
+        client = SolvelaClient(config=ClientConfig(max_payment_amount=None))
+        amount = client._validate_payment(_accept())  # scheme="exact"
+        assert amount == 1000
+
+
 class TestQueryBalanceRpcDiscrimination:
     """`_query_balance` must distinguish ATA-not-found from real RPC errors.
 

--- a/sdks/python/tests/unit/test_config.py
+++ b/sdks/python/tests/unit/test_config.py
@@ -123,3 +123,22 @@ class TestClientBuilder:
     def test_builder_rejects_plain_http_rpc_for_remote_hosts(self) -> None:
         with pytest.raises(ClientError, match="rpc_url"):
             ClientBuilder().rpc_url("http://rpc.example.com")
+
+
+class TestEscrowProgramPinConfig:
+    MAINNET = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU"
+
+    def test_default_config_pins_mainnet(self) -> None:
+        assert ClientConfig().expected_escrow_program_id == self.MAINNET
+
+    def test_builder_override(self) -> None:
+        cfg = (
+            ClientBuilder()
+            .expected_escrow_program_id("EscRowOverride11111111111111111111111111111")
+            .build()
+        )
+        assert cfg.expected_escrow_program_id == "EscRowOverride11111111111111111111111111111"
+
+    def test_builder_disable(self) -> None:
+        cfg = ClientBuilder().disable_escrow_program_pin().build()
+        assert cfg.expected_escrow_program_id is None

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -19,6 +19,7 @@ import {
   ClientError,
   PaymentRequiredError,
   RecipientMismatchError,
+  EscrowProgramMismatchError,
   AmountExceedsMaxError,
   InsufficientBalanceError,
   SignerError,
@@ -372,6 +373,21 @@ export class SolvelaClient {
       accepted.payTo !== this.config.expectedRecipient
     ) {
       throw new RecipientMismatchError(this.config.expectedRecipient, accepted.payTo);
+    }
+
+    // Escrow-program pin: only the escrow scheme signs a deposit bound to a
+    // program ID. Reject before signing if the advertised program differs from
+    // the configured pin (prevents a malicious gateway redirecting the deposit
+    // to an attacker's program). Fail closed: a missing/empty advertised program
+    // against a non-empty pin is a mismatch. Mirrors the recipient check above.
+    if (accepted.scheme === 'escrow' && this.config.expectedEscrowProgram) {
+      const actualProgram = accepted.escrowProgramId ?? '';
+      if (actualProgram !== this.config.expectedEscrowProgram) {
+        throw new EscrowProgramMismatchError(
+          this.config.expectedEscrowProgram,
+          actualProgram,
+        );
+      }
     }
 
     const amount = parseAtomicAmount(accepted.amount);

--- a/sdks/typescript/src/config.ts
+++ b/sdks/typescript/src/config.ts
@@ -1,9 +1,20 @@
+import { MAINNET_ESCROW_PROGRAM_ID } from './constants.js';
+
 export interface ClientConfig {
   gatewayUrl: string;
   rpcUrl: string;
   preferEscrow: boolean;
   timeout: number;
   expectedRecipient?: string;
+  /**
+   * Pins the escrow program ID the client will sign a deposit for. A 402
+   * advertising an escrow scheme whose `escrowProgramId` differs is rejected
+   * before signing, preventing a malicious gateway from redirecting the deposit
+   * to an attacker's program (mirrors `expectedRecipient` for the escrow path).
+   * `DEFAULT_CONFIG` pins this to {@link MAINNET_ESCROW_PROGRAM_ID}; `undefined`
+   * disables the pin (see {@link ClientBuilder.disableEscrowProgramPin}).
+   */
+  expectedEscrowProgram?: string;
   maxPaymentAmount?: number;
   enableCache: boolean;
   enableSessions: boolean;
@@ -25,6 +36,7 @@ export const DEFAULT_CONFIG: ClientConfig = {
   rpcUrl: 'https://api.mainnet-beta.solana.com',
   preferEscrow: false,
   timeout: 180,
+  expectedEscrowProgram: MAINNET_ESCROW_PROGRAM_ID,
   maxPaymentAmount: DEFAULT_MAX_PAYMENT_AMOUNT,
   enableCache: false,
   enableSessions: false,
@@ -79,6 +91,25 @@ export class ClientBuilder {
 
   withExpectedRecipient(recipient: string): ClientBuilder {
     return this.with({ expectedRecipient: recipient });
+  }
+
+  /**
+   * Pin the escrow program ID the client will sign a deposit for. A 402
+   * advertising an escrow scheme whose `escrowProgramId` differs is rejected
+   * before signing. Defaults to {@link MAINNET_ESCROW_PROGRAM_ID}; use this to
+   * point at a different deployment.
+   */
+  withExpectedEscrowProgram(id: string): ClientBuilder {
+    return this.with({ expectedEscrowProgram: id });
+  }
+
+  /**
+   * Clear the escrow-program pin, allowing any advertised escrow program. This
+   * removes a security guarantee; prefer {@link withExpectedEscrowProgram} to
+   * point at a non-default deployment instead.
+   */
+  disableEscrowProgramPin(): ClientBuilder {
+    return this.with({ expectedEscrowProgram: undefined });
   }
 
   withMaxPaymentAmount(amount: number): ClientBuilder {

--- a/sdks/typescript/src/constants.ts
+++ b/sdks/typescript/src/constants.ts
@@ -1,5 +1,12 @@
 export const X402_VERSION = 2;
 export const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 export const SOLANA_NETWORK = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+/**
+ * Deployed Solvela escrow program on Solana mainnet-beta. `DEFAULT_CONFIG` pins
+ * `expectedEscrowProgram` to this so an escrow deposit is never signed for an
+ * unexpected program (mirrors the hardcoded {@link USDC_MINT} /
+ * {@link SOLANA_NETWORK}). Matches the Rust SDK's `MAINNET_ESCROW_PROGRAM_ID`.
+ */
+export const MAINNET_ESCROW_PROGRAM_ID = '9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU';
 export const MAX_TIMEOUT_SECONDS = 300;
 export const PLATFORM_FEE_PERCENT = 5;

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -65,6 +65,16 @@ export class RecipientMismatchError extends ClientError {
   }
 }
 
+export class EscrowProgramMismatchError extends ClientError {
+  constructor(
+    public readonly expected: string,
+    public readonly actual: string,
+  ) {
+    super(`Escrow program mismatch: expected ${expected}, got ${actual}`);
+    this.name = 'EscrowProgramMismatchError';
+  }
+}
+
 export class AmountExceedsMaxError extends ClientError {
   constructor(
     public readonly amount: number,

--- a/sdks/typescript/src/signer.ts
+++ b/sdks/typescript/src/signer.ts
@@ -370,9 +370,12 @@ export class KeypairSigner implements Signer {
    * forever, so we bound the request with an `AbortController` +
    * {@link RPC_TIMEOUT_MS} (same pattern as `src/transport.ts`, and parity with
    * the Go `http.Client{Timeout: 30s}` / Python `httpx ... timeout=30`). The
-   * 200-path body is read as text and rejected if it exceeds
-   * {@link MAX_RPC_BODY_BYTES} so a hostile RPC cannot OOM the agent (parity with
-   * the Go `io.LimitReader` cap), then `JSON.parse`d.
+   * 200-path body is read as raw bytes and rejected if it exceeds
+   * {@link MAX_RPC_BODY_BYTES} so a hostile RPC cannot OOM the agent. The cap is
+   * measured in bytes (`ArrayBuffer.byteLength`) to be byte-exact with the Go
+   * `io.LimitReader` cap — `String.length` counts UTF-16 code units, which
+   * under-counts multi-byte UTF-8 sequences and would let an over-cap body slip
+   * through. The bytes are then UTF-8 decoded and `JSON.parse`d.
    */
   private async postRpc(
     method: string,
@@ -402,19 +405,25 @@ export class KeypairSigner implements Signer {
       if (resp.status !== 200) {
         throw new SignerError(`${label} RPC HTTP ${resp.status}`);
       }
-      // Read the success body as text under a size cap (Go's io.LimitReader
+      // Read the success body as raw bytes under a size cap (Go's io.LimitReader
       // equivalent) BEFORE parsing, so an unbounded/hostile body cannot OOM the
-      // agent. Only then JSON.parse, preserving the malformed-JSON handling.
+      // agent. The cap is measured in bytes — not String.length (UTF-16 code
+      // units) — to be byte-exact with Go's io.LimitReader. Only then UTF-8
+      // decode + JSON.parse, preserving the malformed-JSON handling.
       let text: string;
       try {
-        text = await resp.text();
-      } catch {
+        const buf = await resp.arrayBuffer();
+        if (buf.byteLength > MAX_RPC_BODY_BYTES) {
+          throw new SignerError(
+            `${label} RPC: response body exceeds ${MAX_RPC_BODY_BYTES} bytes`,
+          );
+        }
+        text = new TextDecoder('utf-8', { fatal: false }).decode(buf);
+      } catch (e) {
+        if (e instanceof SignerError) {
+          throw e;
+        }
         throw new SignerError(`${label} RPC: malformed JSON body`);
-      }
-      if (text.length > MAX_RPC_BODY_BYTES) {
-        throw new SignerError(
-          `${label} RPC: response body exceeds ${MAX_RPC_BODY_BYTES} bytes`,
-        );
       }
       try {
         return JSON.parse(text) as { result?: unknown; error?: unknown };

--- a/sdks/typescript/tests/unit/security_validation.test.ts
+++ b/sdks/typescript/tests/unit/security_validation.test.ts
@@ -6,11 +6,16 @@ import {
   PaymentAccept,
   PaymentRequired,
 } from '../../src/types.js';
-import { ClientError, SignerError, AmountExceedsMaxError } from '../../src/errors.js';
+import {
+  ClientError,
+  SignerError,
+  AmountExceedsMaxError,
+  EscrowProgramMismatchError,
+} from '../../src/errors.js';
 import type { Signer } from '../../src/signer.js';
 import type { Resource } from '../../src/types.js';
 import { PaymentPayload, SolanaPayload } from '../../src/types.js';
-import { SOLANA_NETWORK, USDC_MINT } from '../../src/constants.js';
+import { SOLANA_NETWORK, USDC_MINT, MAINNET_ESCROW_PROGRAM_ID } from '../../src/constants.js';
 
 /**
  * Coverage for security audit fixes:
@@ -42,15 +47,20 @@ function pr(overrides: Partial<{
   network: string;
   asset?: string;
   payTo: string;
+  scheme: string;
+  escrowProgramId?: string;
 }>): Record<string, unknown> {
   const accepted: Record<string, unknown> = {
-    scheme: 'exact',
+    scheme: overrides.scheme ?? 'exact',
     network: overrides.network ?? SOLANA_NETWORK,
     amount: overrides.amount ?? '1000000',
     asset: overrides.asset ?? USDC_MINT,
     pay_to: overrides.payTo ?? '11111111111111111111111111111111',
     max_timeout_seconds: 300,
   };
+  if (overrides.escrowProgramId !== undefined) {
+    accepted.escrow_program_id = overrides.escrowProgramId;
+  }
   return {
     x402_version: 2,
     resource: { url: '/v1/chat/completions', method: 'POST' },
@@ -381,5 +391,78 @@ describe('Security: Scheme literal validation', () => {
     expect(() =>
       PaymentAccept.fromJSON({ ...validBase, scheme: 'escrow' }),
     ).not.toThrow();
+  });
+});
+
+describe('Security: escrow program pin before signing', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const ATTACKER = 'AttackerProgram1111111111111111111111111111';
+
+  it('rejects an escrow 402 whose program differs from the default pin, before signing', async () => {
+    mockFetchOnce(402, pr({ scheme: 'escrow', escrowProgramId: ATTACKER }));
+
+    const signer = new StubSigner();
+    // preferEscrow so findCompatibleScheme selects the escrow accept under test.
+    const client = new SolvelaClient({ signer, config: { preferEscrow: true } });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await expect(client.chat(request)).rejects.toThrow(EscrowProgramMismatchError);
+    expect(signer.called).toBe(false);
+  });
+
+  it('fails closed when the escrow program is missing from the 402', async () => {
+    // No escrow_program_id field at all -> treated as '' -> mismatch vs pin.
+    mockFetchOnce(402, pr({ scheme: 'escrow' }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer, config: { preferEscrow: true } });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await expect(client.chat(request)).rejects.toThrow(EscrowProgramMismatchError);
+    expect(signer.called).toBe(false);
+  });
+
+  it('proceeds to sign when the escrow program matches the default mainnet pin', async () => {
+    mockFetchOnce(402, pr({ scheme: 'escrow', escrowProgramId: MAINNET_ESCROW_PROGRAM_ID }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer, config: { preferEscrow: true } });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    // The stub signer returns a payload without real RPC; reaching it proves the
+    // pin did NOT reject a legitimate program. The retried request then resolves
+    // against the mocked fetch (still 402), but the signer must have been called.
+    await client.chat(request).catch(() => {});
+    expect(signer.called).toBe(true);
+  });
+
+  it('proceeds to sign for any program when the pin is disabled', async () => {
+    mockFetchOnce(402, pr({ scheme: 'escrow', escrowProgramId: ATTACKER }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({
+      signer,
+      config: { preferEscrow: true, expectedEscrowProgram: undefined },
+    });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await client.chat(request).catch(() => {});
+    expect(signer.called).toBe(true);
+  });
+
+  it('does not apply the escrow pin to an exact-scheme 402 (back-compat)', async () => {
+    // An exact accept has no escrow program; the pin must not interfere.
+    mockFetchOnce(402, pr({ scheme: 'exact' }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await client.chat(request).catch(() => {});
+    expect(signer.called).toBe(true);
   });
 });

--- a/sdks/typescript/tests/unit/signer.test.ts
+++ b/sdks/typescript/tests/unit/signer.test.ts
@@ -610,6 +610,24 @@ describe('Escrow scheme signing (no silent fallback)', () => {
     ).rejects.toThrow(/exceeds 65536 bytes/);
   });
 
+  it('caps the RPC body by UTF-8 byte length, not UTF-16 code units', async () => {
+    // Regression for #484: the cap must be byte-exact (parity with Go's
+    // io.LimitReader). A body padded with multi-byte UTF-8 characters can be
+    // <= 65536 in String.length (UTF-16 code units) while exceeding 65536
+    // bytes. The old `text().length` check would let it through; the
+    // `arrayBuffer().byteLength` check must reject it.
+    const pad = 'é'.repeat(40_000); // 'é' = 1 code unit, 2 UTF-8 bytes
+    const body = `{"jsonrpc":"2.0","id":1,"result":1000000,"pad":"${pad}"}`;
+    // Sanity: under the cap by code units, over it by bytes.
+    expect(body.length).toBeLessThanOrEqual(65_536);
+    expect(Buffer.byteLength(body, 'utf-8')).toBeGreaterThan(65_536);
+    mockRpc({ getSlot: { raw: body } });
+    const signer = new KeypairSigner(goldenAgentWallet(), RPC_URL);
+    await expect(
+      signer.signPayment(2625, GOLDEN_PROVIDER, resource(), escrowAccept()),
+    ).rejects.toThrow(/exceeds 65536 bytes/);
+  });
+
   it('the agent secret key never appears in an escrow error message', async () => {
     // Drive a builder-level failure after RPC by handing a malformed provider in
     // the accept's pay_to. The golden wallet seed is all 42 (0x2a); assert it


### PR DESCRIPTION
Closes #484.

## What

Mirrors the **Rust** SDK's `expected_escrow_program_id` guard into **Go, Python, and TypeScript**, closing the cross-SDK gap where the gateway-supplied `escrow_program_id` was signed into an escrow deposit **without a whitelist check** — asymmetric with the `exact` path's existing `expected_recipient`/`expectedRecipient` guard. A compromised/malicious gateway could otherwise redirect a deposit to an attacker's program.

Each SDK gains, **scheme-gated to escrow** and enforced **before signing**:
- a **default mainnet pin** to `MAINNET_ESCROW_PROGRAM_ID` (`9neDHou…tHLU`), matching Rust — each SDK already hardcodes mainnet `USDC_MINT` + network, so this is consistent, not a surprise
- an `expectedEscrowProgram` / `expected_escrow_program_id` config + setter
- a disable-pin escape hatch (`disableEscrowProgramPin` / `disable_escrow_program_pin` / `DisableEscrowProgramPin`)
- an `EscrowProgramMismatchError` — **fail-closed**: a missing/empty advertised program vs a non-empty pin is treated as a mismatch

**TS secondary (also in #484):** the RPC body cap now uses `arrayBuffer().byteLength` (byte-exact, matching Go's `io.LimitReader`) instead of `text().length` (UTF-16 code units).

## Invariants
- Wire format + golden vector **untouched** — pre-sign gate only, no change to the deposit transaction or money math.
- No silent fallback: rejects with a typed error before signing; never downgrades escrow→exact or signs for an unknown program.
- Scheme-gated: exact-path billing/back-compat unaffected.

## Tests (tests-first, all three SDKs)
mismatch → rejected before signing; match → proceeds; unset/disabled → proceeds (back-compat); exact-path unaffected; escrow golden-vector tests still green. Plus a TS byte-exact regression for the RPC cap. Verified: Go `go test ./...` ok + vet/fmt clean; Python 250 passed + ruff/mypy clean; TS build + lint + 209 passed.

## Note on Rust parity
Go/Python/TS use a two-state model (default-pinned field; empty/None/undefined disables) vs Rust's `Option<Option<String>>` three-state — behavior is equivalent via the explicit disable method. Rust's startup "pin is None" warning was not added (none of the SDKs have that idiom for the existing `expected_recipient` either).

Implemented via the `solvela-money-path-engineer` agent.