### PR TITLE
fix(gateway): team budget config DB error fails closed, no error-cache (#501)

### DIFF
--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -114,6 +114,47 @@ enum TenantLookup {
     DbError,
 }
 
+/// Result of looking up a team's `team_budgets` row.
+///
+/// Distinguishes a CONFIRMED-ABSENT row from a transient DB ERROR (#501),
+/// exactly as [`TenantLookup`] does for the per-tenant path. The two MUST be
+/// surfaced differently: a confirmed absence means the team simply has no
+/// budget configured (skip team enforcement — the legacy behavior), whereas a
+/// DB error is a transient infrastructure blip whose answer is unknown.
+///
+/// Before #501 `get_team_budget_config` collapsed a DB error into a plain
+/// `None` (indistinguishable from absence) AND cached that error-derived "none"
+/// sentinel for the full TTL — silently disabling the team cap for every member
+/// of the team for up to a minute (aggregate spend across N wallets escaped the
+/// team bound). The caller now maps a `DbError` to `UsageError::Database` and
+/// denies the request (fail-closed), and only `Found`/`Absent` are ever cached.
+#[derive(Debug, Clone)]
+enum TeamLookup {
+    /// A `team_budgets` row exists for the team.
+    Found(TeamBudgetConfig),
+    /// The query SUCCEEDED and confirmed no row exists (no team budget).
+    Absent,
+    /// The query ERRORED (transient DB problem) — budget state unknown.
+    DbError,
+}
+
+impl TeamLookup {
+    /// The Redis cache value to write for this lookup, or `None` to write
+    /// nothing. Mirrors the tenant path: a `Found` row caches its serialized
+    /// JSON, a confirmed `Absent` caches the `"none"` sentinel, and a transient
+    /// `DbError` caches NOTHING (so a blip can't poison the team cap for a full
+    /// TTL — the next request re-attempts the DB read).
+    fn cache_value(&self) -> Option<String> {
+        match self {
+            TeamLookup::Found(cfg) => {
+                Some(serde_json::to_string(cfg).unwrap_or_else(|_| "none".to_string()))
+            }
+            TeamLookup::Absent => Some("none".to_string()),
+            TeamLookup::DbError => None,
+        }
+    }
+}
+
 /// Outcome of the per-tenant enforcement decision matrix.
 ///
 /// Pure function of three booleans so the money-path policy can be unit-tested
@@ -646,35 +687,57 @@ impl UsageTracker {
         // permissive individual budget bypass a tighter team cap).
         match get_team_for_wallet(&mut conn, self.db_pool.as_ref(), wallet_address).await {
             Ok(Some(tid)) => {
-                let team_config =
-                    get_team_budget_config(&mut conn, self.db_pool.as_ref(), tid).await;
+                // #501: a DB error reading `team_budgets` must NOT be collapsed
+                // into "no team budget" (fail-open). `get_team_budget_config`
+                // now returns a `TeamLookup` that distinguishes a configured
+                // budget, a confirmed absence, and a transient DB error.
+                match get_team_budget_config(&mut conn, self.db_pool.as_ref(), tid).await {
+                    TeamLookup::Found(team_cfg) => {
+                        let tid_str = tid.to_string();
 
-                if let Some(team_cfg) = team_config {
-                    let tid_str = tid.to_string();
-
-                    if let Some(hourly_limit) = team_cfg.hourly {
-                        let _ = try_commit!(
-                            format!("team_spend:{}:{}", tid_str, now.format("%Y-%m-%dT%H")),
-                            estimated_cost_usdc,
-                            hourly_limit,
-                            7200
-                        );
+                        if let Some(hourly_limit) = team_cfg.hourly {
+                            let _ = try_commit!(
+                                format!("team_spend:{}:{}", tid_str, now.format("%Y-%m-%dT%H")),
+                                estimated_cost_usdc,
+                                hourly_limit,
+                                7200
+                            );
+                        }
+                        if let Some(daily_limit) = team_cfg.daily {
+                            let _ = try_commit!(
+                                format!("team_spend:{}:{}", tid_str, now.format("%Y-%m-%d")),
+                                estimated_cost_usdc,
+                                daily_limit,
+                                86400
+                            );
+                        }
+                        if let Some(monthly_limit) = team_cfg.monthly {
+                            let _ = try_commit!(
+                                format!("team_spend:{}:{}", tid_str, now.format("%Y-%m")),
+                                estimated_cost_usdc,
+                                monthly_limit,
+                                86400 * 31
+                            );
+                        }
                     }
-                    if let Some(daily_limit) = team_cfg.daily {
-                        let _ = try_commit!(
-                            format!("team_spend:{}:{}", tid_str, now.format("%Y-%m-%d")),
-                            estimated_cost_usdc,
-                            daily_limit,
-                            86400
-                        );
+                    TeamLookup::Absent => {
+                        // Team has no budget configured — nothing to enforce.
                     }
-                    if let Some(monthly_limit) = team_cfg.monthly {
-                        let _ = try_commit!(
-                            format!("team_spend:{}:{}", tid_str, now.format("%Y-%m")),
-                            estimated_cost_usdc,
-                            monthly_limit,
-                            86400 * 31
+                    TeamLookup::DbError => {
+                        // Fail-closed: a transient DB error reading the team cap
+                        // must deny (not silently skip team enforcement), and
+                        // must release the wallet/tenant counters already
+                        // committed above so a denied request leaks no budget.
+                        rollback_committed(&mut conn, &committed).await;
+                        warn!(
+                            wallet = %wallet_address,
+                            team_id = %tid,
+                            "team_budget_db_error: team_budgets read failed; \
+                             denying request (fail-closed) as a transient DB error"
                         );
+                        return Err(UsageError::Database(
+                            "team_budgets lookup failed".to_string(),
+                        ));
                     }
                 }
             }
@@ -1395,12 +1458,23 @@ async fn get_team_for_wallet(
 }
 
 /// Load team budget config from `team_budgets` table. Cached in Redis with 60s TTL.
-/// Returns `None` if no budget row exists for the team.
+///
+/// Returns a [`TeamLookup`] that distinguishes a configured budget
+/// ([`TeamLookup::Found`]) from a confirmed absence ([`TeamLookup::Absent`]) and
+/// a transient DB error ([`TeamLookup::DbError`]) — #501. The caller maps a
+/// `DbError` to `UsageError::Database` and denies the request (fail-closed)
+/// rather than silently skipping the team cap. Only `Found`/`Absent` are cached;
+/// a `DbError` is NEVER cached, so a transient error cannot poison the "none"
+/// sentinel for a full TTL — the next request re-attempts the DB read.
+///
+/// Mirrors the `persist`/no-cache-on-error pattern of `get_wallet_budget_config`
+/// and the `TenantLookup` shape of `get_tenant_budget_config`, including the
+/// corrupt-cache `DEL` (a bad entry is deleted before falling through to DB).
 async fn get_team_budget_config(
     conn: &mut redis::aio::MultiplexedConnection,
     db_pool: Option<&sqlx::PgPool>,
     team_id: Uuid,
-) -> Option<TeamBudgetConfig> {
+) -> TeamLookup {
     let cache_key = format!("team_budget:{team_id}");
 
     // Try Redis cache
@@ -1410,15 +1484,27 @@ async fn get_team_budget_config(
         .await
     {
         if json_str == "none" {
-            return None;
+            return TeamLookup::Absent;
         }
-        if let Ok(config) = serde_json::from_str::<TeamBudgetConfig>(&json_str) {
-            return Some(config);
+        match serde_json::from_str::<TeamBudgetConfig>(&json_str) {
+            Ok(config) => return TeamLookup::Found(config),
+            Err(e) => {
+                // Corrupt cache entry — DEL it before falling through to DB so
+                // it can't be re-read on the next request (mirrors the wallet
+                // path). Do NOT serve it as an absence.
+                tracing::warn!(cache_key = %cache_key, error = %e, "corrupted team budget cache entry, falling through to DB");
+                let _ = redis::cmd("DEL")
+                    .arg(&cache_key)
+                    .query_async::<()>(conn)
+                    .await;
+            }
         }
     }
 
-    // Cache miss — query DB
-    let config = if let Some(pool) = db_pool {
+    // Cache miss — query DB. A DB error returns `DbError` WITHOUT caching, so a
+    // transient error cannot poison the "none" sentinel for a full TTL. Only a
+    // successful read (`Found`/`Absent`) is cached.
+    let lookup = if let Some(pool) = db_pool {
         match sqlx::query_as::<_, (Option<f64>, Option<f64>, Option<f64>)>(
             r#"SELECT
                 hourly_limit_usdc::DOUBLE PRECISION,
@@ -1431,35 +1517,34 @@ async fn get_team_budget_config(
         .fetch_optional(pool)
         .await
         {
-            Ok(Some((hourly, daily, monthly))) => Some(TeamBudgetConfig {
+            Ok(Some((hourly, daily, monthly))) => TeamLookup::Found(TeamBudgetConfig {
                 hourly,
                 daily,
                 monthly,
             }),
-            Ok(None) => None,
+            Ok(None) => TeamLookup::Absent,
             Err(e) => {
-                warn!(team_id = %team_id, error = %e, "failed to query team_budgets");
-                None
+                warn!(team_id = %team_id, error = %e, "failed to query team_budgets — not caching");
+                TeamLookup::DbError
             }
         }
     } else {
-        None
+        // No DB pool — a stable "no team budget" answer; safe to cache.
+        TeamLookup::Absent
     };
 
-    // Cache result
-    let cache_val = match &config {
-        Some(cfg) => serde_json::to_string(cfg).unwrap_or_else(|_| "none".to_string()),
-        None => "none".to_string(),
-    };
-    let _: Result<(), _> = redis::cmd("SET")
-        .arg(&cache_key)
-        .arg(&cache_val)
-        .arg("EX")
-        .arg(TEAM_BUDGET_CACHE_TTL)
-        .query_async(conn)
-        .await;
+    // Cache result — only `Found`/`Absent`; never a transient error-derived value.
+    if let Some(cache_val) = lookup.cache_value() {
+        let _: Result<(), _> = redis::cmd("SET")
+            .arg(&cache_key)
+            .arg(&cache_val)
+            .arg("EX")
+            .arg(TEAM_BUDGET_CACHE_TTL)
+            .query_async(conn)
+            .await;
+    }
 
-    config
+    lookup
 }
 
 /// Load the `(wallet, tenant)` budget config from `tenant_budgets`. Cached in
@@ -2428,6 +2513,49 @@ mod tests {
         let json = serde_json::to_string(&config).expect("serialize");
         let back: TenantBudgetConfig = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.hourly, Some(1.0));
+        assert_eq!(back.daily, Some(10.0));
+        assert!(back.monthly.is_none());
+    }
+
+    /// #501: the cache-derivation contract for `get_team_budget_config`. A
+    /// transient DB error must produce NO cache write (so a blip cannot poison
+    /// the team cap for a full TTL), a confirmed absence caches the `"none"`
+    /// sentinel, and a found row caches its serialized JSON. Mirrors the
+    /// `TenantLookup` no-cache-on-error behavior.
+    #[test]
+    fn test_team_lookup_cache_value_never_caches_db_error() {
+        // DB error → never cached.
+        assert_eq!(
+            TeamLookup::DbError.cache_value(),
+            None,
+            "a transient team_budgets DB error must NEVER be cached"
+        );
+
+        // Confirmed absence → "none" sentinel (regression guard for the
+        // happy-path cache fill).
+        assert_eq!(
+            TeamLookup::Absent.cache_value(),
+            Some("none".to_string()),
+            "a confirmed-absent team budget must cache the \"none\" sentinel"
+        );
+
+        // Found → serialized JSON that round-trips back to the same config and
+        // is distinct from the absence sentinel.
+        let cfg = TeamBudgetConfig {
+            hourly: Some(0.50),
+            daily: Some(10.0),
+            monthly: None,
+        };
+        let cached = TeamLookup::Found(cfg)
+            .cache_value()
+            .expect("a found team budget must be cached");
+        assert_ne!(
+            cached, "none",
+            "a real budget must not serialize to \"none\""
+        );
+        let back: TeamBudgetConfig =
+            serde_json::from_str(&cached).expect("cached team budget must round-trip");
+        assert_eq!(back.hourly, Some(0.50));
         assert_eq!(back.daily, Some(10.0));
         assert!(back.monthly.is_none());
     }

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -2087,3 +2087,250 @@ async fn tenant_partial_window_rollback_on_monthly_trip(pool: PgPool) {
 
     redis_del_tenant(&client, &wallet, tenant).await;
 }
+
+/// Seed an org + team and map `wallet` into the team. Returns the `team_id`.
+async fn seed_team_for_wallet(pool: &PgPool, wallet: &str) -> Uuid {
+    let owner_wallet = format!("test_owner_{}", Uuid::new_v4().simple());
+    let org_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO organizations (name, slug, owner_wallet) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind("test-org")
+    .bind(format!("slug-{}", Uuid::new_v4().simple()))
+    .bind(&owner_wallet)
+    .fetch_one(pool)
+    .await
+    .expect("create org");
+
+    let team_id: Uuid =
+        sqlx::query_scalar("INSERT INTO teams (org_id, name) VALUES ($1, $2) RETURNING id")
+            .bind(org_id)
+            .bind(format!("team-{}", Uuid::new_v4().simple()))
+            .fetch_one(pool)
+            .await
+            .expect("create team");
+
+    sqlx::query("INSERT INTO team_wallets (team_id, wallet_address) VALUES ($1, $2)")
+        .bind(team_id)
+        .bind(wallet)
+        .execute(pool)
+        .await
+        .expect("assign wallet to team");
+
+    team_id
+}
+
+/// #501: a transient DB error reading `team_budgets` for a team member must
+/// FAIL CLOSED — deny the request as a transient `UsageError::Database`, roll
+/// back the already-committed wallet counters, and NEVER cache an error-derived
+/// "no team budget" sentinel (which would silently disable the team cap for
+/// every member of the team for a full TTL).
+///
+/// The DB error is forced deterministically by dropping the `team_budgets`
+/// table inside this test's isolated `#[sqlx::test]` database: membership still
+/// resolves via the separate `team_wallets` table, but the team-budget SELECT
+/// errors with "relation does not exist" — a real, non-absence DB error.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_team_config_db_error_fails_closed_and_rolls_back(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+
+    // Wallet is a team member with a permissive individual cap — if the team
+    // path fail-OPENED, this request would sail through on the wallet cap.
+    let team_id = seed_team_for_wallet(&pool, &wallet).await;
+    sqlx::query(
+        "INSERT INTO wallet_budgets (wallet_address, hourly_limit_usdc, daily_limit_usdc) \
+         VALUES ($1, 50.00, 100.00)",
+    )
+    .bind(&wallet)
+    .execute(&pool)
+    .await
+    .expect("seed permissive wallet caps");
+
+    // Force a real DB error on the team_budgets read only (membership via
+    // team_wallets still resolves). CASCADE drops the updated_at trigger too.
+    sqlx::query("DROP TABLE team_budgets CASCADE")
+        .execute(&pool)
+        .await
+        .expect("drop team_budgets to force a DB error on the team-budget read");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    let err = tracker
+        .check_budget(&wallet, 0.10, None)
+        .await
+        .expect_err("team_budgets DB error must fail closed (deny)");
+    match err {
+        // Transient infra error, retry-safe — NOT a silent skip of team enforcement.
+        UsageError::Database(_) => {}
+        other => panic!("expected transient Database error, got {other:?}"),
+    }
+
+    // Rollback completeness: the wallet hourly + daily counters reserved before
+    // the team gate erred must be released (no leaked spend on a denied request).
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+    let hour_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H"));
+    let leaked_day = get_redis_spend(&client, &day_key).await.expect("get day");
+    let leaked_hour = get_redis_spend(&client, &hour_key).await.expect("get hour");
+    assert_eq!(
+        leaked_day, 0.0,
+        "denied request must leak no wallet daily spend"
+    );
+    assert_eq!(
+        leaked_hour, 0.0,
+        "denied request must leak no wallet hourly spend"
+    );
+
+    // The error-derived "no team budget" answer must NOT have been cached: a
+    // single transient blip must not poison the team cap for a full TTL.
+    let team_cache_key = format!("team_budget:{team_id}");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let cached: Option<String> = redis::cmd("GET")
+        .arg(&team_cache_key)
+        .query_async(&mut conn)
+        .await
+        .expect("read team_budget cache");
+    assert_eq!(
+        cached, None,
+        "a team_budgets DB error must NOT be cached under team_budget:{{team_id}}"
+    );
+
+    redis_del(
+        &client,
+        &[
+            &day_key,
+            &hour_key,
+            &team_cache_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+        ],
+    )
+    .await;
+}
+
+/// #501 regression guard: real team-row ABSENCE (query OK, no `team_budgets`
+/// row) is NOT an error — the request proceeds (team enforcement skipped) AND
+/// the `"none"` sentinel IS cached so repeated misses don't re-hit the DB.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_team_config_absent_proceeds_and_caches_none(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    // Team member, but NO team_budgets row provisioned for the team.
+    let team_id = seed_team_for_wallet(&pool, &wallet).await;
+    let team_cache_key = format!("team_budget:{team_id}");
+    redis_del(&client, &[&team_cache_key]).await;
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    tracker
+        .check_budget(&wallet, 0.50, None)
+        .await
+        .expect("no team budget row → request proceeds (team enforcement skipped)");
+
+    // The "none" sentinel must be cached for the absence (happy-path cache fill).
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let cached: Option<String> = redis::cmd("GET")
+        .arg(&team_cache_key)
+        .query_async(&mut conn)
+        .await
+        .expect("read team_budget cache");
+    assert_eq!(
+        cached.as_deref(),
+        Some("none"),
+        "a confirmed-absent team budget must cache the \"none\" sentinel"
+    );
+
+    let now = Utc::now();
+    redis_del(
+        &client,
+        &[
+            &team_cache_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%d")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m")),
+        ],
+    )
+    .await;
+}
+
+/// #501: a corrupt/undeserializable `team_budget:{team_id}` cache entry must be
+/// DEL'd and the DB re-queried (mirrors the wallet path's corrupt-cache DEL),
+/// rather than silently falling through and leaving the bad key to be re-read.
+#[sqlx::test(migrations = "../../migrations")]
+async fn check_budget_team_config_corrupt_cache_is_deled_and_requeried(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+
+    // Team member with a real team budget in the DB ($0.10/day).
+    let team_id = seed_team_for_wallet(&pool, &wallet).await;
+    sqlx::query("INSERT INTO team_budgets (team_id, daily_limit_usdc) VALUES ($1, 0.10)")
+        .bind(team_id)
+        .execute(&pool)
+        .await
+        .expect("seed team budget");
+
+    let team_cache_key = format!("team_budget:{team_id}");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    // Prime a corrupt cache entry (not "none", not valid JSON).
+    let _: () = redis::cmd("SET")
+        .arg(&team_cache_key)
+        .arg("not-valid-json")
+        .arg("EX")
+        .arg(60)
+        .query_async(&mut conn)
+        .await
+        .expect("prime corrupt team cache");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // Request within the team cap → must proceed once the corrupt cache is
+    // discarded and the real ($0.10) DB row is re-read.
+    tracker
+        .check_budget(&wallet, 0.05, None)
+        .await
+        .expect("corrupt team cache must be discarded and DB re-queried");
+
+    // The corrupt entry must have been replaced by a valid serialized config
+    // (DEL on detect, then the fresh DB read is re-cached) — never left corrupt.
+    let cached: Option<String> = redis::cmd("GET")
+        .arg(&team_cache_key)
+        .query_async(&mut conn)
+        .await
+        .expect("read team_budget cache after re-query");
+    let cached = cached.expect("team budget must be re-cached after corrupt-cache DEL");
+    assert_ne!(
+        cached, "not-valid-json",
+        "the corrupt cache entry must not survive"
+    );
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&cached).is_ok(),
+        "re-cached team budget must be valid JSON, got {cached}"
+    );
+
+    let now = Utc::now();
+    redis_del(
+        &client,
+        &[
+            &team_cache_key,
+            &format!("budget_config:{wallet}"),
+            &format!("team_member:{wallet}"),
+            &format!("team_spend:{}:{}", team_id, now.format("%Y-%m-%d")),
+            &format!("team_spend:{}:{}", team_id, now.format("%Y-%m-%dT%H")),
+            &format!("team_spend:{}:{}", team_id, now.format("%Y-%m")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%d")),
+        ],
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary

`get_team_budget_config` (in `crates/gateway/src/usage.rs`) treated a transient Postgres error on the `team_budgets` read **identically to "no row exists"** — it returned a plain `None` and then **cached that error-derived `"none"` sentinel** under `team_budget:{team_id}` for the full 60s TTL.

Effect (**fail-open → money-path bug**): a single transient DB blip silently disabled the **team** cap for *every member of the team* for up to a minute. Aggregate spend across N wallets could then escape the team bound. Individual wallet caps still applied, but the team cap is the whole point of teams. Secondary: the corrupt-JSON cache branch fell through to DB **without DEL-ing** the bad key.

This diverged from the correct `get_wallet_budget_config` / `get_tenant_budget_config` paths, which distinguish a DB **error** from real **absence** and refuse to cache the error-derived fallback.

## Fix — mirror the wallet/tenant paths exactly

- New `TeamLookup` enum (`Found` / `Absent` / `DbError`), same shape as the existing `TenantLookup`.
- `get_team_budget_config` now returns `TeamLookup`:
  - **Real absence** (query OK, no row) → `Absent`, still caches the `"none"` sentinel (happy path unchanged).
  - **DB error** → `DbError`, caches **nothing** (`TeamLookup::cache_value` → `None`), so a transient blip can't poison the team cap for a full TTL.
  - **Corrupt cache entry** → `DEL`'d before falling through to DB (mirrors the wallet path).
- `check_budget` maps `TeamLookup::DbError` to a **fail-closed deny**: it rolls back the already-committed wallet/tenant counters and returns `UsageError::Database` (transient, retry-safe) instead of silently skipping team enforcement.

Wallet/tenant enforcement semantics are unchanged — only the team path was brought in line.

## Tests (added first, TDD)

Unit (no DB):
- `test_team_lookup_cache_value_never_caches_db_error` — `DbError` is never cached, `Absent` caches `"none"`, `Found` round-trips.

Integration through the real `check_budget` path (`#[sqlx::test]`, live Postgres + Redis):
- `check_budget_team_config_db_error_fails_closed_and_rolls_back` — forces a real `team_budgets` DB error (drops the table inside the test's isolated DB; membership still resolves via the separate `team_wallets` table), asserts the request is **denied** with `Database`, the committed wallet hourly+daily counters are **rolled back to 0** (no leak), and **nothing** is cached under `team_budget:{team_id}`.
- `check_budget_team_config_absent_proceeds_and_caches_none` — real absence: request proceeds (team enforcement skipped) and the `"none"` sentinel **is** cached (regression guard for the happy path).
- `check_budget_team_config_corrupt_cache_is_deled_and_requeried` — a corrupt cache entry is DEL'd and the DB is re-queried (and re-cached as valid JSON).

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo test -p gateway` (with live Postgres + Redis): all green — 720 lib unit, 39 `usage_redis` (incl. the 3 new), 170 integration, plus orgs/stats/usage suites; 0 failures.

Closes #501