### PR TITLE
feat(gateway): per-tenant budget enforcement (PR2, Option B)

### DIFF
--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -706,9 +706,15 @@ pub async fn chat_completions(
                 ));
             }
 
+            // Pass the (forgeable, attribution-only) x-tenant tag so the
+            // per-tenant budget gate can enforce a provisioned `(wallet, tenant)`
+            // bucket and apply the require_tenant fail-closed policy. All tenant
+            // rejections (TenantRequired / TenantNotProvisioned) and budget
+            // overruns map to a 400 via BadRequest below — and they fire here,
+            // pre-settlement / pre-provider-call.
             budget_reservation = match state
                 .usage
-                .check_budget(&wallet_address, estimated_cost)
+                .check_budget(&wallet_address, estimated_cost, tenant.as_deref())
                 .await
             {
                 Ok(reservation) => reservation,

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -1123,6 +1123,11 @@ pub async fn chat_completions(
                             request_id: request_id.clone(),
                             session_id: session_id.clone(),
                             tenant: tenant.clone(),
+                            // Reconcile per-tenant counters only when
+                            // check_budget actually enforced a provisioned bucket
+                            // (decision == Enforce). Threaded from the reservation
+                            // so the Skip path never accumulates per-tenant spend.
+                            tenant_enforced: budget_reservation.tenant_enforced(),
                             estimated_cost_usdc: Some(estimated_cost),
                         });
                     }
@@ -1171,6 +1176,9 @@ pub async fn chat_completions(
                     request_id: request_id.clone(),
                     session_id: session_id.clone(),
                     tenant: tenant.clone(),
+                    // Same gating as the usage-present arm: reconcile per-tenant
+                    // counters only when a provisioned bucket was enforced.
+                    tenant_enforced: budget_reservation.tenant_enforced(),
                     estimated_cost_usdc: Some(estimated_cost),
                 });
             }

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -571,6 +571,9 @@ pub async fn proxy_service(
         // x-tenant header. Per-tenant attribution for the proxy path can be
         // added later; None leaves these rows untagged for now.
         tenant: None,
+        // No tenant tag is read on the proxy path, so no per-tenant bucket is
+        // enforced — never reconcile per-tenant counters here.
+        tenant_enforced: false,
         // Service-marketplace proxy doesn't go through `check_budget`
         // (it has flat per-request pricing, not per-wallet budgets), so no
         // reservation is committed and log_spend increments by the full

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -31,6 +31,25 @@ const TEAM_MEMBER_CACHE_TTL: u64 = 60;
 /// TTL for cached team budget config in Redis (seconds).
 const TEAM_BUDGET_CACHE_TTL: u64 = 60;
 
+/// TTL for cached per-tenant budget config / provisioning lookups (seconds).
+const TENANT_BUDGET_CACHE_TTL: u64 = 60;
+
+// ---------------------------------------------------------------------------
+// SECURITY BOUNDARY — per-tenant budgets are cooperative accounting, NOT isolation
+// ---------------------------------------------------------------------------
+//
+// The `x-tenant` header that drives per-tenant budgets (see
+// `tenant_enforcement_decision`, `check_budget`'s tenant bucket, and the
+// `spend:{wallet}:{tenant}:{period}` counters) is UNAUTHENTICATED and FORGEABLE.
+// Per-tenant budgets are **cooperative accounting under ONE trusted
+// single-wallet proxy** (e.g. Telsi metering its own downstream customers) —
+// they are **NOT a security boundary between mutually-distrusting tenants**.
+// Anyone who controls the wallet's traffic can set any tenant tag, attributing
+// spend to (or evading a cap under) an arbitrary tenant. The authoritative,
+// non-forgeable budget is the wallet (and team) cap; the tenant bucket is a
+// sub-allocation convenience for a cooperating proxy. Do not later mistake this
+// for isolation.
+
 /// Cached budget configuration for a wallet, stored in Redis as JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BudgetConfig {
@@ -55,6 +74,65 @@ pub struct TeamBudgetConfig {
     pub hourly: Option<f64>,
     pub daily: Option<f64>,
     pub monthly: Option<f64>,
+}
+
+/// Cached per-tenant budget configuration, stored in Redis as JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TenantBudgetConfig {
+    pub hourly: Option<f64>,
+    pub daily: Option<f64>,
+    pub monthly: Option<f64>,
+}
+
+/// Outcome of the per-tenant enforcement decision matrix.
+///
+/// Pure function of three booleans so the money-path policy can be unit-tested
+/// exhaustively with no Redis/DB. See [`tenant_enforcement_decision`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TenantDecision {
+    /// A provisioned `(wallet, tenant)` budget row exists for the supplied tag —
+    /// enforce its hourly/daily/monthly bucket atomically.
+    Enforce,
+    /// The wallet has `require_tenant = TRUE` but the request carried no tenant
+    /// tag — reject (fail-closed) before any provider call/settlement.
+    RejectRequired,
+    /// The wallet has `require_tenant = TRUE`, a tag was supplied, but no
+    /// `tenant_budgets` row exists for it — reject (provision-first).
+    RejectNotProvisioned,
+    /// No per-tenant enforcement applies (wallet/team enforcement only). This is
+    /// the path every existing wallet takes today.
+    Skip,
+}
+
+/// Per-tenant budget enforcement decision matrix (pure — the money-path
+/// contract). Given:
+///
+/// - `require_tenant`: the wallet's `wallet_budgets.require_tenant` flag,
+/// - `tag`: the validated `x-tenant` value (`None` if untagged),
+/// - `has_row`: whether a `tenant_budgets` row exists for `(wallet, tag)`,
+///
+/// returns what the tenant bucket should do. A provisioned tenant budget is
+/// always enforced when its tag is present (`Enforce`), regardless of
+/// `require_tenant`. When `require_tenant` is set, an untagged request is
+/// rejected (`RejectRequired`) and a tagged-but-unprovisioned request is
+/// rejected (`RejectNotProvisioned`). Otherwise there is no tenant enforcement
+/// (`Skip`) — byte-for-byte the legacy wallet/team-only path.
+pub fn tenant_enforcement_decision(
+    require_tenant: bool,
+    tag: Option<&str>,
+    has_row: bool,
+) -> TenantDecision {
+    match (require_tenant, tag, has_row) {
+        // A provisioned tenant budget is enforced whenever its tag is present,
+        // independent of require_tenant.
+        (_, Some(_), true) => TenantDecision::Enforce,
+        // Enforced wallet, no tag → fail-closed.
+        (true, None, _) => TenantDecision::RejectRequired,
+        // Enforced wallet, tag present but no provisioned row → provision-first.
+        (true, Some(_), false) => TenantDecision::RejectNotProvisioned,
+        // Unenforced wallet: no tag, or tag with no row → no tenant enforcement.
+        (false, _, _) => TenantDecision::Skip,
+    }
 }
 
 /// Tolerance for f64 USDC comparisons.
@@ -150,6 +228,18 @@ pub enum UsageError {
 
     #[error("not configured")]
     NotConfigured,
+
+    #[error(
+        "wallet {wallet} requires an x-tenant tag: this wallet is configured to \
+         spend only under a provisioned tenant; supply a valid x-tenant header"
+    )]
+    TenantRequired { wallet: String },
+
+    #[error(
+        "tenant '{tenant}' is not provisioned for wallet {wallet}: this wallet \
+         may only spend under a known, provisioned tenant"
+    )]
+    TenantNotProvisioned { wallet: String, tenant: String },
 }
 
 /// Usage tracker with optional PostgreSQL and Redis backends.
@@ -264,6 +354,7 @@ impl UsageTracker {
             let client = client.clone();
             let db_pool = self.db_pool.clone();
             let wallet = entry.wallet_address;
+            let tenant = entry.tenant;
             let cost = match entry.estimated_cost_usdc {
                 Some(reserved) => entry.cost_usdc - reserved,
                 None => entry.cost_usdc,
@@ -299,6 +390,28 @@ impl UsageTracker {
                 // Monthly spend counter
                 let month_key = format!("spend:{}:{}", wallet, now.format("%Y-%m"));
                 incr_and_expire(&mut conn, &month_key, cost, 86400 * 31).await;
+
+                // Per-tenant counters: settle the same `cost` delta on the
+                // `spend:{wallet}:{tenant}:{period}` keys that `check_budget`'s
+                // `Enforce` arm reserved against. Mirrors the wallet/team
+                // reconciliation. Runs whenever the spend row carried a tenant
+                // tag (`entry.tenant`), symmetric with the wallet counter; if no
+                // tenant budget was provisioned the counter merely tracks tagged
+                // spend and self-expires (harmless). The header is forgeable —
+                // see the module-level security note.
+                if let Some(tag) = tenant.as_deref() {
+                    let tenant_hour_key =
+                        format!("spend:{}:{}:{}", wallet, tag, now.format("%Y-%m-%dT%H"));
+                    incr_and_expire(&mut conn, &tenant_hour_key, cost, 7200).await;
+
+                    let tenant_day_key =
+                        format!("spend:{}:{}:{}", wallet, tag, now.format("%Y-%m-%d"));
+                    incr_and_expire(&mut conn, &tenant_day_key, cost, 86400).await;
+
+                    let tenant_month_key =
+                        format!("spend:{}:{}:{}", wallet, tag, now.format("%Y-%m"));
+                    incr_and_expire(&mut conn, &tenant_month_key, cost, 86400 * 31).await;
+                }
 
                 // Team-level counters: look up team membership.
                 // log_spend runs in a fire-and-forget tokio::spawn after the
@@ -358,9 +471,18 @@ impl UsageTracker {
         &self,
         wallet_address: &str,
         estimated_cost_usdc: f64,
+        tenant: Option<&str>,
     ) -> Result<BudgetReservation, UsageError> {
         // No Redis configured — apply a conservative per-request hard cap.
         // No counters are committed, so the reservation is empty (release is a no-op).
+        //
+        // NOTE: the per-tenant fail-closed gates (TenantRequired /
+        // TenantNotProvisioned) are NOT applied on this no-Redis branch. They
+        // depend on reading `wallet_budgets.require_tenant` and `tenant_budgets`
+        // from the DB, which is read via the Redis-cached helpers below. With no
+        // Redis the operator is already in degraded single-cap mode (Rule #12);
+        // tenant enforcement is a feature of the Redis/DB-backed path. This keeps
+        // the no-Redis path byte-for-byte unchanged from before PR2.
         if self.redis_client.is_none() {
             const NO_REDIS_REQUEST_CAP_USDC: f64 = 1.0;
             if estimated_cost_usdc > NO_REDIS_REQUEST_CAP_USDC {
@@ -517,6 +639,99 @@ impl UsageTracker {
                     "team membership lookup failed; denying request (fail-closed)"
                 );
                 return Err(UsageError::Database(e));
+            }
+        }
+
+        // --- Per-tenant budget enforcement ---
+        //
+        // SECURITY: see the module-level "cooperative accounting, NOT isolation"
+        // note — `tenant` comes from the forgeable `x-tenant` header.
+        //
+        // Decision matrix (pure, see `tenant_enforcement_decision`):
+        //   * provisioned `(wallet, tenant)` row present  → enforce the bucket
+        //     (whether or not require_tenant is set).
+        //   * require_tenant=TRUE, no tag                 → RejectRequired.
+        //   * require_tenant=TRUE, tag but no row         → RejectNotProvisioned.
+        //   * otherwise                                   → Skip (wallet/team only).
+        //
+        // We load the wallet's require_tenant flag and (when a tag is present)
+        // the tenant_budgets row in one combined helper so the no-tenant path
+        // adds no extra round-trip relative to pre-PR2 when require_tenant is
+        // unset and no tag is supplied.
+        let (require_tenant, tenant_config) =
+            get_tenant_enforcement(&mut conn, self.db_pool.as_ref(), wallet_address, tenant).await;
+
+        match tenant_enforcement_decision(require_tenant, tenant, tenant_config.is_some()) {
+            TenantDecision::Skip => {}
+            TenantDecision::RejectRequired => {
+                // Fail-closed BEFORE settlement: nothing has been broadcast yet,
+                // but earlier wallet/team windows were reserved — release them so
+                // a rejected request leaks no budget.
+                rollback_committed(&mut conn, &committed).await;
+                warn!(
+                    wallet = %wallet_address,
+                    "tenant_required: wallet requires an x-tenant tag; denying untagged request"
+                );
+                return Err(UsageError::TenantRequired {
+                    wallet: wallet_address.to_string(),
+                });
+            }
+            TenantDecision::RejectNotProvisioned => {
+                rollback_committed(&mut conn, &committed).await;
+                warn!(
+                    wallet = %wallet_address,
+                    tenant = tenant.unwrap_or("<none>"),
+                    "tenant_not_provisioned: enforced wallet, unknown tenant; denying request"
+                );
+                return Err(UsageError::TenantNotProvisioned {
+                    wallet: wallet_address.to_string(),
+                    tenant: tenant.unwrap_or_default().to_string(),
+                });
+            }
+            TenantDecision::Enforce => {
+                // Safe: Enforce is only returned when both `tenant` is Some and a
+                // row exists. Counters key `spend:{wallet}:{tenant}:{period}`.
+                let tag = tenant.unwrap_or_default();
+                let tcfg = tenant_config.unwrap_or(TenantBudgetConfig {
+                    hourly: None,
+                    daily: None,
+                    monthly: None,
+                });
+
+                if let Some(hourly_limit) = tcfg.hourly {
+                    let _ = try_commit!(
+                        format!(
+                            "spend:{}:{}:{}",
+                            wallet_address,
+                            tag,
+                            now.format("%Y-%m-%dT%H")
+                        ),
+                        estimated_cost_usdc,
+                        hourly_limit,
+                        7200
+                    );
+                }
+                if let Some(daily_limit) = tcfg.daily {
+                    let _ = try_commit!(
+                        format!(
+                            "spend:{}:{}:{}",
+                            wallet_address,
+                            tag,
+                            now.format("%Y-%m-%d")
+                        ),
+                        estimated_cost_usdc,
+                        daily_limit,
+                        86400
+                    );
+                }
+                if let Some(monthly_limit) = tcfg.monthly {
+                    let _ = try_commit!(
+                        format!("spend:{}:{}:{}", wallet_address, tag, now.format("%Y-%m")),
+                        estimated_cost_usdc,
+                        monthly_limit,
+                        86400 * 31
+                    );
+                }
             }
         }
 
@@ -1009,6 +1224,171 @@ async fn get_team_budget_config(
     config
 }
 
+/// Load the per-tenant enforcement inputs for a wallet+tag in one combined
+/// lookup: the wallet's `require_tenant` flag and (when a tag is present) the
+/// `(wallet, tenant)` `tenant_budgets` row.
+///
+/// Returns `(require_tenant, tenant_config)`. `tenant_config` is `None` when no
+/// tag is supplied OR no provisioned row exists for the tag — the
+/// [`tenant_enforcement_decision`] matrix distinguishes those two cases using
+/// `require_tenant`.
+///
+/// Caching mirrors the wallet/team helpers (Redis, 60s TTL):
+/// - `tenant_require:{wallet}` → "1"/"0" sentinel for the flag.
+/// - `tenant_budget:{wallet}:{tenant}` → JSON config, or "none" sentinel.
+///
+/// **Fail-closed posture:** unlike the display-only helpers, a DB error here
+/// returns `require_tenant = true` with `tenant_config = None`. If we cannot
+/// confirm the wallet is unenforced, we must treat it as enforced — so a
+/// transient DB blip denies (`RejectRequired`/`RejectNotProvisioned`) rather
+/// than silently bypassing a configured tenant gate. Wallets that never set the
+/// flag are unaffected in steady state (the read succeeds and returns false).
+async fn get_tenant_enforcement(
+    conn: &mut redis::aio::MultiplexedConnection,
+    db_pool: Option<&sqlx::PgPool>,
+    wallet: &str,
+    tenant: Option<&str>,
+) -> (bool, Option<TenantBudgetConfig>) {
+    // --- require_tenant flag ---
+    let require_cache_key = format!("tenant_require:{wallet}");
+    let require_tenant = {
+        let cached: Option<String> = redis::cmd("GET")
+            .arg(&require_cache_key)
+            .query_async(conn)
+            .await
+            .ok()
+            .flatten();
+        match cached.as_deref() {
+            Some("1") => Some(true),
+            Some("0") => Some(false),
+            _ => None,
+        }
+    };
+
+    let require_tenant = match require_tenant {
+        Some(v) => v,
+        None => {
+            let value = if let Some(pool) = db_pool {
+                match sqlx::query_as::<_, (bool,)>(
+                    "SELECT require_tenant FROM wallet_budgets WHERE wallet_address = $1",
+                )
+                .bind(wallet)
+                .fetch_optional(pool)
+                .await
+                {
+                    Ok(Some((flag,))) => flag,
+                    // No wallet_budgets row → never enforced (matches the
+                    // default-FALSE column semantics for unconfigured wallets).
+                    Ok(None) => false,
+                    Err(e) => {
+                        // Fail-closed: cannot confirm the wallet is unenforced.
+                        warn!(
+                            wallet = %wallet,
+                            error = %e,
+                            "failed to query wallet_budgets.require_tenant — failing closed (enforced)"
+                        );
+                        true
+                    }
+                }
+            } else {
+                // No DB pool — operator chose to run without a DB; nothing to
+                // enforce (consistent with team membership returning None).
+                false
+            };
+            let sentinel = if value { "1" } else { "0" };
+            let _: Result<(), _> = redis::cmd("SET")
+                .arg(&require_cache_key)
+                .arg(sentinel)
+                .arg("EX")
+                .arg(TENANT_BUDGET_CACHE_TTL)
+                .query_async(conn)
+                .await;
+            value
+        }
+    };
+
+    // --- tenant_budgets row (only when a tag is present) ---
+    let tenant_config = match tenant {
+        None => None,
+        Some(tag) => get_tenant_budget_config(conn, db_pool, wallet, tag).await,
+    };
+
+    (require_tenant, tenant_config)
+}
+
+/// Load the `(wallet, tenant)` budget config from `tenant_budgets`. Cached in
+/// Redis with 60s TTL (`tenant_budget:{wallet}:{tenant}`), with a "none"
+/// sentinel for "no provisioned row" to avoid repeated DB misses.
+///
+/// Returns `None` when no row exists. On a DB error returns `None` (the
+/// require_tenant fail-closed posture in [`get_tenant_enforcement`] is what
+/// guards the enforced-wallet case; an unenforced wallet with a transient DB
+/// error simply skips tenant enforcement, falling back to wallet/team caps).
+async fn get_tenant_budget_config(
+    conn: &mut redis::aio::MultiplexedConnection,
+    db_pool: Option<&sqlx::PgPool>,
+    wallet: &str,
+    tenant: &str,
+) -> Option<TenantBudgetConfig> {
+    let cache_key = format!("tenant_budget:{wallet}:{tenant}");
+
+    if let Ok(Some(json_str)) = redis::cmd("GET")
+        .arg(&cache_key)
+        .query_async::<Option<String>>(conn)
+        .await
+    {
+        if json_str == "none" {
+            return None;
+        }
+        if let Ok(config) = serde_json::from_str::<TenantBudgetConfig>(&json_str) {
+            return Some(config);
+        }
+    }
+
+    let config = if let Some(pool) = db_pool {
+        match sqlx::query_as::<_, (Option<f64>, Option<f64>, Option<f64>)>(
+            r#"SELECT
+                hourly_limit_usdc::DOUBLE PRECISION,
+                daily_limit_usdc::DOUBLE PRECISION,
+                monthly_limit_usdc::DOUBLE PRECISION
+            FROM tenant_budgets
+            WHERE wallet_address = $1 AND tenant = $2"#,
+        )
+        .bind(wallet)
+        .bind(tenant)
+        .fetch_optional(pool)
+        .await
+        {
+            Ok(Some((hourly, daily, monthly))) => Some(TenantBudgetConfig {
+                hourly,
+                daily,
+                monthly,
+            }),
+            Ok(None) => None,
+            Err(e) => {
+                warn!(wallet = %wallet, tenant = %tenant, error = %e, "failed to query tenant_budgets");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let cache_val = match &config {
+        Some(cfg) => serde_json::to_string(cfg).unwrap_or_else(|_| "none".to_string()),
+        None => "none".to_string(),
+    };
+    let _: Result<(), _> = redis::cmd("SET")
+        .arg(&cache_key)
+        .arg(&cache_val)
+        .arg("EX")
+        .arg(TENANT_BUDGET_CACHE_TTL)
+        .query_async(conn)
+        .await;
+
+    config
+}
+
 /// Read the current spend from Redis for a given key pattern.
 /// Public helper used by budget API endpoints to report current spend.
 pub async fn get_redis_spend(client: &redis::Client, key: &str) -> Result<f64, UsageError> {
@@ -1322,7 +1702,7 @@ mod tests {
         // Without Redis, the conservative cap is $1.00.  A cost of exactly $1.00
         // (not strictly greater) must be allowed through.
         let tracker = UsageTracker::noop();
-        let result = tracker.check_budget("wallet123", 1.0).await;
+        let result = tracker.check_budget("wallet123", 1.0, None).await;
         assert!(result.is_ok(), "cost equal to cap should be allowed");
     }
 
@@ -1331,7 +1711,7 @@ mod tests {
         // Without Redis, requests exceeding $1.00 must be rejected to prevent
         // runaway spend on high-cost models.
         let tracker = UsageTracker::noop();
-        let result = tracker.check_budget("wallet123", 1.01).await;
+        let result = tracker.check_budget("wallet123", 1.01, None).await;
         assert!(
             matches!(result, Err(UsageError::BudgetExceeded { .. })),
             "cost above cap should be rejected when Redis is unavailable"
@@ -1341,7 +1721,7 @@ mod tests {
     #[tokio::test]
     async fn test_noop_tracker_check_budget_passes_below_cap() {
         let tracker = UsageTracker::noop();
-        let result = tracker.check_budget("wallet123", 0.50).await;
+        let result = tracker.check_budget("wallet123", 0.50, None).await;
         assert!(result.is_ok(), "cost below cap should be allowed");
     }
 
@@ -1357,7 +1737,7 @@ mod tests {
         let tracker = UsageTracker::noop();
         // A within-cap check yields an (empty) reservation without Redis.
         let reservation = tracker
-            .check_budget("wallet123", 0.50)
+            .check_budget("wallet123", 0.50, None)
             .await
             .expect("within-cap check_budget must succeed without Redis");
         assert!(
@@ -1639,5 +2019,192 @@ mod tests {
             MIGRATION_007.contains("update_updated_at_column()"),
             "trigger must use the generic update_updated_at_column function"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // PR2: per-tenant budget enforcement
+    // -----------------------------------------------------------------------
+
+    /// Exhaustive truth table for the money-path decision matrix. Every
+    /// (require_tenant, tag_present, has_row) cell is pinned. This is the
+    /// contract; it must stay byte-for-byte as specified in the PR brief.
+    #[test]
+    fn test_tenant_enforcement_decision_matrix_exhaustive() {
+        use TenantDecision::*;
+        // require_tenant = FALSE (default for every existing wallet)
+        assert_eq!(
+            tenant_enforcement_decision(false, None, false),
+            Skip,
+            "unenforced + untagged → Skip"
+        );
+        assert_eq!(
+            tenant_enforcement_decision(false, None, true),
+            Skip,
+            "unenforced + untagged → Skip even if a (stale) row flag is set"
+        );
+        assert_eq!(
+            tenant_enforcement_decision(false, Some("acme"), false),
+            Skip,
+            "unenforced + tagged + no row → Skip (wallet/team only)"
+        );
+        assert_eq!(
+            tenant_enforcement_decision(false, Some("acme"), true),
+            Enforce,
+            "unenforced + tagged + provisioned row → Enforce"
+        );
+
+        // require_tenant = TRUE
+        assert_eq!(
+            tenant_enforcement_decision(true, None, false),
+            RejectRequired,
+            "enforced + untagged → RejectRequired"
+        );
+        assert_eq!(
+            tenant_enforcement_decision(true, None, true),
+            RejectRequired,
+            "enforced + untagged → RejectRequired regardless of row flag"
+        );
+        assert_eq!(
+            tenant_enforcement_decision(true, Some("ghost"), false),
+            RejectNotProvisioned,
+            "enforced + tagged + no row → RejectNotProvisioned"
+        );
+        assert_eq!(
+            tenant_enforcement_decision(true, Some("acme"), true),
+            Enforce,
+            "enforced + tagged + provisioned row → Enforce"
+        );
+    }
+
+    /// Backward-compat invariant at the policy layer: an unenforced wallet
+    /// (require_tenant=FALSE) yields `Skip` whether or not a tag is present, as
+    /// long as no provisioned row exists — identical to the pre-PR2
+    /// wallet/team-only path. (The Redis-counter equivalent is proven in the
+    /// integration suite.)
+    #[test]
+    fn test_tenant_decision_backward_compat_unenforced_wallet() {
+        assert_eq!(
+            tenant_enforcement_decision(false, None, false),
+            tenant_enforcement_decision(false, Some("anything"), false),
+            "unenforced wallet with no provisioned row must behave identically \
+             tagged or untagged (both Skip)"
+        );
+    }
+
+    #[test]
+    fn test_tenant_error_messages() {
+        let err = UsageError::TenantRequired {
+            wallet: "WalletABC".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("WalletABC"), "must name the wallet");
+        assert!(msg.contains("x-tenant"), "must mention the required header");
+
+        let err = UsageError::TenantNotProvisioned {
+            wallet: "WalletABC".to_string(),
+            tenant: "ghost".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("WalletABC"), "must name the wallet");
+        assert!(msg.contains("ghost"), "must name the unprovisioned tenant");
+    }
+
+    #[test]
+    fn test_tenant_spend_key_format() {
+        // The per-tenant counters key `spend:{wallet}:{tenant}:{period}`.
+        let wallet = "WalletABC";
+        let tenant = "acme";
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 4, 5)
+            .expect("valid date")
+            .and_hms_opt(14, 30, 0)
+            .expect("valid time");
+        assert_eq!(
+            format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%dT%H")),
+            "spend:WalletABC:acme:2026-04-05T14"
+        );
+        assert_eq!(
+            format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d")),
+            "spend:WalletABC:acme:2026-04-05"
+        );
+        assert_eq!(
+            format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m")),
+            "spend:WalletABC:acme:2026-04"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_noop_tracker_check_budget_ignores_tenant_without_redis() {
+        // Backward-compat / no-Redis: the tenant fail-closed gates are NOT applied
+        // on the no-Redis branch (they need the DB-backed flag). A within-cap
+        // request passes whether tagged or untagged.
+        let tracker = UsageTracker::noop();
+        tracker
+            .check_budget("wallet123", 0.50, None)
+            .await
+            .expect("untagged within-cap must pass without Redis");
+        tracker
+            .check_budget("wallet123", 0.50, Some("acme"))
+            .await
+            .expect("tagged within-cap must pass identically without Redis");
+    }
+
+    /// Migration 011 SQL (loaded from file).
+    const MIGRATION_011: &str = include_str!("../../../migrations/011_tenant_budgets.sql");
+
+    #[test]
+    fn test_migration_011_creates_tenant_budgets_table() {
+        assert!(
+            MIGRATION_011.contains("CREATE TABLE IF NOT EXISTS tenant_budgets"),
+            "migration must create tenant_budgets table"
+        );
+        assert!(
+            MIGRATION_011.contains("PRIMARY KEY (wallet_address, tenant)"),
+            "tenant_budgets PK must be (wallet_address, tenant)"
+        );
+        for col in [
+            "hourly_limit_usdc",
+            "daily_limit_usdc",
+            "monthly_limit_usdc",
+        ] {
+            assert!(
+                MIGRATION_011.contains(col),
+                "tenant_budgets must have {col}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_migration_011_adds_require_tenant_column() {
+        assert!(
+            MIGRATION_011
+                .contains("ADD COLUMN IF NOT EXISTS require_tenant BOOLEAN NOT NULL DEFAULT FALSE"),
+            "migration must add require_tenant column defaulting to FALSE"
+        );
+    }
+
+    #[test]
+    fn test_migration_011_creates_updated_at_trigger() {
+        assert!(
+            MIGRATION_011.contains("trg_tenant_budgets_updated_at"),
+            "migration must create updated_at trigger for tenant_budgets"
+        );
+        assert!(
+            MIGRATION_011.contains("update_updated_at_column()"),
+            "trigger must use the generic update_updated_at_column function"
+        );
+    }
+
+    #[test]
+    fn test_tenant_budget_config_serialization_roundtrip() {
+        let config = TenantBudgetConfig {
+            hourly: Some(1.0),
+            daily: Some(10.0),
+            monthly: None,
+        };
+        let json = serde_json::to_string(&config).expect("serialize");
+        let back: TenantBudgetConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.hourly, Some(1.0));
+        assert_eq!(back.daily, Some(10.0));
+        assert!(back.monthly.is_none());
     }
 }

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -56,6 +56,16 @@ pub struct BudgetConfig {
     pub hourly: Option<f64>,
     pub daily: Option<f64>,
     pub monthly: Option<f64>,
+    /// Whether this wallet is configured `require_tenant = TRUE` in
+    /// `wallet_budgets` — i.e. it may only spend under a tagged, provisioned
+    /// tenant. Read from the SAME `wallet_budgets` row as the limits so the
+    /// tenant gate needs no extra Redis/DB round-trip (N2).
+    ///
+    /// `#[serde(default)]` so cached JSON written before this field existed
+    /// (pre-N2) still deserializes — the absent field defaults to `false`
+    /// (unenforced), which is the safe, backward-compatible value.
+    #[serde(default)]
+    pub require_tenant: bool,
 }
 
 impl Default for BudgetConfig {
@@ -64,6 +74,7 @@ impl Default for BudgetConfig {
             hourly: None,
             daily: Some(DEFAULT_DAILY_LIMIT_USDC),
             monthly: None,
+            require_tenant: false,
         }
     }
 }
@@ -82,6 +93,25 @@ pub struct TenantBudgetConfig {
     pub hourly: Option<f64>,
     pub daily: Option<f64>,
     pub monthly: Option<f64>,
+}
+
+/// Result of looking up a `(wallet, tenant)` `tenant_budgets` row.
+///
+/// Distinguishes a CONFIRMED-ABSENT row from a transient DB ERROR (N3). The two
+/// must be surfaced differently for an enforced wallet: a confirmed absence is a
+/// genuine "not provisioned" config issue (`TenantNotProvisioned`), whereas a DB
+/// error is a transient infrastructure blip that should map to
+/// `UsageError::Database` so operators don't chase a phantom provisioning
+/// problem. Both still deny the request for an enforced wallet (fail-closed) —
+/// only the surfaced error variant differs.
+#[derive(Debug, Clone)]
+enum TenantLookup {
+    /// A provisioned `tenant_budgets` row exists for `(wallet, tenant)`.
+    Found(TenantBudgetConfig),
+    /// The query SUCCEEDED and confirmed no row exists.
+    Absent,
+    /// The query ERRORED (transient DB problem) — provisioning state unknown.
+    DbError,
 }
 
 /// Outcome of the per-tenant enforcement decision matrix.
@@ -674,17 +704,58 @@ impl UsageTracker {
         //   * require_tenant=TRUE, tag but no row         → RejectNotProvisioned.
         //   * otherwise                                   → Skip (wallet/team only).
         //
-        // We load the wallet's require_tenant flag and (when a tag is present)
-        // the tenant_budgets row in one combined helper so the no-tenant path
-        // adds no extra round-trip relative to pre-PR2 when require_tenant is
-        // unset and no tag is supplied.
-        let (require_tenant, tenant_config) =
-            get_tenant_enforcement(&mut conn, self.db_pool.as_ref(), wallet_address, tenant).await;
+        // Round-trip cost (N2): `require_tenant` rides on the `BudgetConfig` read
+        // above (`get_wallet_budget_config`) — the same `wallet_budgets` row read
+        // it already performs — so there is NO extra Redis/DB round-trip for the
+        // no-tenant path. A tagged request additionally reads the
+        // `tenant_budgets` row (cached 60s); an untagged request reads nothing
+        // more here.
+        let require_tenant = config.require_tenant;
 
-        // Set true only on the `Enforce` arm. Threaded out via
+        // The tenant_budgets row is read ONLY when a tag is present. The lookup
+        // distinguishes a confirmed-absent row from a transient DB error (N3):
+        // for an enforced wallet a DB error surfaces as `UsageError::Database`
+        // (transient infra) rather than `TenantNotProvisioned` (a config issue),
+        // while still denying the request.
+        let tenant_lookup = match tenant {
+            None => TenantLookup::Absent,
+            Some(tag) => {
+                get_tenant_budget_config(&mut conn, self.db_pool.as_ref(), wallet_address, tag)
+                    .await
+            }
+        };
+
+        // N3: a DB error reading `tenant_budgets` for an ENFORCED wallet is
+        // fail-closed (deny) but surfaced as a transient `Database` error, not
+        // `TenantNotProvisioned`. For an UNENFORCED wallet a DB error simply
+        // skips tenant enforcement (the wallet/team cap is the authoritative
+        // backstop) — handled below via `has_row = false` → `Skip`.
+        if matches!(tenant_lookup, TenantLookup::DbError) && require_tenant {
+            rollback_committed(&mut conn, &committed).await;
+            warn!(
+                wallet = %wallet_address,
+                "tenant_lookup_db_error: enforced wallet, tenant_budgets read failed; \
+                 denying request (fail-closed) as a transient DB error"
+            );
+            return Err(UsageError::Database(
+                "tenant_budgets lookup failed".to_string(),
+            ));
+        }
+
+        // For the decision matrix, a `Found` row means has_row=true; `Absent` and
+        // (for an unenforced wallet) `DbError` both mean has_row=false → Skip.
+        let tenant_config: Option<TenantBudgetConfig> = match tenant_lookup {
+            TenantLookup::Found(cfg) => Some(cfg),
+            TenantLookup::Absent | TenantLookup::DbError => None,
+        };
+
+        // Set true only when a provisioned tenant bucket was enforced AND at
+        // least one window counter was actually committed (N4). Threaded out via
         // `BudgetReservation::tenant_enforced` so `log_spend` reconciles the
-        // per-tenant counters ONLY when a provisioned bucket was actually
-        // enforced (not on the pre-provisioning `Skip` path).
+        // per-tenant counters ONLY for windows that were actually reserved — a
+        // limitless provisioned row commits nothing, so it must NOT report
+        // enforced (otherwise log_spend would write counters check_budget never
+        // reserved).
         let mut tenant_enforced = false;
 
         match tenant_enforcement_decision(require_tenant, tenant, tenant_config.is_some()) {
@@ -722,7 +793,6 @@ impl UsageTracker {
                 });
             }
             TenantDecision::Enforce => {
-                tenant_enforced = true;
                 // `Enforce` is only returned when both `tenant` is `Some` and a
                 // provisioned row exists. Using `.expect`/`unreachable!` (instead
                 // of `unwrap_or_default()` / an all-None default) turns a future
@@ -737,7 +807,7 @@ impl UsageTracker {
 
                 // A provisioned row with NO hourly/daily/monthly limit set means
                 // enforcement is a silent no-op (no `try_commit!` fires). Surface
-                // it for observability — behaviour is unchanged.
+                // it for observability.
                 let any_limit =
                     tcfg.hourly.is_some() || tcfg.daily.is_some() || tcfg.monthly.is_some();
                 if !any_limit {
@@ -748,6 +818,14 @@ impl UsageTracker {
                          hourly/daily/monthly limit set — enforcement is a silent no-op"
                     );
                 }
+
+                // N4: report enforced ONLY when at least one window counter was
+                // actually committed below (i.e. at least one limit is Some). A
+                // limitless provisioned row reserves zero counters, so it must NOT
+                // report enforced — otherwise `log_spend` would write per-tenant
+                // counters that `check_budget` never reserved, breaking the
+                // reserve/settle symmetry.
+                tenant_enforced = any_limit;
 
                 if let Some(hourly_limit) = tcfg.hourly {
                     let _ = try_commit!(
@@ -1082,12 +1160,28 @@ fn restrictive_budget_fallback() -> BudgetConfig {
         hourly: Some(0.50),
         daily: Some(1.0),
         monthly: Some(10.0),
+        // Fail OPEN for the tenant gate on a wallet-config DB error: the
+        // restrictive hourly/daily/monthly caps above are the authoritative,
+        // non-forgeable backstop. Setting this `true` on a transient blip would
+        // reject ALL untagged traffic gateway-wide. The error path that returns
+        // this value MUST NOT cache it (see `get_wallet_budget_config`), so the
+        // next request re-attempts the DB read rather than serving a poisoned
+        // `require_tenant=false` for a full TTL.
+        require_tenant: false,
     }
 }
 
 /// Load per-wallet budget config. Checks Redis cache first (`budget_config:{wallet}`),
 /// falls back to DB query, caches result in Redis with 60s TTL.
 /// Returns default config ($100/day) if no row exists; restrictive fallback on DB error.
+///
+/// Reads the wallet's `require_tenant` flag from the SAME `wallet_budgets` row,
+/// surfaced on [`BudgetConfig::require_tenant`]. The tenant gate consumes it from
+/// here, so the no-tenant path adds NO extra Redis/DB round-trip relative to
+/// pre-PR2 (N2 — the previous separate `tenant_require:{wallet}` lookup was
+/// removed). On a DB error the restrictive fallback (with `require_tenant=false`)
+/// is returned but NOT cached, so a transient blip cannot poison the cache for a
+/// full TTL.
 async fn get_wallet_budget_config(
     conn: &mut redis::aio::MultiplexedConnection,
     db_pool: Option<&sqlx::PgPool>,
@@ -1113,13 +1207,19 @@ async fn get_wallet_budget_config(
         }
     }
 
-    // Cache miss — query DB
-    let config = if let Some(pool) = db_pool {
-        match sqlx::query_as::<_, (Option<f64>, Option<f64>, Option<f64>)>(
+    // Cache miss — query DB. `persist` is true only when the query SUCCEEDED
+    // (a real row, a confirmed absence, or no DB pool). On a DB error we return
+    // the restrictive fallback WITHOUT caching, so a transient error cannot
+    // poison the cache (including its `require_tenant=false`) for a full TTL —
+    // the next request re-attempts the DB read. Mirrors the `persist` pattern in
+    // `get_tenant_enforcement` / `get_tenant_budget_config`.
+    let (config, persist) = if let Some(pool) = db_pool {
+        match sqlx::query_as::<_, (Option<f64>, Option<f64>, Option<f64>, bool)>(
             r#"SELECT
                 hourly_limit_usdc::DOUBLE PRECISION,
                 daily_limit_usdc::DOUBLE PRECISION,
-                monthly_limit_usdc::DOUBLE PRECISION
+                monthly_limit_usdc::DOUBLE PRECISION,
+                require_tenant
             FROM wallet_budgets
             WHERE wallet_address = $1"#,
         )
@@ -1127,32 +1227,41 @@ async fn get_wallet_budget_config(
         .fetch_optional(pool)
         .await
         {
-            Ok(Some((hourly, daily, monthly))) => BudgetConfig {
-                hourly,
-                daily: daily.or(Some(DEFAULT_DAILY_LIMIT_USDC)),
-                monthly,
-            },
-            Ok(None) => BudgetConfig::default(),
+            Ok(Some((hourly, daily, monthly, require_tenant))) => (
+                BudgetConfig {
+                    hourly,
+                    daily: daily.or(Some(DEFAULT_DAILY_LIMIT_USDC)),
+                    monthly,
+                    require_tenant,
+                },
+                true,
+            ),
+            // No wallet_budgets row → default config, require_tenant=false
+            // (matches the column's DEFAULT FALSE for unconfigured wallets).
+            Ok(None) => (BudgetConfig::default(), true),
             Err(e) => {
-                warn!(wallet = %wallet, error = %e, "failed to query wallet_budgets — using restrictive fallback");
-                restrictive_budget_fallback()
+                warn!(wallet = %wallet, error = %e, "failed to query wallet_budgets — using restrictive fallback (not caching)");
+                (restrictive_budget_fallback(), false)
             }
         }
     } else {
-        BudgetConfig::default()
+        (BudgetConfig::default(), true)
     };
 
-    // Cache in Redis (best-effort)
-    if let Ok(json_str) = serde_json::to_string(&config) {
-        if let Err(e) = redis::cmd("SET")
-            .arg(&cache_key)
-            .arg(&json_str)
-            .arg("EX")
-            .arg(BUDGET_CONFIG_CACHE_TTL)
-            .query_async::<()>(conn)
-            .await
-        {
-            tracing::warn!(cache_key = %cache_key, error = %e, "failed to write to Redis cache");
+    // Cache in Redis (best-effort) — only when the value is authoritative (a
+    // successful read), never an error-derived restrictive fallback.
+    if persist {
+        if let Ok(json_str) = serde_json::to_string(&config) {
+            if let Err(e) = redis::cmd("SET")
+                .arg(&cache_key)
+                .arg(&json_str)
+                .arg("EX")
+                .arg(BUDGET_CONFIG_CACHE_TTL)
+                .query_async::<()>(conn)
+                .await
+            {
+                tracing::warn!(cache_key = %cache_key, error = %e, "failed to write to Redis cache");
+            }
         }
     }
 
@@ -1298,137 +1407,29 @@ async fn get_team_budget_config(
     config
 }
 
-/// Load the per-tenant enforcement inputs for a wallet+tag in one combined
-/// lookup: the wallet's `require_tenant` flag and (when a tag is present) the
-/// `(wallet, tenant)` `tenant_budgets` row.
-///
-/// Returns `(require_tenant, tenant_config)`. `tenant_config` is `None` when no
-/// tag is supplied OR no provisioned row exists for the tag — the
-/// [`tenant_enforcement_decision`] matrix distinguishes those two cases using
-/// `require_tenant`.
-///
-/// Caching mirrors the wallet/team helpers (Redis, 60s TTL):
-/// - `tenant_require:{wallet}` → "1"/"0" sentinel for the flag.
-/// - `tenant_budget:{wallet}:{tenant}` → JSON config, or "none" sentinel.
-///
-/// **Fail-OPEN posture on DB error:** a DB error reading
-/// `wallet_budgets.require_tenant` returns `require_tenant = false` with
-/// `tenant_config = None` — i.e. NO tenant enforcement for that request. The
-/// rationale: the wallet (and team) cap is the authoritative, non-forgeable
-/// backstop and still applies, so a request can never escape its real spend
-/// limit. Failing CLOSED here would let a single transient DB blip reject ALL
-/// untagged traffic gateway-wide; failing open degrades only the optional
-/// sub-allocation convenience while the hard cap holds. This mirrors how
-/// `get_wallet_budget_config` / `get_team_for_wallet` / `get_tenant_budget_config`
-/// already degrade on DB error.
-///
-/// Critically, on a DB error we return the fallback WITHOUT writing the Redis
-/// sentinel, so a transient error cannot poison the cache for a full TTL — the
-/// next request re-attempts the DB read. The sentinel is only written when the
-/// query SUCCEEDED.
-///
-/// **Steady-state policy is unchanged:** when the flag READS `true`, an untagged
-/// request is still rejected (`RejectRequired`) and a tagged-but-unprovisioned
-/// request is still rejected (`RejectNotProvisioned`) — fail-closed. The
-/// fail-open behaviour applies ONLY to the DB-error path, not to a wallet that
-/// is genuinely configured as enforced.
-async fn get_tenant_enforcement(
-    conn: &mut redis::aio::MultiplexedConnection,
-    db_pool: Option<&sqlx::PgPool>,
-    wallet: &str,
-    tenant: Option<&str>,
-) -> (bool, Option<TenantBudgetConfig>) {
-    // --- require_tenant flag ---
-    let require_cache_key = format!("tenant_require:{wallet}");
-    let require_tenant = {
-        let cached: Option<String> = redis::cmd("GET")
-            .arg(&require_cache_key)
-            .query_async(conn)
-            .await
-            .ok()
-            .flatten();
-        match cached.as_deref() {
-            Some("1") => Some(true),
-            Some("0") => Some(false),
-            _ => None,
-        }
-    };
-
-    let require_tenant = match require_tenant {
-        Some(v) => v,
-        None => {
-            // The DB read yields a (value, persist) pair: `persist` is true only
-            // when the query SUCCEEDED, so a DB error never writes an
-            // error-derived sentinel into Redis (which would poison the cache for
-            // a full TTL). On DB error we fail OPEN (false) per the doc comment —
-            // the wallet/team cap remains the authoritative backstop.
-            let (value, persist) = if let Some(pool) = db_pool {
-                match sqlx::query_as::<_, (bool,)>(
-                    "SELECT require_tenant FROM wallet_budgets WHERE wallet_address = $1",
-                )
-                .bind(wallet)
-                .fetch_optional(pool)
-                .await
-                {
-                    Ok(Some((flag,))) => (flag, true),
-                    // No wallet_budgets row → never enforced (matches the
-                    // default-FALSE column semantics for unconfigured wallets).
-                    Ok(None) => (false, true),
-                    Err(e) => {
-                        // Fail-OPEN: cannot confirm the flag; the non-forgeable
-                        // wallet/team cap still applies. Do NOT cache this
-                        // error-derived value — re-attempt the DB read next request.
-                        warn!(
-                            wallet = %wallet,
-                            error = %e,
-                            "failed to query wallet_budgets.require_tenant — failing open (unenforced); not caching"
-                        );
-                        (false, false)
-                    }
-                }
-            } else {
-                // No DB pool — operator chose to run without a DB; nothing to
-                // enforce (consistent with team membership returning None). This
-                // is not an error, so it is safe to cache.
-                (false, true)
-            };
-            if persist {
-                let sentinel = if value { "1" } else { "0" };
-                let _: Result<(), _> = redis::cmd("SET")
-                    .arg(&require_cache_key)
-                    .arg(sentinel)
-                    .arg("EX")
-                    .arg(TENANT_BUDGET_CACHE_TTL)
-                    .query_async(conn)
-                    .await;
-            }
-            value
-        }
-    };
-
-    // --- tenant_budgets row (only when a tag is present) ---
-    let tenant_config = match tenant {
-        None => None,
-        Some(tag) => get_tenant_budget_config(conn, db_pool, wallet, tag).await,
-    };
-
-    (require_tenant, tenant_config)
-}
-
 /// Load the `(wallet, tenant)` budget config from `tenant_budgets`. Cached in
 /// Redis with 60s TTL (`tenant_budget:{wallet}:{tenant}`), with a "none"
 /// sentinel for "no provisioned row" to avoid repeated DB misses.
 ///
-/// Returns `None` when no row exists. On a DB error returns `None` (the
-/// require_tenant fail-closed posture in [`get_tenant_enforcement`] is what
-/// guards the enforced-wallet case; an unenforced wallet with a transient DB
-/// error simply skips tenant enforcement, falling back to wallet/team caps).
+/// Returns a [`TenantLookup`] that distinguishes a provisioned row
+/// ([`TenantLookup::Found`]) from a confirmed absence ([`TenantLookup::Absent`])
+/// and a transient DB error ([`TenantLookup::DbError`]) — N3. The caller maps a
+/// `DbError` on an enforced wallet to `UsageError::Database` (transient infra)
+/// rather than `TenantNotProvisioned` (a config issue), while still denying the
+/// request. Only `Found`/`Absent` are cached; a `DbError` is never cached, so a
+/// transient error cannot poison the "none" sentinel for a full TTL — the next
+/// request re-attempts the DB read.
+///
+/// `require_tenant` is NOT read here: it now rides on
+/// [`BudgetConfig::require_tenant`] from the wallet-config read that
+/// `check_budget` already performs (N2), so the no-tenant path adds no extra
+/// round-trip.
 async fn get_tenant_budget_config(
     conn: &mut redis::aio::MultiplexedConnection,
     db_pool: Option<&sqlx::PgPool>,
     wallet: &str,
     tenant: &str,
-) -> Option<TenantBudgetConfig> {
+) -> TenantLookup {
     let cache_key = format!("tenant_budget:{wallet}:{tenant}");
 
     if let Ok(Some(json_str)) = redis::cmd("GET")
@@ -1437,18 +1438,17 @@ async fn get_tenant_budget_config(
         .await
     {
         if json_str == "none" {
-            return None;
+            return TenantLookup::Absent;
         }
         if let Ok(config) = serde_json::from_str::<TenantBudgetConfig>(&json_str) {
-            return Some(config);
+            return TenantLookup::Found(config);
         }
     }
 
-    // `persist` is true only when the query SUCCEEDED (a real row, or a
-    // confirmed absence). On a DB error we return `None` WITHOUT caching, so a
-    // transient error cannot poison the "none" sentinel for a full TTL — the
-    // next request re-attempts the DB read.
-    let (config, persist) = if let Some(pool) = db_pool {
+    // A DB error returns `DbError` WITHOUT caching, so a transient error cannot
+    // poison the "none" sentinel for a full TTL — the next request re-attempts
+    // the DB read. Only a successful read (`Found`/`Absent`) is cached.
+    let lookup = if let Some(pool) = db_pool {
         match sqlx::query_as::<_, (Option<f64>, Option<f64>, Option<f64>)>(
             r#"SELECT
                 hourly_limit_usdc::DOUBLE PRECISION,
@@ -1462,30 +1462,31 @@ async fn get_tenant_budget_config(
         .fetch_optional(pool)
         .await
         {
-            Ok(Some((hourly, daily, monthly))) => (
-                Some(TenantBudgetConfig {
-                    hourly,
-                    daily,
-                    monthly,
-                }),
-                true,
-            ),
-            Ok(None) => (None, true),
+            Ok(Some((hourly, daily, monthly))) => TenantLookup::Found(TenantBudgetConfig {
+                hourly,
+                daily,
+                monthly,
+            }),
+            Ok(None) => TenantLookup::Absent,
             Err(e) => {
                 warn!(wallet = %wallet, tenant = %tenant, error = %e, "failed to query tenant_budgets — not caching");
-                (None, false)
+                TenantLookup::DbError
             }
         }
     } else {
         // No DB pool — a stable "no provisioned row" answer; safe to cache.
-        (None, true)
+        TenantLookup::Absent
     };
 
-    if persist {
-        let cache_val = match &config {
-            Some(cfg) => serde_json::to_string(cfg).unwrap_or_else(|_| "none".to_string()),
-            None => "none".to_string(),
-        };
+    let cache_val = match &lookup {
+        TenantLookup::Found(cfg) => {
+            Some(serde_json::to_string(cfg).unwrap_or_else(|_| "none".to_string()))
+        }
+        TenantLookup::Absent => Some("none".to_string()),
+        // Never cache a transient error-derived value.
+        TenantLookup::DbError => None,
+    };
+    if let Some(cache_val) = cache_val {
         let _: Result<(), _> = redis::cmd("SET")
             .arg(&cache_key)
             .arg(&cache_val)
@@ -1495,7 +1496,7 @@ async fn get_tenant_budget_config(
             .await;
     }
 
-    config
+    lookup
 }
 
 /// Read the current spend from Redis for a given key pattern.
@@ -2003,6 +2004,8 @@ mod tests {
         assert_eq!(config.daily, Some(100.0));
         assert!(config.hourly.is_none());
         assert!(config.monthly.is_none());
+        // N2: default wallet is unenforced.
+        assert!(!config.require_tenant);
     }
 
     #[test]
@@ -2011,12 +2014,31 @@ mod tests {
             hourly: Some(10.0),
             daily: Some(100.0),
             monthly: None,
+            require_tenant: true,
         };
         let json = serde_json::to_string(&config).expect("should serialize");
         let deserialized: BudgetConfig = serde_json::from_str(&json).expect("should deserialize");
         assert_eq!(deserialized.hourly, Some(10.0));
         assert_eq!(deserialized.daily, Some(100.0));
         assert!(deserialized.monthly.is_none());
+        assert!(deserialized.require_tenant);
+    }
+
+    /// N2 backward-compat: cached `BudgetConfig` JSON written BEFORE the
+    /// `require_tenant` field existed (pre-N2) must still deserialize, with the
+    /// absent field defaulting to `false` (unenforced) via `#[serde(default)]`.
+    /// Without the attribute this would error and corrupt-fall-through to a DB
+    /// read every request during a deploy that left old cache entries.
+    #[test]
+    fn test_budget_config_deserializes_legacy_json_without_require_tenant() {
+        let legacy = r#"{"hourly":null,"daily":0.05,"monthly":null}"#;
+        let cfg: BudgetConfig =
+            serde_json::from_str(legacy).expect("legacy cached JSON must still deserialize");
+        assert_eq!(cfg.daily, Some(0.05));
+        assert!(
+            !cfg.require_tenant,
+            "absent require_tenant must default to false (unenforced)"
+        );
     }
 
     #[test]

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -199,6 +199,16 @@ pub struct SpendLogEntry {
     /// Attribution only — recorded on the spend row for reporting; it does not
     /// gate or change billing. See `validate_tenant` for the accepted charset.
     pub tenant: Option<String>,
+    /// Whether `check_budget` actually ENFORCED a per-tenant bucket for this
+    /// request (i.e. the decision was `Enforce` — a provisioned `(wallet,
+    /// tenant)` row exists). Thread this from
+    /// [`BudgetReservation::tenant_enforced`]. `log_spend` reconciles the
+    /// `spend:{wallet}:{tenant}:{period}` counters ONLY when this is `true`,
+    /// so a tagged-but-unenforced (`Skip`-path) request does not accumulate
+    /// per-tenant spend that a later-provisioned budget would mis-read as
+    /// already-consumed. The per-tenant `tenant` field above is independent and
+    /// still recorded on the Postgres spend row for ATTRIBUTION regardless.
+    pub tenant_enforced: bool,
     /// Cost that was tentatively committed to the Redis spend counters at
     /// `check_budget` time. When `Some`, `log_spend` increments the counters
     /// by `(cost_usdc - estimated_cost_usdc)` so the ledger settles to the
@@ -354,7 +364,16 @@ impl UsageTracker {
             let client = client.clone();
             let db_pool = self.db_pool.clone();
             let wallet = entry.wallet_address;
-            let tenant = entry.tenant;
+            // Reconcile the per-tenant counters ONLY when check_budget actually
+            // enforced a provisioned tenant bucket (decision == Enforce). On the
+            // pre-provisioning Skip path `tenant_enforced` is false even if a tag
+            // is present, so we do not accumulate per-tenant spend that a
+            // later-provisioned budget would mis-read as already-consumed.
+            let tenant = if entry.tenant_enforced {
+                entry.tenant
+            } else {
+                None
+            };
             let cost = match entry.estimated_cost_usdc {
                 Some(reserved) => entry.cost_usdc - reserved,
                 None => entry.cost_usdc,
@@ -394,11 +413,12 @@ impl UsageTracker {
                 // Per-tenant counters: settle the same `cost` delta on the
                 // `spend:{wallet}:{tenant}:{period}` keys that `check_budget`'s
                 // `Enforce` arm reserved against. Mirrors the wallet/team
-                // reconciliation. Runs whenever the spend row carried a tenant
-                // tag (`entry.tenant`), symmetric with the wallet counter; if no
-                // tenant budget was provisioned the counter merely tracks tagged
-                // spend and self-expires (harmless). The header is forgeable —
-                // see the module-level security note.
+                // reconciliation. `tenant` is `Some` here ONLY when
+                // `entry.tenant_enforced` was true (a provisioned bucket was
+                // enforced) — see the gating above. On the Skip path we
+                // deliberately write nothing so pre-provisioning spend does not
+                // accumulate. The header is forgeable — see the module-level
+                // security note.
                 if let Some(tag) = tenant.as_deref() {
                     let tenant_hour_key =
                         format!("spend:{}:{}:{}", wallet, tag, now.format("%Y-%m-%dT%H"));
@@ -661,6 +681,12 @@ impl UsageTracker {
         let (require_tenant, tenant_config) =
             get_tenant_enforcement(&mut conn, self.db_pool.as_ref(), wallet_address, tenant).await;
 
+        // Set true only on the `Enforce` arm. Threaded out via
+        // `BudgetReservation::tenant_enforced` so `log_spend` reconciles the
+        // per-tenant counters ONLY when a provisioned bucket was actually
+        // enforced (not on the pre-provisioning `Skip` path).
+        let mut tenant_enforced = false;
+
         match tenant_enforcement_decision(require_tenant, tenant, tenant_config.is_some()) {
             TenantDecision::Skip => {}
             TenantDecision::RejectRequired => {
@@ -678,25 +704,50 @@ impl UsageTracker {
             }
             TenantDecision::RejectNotProvisioned => {
                 rollback_committed(&mut conn, &committed).await;
+                // `RejectNotProvisioned` is only reached when `tag` is `Some`
+                // (the matrix arm is `(true, Some(_), false)`). Surface a
+                // mis-keyed matrix as an immediate panic rather than a silent
+                // `<none>`/empty-string mis-attribution.
+                let tag = tenant.expect(
+                    "RejectNotProvisioned implies Some(tag) per tenant_enforcement_decision",
+                );
                 warn!(
                     wallet = %wallet_address,
-                    tenant = tenant.unwrap_or("<none>"),
+                    tenant = %tag,
                     "tenant_not_provisioned: enforced wallet, unknown tenant; denying request"
                 );
                 return Err(UsageError::TenantNotProvisioned {
                     wallet: wallet_address.to_string(),
-                    tenant: tenant.unwrap_or_default().to_string(),
+                    tenant: tag.to_string(),
                 });
             }
             TenantDecision::Enforce => {
-                // Safe: Enforce is only returned when both `tenant` is Some and a
-                // row exists. Counters key `spend:{wallet}:{tenant}:{period}`.
-                let tag = tenant.unwrap_or_default();
-                let tcfg = tenant_config.unwrap_or(TenantBudgetConfig {
-                    hourly: None,
-                    daily: None,
-                    monthly: None,
+                tenant_enforced = true;
+                // `Enforce` is only returned when both `tenant` is `Some` and a
+                // provisioned row exists. Using `.expect`/`unreachable!` (instead
+                // of `unwrap_or_default()` / an all-None default) turns a future
+                // matrix mistake into an immediate panic surfaced in tests rather
+                // than a silent counter mis-key (`spend:{wallet}::{period}`) or a
+                // silent no-op. Counters key `spend:{wallet}:{tenant}:{period}`.
+                let tag =
+                    tenant.expect("Enforce implies Some(tag) per tenant_enforcement_decision");
+                let tcfg = tenant_config.unwrap_or_else(|| {
+                    unreachable!("Enforce implies has_row=true (a provisioned tenant_budgets row)")
                 });
+
+                // A provisioned row with NO hourly/daily/monthly limit set means
+                // enforcement is a silent no-op (no `try_commit!` fires). Surface
+                // it for observability — behaviour is unchanged.
+                let any_limit =
+                    tcfg.hourly.is_some() || tcfg.daily.is_some() || tcfg.monthly.is_some();
+                if !any_limit {
+                    warn!(
+                        wallet = %wallet_address,
+                        tenant = %tag,
+                        "tenant_budget_no_limits: provisioned tenant_budgets row has no \
+                         hourly/daily/monthly limit set — enforcement is a silent no-op"
+                    );
+                }
 
                 if let Some(hourly_limit) = tcfg.hourly {
                     let _ = try_commit!(
@@ -735,7 +786,10 @@ impl UsageTracker {
             }
         }
 
-        Ok(BudgetReservation { committed })
+        Ok(BudgetReservation {
+            committed,
+            tenant_enforced,
+        })
     }
 
     /// Release a budget reservation previously returned by [`check_budget`].
@@ -832,6 +886,26 @@ impl UsageTracker {
 #[derive(Debug, Default)]
 pub struct BudgetReservation {
     committed: Vec<(String, f64)>,
+    /// Whether `check_budget` actually enforced a per-tenant bucket for this
+    /// request (i.e. the decision was `Enforce` — a provisioned `(wallet,
+    /// tenant)` row exists). When `false`, `log_spend` must NOT reconcile the
+    /// `spend:{wallet}:{tenant}:{period}` counters: writing them on the
+    /// pre-provisioning `Skip` path would accumulate tagged spend that a
+    /// later-provisioned budget would then read as already-consumed, causing a
+    /// spurious `BudgetExceeded` mid-window. Per-tenant ATTRIBUTION reporting
+    /// reads Postgres `spend_logs`, not these Redis counters, so gating the
+    /// counter writes here loses nothing for reporting.
+    tenant_enforced: bool,
+}
+
+impl BudgetReservation {
+    /// Whether a per-tenant budget bucket was actually enforced for the request
+    /// that produced this reservation. The chat handler threads this into
+    /// `SpendLogEntry.tenant_enforced` so `log_spend` only reconciles the
+    /// per-tenant counters when enforcement was real.
+    pub fn tenant_enforced(&self) -> bool {
+        self.tenant_enforced
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1237,12 +1311,27 @@ async fn get_team_budget_config(
 /// - `tenant_require:{wallet}` → "1"/"0" sentinel for the flag.
 /// - `tenant_budget:{wallet}:{tenant}` → JSON config, or "none" sentinel.
 ///
-/// **Fail-closed posture:** unlike the display-only helpers, a DB error here
-/// returns `require_tenant = true` with `tenant_config = None`. If we cannot
-/// confirm the wallet is unenforced, we must treat it as enforced — so a
-/// transient DB blip denies (`RejectRequired`/`RejectNotProvisioned`) rather
-/// than silently bypassing a configured tenant gate. Wallets that never set the
-/// flag are unaffected in steady state (the read succeeds and returns false).
+/// **Fail-OPEN posture on DB error:** a DB error reading
+/// `wallet_budgets.require_tenant` returns `require_tenant = false` with
+/// `tenant_config = None` — i.e. NO tenant enforcement for that request. The
+/// rationale: the wallet (and team) cap is the authoritative, non-forgeable
+/// backstop and still applies, so a request can never escape its real spend
+/// limit. Failing CLOSED here would let a single transient DB blip reject ALL
+/// untagged traffic gateway-wide; failing open degrades only the optional
+/// sub-allocation convenience while the hard cap holds. This mirrors how
+/// `get_wallet_budget_config` / `get_team_for_wallet` / `get_tenant_budget_config`
+/// already degrade on DB error.
+///
+/// Critically, on a DB error we return the fallback WITHOUT writing the Redis
+/// sentinel, so a transient error cannot poison the cache for a full TTL — the
+/// next request re-attempts the DB read. The sentinel is only written when the
+/// query SUCCEEDED.
+///
+/// **Steady-state policy is unchanged:** when the flag READS `true`, an untagged
+/// request is still rejected (`RejectRequired`) and a tagged-but-unprovisioned
+/// request is still rejected (`RejectNotProvisioned`) — fail-closed. The
+/// fail-open behaviour applies ONLY to the DB-error path, not to a wallet that
+/// is genuinely configured as enforced.
 async fn get_tenant_enforcement(
     conn: &mut redis::aio::MultiplexedConnection,
     db_pool: Option<&sqlx::PgPool>,
@@ -1268,7 +1357,12 @@ async fn get_tenant_enforcement(
     let require_tenant = match require_tenant {
         Some(v) => v,
         None => {
-            let value = if let Some(pool) = db_pool {
+            // The DB read yields a (value, persist) pair: `persist` is true only
+            // when the query SUCCEEDED, so a DB error never writes an
+            // error-derived sentinel into Redis (which would poison the cache for
+            // a full TTL). On DB error we fail OPEN (false) per the doc comment —
+            // the wallet/team cap remains the authoritative backstop.
+            let (value, persist) = if let Some(pool) = db_pool {
                 match sqlx::query_as::<_, (bool,)>(
                     "SELECT require_tenant FROM wallet_budgets WHERE wallet_address = $1",
                 )
@@ -1276,33 +1370,38 @@ async fn get_tenant_enforcement(
                 .fetch_optional(pool)
                 .await
                 {
-                    Ok(Some((flag,))) => flag,
+                    Ok(Some((flag,))) => (flag, true),
                     // No wallet_budgets row → never enforced (matches the
                     // default-FALSE column semantics for unconfigured wallets).
-                    Ok(None) => false,
+                    Ok(None) => (false, true),
                     Err(e) => {
-                        // Fail-closed: cannot confirm the wallet is unenforced.
+                        // Fail-OPEN: cannot confirm the flag; the non-forgeable
+                        // wallet/team cap still applies. Do NOT cache this
+                        // error-derived value — re-attempt the DB read next request.
                         warn!(
                             wallet = %wallet,
                             error = %e,
-                            "failed to query wallet_budgets.require_tenant — failing closed (enforced)"
+                            "failed to query wallet_budgets.require_tenant — failing open (unenforced); not caching"
                         );
-                        true
+                        (false, false)
                     }
                 }
             } else {
                 // No DB pool — operator chose to run without a DB; nothing to
-                // enforce (consistent with team membership returning None).
-                false
+                // enforce (consistent with team membership returning None). This
+                // is not an error, so it is safe to cache.
+                (false, true)
             };
-            let sentinel = if value { "1" } else { "0" };
-            let _: Result<(), _> = redis::cmd("SET")
-                .arg(&require_cache_key)
-                .arg(sentinel)
-                .arg("EX")
-                .arg(TENANT_BUDGET_CACHE_TTL)
-                .query_async(conn)
-                .await;
+            if persist {
+                let sentinel = if value { "1" } else { "0" };
+                let _: Result<(), _> = redis::cmd("SET")
+                    .arg(&require_cache_key)
+                    .arg(sentinel)
+                    .arg("EX")
+                    .arg(TENANT_BUDGET_CACHE_TTL)
+                    .query_async(conn)
+                    .await;
+            }
             value
         }
     };
@@ -1345,7 +1444,11 @@ async fn get_tenant_budget_config(
         }
     }
 
-    let config = if let Some(pool) = db_pool {
+    // `persist` is true only when the query SUCCEEDED (a real row, or a
+    // confirmed absence). On a DB error we return `None` WITHOUT caching, so a
+    // transient error cannot poison the "none" sentinel for a full TTL — the
+    // next request re-attempts the DB read.
+    let (config, persist) = if let Some(pool) = db_pool {
         match sqlx::query_as::<_, (Option<f64>, Option<f64>, Option<f64>)>(
             r#"SELECT
                 hourly_limit_usdc::DOUBLE PRECISION,
@@ -1359,32 +1462,38 @@ async fn get_tenant_budget_config(
         .fetch_optional(pool)
         .await
         {
-            Ok(Some((hourly, daily, monthly))) => Some(TenantBudgetConfig {
-                hourly,
-                daily,
-                monthly,
-            }),
-            Ok(None) => None,
+            Ok(Some((hourly, daily, monthly))) => (
+                Some(TenantBudgetConfig {
+                    hourly,
+                    daily,
+                    monthly,
+                }),
+                true,
+            ),
+            Ok(None) => (None, true),
             Err(e) => {
-                warn!(wallet = %wallet, tenant = %tenant, error = %e, "failed to query tenant_budgets");
-                None
+                warn!(wallet = %wallet, tenant = %tenant, error = %e, "failed to query tenant_budgets — not caching");
+                (None, false)
             }
         }
     } else {
-        None
+        // No DB pool — a stable "no provisioned row" answer; safe to cache.
+        (None, true)
     };
 
-    let cache_val = match &config {
-        Some(cfg) => serde_json::to_string(cfg).unwrap_or_else(|_| "none".to_string()),
-        None => "none".to_string(),
-    };
-    let _: Result<(), _> = redis::cmd("SET")
-        .arg(&cache_key)
-        .arg(&cache_val)
-        .arg("EX")
-        .arg(TENANT_BUDGET_CACHE_TTL)
-        .query_async(conn)
-        .await;
+    if persist {
+        let cache_val = match &config {
+            Some(cfg) => serde_json::to_string(cfg).unwrap_or_else(|_| "none".to_string()),
+            None => "none".to_string(),
+        };
+        let _: Result<(), _> = redis::cmd("SET")
+            .arg(&cache_key)
+            .arg(&cache_val)
+            .arg("EX")
+            .arg(TENANT_BUDGET_CACHE_TTL)
+            .query_async(conn)
+            .await;
+    }
 
     config
 }
@@ -1668,6 +1777,7 @@ mod tests {
             request_id: None,
             session_id: None,
             tenant: None,
+            tenant_enforced: false,
             estimated_cost_usdc: None,
         });
     }
@@ -1743,6 +1853,25 @@ mod tests {
         assert!(
             reservation.committed.is_empty(),
             "no-Redis reservation must commit no counters (release is then a no-op)"
+        );
+        // The no-Redis branch never enforces a tenant bucket, so log_spend must
+        // not reconcile per-tenant counters for it — even when a tag is present.
+        assert!(
+            !reservation.tenant_enforced(),
+            "no-Redis reservation must report tenant_enforced=false"
+        );
+        let tagged = tracker
+            .check_budget("wallet123", 0.50, Some("acme"))
+            .await
+            .expect("within-cap tagged check_budget must succeed without Redis");
+        assert!(
+            !tagged.tenant_enforced(),
+            "no-Redis branch must not enforce a tenant bucket even with a tag"
+        );
+        // A default reservation likewise reports no tenant enforcement.
+        assert!(
+            !BudgetReservation::default().tenant_enforced(),
+            "default reservation must report tenant_enforced=false"
         );
         // Releasing it must be a safe no-op (the failure-path arms call this
         // unconditionally; it must never panic or block).

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -2158,13 +2158,17 @@ async fn test_chat_enforced_wallet_unprovisioned_tenant_returns_400_e2e() {
     .await
     .expect("seed enforced wallet");
 
-    // Clear any cached require_tenant sentinel so the fresh TRUE flag is read.
+    // Clear any cached wallet budget config so the fresh require_tenant=TRUE flag
+    // is read. Since N2 the flag rides on `budget_config:{wallet}` (the prior
+    // separate `tenant_require:{wallet}` sentinel was removed); clear both for
+    // robustness against stale entries from earlier runs.
     {
         let mut conn = redis_client
             .get_multiplexed_async_connection()
             .await
             .expect("redis conn");
         let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(format!("budget_config:{wallet}"))
             .arg(format!("tenant_require:{wallet}"))
             .query_async(&mut conn)
             .await;

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -2088,6 +2088,161 @@ async fn test_chat_with_tenant_header_unaffected() {
     assert!(json["usage"]["total_tokens"].is_number());
 }
 
+/// PR2 end-to-end: an enforced wallet (`require_tenant = TRUE`) receiving a
+/// request whose `x-tenant` tag is NOT provisioned must be rejected with HTTP
+/// 400 through the REAL route (parse → guard → payment-verify → `check_budget`),
+/// not just at the `usage.rs` level. This is the test that proves the PR1→PR2
+/// `tenant.as_deref()` wiring is actually exercised on the chat path: the
+/// forgeable tag flows from the header into `check_budget`, the tenant gate
+/// fires `UsageError::TenantNotProvisioned`, and the handler maps it to a 400
+/// `bad_request` (pre-settlement).
+///
+/// LIMITATION: the default test harness uses `UsageTracker::noop()` with
+/// `db_pool = None`, so `check_budget` takes the no-Redis branch and never reads
+/// `require_tenant`/`tenant_budgets`. The enforcement path is only reachable
+/// with a live Postgres + Redis, so this test self-skips (returns early, like
+/// the semantic-cache tests) when either is unavailable — e.g. in a CI image
+/// without docker-compose up. When infra IS present it asserts the real 400.
+#[tokio::test]
+async fn test_chat_enforced_wallet_unprovisioned_tenant_returns_400_e2e() {
+    // --- Try to connect to live Postgres + Redis; skip if absent. ---
+    let Ok(db_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipping tenant-e2e: DATABASE_URL unset");
+        return;
+    };
+    let pool = match sqlx::PgPool::connect(&db_url).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("skipping tenant-e2e: Postgres unavailable ({e})");
+            return;
+        }
+    };
+    if sqlx::migrate!("../../migrations").run(&pool).await.is_err() {
+        eprintln!("skipping tenant-e2e: migrations failed");
+        return;
+    }
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let redis_client = match redis::Client::open(redis_url) {
+        Ok(c) if c.get_multiplexed_async_connection().await.is_ok() => c,
+        _ => {
+            eprintln!("skipping tenant-e2e: Redis unavailable");
+            return;
+        }
+    };
+
+    // `check_budget` is keyed on the wallet `extract_payer_wallet` derives from
+    // the payment payload. The mock `exact` header carries an undecodable
+    // transaction (`b"mock_signed_tx_bytes"`), so `extract_signer_from_base64_tx`
+    // fails and the wallet falls back to the literal "unknown". We seed the
+    // enforced budget under exactly that key so the gate actually fires for this
+    // request. (The point of the test is the wiring + 400 mapping, not realistic
+    // signer recovery — the signer-decode path is covered by payment_util tests.)
+    let wallet = "unknown".to_string();
+    // Enforce the wallet: require_tenant = TRUE, generous wallet cap so only the
+    // tenant gate can reject. Clean any prior row first for idempotency.
+    let _ = sqlx::query("DELETE FROM tenant_budgets WHERE wallet_address = $1")
+        .bind(&wallet)
+        .execute(&pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM wallet_budgets WHERE wallet_address = $1")
+        .bind(&wallet)
+        .execute(&pool)
+        .await;
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc, require_tenant) \
+         VALUES ($1, 100.00, TRUE)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed enforced wallet");
+
+    // Clear any cached require_tenant sentinel so the fresh TRUE flag is read.
+    {
+        let mut conn = redis_client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("redis conn");
+        let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(format!("tenant_require:{wallet}"))
+            .query_async(&mut conn)
+            .await;
+    }
+
+    // Build a mock-provider app whose UsageTracker is backed by the live
+    // Postgres + Redis (unlike the default noop tracker).
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: mock_provider_registry(),
+        facilitator,
+        usage: gateway::usage::UsageTracker::new(Some(pool.clone()), Some(redis_client.clone())),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: Some(pool.clone()),
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+    });
+    let app = build_router(
+        Arc::clone(&state),
+        RateLimiter::new(RateLimitConfig::default()),
+    );
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("x-tenant", "ghost")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "enforced wallet + unprovisioned tenant must be rejected with 400 via the real route"
+    );
+
+    // Cleanup.
+    let _ = sqlx::query("DELETE FROM wallet_budgets WHERE wallet_address = $1")
+        .bind(&wallet)
+        .execute(&pool)
+        .await;
+}
+
 /// PR1 tenant-attribution: a malformed / over-long `x-tenant` value must NOT
 /// fail the request — `validate_tenant` drops it to `None` and the request
 /// proceeds untagged. Attribution must never become a way to block a paid call.

--- a/crates/gateway/tests/migrations.rs
+++ b/crates/gateway/tests/migrations.rs
@@ -26,6 +26,7 @@ const EXPECTED_TABLES: &[&str] = &[
     "api_keys",
     "audit_logs",
     "team_budgets",
+    "tenant_budgets", // migration 011
 ];
 
 /// Columns whose presence proves the right ALTER TABLE migrations ran.
@@ -36,6 +37,8 @@ const EXPECTED_COLUMNS: &[(&str, &str)] = &[
     ("escrow_claim_queue", "next_retry_at"), // migration 004
     ("wallet_budgets", "updated_at"),        // migration 001
     ("wallet_budgets", "hourly_limit_usdc"), // migration 007
+    ("wallet_budgets", "require_tenant"),    // migration 011
+    ("tenant_budgets", "hourly_limit_usdc"), // migration 011
 ];
 
 #[tokio::test]

--- a/crates/gateway/tests/usage_integration.rs
+++ b/crates/gateway/tests/usage_integration.rs
@@ -93,19 +93,19 @@ async fn check_budget_without_redis_applies_one_dollar_per_request_cap() {
 
     // Below the cap — allowed.
     tracker
-        .check_budget(WALLET_A, 0.50)
+        .check_budget(WALLET_A, 0.50, None)
         .await
         .expect("0.50 USDC must be within the no-Redis cap");
 
     // At the cap — allowed (boundary).
     tracker
-        .check_budget(WALLET_A, 1.00)
+        .check_budget(WALLET_A, 1.00, None)
         .await
         .expect("$1.00 USDC must be at-or-below the cap");
 
     // Above the cap — denied.
     let err = tracker
-        .check_budget(WALLET_A, 1.01)
+        .check_budget(WALLET_A, 1.01, None)
         .await
         .expect_err("anything above $1 must be rejected without Redis");
     match err {

--- a/crates/gateway/tests/usage_integration.rs
+++ b/crates/gateway/tests/usage_integration.rs
@@ -181,6 +181,7 @@ async fn log_spend_persists_row_when_db_configured(pool: PgPool) {
         request_id: Some("req-abc".to_string()),
         session_id: None,
         tenant: None,
+        tenant_enforced: false,
         estimated_cost_usdc: None,
     });
 
@@ -246,6 +247,7 @@ async fn log_spend_with_no_backends_does_not_panic() {
         request_id: None,
         session_id: None,
         tenant: None,
+        tenant_enforced: false,
         estimated_cost_usdc: None,
     });
 }

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -1679,19 +1679,28 @@ async fn wallet_daily_counter_unchanged_by_tag_on_unenforced_wallet(pool: PgPool
     redis_del_tenant(&client, &wallet_tagged, "acme").await;
 }
 
-/// Fail-OPEN on DB error: when the require_tenant read errors (here forced by
-/// closing the Postgres pool before the call), an UNTAGGED request on a wallet
-/// that WAS configured `require_tenant=TRUE` is NOT rejected — enforcement
-/// degrades to the wallet/team cap (the authoritative backstop). Also asserts no
-/// error-derived sentinel was cached (cache-poisoning fix): the
-/// `tenant_require:{wallet}` key must be absent after the failed read.
+/// Fail-OPEN on wallet-config DB error: when the `wallet_budgets` read errors
+/// (forced by closing the Postgres pool), an UNTAGGED request on a wallet that
+/// WAS configured `require_tenant=TRUE` is NOT rejected by the tenant gate —
+/// enforcement degrades to the (restrictive) wallet cap (the authoritative
+/// backstop), with `require_tenant` reading `false` from the restrictive
+/// fallback. Also asserts the error-derived config is NOT cached (N2
+/// cache-poisoning fix): `budget_config:{wallet}` must be absent after the failed
+/// read, so the next request re-attempts the DB.
+///
+/// N2 note: `require_tenant` now rides on `budget_config:{wallet}` (the separate
+/// `tenant_require:{wallet}` sentinel was removed). To isolate the wallet-config
+/// DB error from the H4 team-membership fail-closed path, the team membership is
+/// pre-seeded as a cached "none" so `get_team_for_wallet` is served from Redis
+/// (and does not error on the closed pool) — otherwise the team gate would deny
+/// first and we could never reach the tenant gate.
 #[sqlx::test(migrations = "../../migrations")]
 async fn require_tenant_db_error_fails_open_and_does_not_cache(pool: PgPool) {
     let client = redis_client();
     let wallet = unique_wallet();
 
-    // Configure the wallet as ENFORCED, then close the pool so the flag read
-    // errors at check_budget time.
+    // Configure the wallet as ENFORCED, then close the pool so the wallet-config
+    // read errors at check_budget time.
     sqlx::query(
         "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc, require_tenant) \
          VALUES ($1, 100.00, TRUE)",
@@ -1701,50 +1710,380 @@ async fn require_tenant_db_error_fails_open_and_does_not_cache(pool: PgPool) {
     .await
     .expect("seed enforced wallet");
 
-    // Clear any cached sentinel from prior reads in this test's wallet space.
-    let require_key = format!("tenant_require:{wallet}");
-    redis_del(&client, &[&require_key]).await;
+    // Clear any cached wallet config from prior reads in this wallet's space, and
+    // pre-seed team membership as "none" so the team lookup is served from Redis
+    // (not the closed pool).
+    let config_key = format!("budget_config:{wallet}");
+    let team_key = format!("team_member:{wallet}");
+    redis_del(&client, &[&config_key]).await;
+    {
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("conn");
+        let _: () = redis::cmd("SET")
+            .arg(&team_key)
+            .arg("none")
+            .arg("EX")
+            .arg(60)
+            .query_async(&mut conn)
+            .await
+            .expect("seed team none");
+    }
 
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
     // Force every subsequent DB query on this pool to error.
     pool.close().await;
 
     // Untagged request: with a healthy DB this would be RejectRequired. With the
-    // DB erroring it must FAIL OPEN (Skip) and pass under the wallet cap.
+    // wallet-config DB read erroring, require_tenant reads `false` (restrictive
+    // fallback) → tenant gate Skips, and the request passes under the restrictive
+    // wallet cap ($0.50/hr, $1/day, $10/mo). $0.10 fits.
     tracker
         .check_budget(&wallet, 0.10, None)
         .await
-        .expect("DB error on require_tenant must fail OPEN (untagged passes)");
+        .expect("DB error on wallet config must fail OPEN for the tenant gate (untagged passes)");
 
-    // Cache-poisoning guard: no error-derived sentinel may have been written.
-    let cached = get_redis_spend(&client, &require_key).await;
-    // tenant_require holds "1"/"0" (not a float) when present; absence is what we
-    // assert. get_redis_spend returns Ok(0.0) for a missing key, but a present
-    // sentinel "0"/"1" would parse as a number — assert the key truly is absent.
+    // N2 cache-poisoning guard: the error-derived restrictive fallback must NOT
+    // have been cached — `budget_config:{wallet}` must be absent so the next
+    // request re-attempts the DB read rather than serving require_tenant=false
+    // for a full TTL.
     let mut conn = client
         .get_multiplexed_async_connection()
         .await
         .expect("conn");
     let exists: bool = redis::cmd("EXISTS")
-        .arg(&require_key)
+        .arg(&config_key)
         .query_async(&mut conn)
         .await
         .expect("EXISTS");
     assert!(
         !exists,
-        "a DB error must NOT cache a require_tenant sentinel (cache-poisoning), but {require_key} exists; get_redis_spend={cached:?}"
+        "a wallet-config DB error must NOT cache an error-derived budget_config (cache-poisoning), but {config_key} exists"
     );
 
     let now = Utc::now();
     redis_del(
         &client,
         &[
-            &require_key,
+            &config_key,
+            &team_key,
+            &format!("tenant_require:{wallet}"),
             &format!("spend:{}:{}", wallet, now.format("%Y-%m-%d")),
             &format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H")),
-            &format!("budget_config:{wallet}"),
-            &format!("team_member:{wallet}"),
         ],
     )
     .await;
+}
+
+/// N3: a DB ERROR reading `tenant_budgets` for an ENFORCED wallet (require_tenant
+/// = TRUE) is still fail-closed (deny), but surfaced as the transient
+/// `UsageError::Database` variant — NOT `TenantNotProvisioned` (which would
+/// mislead an operator into chasing a phantom provisioning issue during a DB
+/// blip). Confirmed-absent vs. DB-error are distinguished by `TenantLookup`.
+///
+/// Setup mirrors the fail-open test: pre-seed `budget_config:{wallet}` as cached
+/// (require_tenant=true) and `team_member:{wallet}` as "none" so neither the
+/// wallet-config nor team reads touch the DB, then close the pool so ONLY the
+/// tagged `tenant_budgets` lookup errors.
+#[sqlx::test(migrations = "../../migrations")]
+async fn tenant_lookup_db_error_for_enforced_wallet_surfaces_database_not_not_provisioned(
+    pool: PgPool,
+) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+
+    let config_key = format!("budget_config:{wallet}");
+    let team_key = format!("team_member:{wallet}");
+    let tenant_budget_key = format!("tenant_budget:{wallet}:{tenant}");
+
+    {
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("conn");
+        // Cache an ENFORCED wallet config (require_tenant=true) so the
+        // wallet-config read is served from Redis on the closed pool.
+        let cfg = r#"{"hourly":null,"daily":100.0,"monthly":null,"require_tenant":true}"#;
+        let _: () = redis::cmd("SET")
+            .arg(&config_key)
+            .arg(cfg)
+            .arg("EX")
+            .arg(60)
+            .query_async(&mut conn)
+            .await
+            .expect("seed config");
+        // Team membership "none" so the team lookup is served from Redis.
+        let _: () = redis::cmd("SET")
+            .arg(&team_key)
+            .arg("none")
+            .arg("EX")
+            .arg(60)
+            .query_async(&mut conn)
+            .await
+            .expect("seed team none");
+        // Ensure no cached tenant_budget so the lookup must hit the (closed) DB.
+        let _: i64 = redis::cmd("DEL")
+            .arg(&tenant_budget_key)
+            .query_async(&mut conn)
+            .await
+            .expect("del tenant_budget cache");
+    }
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    // Close the pool so the tenant_budgets read errors (the only uncached read).
+    pool.close().await;
+
+    let err = tracker
+        .check_budget(&wallet, 0.10, Some(tenant))
+        .await
+        .expect_err("enforced wallet + tenant_budgets DB error must deny");
+    match err {
+        UsageError::Database(_) => {}
+        UsageError::TenantNotProvisioned { .. } => panic!(
+            "a transient tenant_budgets DB error must surface as Database, not TenantNotProvisioned"
+        ),
+        other => panic!("expected Database, got {other:?}"),
+    }
+
+    // The transient error must NOT have cached a "none" sentinel for the tenant.
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let exists: bool = redis::cmd("EXISTS")
+        .arg(&tenant_budget_key)
+        .query_async(&mut conn)
+        .await
+        .expect("EXISTS");
+    assert!(
+        !exists,
+        "a tenant_budgets DB error must NOT cache a 'none' sentinel (cache-poisoning)"
+    );
+
+    let now = Utc::now();
+    redis_del(
+        &client,
+        &[
+            &config_key,
+            &team_key,
+            &tenant_budget_key,
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%d")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H")),
+        ],
+    )
+    .await;
+}
+
+/// N4 / 4a: the Skip path's `tenant_enforced` flag must flow from PRODUCTION code
+/// into `log_spend`, never a hard-coded literal. `check_budget` on an unprovisioned
+/// wallet returns a `BudgetReservation` whose `tenant_enforced()` is false; we
+/// thread THAT value into `SpendLogEntry.tenant_enforced` (exactly as the chat
+/// handler does) and assert `log_spend` writes NO per-tenant counter. A future
+/// regression that set the flag true on Skip would write a tenant counter and
+/// fail this test.
+#[sqlx::test(migrations = "../../migrations")]
+async fn skip_path_reservation_flag_suppresses_tenant_counter_through_real_path(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+    let now = Utc::now();
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // Default wallet (no wallet_budgets row, no tenant_budgets row,
+    // require_tenant=FALSE) → tenant decision is Skip even with a tag present.
+    let reservation = tracker
+        .check_budget(&wallet, 0.0050, Some(tenant))
+        .await
+        .expect("Skip-path request must be allowed under the default wallet cap");
+
+    // The value MUST come from production code, not a literal.
+    assert!(
+        !reservation.tenant_enforced(),
+        "Skip path must yield tenant_enforced=false from check_budget"
+    );
+
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 10,
+        output_tokens: 20,
+        cost_usdc: 0.0050,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant: Some(tenant.to_string()),
+        // Sourced from the real reservation, NOT hard-coded.
+        tenant_enforced: reservation.tenant_enforced(),
+        estimated_cost_usdc: Some(0.0050),
+    });
+
+    // The wallet daily counter must materialize (wallet accounting unaffected)...
+    let wallet_day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    wait_for_key(&client, &wallet_day_key)
+        .await
+        .expect("wallet daily counter must be written");
+
+    // ...but NO per-tenant counter may have been written on the Skip path.
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let tenant_spend = get_redis_spend(&client, &tenant_day_key)
+        .await
+        .expect("get tenant spend");
+    assert_eq!(
+        tenant_spend, 0.0,
+        "Skip-path reservation (tenant_enforced=false) must not write a per-tenant counter"
+    );
+
+    redis_del(&client, &[&wallet_day_key]).await;
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// N4: a provisioned tenant row with NO hourly/daily/monthly limits commits zero
+/// tenant counters, so `check_budget` must report `tenant_enforced=false` (only
+/// true when at least one window counter was actually committed). Otherwise
+/// `log_spend` would write per-tenant counters that `check_budget` never
+/// reserved, breaking reserve/settle symmetry.
+#[sqlx::test(migrations = "../../migrations")]
+async fn limitless_provisioned_tenant_row_reports_not_enforced(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+    let now = Utc::now();
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed wallet");
+    // Provisioned row with all-NULL limits (a real, present row, no caps).
+    sqlx::query("INSERT INTO tenant_budgets (wallet_address, tenant) VALUES ($1, $2)")
+        .bind(&wallet)
+        .bind(tenant)
+        .execute(&pool)
+        .await
+        .expect("seed limitless tenant budget");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    let reservation = tracker
+        .check_budget(&wallet, 0.0050, Some(tenant))
+        .await
+        .expect("limitless tenant row must pass under the wallet cap");
+
+    assert!(
+        !reservation.tenant_enforced(),
+        "a limitless provisioned tenant row commits no counters → tenant_enforced must be false"
+    );
+
+    // And no tenant counter should have been committed.
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let tenant_spend = get_redis_spend(&client, &tenant_day_key)
+        .await
+        .expect("get tenant spend");
+    assert_eq!(
+        tenant_spend, 0.0,
+        "limitless tenant row must commit no per-tenant counter"
+    );
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// Partial tenant-window rollback (4b): a provisioned tenant row with hourly +
+/// daily + monthly limits where MONTHLY is near-full. A request whose estimate
+/// fits hourly+daily but trips monthly must roll back the hourly AND daily tenant
+/// counters that were committed before the monthly window rejected — leaving both
+/// back at 0.0 (mirrors the wallet-window rollback assertion).
+#[sqlx::test(migrations = "../../migrations")]
+async fn tenant_partial_window_rollback_on_monthly_trip(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+    let now = Utc::now();
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed wallet");
+    // Tenant: generous hourly + daily, tight monthly (so monthly trips last).
+    sqlx::query(
+        "INSERT INTO tenant_budgets (wallet_address, tenant, hourly_limit_usdc, daily_limit_usdc, monthly_limit_usdc) \
+         VALUES ($1, $2, 100.00, 100.00, 1.00)",
+    )
+    .bind(&wallet)
+    .bind(tenant)
+    .execute(&pool)
+    .await
+    .expect("seed tenant budget");
+
+    // Pre-seed the MONTHLY tenant counter near its $1.00 cap so the request trips
+    // monthly only (hourly+daily are generous and start empty).
+    let tenant_hour_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%dT%H"));
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let tenant_month_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m"));
+    {
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("conn");
+        let _: () = redis::cmd("SET")
+            .arg(&tenant_month_key)
+            .arg("0.95")
+            .arg("EX")
+            .arg(3600)
+            .query_async(&mut conn)
+            .await
+            .expect("seed monthly near cap");
+    }
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // $0.10: hourly (0→0.10) and daily (0→0.10) commit, then monthly
+    // (0.95→1.05 > 1.00) trips → all three must roll back.
+    let err = tracker
+        .check_budget(&wallet, 0.10, Some(tenant))
+        .await
+        .expect_err("monthly tenant cap must reject");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => {
+            assert!(
+                (limit - 1.0).abs() < 1e-9,
+                "limit must be tenant monthly 1.0, got {limit}"
+            );
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    // Hourly AND daily tenant counters must be back at 0.0 (rolled back).
+    let leaked_hour = get_redis_spend(&client, &tenant_hour_key)
+        .await
+        .expect("get tenant hour");
+    let leaked_day = get_redis_spend(&client, &tenant_day_key)
+        .await
+        .expect("get tenant day");
+    assert_eq!(
+        leaked_hour, 0.0,
+        "tenant hourly counter must be rolled back to 0.0 after the monthly trip"
+    );
+    assert_eq!(
+        leaked_day, 0.0,
+        "tenant daily counter must be rolled back to 0.0 after the monthly trip"
+    );
+    // Monthly counter must be unchanged at its pre-seeded value (the trip rolls
+    // back its own add inside the Lua script).
+    let month_val = get_redis_spend(&client, &tenant_month_key)
+        .await
+        .expect("get tenant month");
+    assert!(
+        (month_val - 0.95).abs() < 1e-9,
+        "tenant monthly counter must remain at the pre-seeded 0.95, got {month_val}"
+    );
+
+    redis_del_tenant(&client, &wallet, tenant).await;
 }

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -77,6 +77,7 @@ async fn log_spend_writes_redis_hourly_daily_monthly_counters(pool: PgPool) {
         request_id: None,
         session_id: None,
         tenant: None,
+        tenant_enforced: false,
         estimated_cost_usdc: None,
     });
 
@@ -126,6 +127,7 @@ async fn log_spend_accumulates_across_calls(pool: PgPool) {
         request_id: None,
         session_id: None,
         tenant: None,
+        tenant_enforced: false,
         estimated_cost_usdc: None,
     };
     tracker.log_spend(entry.clone());
@@ -502,6 +504,7 @@ async fn log_spend_writes_team_counters_when_wallet_in_team(pool: PgPool) {
         request_id: None,
         session_id: None,
         tenant: None,
+        tenant_enforced: false,
         estimated_cost_usdc: None,
     });
 
@@ -977,9 +980,11 @@ async fn check_budget_rejects_untagged_when_require_tenant(pool: PgPool) {
     let wallet = unique_wallet();
     let now = Utc::now();
 
+    // Seed BOTH hourly and daily limits so both wallet windows are reserved
+    // before the tenant gate rejects — proves rollback releases ALL windows.
     sqlx::query(
-        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc, require_tenant) \
-         VALUES ($1, 100.00, TRUE)",
+        "INSERT INTO wallet_budgets (wallet_address, hourly_limit_usdc, daily_limit_usdc, require_tenant) \
+         VALUES ($1, 50.00, 100.00, TRUE)",
     )
     .bind(&wallet)
     .execute(&pool)
@@ -997,15 +1002,27 @@ async fn check_budget_rejects_untagged_when_require_tenant(pool: PgPool) {
         other => panic!("expected TenantRequired, got {other:?}"),
     }
 
-    // No budget leak: the wallet daily counter must not have been left committed.
+    // No budget leak: NEITHER the wallet daily NOR the wallet hourly counter
+    // must have been left committed (rollback completeness — all reserved
+    // windows are released on a fail-closed rejection, not just the daily one).
     let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
-    let leaked = get_redis_spend(&client, &day_key).await.expect("get");
-    assert_eq!(leaked, 0.0, "rejected request must leak no wallet spend");
+    let hour_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H"));
+    let leaked_day = get_redis_spend(&client, &day_key).await.expect("get day");
+    let leaked_hour = get_redis_spend(&client, &hour_key).await.expect("get hour");
+    assert_eq!(
+        leaked_day, 0.0,
+        "rejected request must leak no wallet daily spend"
+    );
+    assert_eq!(
+        leaked_hour, 0.0,
+        "rejected request must leak no wallet hourly spend"
+    );
 
     redis_del(
         &client,
         &[
             &day_key,
+            &hour_key,
             &format!("budget_config:{wallet}"),
             &format!("team_member:{wallet}"),
             &format!("tenant_require:{wallet}"),
@@ -1194,6 +1211,10 @@ async fn tenant_counter_reconciles_estimate_to_actual(pool: PgPool) {
         request_id: None,
         session_id: None,
         tenant: Some(tenant.to_string()),
+        // A provisioned tenant bucket was enforced by check_budget above, so the
+        // handler would thread tenant_enforced=true → reconcile per-tenant
+        // counters.
+        tenant_enforced: true,
         estimated_cost_usdc: Some(estimated),
     });
 
@@ -1238,6 +1259,8 @@ async fn log_spend_writes_tenant_counters_with_correct_key(pool: PgPool) {
         request_id: None,
         session_id: None,
         tenant: Some(tenant.to_string()),
+        // Tenant enforcement was active for this request → reconcile counters.
+        tenant_enforced: true,
         estimated_cost_usdc: None,
     });
 
@@ -1248,4 +1271,480 @@ async fn log_spend_writes_tenant_counters_with_correct_key(pool: PgPool) {
     assert_eq!(val.parse::<f64>().unwrap_or(0.0), 0.005);
 
     redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// A provisioned tenant HOURLY budget is enforced on the
+/// `spend:{wallet}:{tenant}:{%Y-%m-%dT%H}` key. A wrong `%H` key derivation
+/// would let this slip through undetected (only daily was covered before).
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_enforces_provisioned_tenant_hourly_limit(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+    let now = Utc::now();
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed wallet budget");
+    sqlx::query(
+        "INSERT INTO tenant_budgets (wallet_address, tenant, hourly_limit_usdc) VALUES ($1, $2, 1.00)",
+    )
+    .bind(&wallet)
+    .bind(tenant)
+    .execute(&pool)
+    .await
+    .expect("seed tenant hourly budget");
+
+    // Pre-seed the tenant HOURLY counter near its $1.00 cap.
+    let tenant_hour_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%dT%H"));
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&tenant_hour_key)
+        .arg("0.95")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed tenant hourly spend");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // $0.04 fits (0.95 + 0.04 = 0.99 ≤ 1.00).
+    tracker
+        .check_budget(&wallet, 0.04, Some(tenant))
+        .await
+        .expect("$0.04 must fit under the tenant hourly cap");
+
+    // $0.10 now breaches the HOURLY cap (0.99 + 0.10 = 1.09 > 1.00).
+    let err = tracker
+        .check_budget(&wallet, 0.10, Some(tenant))
+        .await
+        .expect_err("must reject over the tenant hourly cap");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => {
+            assert!(
+                (limit - 1.0).abs() < 1e-9,
+                "limit must be tenant hourly 1.0, got {limit}"
+            );
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// A provisioned tenant MONTHLY budget is enforced on the
+/// `spend:{wallet}:{tenant}:{%Y-%m}` key. Guards a wrong `%Y-%m` derivation.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_enforces_provisioned_tenant_monthly_limit(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+    let now = Utc::now();
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed wallet budget");
+    sqlx::query(
+        "INSERT INTO tenant_budgets (wallet_address, tenant, monthly_limit_usdc) VALUES ($1, $2, 1.00)",
+    )
+    .bind(&wallet)
+    .bind(tenant)
+    .execute(&pool)
+    .await
+    .expect("seed tenant monthly budget");
+
+    // Pre-seed the tenant MONTHLY counter near its $1.00 cap.
+    let tenant_month_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m"));
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&tenant_month_key)
+        .arg("0.95")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed tenant monthly spend");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    tracker
+        .check_budget(&wallet, 0.04, Some(tenant))
+        .await
+        .expect("$0.04 must fit under the tenant monthly cap");
+
+    let err = tracker
+        .check_budget(&wallet, 0.10, Some(tenant))
+        .await
+        .expect_err("must reject over the tenant monthly cap");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => {
+            assert!(
+                (limit - 1.0).abs() < 1e-9,
+                "limit must be tenant monthly 1.0, got {limit}"
+            );
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// Reconciliation across ALL THREE tenant windows (hour + day + month), not
+/// just day. `check_budget` reserves the estimate on each provisioned window and
+/// `log_spend` settles each to the actual via the (cost − estimate) delta on the
+/// SAME `spend:{wallet}:{tenant}:{period}` key.
+#[sqlx::test(migrations = "../../migrations")]
+async fn tenant_counters_reconcile_all_three_windows(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed wallet");
+    // All three tenant windows provisioned and generous so nothing rejects.
+    sqlx::query(
+        "INSERT INTO tenant_budgets (wallet_address, tenant, hourly_limit_usdc, daily_limit_usdc, monthly_limit_usdc) \
+         VALUES ($1, $2, 10.00, 10.00, 10.00)",
+    )
+    .bind(&wallet)
+    .bind(tenant)
+    .execute(&pool)
+    .await
+    .expect("seed tenant budget");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    let estimated = 0.0050;
+    tracker
+        .check_budget(&wallet, estimated, Some(tenant))
+        .await
+        .expect("reserve estimate");
+
+    let now = Utc::now();
+    let hour_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%dT%H"));
+    let day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let month_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m"));
+
+    for k in [&hour_key, &day_key, &month_key] {
+        let v = get_redis_spend(&client, k).await.expect("get");
+        assert!(
+            (v - estimated).abs() < 1e-9,
+            "after reserve, {k} must equal estimate {estimated}, got {v}"
+        );
+    }
+
+    let actual = 0.0075;
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 10,
+        output_tokens: 20,
+        cost_usdc: actual,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant: Some(tenant.to_string()),
+        tenant_enforced: true,
+        estimated_cost_usdc: Some(estimated),
+    });
+
+    // Each of the three windows must settle to the actual.
+    for k in [&hour_key, &day_key, &month_key] {
+        let mut settled = estimated;
+        for _ in 0..100 {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            if let Ok(v) = get_redis_spend(&client, k).await {
+                settled = v;
+                if (settled - actual).abs() < 1e-9 {
+                    break;
+                }
+            }
+        }
+        assert!(
+            (settled - actual).abs() < 1e-9,
+            "{k} must reconcile estimate→actual to {actual}, got {settled}"
+        );
+    }
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// Core bug-class test: cap-escape blocked END-TO-END. After `log_spend`
+/// reconciles the tenant counter to the actual, a SECOND `check_budget` whose
+/// amount would breach the tenant cap cumulatively is REJECTED. This proves the
+/// counter the handler actually wrote (`log_spend`) is the very one enforcement
+/// reads (`check_budget`) — a wrong-key reconcile would let the second request
+/// through and fail this test.
+#[sqlx::test(migrations = "../../migrations")]
+async fn tenant_cap_escape_blocked_end_to_end(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed wallet");
+    sqlx::query(
+        "INSERT INTO tenant_budgets (wallet_address, tenant, daily_limit_usdc) VALUES ($1, $2, 1.00)",
+    )
+    .bind(&wallet)
+    .bind(tenant)
+    .execute(&pool)
+    .await
+    .expect("seed tenant budget");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // First request: reserve a small estimate, then settle a LARGE actual via
+    // log_spend so the tenant counter ends near the cap (0.90 of 1.00).
+    let estimated = 0.10;
+    tracker
+        .check_budget(&wallet, estimated, Some(tenant))
+        .await
+        .expect("first request fits");
+
+    let actual = 0.90;
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 10,
+        output_tokens: 20,
+        cost_usdc: actual,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant: Some(tenant.to_string()),
+        tenant_enforced: true,
+        estimated_cost_usdc: Some(estimated),
+    });
+
+    // Wait for the counter to settle to the actual (0.90).
+    let now = Utc::now();
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let mut settled = estimated;
+    for _ in 0..100 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        if let Ok(v) = get_redis_spend(&client, &tenant_day_key).await {
+            settled = v;
+            if (settled - actual).abs() < 1e-9 {
+                break;
+            }
+        }
+    }
+    assert!(
+        (settled - actual).abs() < 1e-9,
+        "tenant counter must settle to {actual} before the escape attempt, got {settled}"
+    );
+
+    // Second request: 0.90 + 0.20 = 1.10 > 1.00 → MUST be rejected. If the
+    // reconcile had written a wrong key, the counter read here would still be
+    // ~0.10 (the reservation only) and this would wrongly succeed.
+    let err = tracker
+        .check_budget(&wallet, 0.20, Some(tenant))
+        .await
+        .expect_err("cumulative spend must breach the tenant cap and be rejected");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => {
+            assert!((limit - 1.0).abs() < 1e-9, "limit must be 1.0, got {limit}");
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// Skip-path counter suppression: a tagged request on an UNENFORCED wallet (no
+/// provisioned row, require_tenant=FALSE) must NOT accumulate per-tenant Redis
+/// counters via `log_spend` (tenant_enforced=false). Pre-PR2-fix this would
+/// poison a later-provisioned budget. Also asserts the wallet daily counter
+/// still tracks the spend (attribution/enforcement unaffected for the wallet).
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_skips_tenant_counter_when_not_enforced(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+    let now = Utc::now();
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    // tenant_enforced=false mirrors what the handler threads on the Skip path.
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 1,
+        output_tokens: 1,
+        cost_usdc: 0.0050,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant: Some(tenant.to_string()),
+        tenant_enforced: false,
+        estimated_cost_usdc: None,
+    });
+
+    // Wallet daily counter must materialize (wallet accounting unaffected).
+    let wallet_day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    wait_for_key(&client, &wallet_day_key)
+        .await
+        .expect("wallet daily counter must still be written");
+
+    // The per-tenant counter must NOT have been written.
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let tenant_spend = get_redis_spend(&client, &tenant_day_key)
+        .await
+        .expect("get");
+    assert_eq!(
+        tenant_spend, 0.0,
+        "unenforced (Skip-path) request must not write a per-tenant counter"
+    );
+
+    redis_del(&client, &[&wallet_day_key]).await;
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// Backward-compat: the wallet DAILY counter sum is identical for an unenforced
+/// wallet whether or not a tenant tag is supplied. The tag must not alter wallet
+/// accounting in any way (it only ever drives the optional tenant bucket).
+#[sqlx::test(migrations = "../../migrations")]
+async fn wallet_daily_counter_unchanged_by_tag_on_unenforced_wallet(pool: PgPool) {
+    let client = redis_client();
+    let wallet_untagged = unique_wallet();
+    let wallet_tagged = unique_wallet();
+    let now = Utc::now();
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    let mk = |wallet: &str, tenant: Option<String>| SpendLogEntry {
+        wallet_address: wallet.to_string(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 1,
+        output_tokens: 1,
+        cost_usdc: 0.0050,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant,
+        // Unenforced wallet → Skip path → tenant_enforced is false either way.
+        tenant_enforced: false,
+        estimated_cost_usdc: None,
+    };
+    tracker.log_spend(mk(&wallet_untagged, None));
+    tracker.log_spend(mk(&wallet_tagged, Some("acme".to_string())));
+
+    let untagged_key = format!("spend:{}:{}", wallet_untagged, now.format("%Y-%m-%d"));
+    let tagged_key = format!("spend:{}:{}", wallet_tagged, now.format("%Y-%m-%d"));
+    let u = wait_for_key(&client, &untagged_key)
+        .await
+        .expect("untagged daily counter")
+        .parse::<f64>()
+        .unwrap_or(-1.0);
+    let t = wait_for_key(&client, &tagged_key)
+        .await
+        .expect("tagged daily counter")
+        .parse::<f64>()
+        .unwrap_or(-1.0);
+    assert!(
+        (u - t).abs() < 1e-9 && (u - 0.005).abs() < 1e-9,
+        "wallet daily counter must be identical with/without a tag, got untagged={u} tagged={t}"
+    );
+
+    redis_del(&client, &[&untagged_key, &tagged_key]).await;
+    redis_del_tenant(&client, &wallet_tagged, "acme").await;
+}
+
+/// Fail-OPEN on DB error: when the require_tenant read errors (here forced by
+/// closing the Postgres pool before the call), an UNTAGGED request on a wallet
+/// that WAS configured `require_tenant=TRUE` is NOT rejected — enforcement
+/// degrades to the wallet/team cap (the authoritative backstop). Also asserts no
+/// error-derived sentinel was cached (cache-poisoning fix): the
+/// `tenant_require:{wallet}` key must be absent after the failed read.
+#[sqlx::test(migrations = "../../migrations")]
+async fn require_tenant_db_error_fails_open_and_does_not_cache(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    // Configure the wallet as ENFORCED, then close the pool so the flag read
+    // errors at check_budget time.
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc, require_tenant) \
+         VALUES ($1, 100.00, TRUE)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed enforced wallet");
+
+    // Clear any cached sentinel from prior reads in this test's wallet space.
+    let require_key = format!("tenant_require:{wallet}");
+    redis_del(&client, &[&require_key]).await;
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    // Force every subsequent DB query on this pool to error.
+    pool.close().await;
+
+    // Untagged request: with a healthy DB this would be RejectRequired. With the
+    // DB erroring it must FAIL OPEN (Skip) and pass under the wallet cap.
+    tracker
+        .check_budget(&wallet, 0.10, None)
+        .await
+        .expect("DB error on require_tenant must fail OPEN (untagged passes)");
+
+    // Cache-poisoning guard: no error-derived sentinel may have been written.
+    let cached = get_redis_spend(&client, &require_key).await;
+    // tenant_require holds "1"/"0" (not a float) when present; absence is what we
+    // assert. get_redis_spend returns Ok(0.0) for a missing key, but a present
+    // sentinel "0"/"1" would parse as a number — assert the key truly is absent.
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let exists: bool = redis::cmd("EXISTS")
+        .arg(&require_key)
+        .query_async(&mut conn)
+        .await
+        .expect("EXISTS");
+    assert!(
+        !exists,
+        "a DB error must NOT cache a require_tenant sentinel (cache-poisoning), but {require_key} exists; get_redis_spend={cached:?}"
+    );
+
+    let now = Utc::now();
+    redis_del(
+        &client,
+        &[
+            &require_key,
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%d")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H")),
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+        ],
+    )
+    .await;
 }

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -158,7 +158,7 @@ async fn check_budget_passes_when_under_default_daily_limit(pool: PgPool) {
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
 
     tracker
-        .check_budget(&wallet, 0.50)
+        .check_budget(&wallet, 0.50, None)
         .await
         .expect("default budget must allow $0.50");
 
@@ -209,12 +209,12 @@ async fn check_budget_rejects_when_daily_limit_would_be_exceeded(pool: PgPool) {
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
 
     tracker
-        .check_budget(&wallet, 0.04)
+        .check_budget(&wallet, 0.04, None)
         .await
         .expect("$0.04 must fit");
 
     let err = tracker
-        .check_budget(&wallet, 0.10)
+        .check_budget(&wallet, 0.10, None)
         .await
         .expect_err("must reject when over the daily limit");
     match err {
@@ -278,7 +278,7 @@ async fn check_budget_rejects_when_hourly_limit_would_be_exceeded(pool: PgPool) 
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
 
     let err = tracker
-        .check_budget(&wallet, 0.10)
+        .check_budget(&wallet, 0.10, None)
         .await
         .expect_err("over hourly cap");
     match err {
@@ -328,7 +328,7 @@ async fn check_budget_rejects_when_monthly_limit_would_be_exceeded(pool: PgPool)
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
 
     let err = tracker
-        .check_budget(&wallet, 0.10)
+        .check_budget(&wallet, 0.10, None)
         .await
         .expect_err("over monthly cap");
     match err {
@@ -354,7 +354,7 @@ async fn check_budget_caches_team_membership_as_none_for_non_members(pool: PgPoo
 
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
     tracker
-        .check_budget(&wallet, 0.10)
+        .check_budget(&wallet, 0.10, None)
         .await
         .expect("default $100/day must allow $0.10");
 
@@ -403,12 +403,12 @@ async fn check_budget_uses_pre_populated_redis_cache(pool: PgPool) {
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
 
     tracker
-        .check_budget(&wallet, 0.04)
+        .check_budget(&wallet, 0.04, None)
         .await
         .expect("$0.04 fits under cached cap");
 
     let err = tracker
-        .check_budget(&wallet, 0.06)
+        .check_budget(&wallet, 0.06, None)
         .await
         .expect_err("must reject under the cached cap");
     match err {
@@ -452,7 +452,7 @@ async fn check_budget_falls_through_to_db_when_cache_is_corrupt(pool: PgPool) {
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
 
     tracker
-        .check_budget(&wallet, 0.50)
+        .check_budget(&wallet, 0.50, None)
         .await
         .expect("must use DB after detecting corrupt cache");
 
@@ -586,7 +586,7 @@ async fn check_budget_enforces_team_daily_limit(pool: PgPool) {
     // Wallet's per-wallet cap is the default $100/day; team cap is $0.10.
     // $0.05 pushes team total to $0.14 — exceeds team cap.
     let err = tracker
-        .check_budget(&wallet, 0.05)
+        .check_budget(&wallet, 0.05, None)
         .await
         .expect_err("team daily cap must enforce");
     match err {
@@ -642,7 +642,7 @@ async fn check_budget_redis_get_failure_fails_closed(pool: PgPool) {
 
     let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
     let err = tracker
-        .check_budget(&wallet, 0.10)
+        .check_budget(&wallet, 0.10, None)
         .await
         .expect_err("garbage in Redis must fail closed");
     match err {
@@ -828,7 +828,7 @@ async fn check_budget_serializes_concurrent_callers(pool: PgPool) {
         let tracker = Arc::clone(&tracker);
         let wallet = wallet.clone();
         handles.push(tokio::spawn(async move {
-            tracker.check_budget(&wallet, PER_CALL).await
+            tracker.check_budget(&wallet, PER_CALL, None).await
         }));
     }
 
@@ -869,4 +869,383 @@ async fn check_budget_serializes_concurrent_callers(pool: PgPool) {
         ],
     )
     .await;
+}
+
+// ---------------------------------------------------------------------------
+// PR2: per-tenant budget enforcement
+// ---------------------------------------------------------------------------
+//
+// SECURITY: the x-tenant tag is forgeable; these budgets are cooperative
+// accounting under one trusted single-wallet proxy, NOT isolation (see the
+// module-level note in usage.rs).
+
+/// Cleanup helper for the per-tenant counter + cache keys of a (wallet, tenant).
+async fn redis_del_tenant(client: &redis::Client, wallet: &str, tenant: &str) {
+    let now = Utc::now();
+    redis_del(
+        client,
+        &[
+            &format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%dT%H")),
+            &format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d")),
+            &format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m")),
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+            &format!("tenant_require:{wallet}"),
+            &format!("tenant_budget:{wallet}:{tenant}"),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%d")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m")),
+        ],
+    )
+    .await;
+}
+
+/// A provisioned `(wallet, tenant)` daily budget is enforced when its tag is
+/// present, even though require_tenant is FALSE (default). Under-limit passes;
+/// the next request that would breach the tenant cap is rejected.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_enforces_provisioned_tenant_daily_limit(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+    let now = Utc::now();
+
+    // require_tenant defaults FALSE; only a tenant budget row is provisioned.
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed wallet budget");
+    sqlx::query(
+        "INSERT INTO tenant_budgets (wallet_address, tenant, daily_limit_usdc) VALUES ($1, $2, 1.00)",
+    )
+    .bind(&wallet)
+    .bind(tenant)
+    .execute(&pool)
+    .await
+    .expect("seed tenant budget");
+
+    // Pre-seed the tenant daily counter near its $1.00 cap.
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let _: () = redis::cmd("SET")
+        .arg(&tenant_day_key)
+        .arg("0.95")
+        .arg("EX")
+        .arg(3600)
+        .query_async(&mut conn)
+        .await
+        .expect("seed tenant spend");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // $0.04 fits (0.95 + 0.04 = 0.99 ≤ 1.00).
+    tracker
+        .check_budget(&wallet, 0.04, Some(tenant))
+        .await
+        .expect("$0.04 must fit under the tenant daily cap");
+
+    // $0.10 now breaches (0.99 + 0.10 = 1.09 > 1.00).
+    let err = tracker
+        .check_budget(&wallet, 0.10, Some(tenant))
+        .await
+        .expect_err("must reject over the tenant daily cap");
+    match err {
+        UsageError::BudgetExceeded { limit, .. } => {
+            assert!(
+                (limit - 1.0).abs() < 1e-9,
+                "limit must be tenant 1.0, got {limit}"
+            );
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// require_tenant=TRUE + untagged request → fail-closed (TenantRequired),
+/// and BEFORE any settlement (check_budget runs pre-settlement). Also asserts
+/// no wallet counter was leaked by the rejected request.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_rejects_untagged_when_require_tenant(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc, require_tenant) \
+         VALUES ($1, 100.00, TRUE)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed enforced wallet");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    let err = tracker
+        .check_budget(&wallet, 0.10, None)
+        .await
+        .expect_err("enforced wallet must reject untagged request");
+    match err {
+        UsageError::TenantRequired { wallet: w } => assert_eq!(w, wallet),
+        other => panic!("expected TenantRequired, got {other:?}"),
+    }
+
+    // No budget leak: the wallet daily counter must not have been left committed.
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let leaked = get_redis_spend(&client, &day_key).await.expect("get");
+    assert_eq!(leaked, 0.0, "rejected request must leak no wallet spend");
+
+    redis_del(
+        &client,
+        &[
+            &day_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+            &format!("tenant_require:{wallet}"),
+        ],
+    )
+    .await;
+}
+
+/// require_tenant=TRUE + tag with no provisioned row → fail-closed
+/// (TenantNotProvisioned), before settlement.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_rejects_unknown_tenant_when_require_tenant(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc, require_tenant) \
+         VALUES ($1, 100.00, TRUE)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed enforced wallet");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    let err = tracker
+        .check_budget(&wallet, 0.10, Some("ghost"))
+        .await
+        .expect_err("enforced wallet must reject unprovisioned tenant");
+    match err {
+        UsageError::TenantNotProvisioned { wallet: w, tenant } => {
+            assert_eq!(w, wallet);
+            assert_eq!(tenant, "ghost");
+        }
+        other => panic!("expected TenantNotProvisioned, got {other:?}"),
+    }
+
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let leaked = get_redis_spend(&client, &day_key).await.expect("get");
+    assert_eq!(leaked, 0.0, "rejected request must leak no wallet spend");
+
+    redis_del_tenant(&client, &wallet, "ghost").await;
+}
+
+/// require_tenant=TRUE + tag WITH a provisioned row → allowed (and the tenant
+/// bucket is enforced). Pins the happy path of the enforced wallet.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_allows_provisioned_tenant_when_require_tenant(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc, require_tenant) \
+         VALUES ($1, 100.00, TRUE)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed enforced wallet");
+    sqlx::query(
+        "INSERT INTO tenant_budgets (wallet_address, tenant, daily_limit_usdc) VALUES ($1, $2, 1.00)",
+    )
+    .bind(&wallet)
+    .bind(tenant)
+    .execute(&pool)
+    .await
+    .expect("seed tenant budget");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    tracker
+        .check_budget(&wallet, 0.10, Some(tenant))
+        .await
+        .expect("enforced wallet with provisioned tenant must be allowed");
+
+    // The tenant daily counter must now reflect the reservation.
+    let now = Utc::now();
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let reserved = get_redis_spend(&client, &tenant_day_key)
+        .await
+        .expect("get");
+    assert!(
+        (reserved - 0.10).abs() < 1e-9,
+        "tenant daily counter must hold the reservation, got {reserved}"
+    );
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// Backward-compat: an unenforced wallet (require_tenant=FALSE, no tenant_budgets
+/// row) behaves identically with and without a tenant tag — the wallet daily cap
+/// is the only thing enforced, and a tag adds no rejection. Proven against the
+/// Redis counters.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_backward_compat_unenforced_wallet_ignores_tag(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+
+    // Default wallet (no row → default $100/day, require_tenant=FALSE).
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // Untagged passes.
+    tracker
+        .check_budget(&wallet, 0.10, None)
+        .await
+        .expect("untagged must pass on unenforced wallet");
+    // Tagged (no provisioned row) must ALSO pass — no tenant enforcement applies.
+    tracker
+        .check_budget(&wallet, 0.10, Some(tenant))
+        .await
+        .expect("tagged-but-unprovisioned must pass identically on unenforced wallet");
+
+    // No tenant counter should have been committed by check_budget (Skip path):
+    // tenant enforcement is skipped, so no spend:{wallet}:{tenant}:{period} key.
+    let now = Utc::now();
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let tenant_spend = get_redis_spend(&client, &tenant_day_key)
+        .await
+        .expect("get");
+    assert_eq!(
+        tenant_spend, 0.0,
+        "Skip path must not commit a tenant counter at check_budget time"
+    );
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// Counter reconciliation: with a provisioned tenant budget, `check_budget`
+/// reserves the ESTIMATE on the tenant daily counter and `log_spend` settles it
+/// to the ACTUAL via the (cost - estimated) delta on the SAME
+/// `spend:{wallet}:{tenant}:{period}` key. Net result equals the actual cost.
+#[sqlx::test(migrations = "../../migrations")]
+async fn tenant_counter_reconciles_estimate_to_actual(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, daily_limit_usdc) VALUES ($1, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed wallet");
+    sqlx::query(
+        "INSERT INTO tenant_budgets (wallet_address, tenant, daily_limit_usdc) VALUES ($1, $2, 10.00)",
+    )
+    .bind(&wallet)
+    .bind(tenant)
+    .execute(&pool)
+    .await
+    .expect("seed tenant budget");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // Reserve an estimate of $0.0050 on the tenant bucket.
+    let estimated = 0.0050;
+    tracker
+        .check_budget(&wallet, estimated, Some(tenant))
+        .await
+        .expect("reserve estimate");
+
+    let now = Utc::now();
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let after_reserve = get_redis_spend(&client, &tenant_day_key)
+        .await
+        .expect("get");
+    assert!(
+        (after_reserve - estimated).abs() < 1e-9,
+        "after reserve, tenant counter must equal estimate {estimated}, got {after_reserve}"
+    );
+
+    // Actual came in HIGHER than estimate; log_spend settles the delta.
+    let actual = 0.0075;
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 10,
+        output_tokens: 20,
+        cost_usdc: actual,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant: Some(tenant.to_string()),
+        estimated_cost_usdc: Some(estimated),
+    });
+
+    // Poll until the tenant counter settles to the actual.
+    let mut settled = after_reserve;
+    for _ in 0..100 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        if let Ok(v) = get_redis_spend(&client, &tenant_day_key).await {
+            settled = v;
+            if (settled - actual).abs() < 1e-9 {
+                break;
+            }
+        }
+    }
+    assert!(
+        (settled - actual).abs() < 1e-9,
+        "tenant counter must reconcile estimate→actual to {actual}, got {settled}"
+    );
+
+    redis_del_tenant(&client, &wallet, tenant).await;
+}
+
+/// log_spend writes the per-tenant hourly/daily/monthly counters using the
+/// `spend:{wallet}:{tenant}:{period}` key format when the entry carries a tag
+/// and no estimate was reserved (None → increment full cost).
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_writes_tenant_counters_with_correct_key(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let tenant = "acme";
+    let now = Utc::now();
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 1,
+        output_tokens: 1,
+        cost_usdc: 0.0050,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant: Some(tenant.to_string()),
+        estimated_cost_usdc: None,
+    });
+
+    let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
+    let val = wait_for_key(&client, &tenant_day_key)
+        .await
+        .expect("tenant daily counter must appear at spend:{wallet}:{tenant}:{day}");
+    assert_eq!(val.parse::<f64>().unwrap_or(0.0), 0.005);
+
+    redis_del_tenant(&client, &wallet, tenant).await;
 }

--- a/migrations/011_tenant_budgets.sql
+++ b/migrations/011_tenant_budgets.sql
@@ -10,6 +10,9 @@
 -- wallet's traffic can set any tenant tag.
 --
 -- Additive + idempotent. Mirrors the 005/007/008 trigger pattern.
+-- No FK from tenant_budgets.wallet_address -> wallet_budgets.wallet_address: a
+-- wallet may be provisioned a tenant budget without ever having a wallet_budgets
+-- row (it runs on the default wallet cap), so an FK would wrongly reject those.
 CREATE TABLE IF NOT EXISTS tenant_budgets (
     wallet_address      TEXT        NOT NULL,
     tenant              TEXT        NOT NULL,

--- a/migrations/011_tenant_budgets.sql
+++ b/migrations/011_tenant_budgets.sql
@@ -1,0 +1,32 @@
+-- Per-tenant budget ENFORCEMENT (PR2). Builds on migration 010's attribution-only
+-- `spend_logs.tenant` column. A `tenant_budgets` row sets hourly/daily/monthly
+-- caps on a `(wallet_address, tenant)` bucket; the gateway enforces it atomically
+-- the same way it enforces wallet/team caps.
+--
+-- IMPORTANT (security boundary): the `x-tenant` header is UNAUTHENTICATED and
+-- FORGEABLE. These budgets are cooperative accounting under ONE trusted
+-- single-wallet proxy metering its own downstream customers — they are NOT
+-- isolation between mutually-distrusting tenants. Anyone who controls the
+-- wallet's traffic can set any tenant tag.
+--
+-- Additive + idempotent. Mirrors the 005/007/008 trigger pattern.
+CREATE TABLE IF NOT EXISTS tenant_budgets (
+    wallet_address      TEXT        NOT NULL,
+    tenant              TEXT        NOT NULL,
+    hourly_limit_usdc   DECIMAL(18, 6),
+    daily_limit_usdc    DECIMAL(18, 6),
+    monthly_limit_usdc  DECIMAL(18, 6),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (wallet_address, tenant)
+);
+
+DROP TRIGGER IF EXISTS trg_tenant_budgets_updated_at ON tenant_budgets;
+CREATE TRIGGER trg_tenant_budgets_updated_at
+    BEFORE UPDATE ON tenant_budgets
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Opt-in fail-closed flag: when TRUE, the wallet may only spend under a tagged,
+-- provisioned tenant (untagged or unknown-tenant requests are rejected). Default
+-- FALSE so every existing wallet's behavior is unchanged.
+ALTER TABLE wallet_budgets ADD COLUMN IF NOT EXISTS require_tenant BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## What

PR2 of per-tenant billing. Adds the per-tenant budget **enforcement mechanism** on top of PR1's attribution (#493). Builds on `spend_logs.tenant`; enforces a `(wallet, tenant)` USDC cap the same atomic way wallet/team caps are enforced.

**Option B — enforcement mechanism only, public.** No management/provisioning endpoint (that's the enterprise control-plane boundary). Provisioning is a **dormant hook**: OSS self-hosters insert `tenant_budgets` rows directly.

## Mechanism

- **migration `011_tenant_budgets.sql`** — `tenant_budgets` keyed `(wallet_address, tenant)` (hourly/daily/monthly limits) + `wallet_budgets.require_tenant BOOLEAN DEFAULT FALSE`. Additive, idempotent, `update_updated_at_column` trigger.
- **`check_budget(... , tenant)`** — pure decision matrix `tenant_enforcement_decision(require_tenant, tag, has_row)` → `Enforce | RejectRequired | RejectNotProvisioned | Skip`. `Enforce` reserves on `spend:{wallet}:{tenant}:{period}` via the same atomic `try_commit!` path as wallet/team; rejects roll back any already-committed wallet/team reservations (no leak). Counters reconciled estimated→actual in `log_spend`, gated to enforced requests only.
- **`require_tenant` opt-in (default FALSE)** — when TRUE, untagged or unprovisioned-tenant requests are rejected fail-closed (→ 400), pre-settlement. Every existing wallet (flag FALSE) is byte-for-byte unchanged.

## Security boundary (documented in module + migration)

The `x-tenant` header is **unauthenticated and forgeable**. Per-tenant budgets are **cooperative accounting under one trusted single-wallet proxy** (e.g. a router metering its own downstream customers) — **NOT isolation between distrusting tenants**. The non-forgeable wallet/team cap is the authoritative backstop.

## Degradation

- **No Redis** → no budget enforcement at all (existing posture, Rule #12); tenant gates skipped.
- **DB error reading `require_tenant`** → **fail-open** (treat as unenforced; wallet cap still applies) and **never cache the error-derived value**. Matches how wallet/team config reads degrade; a transient DB blip cannot reject untagged traffic gateway-wide.

## Review

Went through an independent 3-reviewer money-path pass (silent-failure, Rust correctness, test-coverage). Findings fixed: error-derived cache poisoning; unreachable `unwrap_or_default` → `expect`/`unreachable!`; warn on all-NULL-limit no-op; Skip-path counter writes dropped; DB-error degradation set to fail-open. Confirmed correct: rollback atomicity, exhaustive matrix, reserve→settle symmetry.

## Tests

Exhaustive matrix unit tests; hourly/daily/monthly over-limit blocks; reconciliation across all three windows; **cap-escape-blocked** (second `check_budget` after `log_spend` proves the written key is the read key); rollback completeness on reject; fail-open-no-cache; e2e handler (`x-tenant` → 400, self-skips without live PG+Redis). `fmt`/`clippy -D warnings` clean; lib 708 + integration 166 pass; DB/Redis `#[sqlx::test]` suites infra-gated (pre-existing), zero new non-infra failures.

## Not in scope

Tenant provisioning/management API + invoicing/cost-center/control-plane → enterprise, later.