### PR TITLE
ci(security): make gitleaks secret-scan a required check

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -59,6 +59,7 @@ jobs:
               'Docker build',
               'Verify DCO sign-off on every commit',
               'Semantic cache (redis-stack + embedding model)',
+              'Secret scan (gitleaks)',
             ];
             // Authors whose green PRs may be auto-approved. `dependabot[bot]`
             // is included so routine dependency bumps clear review on green CI


### PR DESCRIPTION
Follow-up to #514. Promotes the `Secret scan (gitleaks)` check to a required merge gate.

## Changes
- Adds `'Secret scan (gitleaks)'` to the `REQUIRED` list in `auto-approve.yml` so the auto-approver waits for it (keeps it in sync with branch protection).
- Branch protection on `main` is updated in the same change to require the `Secret scan (gitleaks)` context.

## Why this is safe now (and wasn't in #514)
`required-checks-sync` asserts every `REQUIRED` name ran on the pre-merge `main` commit. The workflow has already run once on `main` (merge of #514 → `completed/success`), so this merge's `before` commit carries the check and the sync stays green. Doing this in #514 itself would have failed that assertion.