### PR TITLE
feat(gateway): admin-token stats auth + proxy tenant injection (Telsi metering, PR3)

### DIFF
--- a/crates/gateway/src/routes/stats.rs
+++ b/crates/gateway/src/routes/stats.rs
@@ -145,26 +145,53 @@ pub async fn wallet_stats(
         }
     };
 
-    match verify_session_token(token, &state.session_secret) {
-        Ok(claims) => {
-            // Verify that the session token's wallet matches the requested path.
-            // build_session_token() in chat.rs populates the wallet field from
-            // extract_payer_wallet_from_payload(), which returns the actual payer
-            // (tx fee payer for direct, agent_pubkey for escrow).
-            if claims.wallet != address {
+    // Two accepted credentials, checked in order:
+    //
+    // 1. The operator's **admin token** (the same secret that gates
+    //    `/v1/admin/stats`). A valid admin token authorizes reading ANY wallet's
+    //    stats — including the per-tenant `by_tenant` breakdown — without a
+    //    chat-derived session token. This is the trusted server-to-server path
+    //    (e.g. Telsi's metering cron) for which a session token is impractical:
+    //    session tokens are only ever issued on a *paid* chat response and the
+    //    caller has no way to mint one out-of-band. Admin auth bypasses the
+    //    wallet-match check by design (the operator reads on behalf of any
+    //    wallet it custodies).
+    //
+    // 2. A wallet-scoped **session token** (the original path), which must match
+    //    the requested wallet exactly.
+    let is_admin = state
+        .admin_token
+        .as_ref()
+        .is_some_and(|admin| admin.verify(token.as_bytes()));
+
+    if is_admin {
+        // Audit trail: an operator admin token read this wallet's billing data
+        // (summary + per-tenant breakdown) on behalf of a wallet it custodies.
+        // Mirrors the structured log on `/v1/admin/stats` so admin reads are
+        // traceable during incident investigation.
+        tracing::info!(wallet = %address, "admin token authorized wallet stats read");
+    } else {
+        match verify_session_token(token, &state.session_secret) {
+            Ok(claims) => {
+                // Verify that the session token's wallet matches the requested path.
+                // build_session_token() in chat.rs populates the wallet field from
+                // extract_payer_wallet_from_payload(), which returns the actual payer
+                // (tx fee payer for direct, agent_pubkey for escrow).
+                if claims.wallet != address {
+                    return Err((
+                        StatusCode::FORBIDDEN,
+                        Json(serde_json::json!({ "error": "token wallet does not match requested address" })),
+                    )
+                        .into_response());
+                }
+            }
+            Err(_) => {
                 return Err((
-                    StatusCode::FORBIDDEN,
-                    Json(serde_json::json!({ "error": "token wallet does not match requested address" })),
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({ "error": "invalid or expired session token" })),
                 )
                     .into_response());
             }
-        }
-        Err(_) => {
-            return Err((
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({ "error": "invalid or expired session token" })),
-            )
-                .into_response());
         }
     }
 

--- a/crates/gateway/tests/stats_http_redis.rs
+++ b/crates/gateway/tests/stats_http_redis.rs
@@ -160,11 +160,21 @@ async fn redis_del_keys(client: &redis::Client, keys: &[&str]) {
 
 async fn get_stats_json(app: axum::Router, wallet: &str) -> (StatusCode, serde_json::Value) {
     let token = session_token_for(wallet);
+    get_stats_json_with_bearer(app, wallet, &token).await
+}
+
+/// Hit the stats endpoint with an arbitrary bearer credential (session token OR
+/// admin token OR garbage) so tests can exercise the auth branches directly.
+async fn get_stats_json_with_bearer(
+    app: axum::Router,
+    wallet: &str,
+    bearer: &str,
+) -> (StatusCode, serde_json::Value) {
     let response = app
         .oneshot(
             Request::builder()
                 .uri(format!("/v1/wallet/{wallet}/stats"))
-                .header("authorization", format!("Bearer {token}"))
+                .header("authorization", format!("Bearer {bearer}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -174,6 +184,95 @@ async fn get_stats_json(app: axum::Router, wallet: &str) -> (StatusCode, serde_j
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let json = serde_json::from_slice(&body).unwrap();
     (status, json)
+}
+
+/// Insert one settled spend row attributed to `tenant`, so the per-tenant
+/// `by_tenant` breakdown has something to surface.
+async fn insert_tenant_spend(
+    pool: &PgPool,
+    wallet: &str,
+    tenant: &str,
+    cost_usdc: &str,
+    input_tokens: i32,
+    output_tokens: i32,
+) {
+    // `id` and `created_at` use their column defaults; `tenant` is the only
+    // attribution field the `by_tenant` rollup needs.
+    sqlx::query(
+        r#"INSERT INTO spend_logs
+             (wallet_address, model, provider, input_tokens, output_tokens, cost_usdc, tenant)
+           VALUES ($1, 'anthropic/claude-sonnet-4', 'anthropic', $2, $3, $4::numeric, $5)"#,
+    )
+    .bind(wallet)
+    .bind(input_tokens)
+    .bind(output_tokens)
+    .bind(cost_usdc)
+    .bind(tenant)
+    .execute(pool)
+    .await
+    .expect("seed tenant spend row");
+}
+
+/// The trusted server-to-server path Telsi's metering cron depends on: the
+/// operator's **admin token** authorizes reading ANY wallet's stats — including
+/// the per-tenant `by_tenant` breakdown — with NO wallet-scoped session token.
+#[sqlx::test(migrations = "../../migrations")]
+async fn stats_endpoint_admin_token_reads_any_wallet_by_tenant(pool: PgPool) {
+    let wallet = random_valid_wallet();
+    insert_tenant_spend(&pool, &wallet, "telsi-tenant-1", "0.500000", 100, 50).await;
+    insert_tenant_spend(&pool, &wallet, "telsi-tenant-2", "0.250000", 40, 20).await;
+    // An untagged row (tenant IS NULL) must count toward the wallet summary but
+    // be EXCLUDED from by_tenant — the exact invariant Telsi's rollup relies on.
+    sqlx::query(
+        r#"INSERT INTO spend_logs (wallet_address, model, provider, input_tokens, output_tokens, cost_usdc)
+           VALUES ($1, 'anthropic/claude-sonnet-4', 'anthropic', 10, 5, 0.100000::numeric)"#,
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed untagged row");
+
+    let usage = UsageTracker::new(Some(pool.clone()), None);
+    let app = stats_router(usage, Some(pool.clone()));
+
+    // Admin token, NOT a session token for `wallet`.
+    let (status, json) = get_stats_json_with_bearer(app, &wallet, TEST_ADMIN_TOKEN).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "admin token must authorize any wallet"
+    );
+    // Summary includes the untagged row (3 requests, 0.85 total).
+    assert_eq!(json["summary"]["total_requests"], 3);
+    assert_eq!(json["summary"]["total_cost_usdc"], "0.850000");
+
+    let by_tenant = json["by_tenant"].as_array().expect("by_tenant array");
+    assert_eq!(
+        by_tenant.len(),
+        2,
+        "only tagged tenants attributed (untagged excluded)"
+    );
+    // Ordered by cost DESC, so tenant-1 (0.5) is first.
+    assert_eq!(by_tenant[0]["tenant"], "telsi-tenant-1");
+    assert_eq!(by_tenant[0]["cost_usdc"], "0.500000");
+    assert_eq!(by_tenant[0]["requests"], 1);
+    assert_eq!(by_tenant[1]["tenant"], "telsi-tenant-2");
+    assert_eq!(by_tenant[1]["cost_usdc"], "0.250000");
+}
+
+/// A garbage bearer that is neither a valid admin token nor a valid session
+/// token must still be rejected — the admin branch must not weaken auth.
+#[sqlx::test(migrations = "../../migrations")]
+async fn stats_endpoint_rejects_invalid_bearer(pool: PgPool) {
+    let wallet = random_valid_wallet();
+    let usage = UsageTracker::new(Some(pool.clone()), None);
+    let app = stats_router(usage, Some(pool.clone()));
+
+    let (status, _json) =
+        get_stats_json_with_bearer(app, &wallet, "not-the-admin-token-and-not-a-session").await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
 
 /// With both Postgres and Redis present, the stats response must surface the

--- a/sdks/rust/crates/solvela-client-proxy/src/main.rs
+++ b/sdks/rust/crates/solvela-client-proxy/src/main.rs
@@ -37,6 +37,13 @@ struct Cli {
     #[arg(long)]
     expected_recipient: Option<String>,
 
+    /// Per-tenant attribution tag. When set, the proxy injects `x-tenant: <id>`
+    /// on every forwarded request (replacing any caller-supplied value), so the
+    /// gateway attributes settled cost to and enforces the budget for this
+    /// tenant. The tenant entrypoint passes this from the `SOLVELA_TENANT` env.
+    #[arg(long)]
+    tenant: Option<String>,
+
     /// Enable debug logging.
     #[arg(short, long)]
     verbose: bool,
@@ -112,10 +119,15 @@ async fn main() {
         .build()
         .unwrap_or_else(|_| reqwest::Client::new());
 
+    if let Some(ref t) = cli.tenant {
+        info!(tenant = %t, "per-tenant attribution enabled — injecting x-tenant");
+    }
+
     let state = Arc::new(proxy::ProxyState {
         client,
         gateway_url,
         http,
+        tenant: cli.tenant,
     });
 
     let app = proxy::build_proxy_router(state);

--- a/sdks/rust/crates/solvela-client-proxy/src/proxy.rs
+++ b/sdks/rust/crates/solvela-client-proxy/src/proxy.rs
@@ -23,6 +23,13 @@ pub struct ProxyState {
     pub client: SolvelaClient,
     pub gateway_url: String,
     pub http: reqwest::Client,
+    /// Per-tenant attribution tag injected as `x-tenant` on every forwarded
+    /// request when set. The gateway attributes settled cost to `(wallet,
+    /// tenant)` and enforces the tenant's budget. `None` = no tag (single-tenant
+    /// / untagged operation). A caller-supplied `x-tenant` is always stripped
+    /// and replaced with this value — the tag is operator-controlled, not
+    /// caller-controlled.
+    pub tenant: Option<String>,
 }
 
 /// Maximum request body size (10 MB — matches gateway limit).
@@ -55,7 +62,7 @@ async fn proxy_handler(
 
     // Build the forwarded request
     let mut req_builder = state.http.request(reqwest_method(&method), &gateway_url);
-    req_builder = forward_headers(req_builder, &headers);
+    req_builder = forward_headers(req_builder, &headers, state.tenant.as_deref());
 
     // Attach body for methods that have one
     if method == Method::POST || method == Method::PUT || method == Method::PATCH {
@@ -144,7 +151,7 @@ async fn handle_402(
 
     // Retry the request with the PAYMENT-SIGNATURE header
     let mut retry_builder = state.http.request(reqwest_method(method), gateway_url);
-    retry_builder = forward_headers(retry_builder, headers);
+    retry_builder = forward_headers(retry_builder, headers, state.tenant.as_deref());
     retry_builder = retry_builder.header("PAYMENT-SIGNATURE", &payment_header);
 
     // Attach body
@@ -182,6 +189,7 @@ async fn handle_402(
 fn forward_headers(
     mut builder: reqwest::RequestBuilder,
     headers: &HeaderMap,
+    tenant: Option<&str>,
 ) -> reqwest::RequestBuilder {
     for (name, value) in headers {
         let name_lower = name.as_str().to_lowercase();
@@ -192,9 +200,19 @@ fn forward_headers(
         // the caller's `accept-encoding` lets the gateway (or a fronting edge
         // proxy) compress the body, which then fails to parse as JSON. Treat it
         // as hop-by-hop here.
+        //
+        // `x-tenant` is stripped here and re-injected below ONLY from the
+        // operator-configured value: the attribution tag is operator-controlled,
+        // never caller-controlled, so a CowAgent-supplied tag cannot spoof or
+        // evade a tenant's budget.
         if matches!(
             name_lower.as_str(),
-            "host" | "connection" | "transfer-encoding" | "payment-signature" | "accept-encoding"
+            "host"
+                | "connection"
+                | "transfer-encoding"
+                | "payment-signature"
+                | "accept-encoding"
+                | "x-tenant"
         ) {
             if name_lower == "payment-signature" {
                 warn!("stripped PAYMENT-SIGNATURE header from caller (security)");
@@ -204,6 +222,10 @@ fn forward_headers(
         if let Ok(v) = value.to_str() {
             builder = builder.header(name.as_str(), v);
         }
+    }
+    // Inject the operator-configured tenant tag, if any.
+    if let Some(t) = tenant {
+        builder = builder.header("x-tenant", t);
     }
     builder
 }

--- a/sdks/rust/crates/solvela-client-proxy/tests/integration.rs
+++ b/sdks/rust/crates/solvela-client-proxy/tests/integration.rs
@@ -9,7 +9,7 @@ use solvela_protocol::{
     CostBreakdown, PaymentAccept, PaymentRequired, Resource, MAX_TIMEOUT_SECONDS,
     PLATFORM_FEE_PERCENT, SOLANA_NETWORK, USDC_MINT, X402_VERSION,
 };
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn test_wallet() -> Wallet {
@@ -56,6 +56,7 @@ fn build_test_app(gateway_url: &str) -> axum::Router {
         client,
         gateway_url: gateway_url.to_string(),
         http: reqwest::Client::new(),
+        tenant: None,
     });
     solvela_client_proxy::build_proxy_router(state)
 }
@@ -326,6 +327,7 @@ async fn test_amount_exceeds_max_returns_error() {
         client,
         gateway_url: mock.uri(),
         http: reqwest::Client::new(),
+        tenant: None,
     });
     let app = solvela_client_proxy::build_proxy_router(state);
 
@@ -347,4 +349,60 @@ async fn test_amount_exceeds_max_returns_error() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["error"]["type"], "amount_exceeds_max");
+}
+
+/// Build a proxy router whose state injects a per-tenant `x-tenant` tag.
+fn build_test_app_with_tenant(gateway_url: &str, tenant: &str) -> axum::Router {
+    let wallet = test_wallet();
+    let config = ClientConfig {
+        gateway_url: gateway_url.to_string(),
+        rpc_url: "http://127.0.0.1:1".to_string(),
+        ..ClientConfig::default()
+    };
+    let client = SolvelaClient::new(wallet, config).unwrap();
+    let state = Arc::new(solvela_client_proxy::ProxyState {
+        client,
+        gateway_url: gateway_url.to_string(),
+        http: reqwest::Client::new(),
+        tenant: Some(tenant.to_string()),
+    });
+    solvela_client_proxy::build_proxy_router(state)
+}
+
+/// With a configured tenant, the proxy injects `x-tenant` on the forwarded
+/// request — AND replaces any caller-supplied value, so the tag is
+/// operator-controlled (not spoofable by `CowAgent`). The mock only matches the
+/// operator's tenant, so a 200 + `.expect(1)` proves both at once.
+#[tokio::test]
+async fn test_tenant_tag_injected_and_caller_value_overridden() {
+    let mock = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header("x-tenant", "telsi-tenant-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let app = build_test_app_with_tenant(&mock.uri(), "telsi-tenant-abc");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                // A forged caller tag that MUST be stripped + replaced.
+                .header("x-tenant", "forged-other-tenant")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"model":"anthropic/claude-sonnet-4"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    // `.expect(1)` is verified on MockServer drop — the only mounted matcher
+    // requires x-tenant == "telsi-tenant-abc", so a hit proves injection +
+    // override.
 }


### PR DESCRIPTION
## Summary

Completes the server-to-server per-tenant metering path on top of attribution (PR1 #493) and budget enforcement (PR2 #498).

- **Gateway** — `/v1/wallet/{address}/stats` now accepts the operator **admin token** as an alternative to a wallet-scoped session token. A valid admin token authorizes reading **any** wallet's stats (including the per-tenant `by_tenant` breakdown) without a chat-derived session token — which a metering cron can't obtain out-of-band, since session tokens are only minted on a paid chat response. The admin branch is a strict short-circuit: with no admin token configured, or on mismatch, auth falls through to the original session-token check **unchanged** (no weakening). Admin reads emit a structured audit log, mirroring `/v1/admin/stats`.
- **Client proxy** — new `--tenant` flag injects an operator-controlled `x-tenant` header on every forwarded request (initial + 402 retry), stripping any caller-supplied value first (case-insensitive). The tag is operator-controlled, never caller-controlled, so a downstream agent cannot spoof or evade a tenant's attribution/budget.

## Security

- `AdminToken::verify` is constant-time (`constant_time_eq`); empty-token env guard yields `None`, not a match-all.
- `x-tenant` strip-and-replace verified airtight on both the initial and 402-retry legs; caller casing variants are normalized before the strip.
- Reviewed via `security-reviewer` — no Critical/High; the one Low (admin-read audit log) is addressed in this PR.

## Tests

- `stats_endpoint_admin_token_reads_any_wallet_by_tenant` — admin token reads any wallet's `by_tenant` rollup; untagged (`tenant IS NULL`) rows count toward the summary but are excluded from `by_tenant`.
- `stats_endpoint_rejects_invalid_bearer` — garbage bearer still 401s (admin branch doesn't weaken auth).
- `test_tenant_tag_injected_and_caller_value_overridden` — proxy injects the operator tag and overrides a forged caller value.

All gateway + proxy suites green locally; `cargo fmt`/`clippy -D warnings` clean on both workspaces.