### PR TITLE
ci(security): add gitleaks secret-scan workflow

### DIFF
--- a/.github/.gitleaksignore
+++ b/.github/.gitleaksignore
@@ -34,3 +34,25 @@ ddab954e4f0dfa4c6332e7e479a988c29ee29d6b:crates/gateway/src/routes/chat/payment.
 
 # api-design skill doc — placeholder X-API-Key example
 828a3187f88bb5187564d9cbcabe05c8dbf1d75b:.claude/skills/api-design/SKILL.md:generic-api-key:306
+
+# --- Refreshed 2026-06-08 (first CI run via secret-scan.yml). All false positives. ---
+
+# Docs/codemap placeholder API keys (`solvela_k_...` examples, not live)
+9d9b73c6d78dd16e114ec3eac4210b3d27158340:docs/CODEMAPS/backend.md:generic-api-key:314
+a1a9cda593ece9fe6d5fe8289034dc1b9cda6879:dashboard/content/docs/enterprise/api-keys.mdx:generic-api-key:51
+a1a9cda593ece9fe6d5fe8289034dc1b9cda6879:dashboard/content/docs/enterprise/api-keys.mdx:generic-api-key:52
+a1a9cda593ece9fe6d5fe8289034dc1b9cda6879:dashboard/content/docs/enterprise/api-keys.mdx:generic-api-key:77
+
+# Docs curl example with `solvela_k_your_key_here` placeholder
+edb69b1dd812a798f825d180107367ad72b3a7f1:dashboard/content/docs/api/rate-limits.mdx:curl-auth-header:54
+
+# Test fixture in orgs/queries.rs (`solvela_k_abc123testkey`) — new commit/lines
+4c20b0652d6cf71aec604b267bb2c0f5f05f236e:crates/gateway/src/orgs/queries.rs:generic-api-key:572
+4c20b0652d6cf71aec604b267bb2c0f5f05f236e:crates/gateway/src/orgs/queries.rs:generic-api-key:585
+
+# Solana public key in example context (agent_pubkey) — public by design
+9574286b57356de108906a0de88e9167a08b2d2f:crates/gateway/src/routes/proxy.rs:generic-api-key:1271
+
+# Placeholder example key text inside the historical root .gitleaksignore triage notes
+# (do not paste the literal token here — gitleaks scans this file's history too)
+7581debe7dc190d431dcdb310d0bba069124bda6:.gitleaksignore:generic-api-key:10

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,61 @@
+name: Secret scan
+
+# Runs gitleaks over the full git history so a committed secret is caught
+# regardless of how deep in history it landed. Accepted false positives
+# (doc placeholders, test fixtures, Solana *public* keys) are fingerprinted
+# in `.github/.gitleaksignore` — review every new fingerprint before adding,
+# and never silence a real secret by ignoring it.
+#
+# This job lands green from day one (no continue-on-error). To make it a
+# branch-protection gate, add it to the REQUIRED list in auto-approve.yml and
+# to branch protection AFTER it has run once on `main` (adding it to REQUIRED
+# in the same PR would make required-checks-sync fail on the merge commit,
+# because the check did not run on the pre-merge `main`).
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned for supply-chain hygiene — bump the version AND the checksum together.
+  GITLEAKS_VERSION: 8.21.2
+  GITLEAKS_SHA256: 5bc41815076e6ed6ef8fbecc9d9b75bcae31f39029ceb55da08086315316e3ba
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks (pinned + checksum-verified)
+        run: |
+          set -euo pipefail
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}"
+          curl -fsSL "$url" -o "$tarball"
+          echo "${GITLEAKS_SHA256}  ${tarball}" | sha256sum --check --strict
+          tar -xzf "$tarball" gitleaks
+          install -m 0755 gitleaks "$RUNNER_TEMP/gitleaks"
+          "$RUNNER_TEMP/gitleaks" version
+
+      - name: Scan git history
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/gitleaks" git \
+            --gitleaks-ignore-path .github/.gitleaksignore \
+            --redact \
+            --no-banner \
+            --verbose


### PR DESCRIPTION
## What

Adds `.github/workflows/secret-scan.yml` — a gitleaks job that scans the **full git history** on every push and PR to `main`.

Closes supply-chain audit finding **§6**: `.github/.gitleaksignore` was curated (2026-04-28) but **no workflow ever ran gitleaks**. The ignore file was orphaned; secret scanning was manual only.

## How

- **Pinned + checksum-verified** gitleaks `8.21.2` binary (`GITLEAKS_SHA256` verified via `sha256sum --check --strict`). Bump version and checksum together.
- Consumes the existing `.github/.gitleaksignore` via `--gitleaks-ignore-path`.
- **No `continue-on-error`** — lands green from day one (a real leak fails the job).
- Reuses the same pinned `actions/checkout` SHA as `dco.yml`; `fetch-depth: 0` for full-history scan.

## Ignore-file refresh

9 fingerprints accumulated in history since the 2026-04-28 curation. **All verified false positives:**
- doc/codemap placeholder `solvela_k_...` keys (CODEMAPS, enterprise/api-keys.mdx, rate-limits.mdx)
- `solvela_k_abc123testkey` test fixture in `orgs/queries.rs` (new commit/lines)
- a Solana **public** agent key in `proxy.rs` (public by design)
- the `sk_live_abc123` placeholder text inside the ignore file's own triage notes

Verified locally: `gitleaks git` reports **"no leaks found" (exit 0)**.

## Not in this PR (intentional)

Not added to the auto-approve `REQUIRED` list or branch protection yet. Adding it in the same PR would fail `required-checks-sync` on the merge commit (the check has not run on pre-merge `main`). **Follow-up:** flip to required once it has run once on `main`.

> Note: `core.hooksPath` on this clone points at `.git/hooks`, not the repo's `.githooks/`, so auto-signoff didn't fire — the commit was signed off manually. Worth running `git config core.hooksPath .githooks` per CLAUDE.md.