### PR TITLE
fix(ci): trigger auto-approve via workflow_run, not check_suite

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,10 +14,21 @@
 # Prerequisite (already enabled via API at creation time): org + repo setting
 # "Allow GitHub Actions to create and approve pull requests" must be ON, else
 # createReview returns 422.
+#
+# Trigger: `workflow_run` on the CI and DCO workflows — NOT `check_suite`.
+# A `check_suite` whose checks were created by Actions' own GITHUB_TOKEN does
+# not re-trigger a `check_suite` workflow (GitHub's recursion guard), so the
+# previous trigger only ever fired for non-PR suites on `main` and never
+# evaluated open PR branches — leaving green PRs unapproved. `workflow_run`
+# fires reliably after each listed workflow completes, on the PR head SHA, and
+# runs the trusted default-branch copy of this file. Together CI + DCO produce
+# every check in REQUIRED below; the script re-verifies the full set for the
+# SHA, so whichever workflow finishes last is the one that approves.
 name: Auto-approve on green CI
 
 on:
-  check_suite:
+  workflow_run:
+    workflows: [CI, DCO]
     types: [completed]
 
 permissions:
@@ -27,16 +38,16 @@ permissions:
 
 jobs:
   approve:
-    # Only bother when the completed suite itself succeeded; the script
+    # Only bother when the triggering workflow succeeded; the script
     # re-verifies every required check regardless.
-    if: github.event.check_suite.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
             const { owner, repo } = context.repo;
-            const sha = context.payload.check_suite.head_sha;
+            const sha = context.payload.workflow_run.head_sha;
 
             // KEEP IN SYNC with branch protection required checks on `main`.
             // Adding/renaming a required check without updating this list


### PR DESCRIPTION
## Problem

The **Auto-approve on green CI** workflow has not been approving open PRs. Every recent run fired against `main`'s tip SHA (`87b920e`) and found no open PR to approve — so green PRs (#503/#505/#506 today, plus the dependabot backlog #466–#483 sitting since 06-04) stayed `REVIEW_REQUIRED` indefinitely and had to be approved by hand.

## Root cause

GitHub's recursion guard: a `check_suite` whose check runs were created by Actions' own `GITHUB_TOKEN` does **not** re-trigger a `check_suite`-triggered workflow. So PR-branch CI completion never invoked the approver; only unrelated suites on `main` did, where there is no open PR at that SHA.

## Fix

Switch the trigger from `check_suite` to **`workflow_run`** on the `CI` and `DCO` workflows (which together emit all six checks in `REQUIRED`). `workflow_run`:

- fires reliably after each listed workflow completes, keyed on the PR head SHA;
- runs the **trusted default-branch copy** of the script — a security improvement, since fork PRs can't influence approver logic;
- the script re-verifies the full `REQUIRED` set for the SHA, so whichever of CI/DCO finishes last is the one that approves.

**No guard logic changed** — open/non-draft, `base=main`, no-fork, author allowlist, money-path exclusion, all-required-green, no `CHANGES_REQUESTED`, and idempotency all carry over verbatim.

## Verification

- `yaml.safe_load` parses; watched names `CI`/`DCO` match the `name:` fields in `ci.yml`/`dco.yml`.
- Edge cases traced: fork PRs still rejected by the fork guard; main-push runs no-op on the now-closed PR; idempotency guard prevents double-approval.
- This fix only governs PRs **once merged** (workflow_run always uses the default-branch copy), so it cannot self-approve its own PR. I'll confirm on the next green PR after merge.