### PR TITLE
ci(security): close auto-approve money-path regex gap (middleware/x402.rs + full routes/chat)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -81,7 +81,8 @@ jobs:
               /^crates\/escrow-tx\//,
               /^programs\/escrow\//,
               /^crates\/protocol\/src\/(payment|settlement|cost|constants)\.rs$/,
-              /^crates\/gateway\/src\/routes\/chat\/(cost|payment)\.rs$/,
+              /^crates\/gateway\/src\/routes\/chat\//,        // whole paid pipeline (mod/cost/payment/provider/response)
+              /^crates\/gateway\/src\/middleware\/(x402|rate_limit)\.rs$/, // payment decode/replay gate + payer-keyed rate limit
               /^crates\/gateway\/src\/escrow\//,
               /^crates\/gateway\/src\/a2a\//,
               /^crates\/gateway\/src\/usage\.rs$/,


### PR DESCRIPTION
## What

Closes a confirmed gap in the `auto-approve.yml` `MONEY_PATH` exclusion — the load-bearing guard that forces human review of any PR touching fund-moving code.

Two payment-path surfaces were not matched by the regex:

- **`crates/gateway/src/middleware/x402.rs`** — the payment-header decode + replay-protection boundary — matched **no** pattern, even though `ci.yml`'s own coverage block classifies it as the payment hot path. A `dependabot[bot]` bump (or `sky64` PR) touching only this file would auto-approve on green CI **without a human**.
- **`routes/chat/(cost|payment).rs`** matched only those two files, leaving the rest of the paid pipeline — `mod.rs`, `provider.rs`, `response.rs` — unmatched.

## Change

```diff
-              /^crates\/gateway\/src\/routes\/chat\/(cost|payment)\.rs$/,
+              /^crates\/gateway\/src\/routes\/chat\//,        // whole paid pipeline (mod/cost/payment/provider/response)
+              /^crates\/gateway\/src\/middleware\/(x402|rate_limit)\.rs$/, // payment decode/replay gate + payer-keyed rate limit
```

Direction is fail-safe: false positives (an extra human review) are acceptable; false negatives (auto-approving money-path code) are the risk being eliminated. `rate_limit.rs` is included because it keys on the on-chain signer — a payment-integrity surface.

## Validation

Asserted the new regex set against representative paths — the six payment-path files match, and non-money-path siblings (`middleware/cors.rs`, `routes/models.rs`, `main.rs`, dashboard, docs) do not:

```
HIT  middleware/x402.rs, middleware/rate_limit.rs,
     routes/chat/{mod,provider,response,cost,payment}.rs
MISS middleware/cors.rs, routes/models.rs, main.rs, dashboard/package.json, README.md
```

## Provenance

Surfaced and confirmed during the 2026-06-08 full security audit (Scope 7). It was a *suspected* candidate in the prior skill-coverage pass; this run verified it real. Tracked in the `solvela-supply-chain-governance` skill (§4) as "the load-bearing one."