### PR TITLE
release(sdk-rust): bump workspace to 0.2.5 for stats() helper

### DIFF
--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ahash",
  "base64",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "futures",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli-args"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bs58",
  "clap",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-proxy"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "axum",
  "clap",

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.91"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump only — `[workspace.package].version` 0.2.4 → 0.2.5 (+ Cargo.lock) to release the additive `SolvelaClient::stats()` helper merged in #489.

## Pre-flight (via payment-sdk-publisher)

- **Additive only** — new `stats()` method; no protocol/wire change. `solvela-protocol` (0.3.0) and `solvela-escrow-tx` (0.2.0) pins unchanged and confirmed resolving against the published versions.
- **All four crates move together** via `version.workspace = true` (workflow's first guardrail invariant holds).
- **Dry-run passed** — `cargo publish --dry-run --locked` for all four crates in topo order (client → cli-args → cli → proxy) against published deps.
- fmt / clippy `-D warnings` / `cargo test -p solvela-client` all green.

## After merge

Tag `sdks/rust/v0.2.5` at the merge commit → fires `sdk-rust-publish.yml` (verify → test → dry-run → publish → visibility). `crates-publish` env + `CARGO_REGISTRY_TOKEN` confirmed present.

Diff is the two Rust files only (`sdks/rust/Cargo.toml`, `sdks/rust/Cargo.lock`).