### PR TITLE
fix(gateway): reservation estimate must use the billing completion-token ceiling (#500)

### DIFF
--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -41,6 +41,48 @@ impl PaymentScheme {
 /// gateway cannot have priced for.
 const DEFAULT_COMPLETION_TOKENS_CAP: u32 = 8192;
 
+/// The maximum `completion_tokens` the billing path can ever charge for, given
+/// the request's `max_tokens` and the model registry entry.
+///
+/// This is the SINGLE source of truth for the completion-token ceiling, shared
+/// by both:
+///   1. the UPFRONT budget reservation / 402 quote
+///      (`chat/mod.rs` — `estimate_cost(..., completion_token_ceiling(...))`), and
+///   2. the SETTLEMENT-time provider-usage cap
+///      ([`cap_usage_to_request_limits`], which clamps the provider's reported
+///      `completion_tokens` to this same value before pricing).
+///
+/// MONEY-PATH INVARIANT (#500): the reservation MUST be an upper bound on what
+/// billing can charge. If the estimate computed a *lower* completion ceiling
+/// than the settlement cap, an omitted-`max_tokens` request could reserve under
+/// its true billable maximum, pass the `(wallet, tenant)` budget gate just
+/// under the cap, then have its actual (larger) usage reconciled by
+/// `log_spend`'s `(billed − reserved)` delta WITHOUT a second cap check —
+/// overshooting the tenant/wallet/team cap by one request. Computing both the
+/// estimate and the settlement cap from THIS function makes that undershoot
+/// structurally impossible.
+///
+/// Ceiling = `min(req_max_tokens, model_info.max_output_tokens,
+/// DEFAULT_COMPLETION_TOKENS_CAP)`, where any absent (`None`) bound is skipped
+/// and the tightest of the present bounds wins. When `req_max_tokens` is `None`
+/// (the caller omitted it), the ceiling falls back to the model's declared max
+/// output (if any), then the default cap — i.e. the largest completion the
+/// gateway could end up billing for that request.
+pub(crate) fn completion_token_ceiling(
+    req_max_tokens: Option<u32>,
+    model_info: &ModelRegistration,
+) -> u32 {
+    [
+        req_max_tokens,
+        model_info.max_output_tokens,
+        Some(DEFAULT_COMPLETION_TOKENS_CAP),
+    ]
+    .into_iter()
+    .flatten()
+    .min()
+    .unwrap_or(DEFAULT_COMPLETION_TOKENS_CAP)
+}
+
 /// Cap a provider-reported `Usage` to limits the gateway has actually priced
 /// for. Provider responses are trusted today (the gateway speaks
 /// OpenAI-compat to the provider and parses the JSON back), but a compromised
@@ -63,15 +105,11 @@ pub(crate) fn cap_usage_to_request_limits(
     req: &ChatRequest,
     model_info: &ModelRegistration,
 ) -> Usage {
-    let completion_cap = [
-        req.max_tokens,
-        model_info.max_output_tokens,
-        Some(DEFAULT_COMPLETION_TOKENS_CAP),
-    ]
-    .into_iter()
-    .flatten()
-    .min()
-    .unwrap_or(DEFAULT_COMPLETION_TOKENS_CAP);
+    // Shared single source of truth with the upfront reservation estimate
+    // (see [`completion_token_ceiling`] and #500): the value the settlement
+    // path caps the provider's `completion_tokens` to here is exactly the value
+    // the reservation reserved for, so billing can never exceed the reservation.
+    let completion_cap = completion_token_ceiling(req.max_tokens, model_info);
 
     let prompt = usage.prompt_tokens.min(model_info.context_window);
     let completion = usage.completion_tokens.min(completion_cap);
@@ -984,6 +1022,69 @@ supports_vision = false
             stream: false,
             tools: None,
             tool_choice: None,
+        }
+    }
+
+    // =========================================================================
+    // completion_token_ceiling — single source of truth for the completion cap
+    // shared by the upfront reservation estimate and the settlement-time
+    // provider-usage cap (#500).
+    // =========================================================================
+
+    #[test]
+    fn completion_ceiling_omitted_max_tokens_falls_back_to_default_cap() {
+        // No req cap, no model cap → DEFAULT_COMPLETION_TOKENS_CAP (8192). This
+        // is the #500 case: the estimate previously used 1000, undershooting the
+        // billable maximum.
+        let mut model = test_model_info();
+        model.max_output_tokens = None;
+        assert_eq!(
+            completion_token_ceiling(None, &model),
+            DEFAULT_COMPLETION_TOKENS_CAP
+        );
+    }
+
+    #[test]
+    fn completion_ceiling_omitted_max_tokens_uses_model_max_when_tighter() {
+        // No req cap, model declares 2048 → 2048 (tighter than the 8192 default).
+        let model = test_model_info(); // max_output_tokens = Some(2048)
+        assert_eq!(completion_token_ceiling(None, &model), 2048);
+    }
+
+    #[test]
+    fn completion_ceiling_provided_max_tokens_wins_when_tightest() {
+        let model = test_model_info(); // max_output_tokens = Some(2048)
+        assert_eq!(completion_token_ceiling(Some(256), &model), 256);
+        // A provided cap above the model max is clamped to the model max.
+        assert_eq!(completion_token_ceiling(Some(9000), &model), 2048);
+    }
+
+    #[test]
+    fn completion_ceiling_matches_cap_usage_completion_cap() {
+        // The settlement cap (`cap_usage_to_request_limits`) and the reservation
+        // ceiling MUST agree for every (req_max, model_max) combination — that
+        // agreement is the #500 fix. Cross-check the two for representative
+        // inputs by clamping a hugely-inflated completion via cap_usage and
+        // comparing to the ceiling directly.
+        for req_max in [None, Some(100), Some(5000), Some(20000)] {
+            for model_max in [None, Some(2048), Some(16384)] {
+                let mut model = test_model_info();
+                model.max_output_tokens = model_max;
+                model.context_window = 1_000_000; // don't let prompt cap interfere
+                let ceiling = completion_token_ceiling(req_max, &model);
+                let req = req_with_max_tokens(req_max);
+                let inflated = solvela_protocol::Usage {
+                    prompt_tokens: 1,
+                    completion_tokens: u32::MAX,
+                    total_tokens: u32::MAX,
+                };
+                let capped = cap_usage_to_request_limits(&inflated, &req, &model);
+                assert_eq!(
+                    capped.completion_tokens, ceiling,
+                    "settlement completion cap must equal the reservation ceiling \
+                     for req_max={req_max:?}, model_max={model_max:?}"
+                );
+            }
         }
     }
 

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -81,6 +81,11 @@ pub(crate) fn completion_token_ceiling(
     .flatten()
     .min()
     .unwrap_or(DEFAULT_COMPLETION_TOKENS_CAP)
+    // Floor at 1: a degenerate `max_tokens = Some(0)` would otherwise yield a
+    // zero ceiling, which under-reserves to nothing on the estimate path and
+    // caps billable completion to zero on the settlement path. The ceiling is
+    // an upper bound on billable completion tokens, so it must never be < 1.
+    .max(1)
 }
 
 /// Cap a provider-reported `Usage` to limits the gateway has actually priced
@@ -332,12 +337,19 @@ pub(crate) fn estimated_atomic_cost(
     registry: &solvela_router::models::ModelRegistry,
     model: &str,
     req: &ChatRequest,
+    model_info: &ModelRegistration,
 ) -> Result<u64, String> {
     let f = registry
         .estimate_cost(
             model,
             estimate_input_tokens(req),
-            req.max_tokens.unwrap_or(1000),
+            // MONEY-PATH INVARIANT (#500): the estimate's completion-token bound
+            // MUST be the same `completion_token_ceiling` the settlement path
+            // caps provider usage to — not a hardcoded 1000. Otherwise an
+            // omitted-`max_tokens` request on a model whose output ceiling
+            // exceeds 1000 would under-estimate (under-reserve / under-claim)
+            // relative to what billing can actually charge.
+            completion_token_ceiling(req.max_tokens, model_info),
         )
         .and_then(|c| {
             c.total
@@ -582,7 +594,7 @@ pub(crate) fn semantic_hit_full_atomic(
 ) -> Option<u64> {
     usage
         .and_then(|u| compute_actual_atomic_cost(u.prompt_tokens, u.completion_tokens, model_info))
-        .or_else(|| estimated_atomic_cost(registry, model, req).ok())
+        .or_else(|| estimated_atomic_cost(registry, model, req, model_info).ok())
         .filter(|&c| c > 0)
 }
 
@@ -1060,6 +1072,16 @@ supports_vision = false
     }
 
     #[test]
+    fn completion_ceiling_floors_zero_max_tokens_to_one() {
+        // Degenerate input: `max_tokens = Some(0)` would otherwise yield a zero
+        // ceiling (under-reserving to nothing / capping billable completion to
+        // zero). The ceiling is an upper bound on billable tokens and must never
+        // drop below 1.
+        let model = test_model_info();
+        assert_eq!(completion_token_ceiling(Some(0), &model), 1);
+    }
+
+    #[test]
     fn completion_ceiling_matches_cap_usage_completion_cap() {
         // The settlement cap (`cap_usage_to_request_limits`) and the reservation
         // ceiling MUST agree for every (req_max, model_max) combination — that
@@ -1346,9 +1368,41 @@ supports_vision = false
     #[test]
     fn test_estimated_atomic_cost_valid_small_amount() {
         let reg = registry_with_cost(1.0); // $1 per million tokens
-        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
+        let result = estimated_atomic_cost(&reg, "test-model", &simple_req(), &test_model_info());
         assert!(result.is_ok(), "valid cost should succeed, got: {result:?}");
         assert!(result.unwrap() > 0, "valid cost should be positive");
+    }
+
+    #[test]
+    fn test_estimated_atomic_cost_uses_completion_ceiling_not_1000() {
+        // #500 regression: with `max_tokens` omitted and a model whose output
+        // ceiling exceeds 1000, the estimate MUST price against the
+        // `completion_token_ceiling`, not the old hardcoded 1000. Pricing is
+        // linear in completion tokens, so a larger ceiling produces a strictly
+        // larger estimate. Drive the difference through the public estimate.
+        let reg = registry_with_cost(1.0);
+        let req = simple_req(); // no max_tokens
+
+        // Model A: completion ceiling = 1000 (matches the old hardcoded value).
+        let mut model_1000 = test_model_info();
+        model_1000.max_output_tokens = Some(1000);
+        let est_1000 = estimated_atomic_cost(&reg, "test-model", &req, &model_1000)
+            .expect("estimate should succeed");
+
+        // Model B: completion ceiling = 8000 (the #500 case — model allows more
+        // output than the old default). The estimate must reflect the higher
+        // ceiling, proving it no longer hardcodes 1000.
+        let mut model_8000 = test_model_info();
+        model_8000.max_output_tokens = Some(8000);
+        let est_8000 = estimated_atomic_cost(&reg, "test-model", &req, &model_8000)
+            .expect("estimate should succeed");
+
+        assert!(
+            est_8000 > est_1000,
+            "estimate for an 8000-token ceiling ({est_8000}) must exceed the \
+             1000-token-ceiling estimate ({est_1000}); the fallback must use \
+             completion_token_ceiling, not a hardcoded 1000"
+        );
     }
 
     // R1 note: tests asserting NaN/+Inf/-Inf input through `registry_with_cost`
@@ -1373,7 +1427,7 @@ supports_vision = false
         // (~1.05e15 USDC) exceeds the cap but stays finite.
         let huge_cost = 1.0e18_f64;
         let reg = registry_with_cost(huge_cost);
-        let result = estimated_atomic_cost(&reg, "test-model", &simple_req());
+        let result = estimated_atomic_cost(&reg, "test-model", &simple_req(), &test_model_info());
         match result {
             Err(e) => assert!(
                 e.contains("overflow") || e.contains("range") || e.contains("exceeds"),
@@ -1387,7 +1441,7 @@ supports_vision = false
     fn test_estimated_atomic_cost_unknown_model_returns_err() {
         let reg = registry_with_cost(1.0);
         let req = make_request("unknown-model", vec![user_msg("hello")]);
-        let result = estimated_atomic_cost(&reg, "unknown-model", &req);
+        let result = estimated_atomic_cost(&reg, "unknown-model", &req, &test_model_info());
         assert!(
             result.is_err(),
             "unknown model must return Err, got: {result:?}"

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -32,9 +32,9 @@ use crate::usage::SpendLogEntry;
 use crate::AppState;
 
 use cost::{
-    cap_usage_to_request_limits, compute_actual_atomic_cost, estimate_input_tokens,
-    estimated_atomic_cost, scheme_realized_discount, spend_cost_atomic, usdc_atomic_amount_checked,
-    usdc_f64_to_atomic_safe, PaymentScheme,
+    cap_usage_to_request_limits, completion_token_ceiling, compute_actual_atomic_cost,
+    estimate_input_tokens, estimated_atomic_cost, scheme_realized_discount, spend_cost_atomic,
+    usdc_atomic_amount_checked, usdc_f64_to_atomic_safe, PaymentScheme,
 };
 use payment::{decode_payment_from_header, extract_payment_info, fire_escrow_claim};
 use provider::{ProviderCallContext, ProviderCallError, ProviderCallResult};
@@ -355,7 +355,10 @@ pub async fn chat_completions(
             .estimate_cost(
                 &req.model,
                 estimate_input_tokens(&req),
-                req.max_tokens.unwrap_or(1000),
+                // #500: reserve for the SAME completion-token ceiling billing
+                // will cap to (not a flat 1000), so an omitted-max_tokens
+                // request can never bill above its reservation.
+                completion_token_ceiling(req.max_tokens, model_info),
             )
             .map_err(|e| GatewayError::Internal(e.to_string()))?;
 
@@ -517,7 +520,14 @@ pub async fn chat_completions(
                 .estimate_cost(
                     &req.model,
                     estimate_input_tokens(&req),
-                    req.max_tokens.unwrap_or(1000),
+                    // #500: same completion-token ceiling as the 402 quote above
+                    // and as the settlement-time `cap_usage_to_request_limits`.
+                    // This figure feeds both the client-amount validation (C1)
+                    // and the budget reservation (M3), so the reservation is an
+                    // upper bound on the billable cost — an omitted-max_tokens
+                    // request cannot reserve under cap and then overshoot via the
+                    // `log_spend` reconciliation delta.
+                    completion_token_ceiling(req.max_tokens, model_info),
                 )
                 .map_err(|e| GatewayError::Internal(e.to_string()))?;
             let expected_amount: u64 = usdc_atomic_amount_checked(&expected_cost.total)

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -1035,7 +1035,7 @@ pub async fn chat_completions(
                 compute_actual_atomic_cost(u.prompt_tokens, u.completion_tokens, model_info)
             } else {
                 Some(
-                    estimated_atomic_cost(&state.model_registry, &req.model, &req)
+                    estimated_atomic_cost(&state.model_registry, &req.model, &req, model_info)
                         .unwrap_or_else(|e| {
                             warn!(
                                 error = %e,

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -5388,9 +5388,14 @@ async fn test_payment_verified_reaches_provider_path() {
 /// check + reserve ahead of settlement.
 ///
 /// The `UsageTracker::noop()` tracker (no Redis) applies a $1.00 per-request hard
-/// cap. The test model `openai/gpt-4o` costs $10.00/M output tokens, so
-/// `max_tokens: 128000` estimates ~$1.28 — over the cap → `check_budget` returns
-/// `BudgetExceeded` → the route maps it to `BadRequest` → HTTP 400.
+/// cap. The test model `openai/gpt-4o` costs $2.50/M input tokens. We drive the
+/// estimate over the cap with a large PROMPT rather than a large `max_tokens`:
+/// after #500 the reservation caps completion tokens at the billing ceiling
+/// (`DEFAULT_COMPLETION_TOKENS_CAP` = 8192 for a model with no declared
+/// `max_output_tokens`), so a huge `max_tokens` no longer inflates the estimate
+/// beyond what billing can actually charge. A ~1.6M-char prompt ≈ 400k input
+/// tokens ≈ $1.00 input cost, ×1.05 fee → over the $1.00 cap → `check_budget`
+/// returns `BudgetExceeded` → the route maps it to `BadRequest` → HTTP 400.
 ///
 /// We inject a `SettleRecordingVerifier` that flips a shared `AtomicBool` if (and
 /// only if) `settle_payment` is reached. We assert the response is 400 AND the
@@ -5405,11 +5410,13 @@ async fn test_over_budget_request_never_settles() {
             settled: Arc::clone(&settled),
         }));
 
-    // ~$1.28 estimated — over the $1.00 no-Redis hard cap.
+    // ~1.6M chars → ~400k input tokens → ~$1.00 input @ $2.50/M; ×1.05 fee plus
+    // the capped completion ceiling pushes the estimate over the $1.00 no-Redis
+    // hard cap regardless of the (now-capped) completion ceiling.
+    let big_prompt = "A".repeat(1_600_000);
     let body = serde_json::json!({
         "model": "openai/gpt-4o",
-        "messages": [{"role": "user", "content": "Hello!"}],
-        "max_tokens": 128000,
+        "messages": [{"role": "user", "content": big_prompt}],
     });
 
     let response = app
@@ -8018,5 +8025,127 @@ async fn settle_unknown_status_returns_400() {
         resp.status().is_client_error(),
         "unknown status enum value must return 4xx, got {}",
         resp.status()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #500: the budget reservation estimate must use the SAME completion-token
+// ceiling the billing path will cap to, so a request that OMITS `max_tokens`
+// cannot reserve under the billable maximum and then overshoot a tenant /
+// wallet / team cap by one request via the reconciliation delta.
+//
+// `DEFAULT_COMPLETION_TOKENS_CAP` is 8192 (crates/gateway/src/routes/chat/cost.rs).
+// For a model with no `max_output_tokens` (e.g. the test gpt-4o entry), the
+// billing path can charge for up to 8192 completion tokens. Before the fix the
+// reservation estimated only `max_tokens.unwrap_or(1000)` output tokens, so the
+// 402 quote / reservation was the cost of 1000 output tokens — strictly below
+// what billing can charge. These tests pin the reservation to the billing
+// ceiling.
+//
+// The 402 `accepts[].amount` is exactly the reserved/quoted atomic-USDC amount
+// (route computes `estimate_cost(...) -> usdc_atomic_amount_checked`), so the
+// 402 amount is the observable proxy for the reservation through the real path.
+// ---------------------------------------------------------------------------
+
+/// Atomic-USDC amount the registry would quote for `model` at the given input /
+/// output token counts. Mirrors the route's own derivation
+/// (`estimate_cost(...).total -> usdc_atomic_amount_checked`) so the test
+/// compares the route's 402 amount against the SAME single source of truth the
+/// route uses, rather than against a hand-derived magic number.
+fn registry_quote_atomic(model: &str, input_tokens: u32, output_tokens: u32) -> u64 {
+    let registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let cost = registry
+        .estimate_cost(model, input_tokens, output_tokens)
+        .expect("model present in test registry");
+    // The route converts the decimal-USDC `total` string to atomic units; replicate.
+    let dot = cost.total.find('.').unwrap();
+    let integer: u64 = cost.total[..dot].parse().unwrap();
+    let frac_padded = format!("{:0<6}", &cost.total[dot + 1..]);
+    let frac: u64 = frac_padded[..6].parse().unwrap();
+    integer * 1_000_000 + frac
+}
+
+/// Fetch the `exact`-scheme reserved/quoted amount from a 402 challenge.
+async fn quote_402_amount_atomic(body: &str) -> u64 {
+    let app = test_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "no-payment request must return 402"
+    );
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let pr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let accepts = pr["accepts"].as_array().expect("accepts array");
+    let exact = accepts
+        .iter()
+        .find(|a| a["scheme"] == "exact")
+        .expect("exact scheme present");
+    exact["amount"]
+        .as_str()
+        .expect("amount is a string")
+        .parse()
+        .expect("amount parses as u64 atomic units")
+}
+
+#[tokio::test]
+async fn reservation_omitted_max_tokens_uses_billing_ceiling_not_1000() {
+    // Prompt of exactly 40 chars -> estimate_input_tokens = 40/4 = 10 input tokens.
+    // gpt-4o declares no max_output_tokens, so the billing completion ceiling is
+    // DEFAULT_COMPLETION_TOKENS_CAP (8192).
+    let prompt = "x".repeat(40);
+    let body = format!(
+        r#"{{"model":"openai/gpt-4o","messages":[{{"role":"user","content":"{prompt}"}}]}}"#
+    );
+    let reserved = quote_402_amount_atomic(&body).await;
+
+    let billing_ceiling_quote = registry_quote_atomic("openai/gpt-4o", 10, 8192);
+    let old_undershoot_quote = registry_quote_atomic("openai/gpt-4o", 10, 1000);
+
+    assert_eq!(
+        reserved, billing_ceiling_quote,
+        "reservation for an omitted max_tokens request must equal the cost of the \
+         billing completion-token ceiling (8192 output tokens), not 1000"
+    );
+    assert!(
+        reserved > old_undershoot_quote,
+        "reservation ({reserved}) must exceed the old 1000-token undershoot \
+         ({old_undershoot_quote}) — otherwise billing can charge above the reservation"
+    );
+}
+
+#[tokio::test]
+async fn reservation_provided_max_tokens_is_unchanged() {
+    // When max_tokens IS provided and is below both the model max and the
+    // default cap, the reservation must equal exactly that provided count —
+    // the fix must not change the estimate for already-capped requests.
+    let prompt = "x".repeat(40); // 10 input tokens
+    let body = format!(
+        r#"{{"model":"openai/gpt-4o","messages":[{{"role":"user","content":"{prompt}"}}],"max_tokens":256}}"#
+    );
+    let reserved = quote_402_amount_atomic(&body).await;
+
+    let provided_quote = registry_quote_atomic("openai/gpt-4o", 10, 256);
+    assert_eq!(
+        reserved, provided_quote,
+        "with max_tokens=256 the reservation must equal the cost of 256 output \
+         tokens (unchanged behavior for already-capped requests)"
+    );
+    // And it must be strictly below the no-cap ceiling, proving the provided cap
+    // is honored rather than always reserving 8192.
+    let ceiling_quote = registry_quote_atomic("openai/gpt-4o", 10, 8192);
+    assert!(
+        reserved < ceiling_quote,
+        "a provided max_tokens=256 must reserve less than the 8192 ceiling"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the single-request budget overshoot reported in #500 (confirmed in review of merged #498).

The per-tenant/wallet budget **reservation** estimated output tokens with `req.max_tokens.unwrap_or(1000)`, while the **billing** path caps actual completion tokens at `min(req.max_tokens, model_info.max_output_tokens, DEFAULT_COMPLETION_TOKENS_CAP=8192)`. When `max_tokens` was omitted and the model allowed >1000 output tokens, the reservation (1000) sat below the billable maximum:

1. the `(wallet, tenant)` budget gate passed just under the cap,
2. the actual response was larger, and
3. `log_spend`'s `(billed − reserved)` reconciliation delta was added to the counter **without re-checking the cap** → one-request overshoot beyond the tenant/wallet/team cap.

## Fix (single source of truth)

Factored the completion-token ceiling into one reusable helper `completion_token_ceiling(req_max_tokens, model_info)` in `crates/gateway/src/routes/chat/cost.rs`, returning `min(req_max_tokens, model_info.max_output_tokens, DEFAULT_COMPLETION_TOKENS_CAP)` (absent bounds skipped). It is now used by **both**:

- the upfront reservation estimate — the 402 quote site (`mod.rs:358`) and the C1 expected-cost / M3 reservation site (`mod.rs:520`); and
- the settlement-time `cap_usage_to_request_limits`.

The reservation is therefore an upper bound on what billing can charge: an omitted-`max_tokens` request can never bill above its reservation. `DEFAULT_COMPLETION_TOKENS_CAP` remains the single constant; no new hardcoded `8192`. When `max_tokens` IS provided, behavior is unchanged.

I grepped `max_tokens.unwrap_or` to confirm there is no third reservation site — the other hits are the provider-call adapters and the A2A handler, which are not the budget-reservation path.

## Tests (TDD — written first, watched fail, then pass)

- `reservation_omitted_max_tokens_uses_billing_ceiling_not_1000` (integration, `oneshot`/`test_app`): the 402 reserved amount equals the 8192-ceiling quote, strictly above the old 1000-token undershoot. **Failed before the fix** (`left: 10526, right: 86042`), passes after.
- `reservation_provided_max_tokens_is_unchanged`: a provided `max_tokens=256` reserves exactly the 256-token cost, below the ceiling.
- `completion_ceiling_*` unit tests + a cross-check asserting the settlement cap equals the reservation ceiling for every `(req_max, model_max)` combination.

Updated `test_over_budget_request_never_settles` to drive the over-budget estimate with a large prompt rather than a large `max_tokens` (its old premise relied on the pre-fix over-reservation).

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test -p gateway` — lib 713 passed / 1 ignored; main 2 passed; integration 167 passed, 1 failed (`semantic_cache_populates_on_miss`, a pre-existing local-Redis-state flake that fails identically on the base commit, independent of this change). The 12 `escrow_queue.rs` `#[sqlx::test]` failures are the known no-live-Postgres failures.

Closes #500