### PR TITLE
fix(gateway): reject require_tenant wallets on /a2a and /proxy paid paths (#499)

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -299,6 +299,35 @@ async fn handle_payment_submitted(
             data: None,
         })?;
 
+    // Issue #499: reject `require_tenant = TRUE` wallets on the A2A path.
+    //
+    // A2A dispatches `chat_with_model_fallback` DIRECTLY (see
+    // `reject_image_data_parts`' note), bypassing the chat route's
+    // `check_budget` per-tenant matrix. A wallet provisioned as
+    // `require_tenant = TRUE` ("may only spend under a tagged, provisioned
+    // tenant") would otherwise defeat that fail-closed guarantee here. Rather
+    // than add per-tenant metering to A2A (deliberately out of scope), we fail
+    // the task cleanly BEFORE any settlement / provider call, so a rejected
+    // request takes no spend. The wallet must use `POST /v1/chat/completions`.
+    //
+    // Degradation matches the chat path: `require_tenant_for_wallet` returns
+    // `false` (do not reject) when Redis is absent or on a transient Redis/DB
+    // read error (the wallet caps are the backstop) — see its doc.
+    let payer_wallet = crate::payment_util::extract_payer_wallet(&payload);
+    if state.usage.require_tenant_for_wallet(&payer_wallet).await {
+        warn!(
+            task_id,
+            "A2A request rejected: payer wallet requires per-tenant budgeting (#499)"
+        );
+        return Err(JsonRpcErrorData {
+            code: ERR_PAYMENT_FAILED,
+            message: "This wallet requires per-tenant budgeting; use \
+                      POST /v1/chat/completions"
+                .to_string(),
+            data: None,
+        });
+    }
+
     // Verify payment (skip in dev bypass mode)
     let tx_signature = if state.dev_bypass_payment {
         warn!(
@@ -1625,6 +1654,71 @@ supports_vision = false
         assert!(
             !err.message.contains("verifier"),
             "must not leak verifier internals: {}",
+            err.message
+        );
+    }
+
+    /// #499 regression guard: a NORMAL wallet (`require_tenant` false — the
+    /// no-Redis/noop `UsageTracker` reports false, pinned by the usage.rs unit
+    /// test) must NOT be rejected by the new require_tenant gate on the A2A path.
+    /// It must proceed PAST the gate to settlement/verification.
+    ///
+    /// With an empty facilitator, verification fails with ERR_PAYMENT_FAILED —
+    /// but crucially with the verifier-failure message, NOT the #499 per-tenant
+    /// rejection. If the gate had wrongly rejected this wallet, the error message
+    /// would mention "per-tenant budgeting" and verification would never run.
+    ///
+    /// The positive-reject case (`require_tenant = TRUE` → fail the task, no
+    /// settlement) cannot be exercised here: forcing the flag TRUE needs a live
+    /// DB-backed `wallet_budgets` row, which the noop-tracker test state lacks.
+    /// It is pinned by the usage.rs degradation test plus the shared accessor.
+    #[tokio::test]
+    async fn payment_submitted_normal_wallet_not_rejected_reaches_verification() {
+        let state = test_state_with_redis();
+        let new_params = user_msg_with_text("test", Some("test-model"));
+        let task_value = handle_new_request(&state, &new_params).await.expect("task");
+        let task_id = task_value["id"].as_str().expect("id").to_string();
+
+        let tx_raw = format!("test_tx_{}", uuid::Uuid::new_v4().simple());
+        let payload = json!({
+            "x402_version": solvela_x402::types::X402_VERSION,
+            "resource": {"url": "/v1/chat/completions", "method": "POST"},
+            "accepted": {
+                "scheme": "exact",
+                "network": solvela_x402::types::SOLANA_NETWORK,
+                "amount": "1000",
+                "asset": solvela_x402::types::USDC_MINT,
+                "pay_to": "11111111111111111111111111111111",
+                "max_timeout_seconds": solvela_x402::types::MAX_TIMEOUT_SECONDS,
+            },
+            "payload": { "transaction": tx_raw }
+        });
+
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            x402_meta::STATUS_KEY.to_string(),
+            json!(x402_meta::PAYMENT_SUBMITTED),
+        );
+        metadata.insert(x402_meta::PAYLOAD_KEY.to_string(), payload);
+
+        let params = MessageSendParams {
+            message: Message {
+                role: MessageRole::User,
+                parts: vec![Part::Text {
+                    text: "pay".to_string(),
+                }],
+                metadata: Some(metadata),
+            },
+            task_id: Some(task_id.clone()),
+        };
+
+        let err = handle_payment_submitted(&state, &HeaderMap::new(), &task_id, &params)
+            .await
+            .expect_err("empty facilitator must fail verification (past the #499 gate)");
+        assert_eq!(err.code, ERR_PAYMENT_FAILED);
+        assert!(
+            !err.message.contains("per-tenant"),
+            "normal wallet must NOT be rejected by the #499 gate; got: {}",
             err.message
         );
     }

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -1723,6 +1723,190 @@ supports_vision = false
         );
     }
 
+    /// Like [`test_state_with_redis`] (Redis-backed `cache`, required by the A2A
+    /// task store) but the `UsageTracker` is also Redis-backed
+    /// (`UsageTracker::new(None, Some(redis))`, `db_pool = None`) so
+    /// `require_tenant_for_wallet` resolves the flag from the Redis cache key
+    /// `budget_config:{wallet}` — a cache hit never touches the DB, so no live
+    /// Postgres is needed. Self-returns `None` if local Redis is unavailable so
+    /// the caller can skip cleanly.
+    fn test_state_redis_tracker() -> Option<(Arc<AppState>, redis::Client)> {
+        use crate::cache::{CacheConfig, ResponseCache};
+
+        let redis_client = redis::Client::open("redis://127.0.0.1:6379").ok()?;
+        let cache = ResponseCache::from_client(redis_client.clone(), CacheConfig::default())
+            .expect("ResponseCache::from_client should not connect");
+        let state = Arc::new(AppState {
+            config: AppConfig::default(),
+            model_registry: ModelRegistry::from_toml(
+                r#"
+[models.test-model]
+provider = "test"
+model_id = "test-model"
+display_name = "Test"
+input_cost_per_million = 1.0
+output_cost_per_million = 2.0
+context_window = 4096
+supports_streaming = false
+supports_tools = false
+supports_vision = false
+                "#,
+            )
+            .expect("valid test model TOML"),
+            service_registry: RwLock::new(ServiceRegistry::empty()),
+            providers: ProviderRegistry::from_env(reqwest::Client::new()),
+            facilitator: Facilitator::new(vec![]),
+            usage: UsageTracker::new(None, Some(redis_client.clone())),
+            cache: Some(cache),
+            semantic_cache: None,
+            provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+            escrow_claimer: None,
+            fee_payer_pool: None,
+            nonce_pool: None,
+            db_pool: None,
+            session_secret: b"test-secret".to_vec(),
+            http_client: reqwest::Client::new(),
+            replay_set: AppState::new_replay_set(),
+            slot_cache: new_slot_cache(),
+            escrow_metrics: None,
+            admin_token: None,
+            api_key_hmac_secret: None,
+            prometheus_handle: None,
+            dev_bypass_payment: false,
+        });
+        Some((state, redis_client))
+    }
+
+    /// #499 POSITIVE-reject pin (A2A path): a wallet provisioned
+    /// `require_tenant = TRUE` MUST fail the task with `ERR_PAYMENT_FAILED` and
+    /// the per-tenant guidance message BEFORE any settlement.
+    ///
+    /// Forcing `require_tenant = TRUE` WITHOUT a live Postgres:
+    /// `require_tenant_for_wallet` → `get_wallet_budget_config` consults the
+    /// Redis cache key `budget_config:{wallet}` FIRST and returns it verbatim on
+    /// a hit, never touching the DB (`db_pool = None`). We seed that key with a
+    /// `BudgetConfig { require_tenant: true, .. }`. The escrow payload carries
+    /// the payer in `agent_pubkey` (returned verbatim by `extract_payer_wallet`),
+    /// so we use a unique per-run wallet and seed exactly its key.
+    ///
+    /// Proof settlement did NOT happen: the gate returns BEFORE the replay-record
+    /// / verify / settle block, so (a) the error is the gate's per-tenant message
+    /// (a verifier/replay failure would carry a different message — contrast the
+    /// `normal_wallet` test which asserts the inverse) and (b) the tx was never
+    /// recorded in the in-memory `replay_set` (the first side-effect past the
+    /// gate). Self-skips if local Redis is unavailable.
+    #[tokio::test]
+    async fn payment_submitted_require_tenant_wallet_rejected_before_settlement() {
+        let Some((state, redis_client)) = test_state_redis_tracker() else {
+            eprintln!("skipping A2A require_tenant reject test: Redis unavailable");
+            return;
+        };
+        let mut conn = match redis_client.get_multiplexed_async_connection().await {
+            Ok(c) => c,
+            Err(_) => {
+                eprintln!("skipping A2A require_tenant reject test: Redis unavailable");
+                return;
+            }
+        };
+
+        let payer = format!("ReqTenantA2a{}", uuid::Uuid::new_v4().simple());
+        let cache_key = format!("budget_config:{payer}");
+        let cached = serde_json::to_string(&crate::usage::BudgetConfig {
+            hourly: None,
+            daily: Some(100.0),
+            monthly: None,
+            require_tenant: true,
+        })
+        .unwrap();
+        let _: () = redis::cmd("SET")
+            .arg(&cache_key)
+            .arg(&cached)
+            .arg("EX")
+            .arg(60)
+            .query_async(&mut conn)
+            .await
+            .expect("seed budget_config cache");
+
+        let new_params = user_msg_with_text("test", Some("test-model"));
+        let task_value = handle_new_request(&state, &new_params).await.expect("task");
+        let task_id = task_value["id"].as_str().expect("id").to_string();
+
+        // Escrow payload so `extract_payer_wallet` returns `agent_pubkey` verbatim.
+        let deposit_tx = format!("a2a_deposit_{}", uuid::Uuid::new_v4().simple());
+        let service_id_b64 = {
+            use base64::Engine as _;
+            base64::engine::general_purpose::STANDARD.encode([0u8; 32])
+        };
+        let payload = json!({
+            "x402_version": solvela_x402::types::X402_VERSION,
+            "resource": {"url": "/v1/chat/completions", "method": "POST"},
+            "accepted": {
+                "scheme": "escrow",
+                "network": solvela_x402::types::SOLANA_NETWORK,
+                "amount": "1000",
+                "asset": solvela_x402::types::USDC_MINT,
+                "pay_to": "11111111111111111111111111111111",
+                "max_timeout_seconds": solvela_x402::types::MAX_TIMEOUT_SECONDS,
+            },
+            "payload": {
+                "deposit_tx": deposit_tx,
+                "service_id": service_id_b64,
+                "agent_pubkey": payer,
+            }
+        });
+
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            x402_meta::STATUS_KEY.to_string(),
+            json!(x402_meta::PAYMENT_SUBMITTED),
+        );
+        metadata.insert(x402_meta::PAYLOAD_KEY.to_string(), payload);
+
+        let params = MessageSendParams {
+            message: Message {
+                role: MessageRole::User,
+                parts: vec![Part::Text {
+                    text: "pay".to_string(),
+                }],
+                metadata: Some(metadata),
+            },
+            task_id: Some(task_id.clone()),
+        };
+
+        let err = handle_payment_submitted(&state, &HeaderMap::new(), &task_id, &params)
+            .await
+            .expect_err("require_tenant wallet must be rejected by the #499 gate");
+
+        // Clean up the seeded key regardless of assertion outcome below.
+        let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(&cache_key)
+            .query_async(&mut conn)
+            .await;
+
+        // (a) The rejection is the #499 gate's, with the per-tenant guidance.
+        //     This message can ONLY be produced by the gate, which in the source
+        //     returns BEFORE the replay-record / verify / settle block — so its
+        //     presence is itself proof that settlement was never reached
+        //     (contrast `..normal_wallet..` which asserts the inverse).
+        assert_eq!(err.code, ERR_PAYMENT_FAILED);
+        assert!(
+            err.message.contains("per-tenant"),
+            "require_tenant wallet must be rejected by the #499 gate with the \
+             per-tenant guidance message; got: {}",
+            err.message
+        );
+        // (b) Settlement did NOT happen — concrete probe: the replay-record is the
+        //     FIRST side-effect past the gate. If the gate rejected pre-settlement
+        //     the deposit_tx was never recorded, so a fresh check_and_record_tx
+        //     now SUCCEEDS (returns Ok). If settlement code had run, the tx would
+        //     already be recorded and this call would Err (replay detected).
+        let cache = state.cache.as_ref().expect("redis cache configured");
+        cache.check_and_record_tx(&deposit_tx, false).await.expect(
+            "deposit_tx must NOT have been replay-recorded — the #499 gate \
+                 rejects before any replay record / settlement",
+        );
+    }
+
     /// Resending the same tx_raw a second time hits the replay-detected branch
     /// (the first call records the tx in Redis even though facilitator fails).
     #[tokio::test]

--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -65,6 +65,15 @@ pub enum GatewayError {
     #[error("bad request: {0}")]
     BadRequest(String),
 
+    /// The caller is authenticated/paying but not PERMITTED on this path. Maps
+    /// to 403 Forbidden. Used by the service-marketplace proxy to reject a
+    /// `require_tenant = TRUE` wallet (issue #499) BEFORE any settlement — such
+    /// a wallet may only spend through `POST /v1/chat/completions`, which runs
+    /// the per-tenant budget matrix. The inner message is forwarded verbatim and
+    /// must stay a static, safe-to-share string (no internal detail).
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+
     /// The request carried content the gateway accepts on the wire but does
     /// not yet process — currently image/multimodal content parts. Maps to
     /// 415 Unsupported Media Type. The inner message is forwarded verbatim
@@ -134,6 +143,7 @@ impl IntoResponse for GatewayError {
                 )
             }
             GatewayError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "bad_request", msg.clone()),
+            GatewayError::Forbidden(msg) => (StatusCode::FORBIDDEN, "forbidden", msg.clone()),
             GatewayError::UnsupportedMediaType(msg) => (
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,
                 "unsupported_media_type",
@@ -256,6 +266,21 @@ mod tests {
             error_response(GatewayError::BadRequest("missing field".to_string())).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(json["error"]["type"], "bad_request");
+    }
+
+    #[tokio::test]
+    async fn test_forbidden_returns_403() {
+        // Issue #499: require_tenant wallets rejected on the proxy path get 403.
+        let (status, json) = error_response(GatewayError::Forbidden(
+            "this wallet requires per-tenant budgeting; use POST /v1/chat/completions".to_string(),
+        ))
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(json["error"]["type"], "forbidden");
+        assert!(json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("per-tenant budgeting"));
     }
 
     #[tokio::test]

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -323,6 +323,31 @@ pub async fn proxy_service(
         _ => {}
     }
 
+    // Issue #499: reject `require_tenant = TRUE` wallets on this path.
+    //
+    // The service-marketplace proxy does NOT run `check_budget`'s per-tenant
+    // budget matrix (see the spend-log note below), so a wallet provisioned as
+    // `require_tenant = TRUE` — meaning "may only spend under a tagged,
+    // provisioned tenant" — would otherwise bypass that fail-closed guarantee
+    // here. Rather than add full per-tenant metering to the proxy (deliberately
+    // out of scope), we REJECT before any replay record, settlement, or upstream
+    // call, so a rejected request takes no spend. The wallet must use
+    // `POST /v1/chat/completions`, which enforces the tenant matrix.
+    //
+    // Degradation matches the chat path exactly: `require_tenant_for_wallet`
+    // returns `false` (do not reject) when Redis is absent or on a transient
+    // Redis/DB read error (the wallet caps are the backstop) — see its doc.
+    let payer_wallet = extract_payer_wallet(&payload);
+    if state.usage.require_tenant_for_wallet(&payer_wallet).await {
+        warn!(
+            service_id = %service_id,
+            "proxy request rejected: payer wallet requires per-tenant budgeting (#499)"
+        );
+        return Err(GatewayError::Forbidden(
+            "this wallet requires per-tenant budgeting; use POST /v1/chat/completions".to_string(),
+        ));
+    }
+
     // Replay protection
     let tx_raw = match &payload.payload {
         solvela_x402::types::PayloadData::Direct(p) => &p.transaction,
@@ -435,8 +460,9 @@ pub async fn proxy_service(
         }
     }
 
-    // Extract the actual PAYER wallet (not the recipient pay_to address)
-    let wallet_address = extract_payer_wallet(&payload);
+    // The actual PAYER wallet (not the recipient pay_to address) was already
+    // extracted above for the #499 require_tenant gate; reuse it.
+    let wallet_address = payer_wallet;
     let tx_signature = match &payload.payload {
         solvela_x402::types::PayloadData::Direct(p) => Some(p.transaction.clone()),
         solvela_x402::types::PayloadData::Escrow(p) => Some(p.deposit_tx.clone()),

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -908,6 +908,61 @@ impl UsageTracker {
         rollback_committed(&mut conn, &reservation.committed).await;
     }
 
+    /// Read the wallet's `require_tenant` flag from the SAME source
+    /// [`check_budget`] uses (`get_wallet_budget_config` → `wallet_budgets` row,
+    /// cached in Redis), so the answer cannot drift from the value the chat
+    /// route's tenant gate enforces.
+    ///
+    /// Used by the paid paths that do NOT run the full `check_budget` tenant
+    /// matrix — the A2A handler and the service-marketplace proxy (issue #499) —
+    /// to REJECT (fail-closed) a request from a `require_tenant = TRUE` wallet
+    /// before any settlement or provider call. Those paths deliberately do not
+    /// implement per-tenant metering; rejecting is the documented fix.
+    ///
+    /// **Degradation mirrors [`check_budget`] exactly** so the two paths agree:
+    /// - No Redis configured → returns `false` (do NOT reject). `check_budget`'s
+    ///   no-Redis branch likewise skips the tenant gates (degraded single-cap
+    ///   mode, Rule #12); enforcing here would diverge from the chat path.
+    /// - On a Redis connection failure, or a DB error reading `wallet_budgets`,
+    ///   `get_wallet_budget_config` returns the restrictive fallback whose
+    ///   `require_tenant` is `false` (it fails OPEN on the gate, with the
+    ///   restrictive hourly/daily/monthly caps as the non-forgeable backstop —
+    ///   see `restrictive_budget_fallback`). We surface that same `false` here,
+    ///   so a transient blip does not reject all traffic on these paths either.
+    ///
+    /// [`check_budget`]: Self::check_budget
+    pub async fn require_tenant_for_wallet(&self, wallet_address: &str) -> bool {
+        // No Redis → mirror check_budget's no-Redis branch: tenant gates are a
+        // feature of the Redis/DB-backed path; return false (don't reject).
+        let Some(client) = &self.redis_client else {
+            return false;
+        };
+
+        let mut conn = match client.get_multiplexed_async_connection().await {
+            Ok(c) => c,
+            Err(e) => {
+                // Fail OPEN for the gate on a Redis connection failure, matching
+                // the restrictive-fallback policy in get_wallet_budget_config:
+                // the wallet/team caps are the authoritative backstop, and
+                // rejecting all traffic on a transient blip is worse. (The chat
+                // path's check_budget denies on Redis failure via its own budget
+                // counters; here we have no counter to consult, so we mirror the
+                // get_wallet_budget_config fallback's require_tenant=false.)
+                warn!(
+                    wallet = %wallet_address,
+                    error = %e,
+                    "require_tenant_for_wallet: Redis connection failed; treating as \
+                     require_tenant=false (fail-open gate, wallet caps remain the backstop)"
+                );
+                return false;
+            }
+        };
+
+        let config =
+            get_wallet_budget_config(&mut conn, self.db_pool.as_ref(), wallet_address).await;
+        config.require_tenant
+    }
+
     /// Get spending summary for a wallet.
     pub async fn get_summary(&self, wallet_address: &str) -> Result<SpendSummary, UsageError> {
         if let Some(pool) = &self.db_pool {
@@ -1781,6 +1836,24 @@ mod tests {
             tenant_enforced: false,
             estimated_cost_usdc: None,
         });
+    }
+
+    /// Issue #499 degradation pin: with no Redis configured,
+    /// `require_tenant_for_wallet` must return `false` (do NOT reject),
+    /// mirroring `check_budget`'s no-Redis branch which skips the tenant gates
+    /// entirely (degraded single-cap mode, Rule #12). If this ever flipped to
+    /// `true`, the A2A/proxy paths would reject ALL traffic whenever Redis is
+    /// down — a divergence from the chat path.
+    #[tokio::test]
+    async fn test_require_tenant_for_wallet_noop_returns_false() {
+        let tracker = UsageTracker::noop();
+        assert!(
+            !tracker
+                .require_tenant_for_wallet("AnyWalletAddress11111111111111111111111111")
+                .await,
+            "no-Redis tracker must report require_tenant=false (do not reject), \
+             mirroring check_budget's no-Redis branch"
+        );
     }
 
     #[test]

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -6687,6 +6687,65 @@ async fn test_proxy_returns_503_for_unhealthy_service() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #499 — require_tenant reject on the service-marketplace proxy path
+// ---------------------------------------------------------------------------
+
+/// #499 regression guard: a NORMAL wallet (`require_tenant` absent/false) must
+/// NOT be rejected by the new gate on the proxy path — it must reach settlement.
+///
+/// With `UsageTracker::noop()` (no Redis), `require_tenant_for_wallet` returns
+/// `false` (mirrors `check_budget`'s no-Redis branch — pinned by the usage.rs
+/// unit test), so the gate is a no-op. We inject a `SettleRecordingVerifier` and
+/// assert the settlement flag is `true` — proving the request passed the gate
+/// and settled (the response then fails downstream at the unresolvable
+/// `search.example.com` SSRF/fetch, which is expected and irrelevant here).
+///
+/// The positive-reject case (`require_tenant = TRUE` → 403, no settlement) is
+/// pinned by the proxy unit-level decision (the `Forbidden` mapping in error.rs
+/// `test_forbidden_returns_403`) plus the usage.rs degradation pin; it cannot be
+/// exercised end-to-end here because forcing `require_tenant = TRUE` requires a
+/// live Redis/DB-backed `wallet_budgets` row, which the no-backend `test_app`
+/// intentionally lacks.
+#[tokio::test]
+async fn test_proxy_normal_wallet_not_rejected_and_settles() {
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        mock_provider_registry(),
+        Arc::new(SettleRecordingVerifier {
+            settled: Arc::clone(&settled),
+        }),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/web-search/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/services/web-search/proxy"),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // The #499 gate must NOT have rejected this normal wallet.
+    assert_ne!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a normal (require_tenant=false) wallet must not be rejected by the #499 gate"
+    );
+    // Settlement must have been reached — the request passed the gate.
+    assert!(
+        settled.load(std::sync::atomic::Ordering::SeqCst),
+        "a normal wallet must reach settlement on the proxy path (gate is a no-op for it)"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Registration tests (POST /v1/services/register)
 // ---------------------------------------------------------------------------
 

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -1841,6 +1841,37 @@ fn valid_payment_header(resource_url: &str) -> String {
     base64::engine::general_purpose::STANDARD.encode(&json)
 }
 
+/// Build an escrow PaymentPayload header whose payer (`agent_pubkey`) is the
+/// caller-supplied value. `extract_payer_wallet` returns `agent_pubkey` verbatim
+/// for an escrow payload (no tx decode), so this lets a test target a unique,
+/// deterministic payer-wallet Redis key (`budget_config:{payer}`). Used by the
+/// #499 positive-reject proxy test.
+fn valid_escrow_payment_header_for_payer(resource_url: &str, agent_pubkey: &str) -> String {
+    let payload = PaymentPayload {
+        x402_version: 2,
+        resource: Resource {
+            url: resource_url.to_string(),
+            method: "POST".to_string(),
+        },
+        accepted: PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: SOLANA_NETWORK.to_string(),
+            amount: TEST_PAYMENT_AMOUNT.to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: TEST_RECIPIENT_WALLET.to_string(),
+            max_timeout_seconds: 300,
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
+        },
+        payload: PayloadData::Escrow(EscrowPayload {
+            deposit_tx: base64::engine::general_purpose::STANDARD.encode(b"mock_deposit_tx_bytes"),
+            service_id: base64::engine::general_purpose::STANDARD.encode([0u8; 32]),
+            agent_pubkey: agent_pubkey.to_string(),
+        }),
+    };
+    let json = serde_json::to_vec(&payload).unwrap();
+    base64::engine::general_purpose::STANDARD.encode(&json)
+}
+
 /// Build a valid escrow PaymentPayload header.
 fn valid_escrow_payment_header(resource_url: &str) -> String {
     let payload = PaymentPayload {
@@ -6742,6 +6773,148 @@ async fn test_proxy_normal_wallet_not_rejected_and_settles() {
     assert!(
         settled.load(std::sync::atomic::Ordering::SeqCst),
         "a normal wallet must reach settlement on the proxy path (gate is a no-op for it)"
+    );
+}
+
+/// #499 POSITIVE-reject pin (proxy path): a wallet provisioned
+/// `require_tenant = TRUE` MUST be rejected with 403 `GatewayError::Forbidden`
+/// BEFORE any settlement on the service-marketplace proxy path.
+///
+/// Forcing `require_tenant = TRUE` WITHOUT a live Postgres: `proxy_service`
+/// resolves the flag via `UsageTracker::require_tenant_for_wallet` →
+/// `get_wallet_budget_config`, which consults the Redis cache key
+/// `budget_config:{wallet}` FIRST and returns it verbatim on a hit, never
+/// touching the DB (`db_pool = None` here). We pre-seed that key with a
+/// `BudgetConfig { require_tenant: true, .. }` so the gate sees `true`.
+///
+/// The escrow header carries the payer pubkey directly (`extract_payer_wallet`
+/// returns `agent_pubkey` with no tx decode), so we pick a unique per-run wallet
+/// and seed exactly its key — no `"unknown"` global-key collision with other
+/// tests.
+///
+/// We inject a `SettleRecordingVerifier` and assert (a) the response is 403 and
+/// (b) `settled == false` — proving the reject fires BEFORE settlement, so a
+/// rejected request takes no spend. Self-skips if local Redis is unavailable.
+#[tokio::test]
+async fn test_proxy_require_tenant_wallet_rejected_before_settlement() {
+    let client = match redis::Client::open("redis://127.0.0.1:6379") {
+        Ok(c) if c.get_multiplexed_async_connection().await.is_ok() => c,
+        _ => {
+            eprintln!("skipping proxy require_tenant reject test: Redis unavailable");
+            return;
+        }
+    };
+
+    // Unique payer per run → unique `budget_config:{wallet}` key.
+    let payer = format!("ReqTenantProxy{}", uuid::Uuid::new_v4().simple());
+    let cache_key = format!("budget_config:{payer}");
+
+    // Seed the SAME cache key get_wallet_budget_config reads, with
+    // require_tenant=TRUE, via the public BudgetConfig serde shape.
+    let cached = serde_json::to_string(&gateway::usage::BudgetConfig {
+        hourly: None,
+        daily: Some(100.0),
+        monthly: None,
+        require_tenant: true,
+    })
+    .unwrap();
+    {
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("redis conn");
+        let _: () = redis::cmd("SET")
+            .arg(&cache_key)
+            .arg(&cached)
+            .arg("EX")
+            .arg(60)
+            .query_async(&mut conn)
+            .await
+            .expect("seed budget_config cache");
+    }
+
+    // Build the proxy app with a Redis-backed UsageTracker (db_pool = None) so the
+    // gate resolves require_tenant from the seeded Redis cache, plus a recording
+    // verifier so we can assert settlement was NOT reached.
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(SettleRecordingVerifier {
+            settled: Arc::clone(&settled),
+        }) as Arc<dyn PaymentVerifier>]);
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: mock_provider_registry(),
+        facilitator,
+        usage: gateway::usage::UsageTracker::new(None, Some(client.clone())),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: None,
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+    });
+    let app = build_router(
+        Arc::clone(&state),
+        RateLimiter::new(RateLimitConfig::default()),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/web-search/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_escrow_payment_header_for_payer("/v1/services/web-search/proxy", &payer),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Clean up the seeded key regardless of assertion outcome below.
+    {
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("redis conn");
+        let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(&cache_key)
+            .query_async(&mut conn)
+            .await;
+    }
+
+    // (a) The #499 gate must reject the require_tenant wallet with 403.
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a require_tenant=TRUE wallet must be rejected with 403 on the proxy path"
+    );
+    // (b) Settlement must NOT have been reached — the gate fires first, so a
+    //     rejected request takes no spend.
+    assert!(
+        !settled.load(std::sync::atomic::Ordering::SeqCst),
+        "settlement must NOT run when a require_tenant wallet is rejected (#499)"
     );
 }
 


### PR DESCRIPTION
## Problem

`require_tenant = TRUE` on a wallet is a fail-closed flag: that wallet may only
spend under a provisioned, tagged tenant. `check_budget` enforces this on
`POST /v1/chat/completions`, but **two other paid paths bypass `check_budget`
entirely**, defeating the guarantee:

- **A2A** — `a2a/handler::handle_payment_submitted` calls
  `chat_with_model_fallback` directly (provider layer), skipping the tenant matrix.
- **Service-marketplace proxy** — `routes/proxy::proxy_service` has flat
  per-request pricing and never runs `check_budget`.

## Fix: REJECT, not enforce (decided on the issue)

On both paths, if the **paying wallet** has `require_tenant = TRUE`, reject the
request **before any replay record, settlement, or provider call** — a rejected
request takes no spend. Adding full per-tenant metering to these paths is
intentionally out of scope (a later issue if ever needed).

- New `UsageTracker::require_tenant_for_wallet` reuses the **same source**
  `check_budget` reads (`get_wallet_budget_config` → `wallet_budgets`,
  Redis-cached), so the flag cannot drift from the chat path's gate.
- **Degradation mirrors the chat path exactly**: no Redis, or a transient
  Redis/DB read error, both resolve to `require_tenant = false` (fail-open on the
  gate, with the restrictive wallet caps as the non-forgeable backstop — see
  `restrictive_budget_fallback`). A transient blip never rejects all traffic on
  these paths, matching what the chat path already does.
- **A2A** fails the task cleanly (`ERR_PAYMENT_FAILED`) with a message pointing
  the caller to `POST /v1/chat/completions`.
- **Proxy** returns a new `403 GatewayError::Forbidden` with the same guidance.

The gate runs after the payer wallet is known (`extract_payer_wallet`) but before
settlement on each path. No money-math changed; the 5% fee / cost breakdown paths
are untouched.

## Tests

- `usage::tests::test_require_tenant_for_wallet_noop_returns_false` — pins the
  no-Redis degradation (must NOT reject).
- `error::tests::test_forbidden_returns_403` — pins the 403 mapping.
- `a2a::handler::tests::payment_submitted_normal_wallet_not_rejected_reaches_verification`
  — a normal wallet passes the gate and reaches verification (Redis-gated, like
  the other A2A tests).
- `integration::test_proxy_normal_wallet_not_rejected_and_settles` — a normal
  wallet passes the gate and settles on the proxy path (via `SettleRecordingVerifier`).

The positive-reject (`require_tenant=TRUE`) path needs a live DB-backed
`wallet_budgets` row, which the no-backend test harness lacks; it is pinned by the
degradation + shared-accessor tests above.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test -p gateway` lib: 712 passed / 0 failed; integration: 167 passed / 0
  failed. Only the documented `escrow_queue` `#[sqlx::test]` cases fail (no live
  Postgres) — no new failures.

Closes #499