### PR TITLE
ci(security): pin helius-mcp to 1.3.0 (was @latest)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,7 @@
     },
     "helius": {
       "command": "npx",
-      "args": ["helius-mcp@latest"],
+      "args": ["helius-mcp@1.3.0"],
       "env": {
         "HELIUS_API_KEY": "${HELIUS_API_KEY}"
       }


### PR DESCRIPTION
## What

Pins the **wallet-capable** `helius` MCP server in `.mcp.json` from `helius-mcp@latest` to `helius-mcp@1.3.0`.

```diff
-      "args": ["helius-mcp@latest"],
+      "args": ["helius-mcp@1.3.0"],
```

## Why

The helius MCP's toolset includes `transferSol`, `transferToken`, and `generateKeypair`, and it reads `HELIUS_API_KEY` from the environment. Launched via `npx helius-mcp@latest`, the version floats — any future upstream release (including a compromised one) would auto-execute with fund-moving capability the next time the MCP starts, with no review step. `.mcp.json` is tracked, so the floating pin ships to every clone.

`1.3.0` is the current `latest` (published 2026-03-12) and the version this environment already runs, so this is a no-behavior-change lock. Future bumps now require an explicit, reviewable edit — each treated as a supply-chain event.

## Provenance

Surfaced and confirmed during the 2026-06-08 full security audit (Scope 8 — agent/MCP/hook surface). Tracked in the `solvela-supply-chain-governance` skill (§6) as a standing finding.