### PR TITLE
ci(security): make cargo-deny dependency hygiene a required check

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -56,6 +56,7 @@ jobs:
               'Rust (fmt, clippy, test)',
               'Smoke test (boot gateway + curl endpoints)',
               'Security audit (cargo-audit)',
+              'Dependency hygiene (cargo-deny)',
               'Docker build',
               'Verify DCO sign-off on every commit',
               'Semantic cache (redis-stack + embedding model)',


### PR DESCRIPTION
Closes the asymmetry where `Security audit (cargo-audit)` is required but `Dependency hygiene (cargo-deny)` is not — governance skill §1 expects both in the required set.

## Changes
- Adds `'Dependency hygiene (cargo-deny)'` to the `REQUIRED` list in `auto-approve.yml` (grouped next to cargo-audit).
- Branch protection on `main` updated in the same change to require the `Dependency hygiene (cargo-deny)` context.

## Why
`cargo deny check` is the only CI gate enforcing **crates.io-only sources** (a single unvetted git/unknown-registry dep = unreviewed code on the money path), in addition to licenses, bans, and RustSec advisories. cargo-audit and cargo-deny intentionally diverge (full `Cargo.lock` vs `[graph].targets`), so both belong in the gate.

## Safe to do in one PR
Unlike gitleaks (#515), cargo-deny already runs on `main` and is green, so `required-checks-sync` stays green on this merge — no two-step needed.

## Tradeoff (already accepted for cargo-audit)
cargo-deny's advisories/licenses sections can spontaneously fail on an unrelated PR when a new RustSec advisory drops; resolved by adding a traced ignore to `deny.toml` per skill §1. Same property cargo-audit already has as a required check.