### PR TITLE
fix(security): close money-path auto-approve gap + pin helius-mcp

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -83,6 +83,7 @@ jobs:
               /^crates\/gateway\/src\/escrow\//,
               /^crates\/gateway\/src\/a2a\//,
               /^crates\/gateway\/src\/usage\.rs$/,
+              /^crates\/gateway\/src\/middleware\/x402\.rs$/, // payment header decode / replay / extract
               /(^|\/)signer\.(rs|ts|py|go)$/, // SDK signing modules (any language)
               /^sdks\/.*\/escrow/,            // SDK escrow paths
             ];

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,7 @@
     },
     "helius": {
       "command": "npx",
-      "args": ["helius-mcp@latest"],
+      "args": ["helius-mcp@1.3.0"],
       "env": {
         "HELIUS_API_KEY": "${HELIUS_API_KEY}"
       }


### PR DESCRIPTION
## What

Two small, verified hardening fixes surfaced by the 2026-06-08 security-audit skill-coverage pass.

### 1. Close a money-path gap in the auto-approve gate
`.github/workflows/auto-approve.yml` `MONEY_PATH` lets a PR skip human review only when it touches **no** payment-path file. `crates/gateway/src/middleware/x402.rs` — the code that **decodes the `PAYMENT-SIGNATURE` header, enforces the size cap, and runs replay protection** — matched none of the existing patterns (it sits outside `routes/chat/`, `escrow/`, `a2a/`, and `usage.rs`). A change to it could therefore be auto-approved without a human looking. Added one regex line.

### 2. Pin the Helius MCP
`.mcp.json` ran `helius-mcp@latest`. That MCP can **sign and broadcast transfers** (`transferSol`, `transferToken`, `generateKeypair`), and `@latest` pulls whatever is published on every `npx` invocation — an unreviewed-code-on-a-wallet-capable-tool supply-chain risk. Pinned to `@1.3.0` (current `latest`).

## Verification
- `.mcp.json` parses as JSON; `auto-approve.yml` parses as YAML (both checked locally).
- The new regex `^crates/gateway/src/middleware/x402\.rs$` is anchored and matches only that file.

## Not in scope (possible follow-ups)
The same review noted `routes/chat/mod.rs` (orchestrates verify→settle→cache) and the replay-protection cache are arguably money-path too but currently uncovered by `MONEY_PATH`. Left out to keep this PR surgical to the one verified gap — happy to broaden in a follow-up if you'd prefer the whole `routes/chat/` dir covered.