### PR TITLE
chore(ci): allow dependabot[bot] in auto-approve allowlist

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -60,7 +60,15 @@ jobs:
               'Verify DCO sign-off on every commit',
               'Semantic cache (redis-stack + embedding model)',
             ];
-            const ALLOW = ['sky64'];
+            // Authors whose green PRs may be auto-approved. `dependabot[bot]`
+            // is included so routine dependency bumps clear review on green CI
+            // without a manual approve-as-bot step. This is safe because every
+            // other guard still applies: dependabot pushes to a same-repo branch
+            // (passes the no-fork check), the money-path exclusion below still
+            // blocks any bump that touches fund-moving code, and the full
+            // REQUIRED set must be green. Approve-only — merge stays manual
+            // (or dependabot's own auto-merge, where enabled per-PR).
+            const ALLOW = ['sky64', 'dependabot[bot]'];
 
             // Money-path surfaces: code that signs / verifies / settles payments,
             // computes cost, or touches escrow / USDC. A PR touching ANY of these


### PR DESCRIPTION
Adds `dependabot[bot]` to the auto-approve author allowlist so routine dependency bumps clear the required review on green CI automatically — closing the gap that left #466–#483 sitting unapproved and needing manual bot-approval.

**Safe by construction** — every other guard is unchanged:
- dependabot pushes to a **same-repo** branch → passes the no-fork guard;
- the **money-path exclusion** still blocks any bump touching fund-moving code;
- the full **REQUIRED** check set must be green for the head SHA.

Approve-only, as before — a human (or dependabot's own per-PR auto-merge) still triggers the actual merge. Follows the #507 `workflow_run` trigger fix; takes effect for dependabot PRs once merged.