### PR TITLE
fix(signer-core): escrow deposit byte-parity + expiry bounds (HIGH money-path)

### DIFF
--- a/sdks/signer-core/package.json
+++ b/sdks/signer-core/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "node --import tsx/esm --test tests/parse-402.test.ts tests/scheme-filter.test.ts tests/stub-guard.test.ts tests/redact.test.ts tests/sign.test.ts",
+    "test": "node --import tsx/esm --test tests/parse-402.test.ts tests/scheme-filter.test.ts tests/stub-guard.test.ts tests/redact.test.ts tests/sign.test.ts tests/escrow.test.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "tsc"
   },

--- a/sdks/signer-core/src/escrow.ts
+++ b/sdks/signer-core/src/escrow.ts
@@ -134,6 +134,21 @@ export const MIN_PLAUSIBLE_SLOT = 1_000_000;
  * precision.
  */
 export function escrowExpirySlot(currentSlot: number, maxTimeoutSeconds: number): number {
+  // FINDING B (audit 2026-06-08): fail closed on a non-finite input. This is a
+  // public export; before the guard a NaN timeout silently returned NaN
+  // (Math.max(NaN, 0) === NaN, which then flowed into `assertValidExpirySlot` /
+  // `u64LE`) and Infinity was silently clamped to the 10000-slot ceiling — both
+  // hide a real input error on a value path. The canonical signers never feed a
+  // non-integer here (Rust `u64` / Go `int` reject at deserialization; the
+  // canonical TS signer rejects with `!Number.isInteger` — see the Finding A note
+  // in sign.ts), so this guard only ever fires on genuinely malformed input and
+  // does NOT reject any value the canonical path produces.
+  if (!Number.isFinite(maxTimeoutSeconds)) {
+    throw new SigningError('max_timeout_seconds must be a finite number of seconds');
+  }
+  if (!Number.isFinite(currentSlot)) {
+    throw new SigningError('current_slot must be a finite number');
+  }
   const timeout = Math.max(maxTimeoutSeconds, 0);
   // timeout * 1000 / 400, floored to whole slots (matches the Rust integer math).
   const timeoutSlots = Math.floor((timeout * 1000) / 400);
@@ -252,16 +267,27 @@ function assertValidAmount(amount: number): void {
 }
 
 /**
- * Reject a non-integer, non-finite, or non-positive expiry slot.
+ * Reject a non-safe-integer, non-finite, or non-positive expiry slot.
  *
  * `expiry_slot` is encoded directly into the on-chain `u64` via {@link u64LE}.
  * An `expirySlot` of 0 silently encodes a dead-on-arrival deposit, and
  * `NaN`/`Infinity`/`-1` make `BigInt(value)` throw a raw untyped error rather
  * than a `SigningError`. Fail closed here, parallel to {@link assertValidAmount}.
+ *
+ * FINDING C (audit 2026-06-08): use `Number.isSafeInteger` (not the looser
+ * `Number.isInteger`) and an implicit MAX_SAFE_INTEGER ceiling, mirroring
+ * {@link assertValidAmount}. A value above `Number.MAX_SAFE_INTEGER` does not
+ * round-trip faithfully through an IEEE-754 double, so it cannot encode exactly
+ * into the on-chain `u64` — `Number.isInteger(2**53)` is `true` but the value is
+ * already lossy. Overflow here is theoretical (the canonical `escrowExpirySlot`
+ * caps the offset at 10000 slots above a plausible slot), but it makes the two
+ * validators symmetric so neither can be the weak link.
  */
 function assertValidExpirySlot(expirySlot: number): void {
-  if (!Number.isInteger(expirySlot)) {
-    throw new SigningError('expiry_slot must be a positive integer');
+  if (!Number.isSafeInteger(expirySlot)) {
+    throw new SigningError(
+      'expiry_slot must be a positive safe integer (<= Number.MAX_SAFE_INTEGER)',
+    );
   }
   if (expirySlot <= 0) {
     throw new SigningError('expiry_slot must be a positive integer');

--- a/sdks/signer-core/src/escrow.ts
+++ b/sdks/signer-core/src/escrow.ts
@@ -1,0 +1,505 @@
+/**
+ * Escrow deposit-transaction builder for @solvela/signer-core.
+ *
+ * Faithful port of the canonical Rust builder `crates/escrow-tx/src/deposit.rs`
+ * (+ `pda.rs`), kept byte-for-byte identical to the canonical TypeScript SDK
+ * builder `sdks/typescript/src/escrow.ts`. The output MUST reproduce
+ * {@link GOLDEN_VECTOR_B64} for the fixed golden-vector input; the gateway
+ * verifier (`crates/x402/src/escrow/`) independently re-derives the same layout,
+ * so any divergence here is a fund-misdirection bug, not a style nit.
+ *
+ * Why this exists as a local port (not an import of `@solvela/sdk`):
+ * signer-core is deliberately self-contained — see the history note in
+ * `sign.ts`. The published `@solvela/sdk` was wire-incompatible with the
+ * production gateway, and signer-core was created specifically to avoid a dead
+ * workspace dependency on it. So we port the canonical builder verbatim and pin
+ * it against the same Rust golden vector + a drift-guard test, rather than
+ * depending on the canonical SDK package.
+ *
+ * Wire layout (single source of truth — see the Rust file and the `solvela-x402`
+ * skill):
+ *
+ *   - Escrow PDA seeds: `[b"escrow", agent_pubkey(32), service_id(32)]`.
+ *   - Vault ATA: `ATA(escrow_pda, usdc_mint)` (escrow PDA is off-curve, so the
+ *     derivation must allow an off-curve owner).
+ *   - Instruction data (56 bytes): `anchorDiscriminator("deposit")[8]` ||
+ *     `amount: u64 LE` || `service_id: [32]` || `expiry_slot: u64 LE`.
+ *   - Account list sorted by writability; program key appended last (index 9).
+ *   - Instruction account-index order: `[0, 4, 5, 1, 2, 3, 6, 7, 8]`.
+ *   - Legacy message header `[1, 0, 6]`; length prefixes are single-byte
+ *     compact-u16 (valid only for lengths <= 127 — reject larger rather than
+ *     truncating).
+ *   - Wire tx: `compact-u16(1) || ed25519_signature(64) || message`, then base64
+ *     (standard alphabet).
+ *
+ * We deliberately do NOT use `@solana/web3.js`'s `Message` / `Transaction`
+ * compilation to assemble the escrow message: those re-derive their own account
+ * ordering and would not match the canonical writability-sorted layout
+ * byte-for-byte (that v0-VersionedTransaction approach was the wire-drift bug
+ * this builder replaces). We use web3.js / spl-token only for the primitives
+ * whose output is canonical and already pinned as ground truth:
+ * `PublicKey.findProgramAddressSync` (PDA + ATA derivation) — the golden vector
+ * is the arbiter that these agree — plus a raw ed25519 signature over the
+ * serialized message bytes. The Anchor discriminator and account ordering are
+ * computed locally with the Node `crypto` stdlib.
+ */
+
+import { createHash, createPrivateKey, sign as edSign } from 'node:crypto';
+
+import { Keypair, PublicKey } from '@solana/web3.js';
+import {
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID as SPL_TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID as SPL_ATA_PROGRAM_ID,
+} from '@solana/spl-token';
+
+import { SigningError } from './sign.js';
+
+// ---------------------------------------------------------------------------
+// Well-known program constants (match crates/escrow-tx/src/pda.rs).
+// ---------------------------------------------------------------------------
+
+const TOKEN_PROGRAM_ID = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+const ATA_PROGRAM_ID = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
+const SYSTEM_PROGRAM_ID = '11111111111111111111111111111111';
+
+/**
+ * Largest length representable as a single compact-u16 byte. Lengths above this
+ * would require a continuation byte; emitting a bare byte there would corrupt
+ * the encoding, so we reject (mirrors the Rust/Go/Python/TS builders).
+ */
+const COMPACT_U16_SINGLE_BYTE_MAX = 127;
+
+const SIGNATURE_LENGTH = 64;
+const PUBKEY_LENGTH = 32;
+const IX_DATA_LENGTH = 56;
+
+/**
+ * DER prefix for a PKCS#8-wrapped Ed25519 private key (RFC 8410). The 32-byte
+ * raw seed is appended to form a complete PKCS#8 key Node's crypto can import.
+ * Mirrors the canonical SDK `Wallet.signMessage` path: we sign the raw legacy
+ * message bytes directly (NOT via `Transaction.sign`, which would re-compile and
+ * re-order the message and break byte-for-byte parity with the golden vector).
+ */
+const ED25519_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+
+// ---------------------------------------------------------------------------
+// Escrow expiry-slot bounds (mirror the Rust/Go/Python/TS SDK signers).
+//
+// FINDING 2 (audit 2026-06-08): signer-core previously used
+// `Math.max(Math.floor(maxTimeoutSeconds*1000/400), 10)` — a 10-slot floor with
+// no upper clamp and no plausibility check. The gateway verifier rejects when
+// expiry_slot - current_slot < MIN_EXPIRY_BUFFER_SLOTS (50)
+// (crates/x402/src/escrow/verifier.rs), so a signer-core deposit with
+// maxTimeoutSeconds < ~20 was dead-on-arrival. These constants are ported
+// verbatim from sdks/typescript/src/signer.ts (and go/python/rust) so all
+// signers choose compatible expiry slots and none is bounced.
+// ---------------------------------------------------------------------------
+
+/**
+ * Upper bound on how far ahead an escrow may expire (~66 min). Rejects a
+ * malicious/misconfigured gateway from pushing expiry to "never".
+ */
+export const MAX_ESCROW_EXPIRY_SLOTS_AHEAD = 10_000;
+
+/**
+ * Lower bound on expiry distance. Mirrors AND exceeds the gateway's
+ * MIN_EXPIRY_BUFFER_SLOTS = 50 (crates/x402/src/escrow/verifier.rs); the extra
+ * headroom (150 vs 50) absorbs slot-skew between the slot we read and the slot
+ * the gateway verifies against. ~150 slots ~= 60 s.
+ */
+export const MIN_ESCROW_EXPIRY_SLOTS_AHEAD = 150;
+
+/**
+ * Floor below which a getSlot result is implausible and rejected. A stub /
+ * genesis / freshly-reset validator can answer getSlot with a near-zero slot;
+ * computing an escrow expiry from that base yields an already-expired (or
+ * trivially-near-expiry) deposit the gateway would bounce. Mainnet/devnet have
+ * been well past this for years. Fail closed rather than silently signing a
+ * dead-on-arrival escrow deposit.
+ */
+export const MIN_PLAUSIBLE_SLOT = 1_000_000;
+
+/**
+ * Compute the slot at which a now-created escrow PDA should expire.
+ *
+ * Ported from the canonical SDKs' `escrowExpirySlot` / `escrow_expiry_slot`:
+ * ~2.5 slots/s (1000 ms / 400 ms), clamped into
+ * `[MIN_ESCROW_EXPIRY_SLOTS_AHEAD, MAX_ESCROW_EXPIRY_SLOTS_AHEAD]`. The floor
+ * mirrors and exceeds the gateway's MIN_EXPIRY_BUFFER_SLOTS so a too-near expiry
+ * is never bounced; the cap rejects an unbounded-future expiry. A negative
+ * timeout is floored to 0 (never pushes expiry backwards into a dead-on-arrival
+ * deposit). `currentSlot` and the effective offset stay within
+ * Number.MAX_SAFE_INTEGER for any plausible slot, so the add cannot lose
+ * precision.
+ */
+export function escrowExpirySlot(currentSlot: number, maxTimeoutSeconds: number): number {
+  const timeout = Math.max(maxTimeoutSeconds, 0);
+  // timeout * 1000 / 400, floored to whole slots (matches the Rust integer math).
+  const timeoutSlots = Math.floor((timeout * 1000) / 400);
+  const effective = Math.max(
+    MIN_ESCROW_EXPIRY_SLOTS_AHEAD,
+    Math.min(timeoutSlots, MAX_ESCROW_EXPIRY_SLOTS_AHEAD),
+  );
+  return currentSlot + effective;
+}
+
+/**
+ * Fail closed if a getSlot result is implausibly low (stub/genesis/reset node).
+ *
+ * Computing an escrow expiry from a near-zero base slot yields an already- or
+ * trivially-near-expiry deposit the gateway bounces; the MCP standalone-deposit
+ * path would broadcast it on-chain first. Reject rather than sign a
+ * dead-on-arrival escrow. Mirrors the `fetchCurrentSlot` MIN_PLAUSIBLE_SLOT
+ * check in the canonical SDK signers.
+ */
+export function assertPlausibleSlot(slot: number): void {
+  if (typeof slot !== 'number' || !Number.isSafeInteger(slot) || slot < 0) {
+    throw new SigningError('getSlot RPC: missing or invalid result');
+  }
+  if (slot < MIN_PLAUSIBLE_SLOT) {
+    throw new SigningError(
+      `getSlot RPC returned implausibly low slot ${slot} ` +
+        `(< ${MIN_PLAUSIBLE_SLOT}); refusing to build an escrow deposit`,
+    );
+  }
+}
+
+/**
+ * Byte-exact base64 deposit transaction for the fixed golden-vector input,
+ * copied verbatim from `GOLDEN_VECTOR_B64` in `crates/escrow-tx/src/deposit.rs`
+ * (and `sdks/typescript/src/escrow.ts`'s `GOLDEN_VECTOR_B64`).
+ *
+ * DO NOT hand-edit. If this changes, the deposit-tx layout changed — the
+ * on-chain/Rust value is ground truth. The drift-guard test in
+ * `tests/escrow.test.ts` pins this against the Rust source file.
+ *
+ * Fixed input: agent keypair from seed `[42; 32]`, provider
+ * `9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM`, USDC mint
+ * `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`, program
+ * `9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU`, `service_id=[7; 32]`,
+ * `expiry_slot=1_000_750`, `recent_blockhash=[0xAB; 32]`, `amount=2625`.
+ */
+export const GOLDEN_VECTOR_B64 =
+  'Ad449R7ht12UKokgbDUYh29Ey/wDEwPioT/QtJOPKwSO4RHIaFRqS0DH+bPpEo2vCK78jbRLpP/6FV/5TY+qLw8BAAYKGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWFyvMLyv5o/k5XBGVxL9QMaEsQP6v01aK7nXazb0N/wMBS12eVticTdq8DzgM47jC/J8D1uNnFG6ZNqwpSU6GOelSnAbR4dY/56biCP6roeTxLQ8Q4TL7a2ArnBn2RW9HJ+jAiHYL/eHd3PMsF/IJuCQu5SqvEx+s2I0OosbQsG8sb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKmMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgo61GtoIM8r3akxjdsa2N5CEHZ8QBYuAbfwPDOL78eGrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urqwEJCQAEBQECAwYHCDjyI8aJUuHytkEKAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcuRQ8AAAAAAA==';
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+/**
+ * Inputs required to build an escrow deposit transaction.
+ *
+ * `serviceId`, `expirySlot`, and `recentBlockhash` are injected so the builder
+ * is a pure, deterministic function (golden-vector testable). Production code
+ * (the escrow signer in `sign.ts`) generates the CSPRNG `serviceId`, computes
+ * `expirySlot` from the current slot via {@link escrowExpirySlot}, and fetches
+ * the blockhash, then calls this builder.
+ *
+ * SECURITY: the builder reads the keypair's public key and signs the raw
+ * message bytes via an in-process Node `KeyObject` (PKCS#8 import of the
+ * 32-byte seed). The secret bytes are never logged and never leave this module.
+ */
+export interface EscrowDepositParams {
+  /** Agent keypair whose ed25519 key signs the deposit and seeds the escrow PDA. */
+  readonly keypair: Keypair;
+  /** Base58-encoded provider wallet pubkey. */
+  readonly providerWalletB58: string;
+  /** Base58-encoded USDC mint pubkey. */
+  readonly usdcMintB58: string;
+  /** Base58-encoded escrow program id. */
+  readonly escrowProgramIdB58: string;
+  /** Amount to deposit in atomic USDC units (must be a positive integer). */
+  readonly amount: number;
+  /** 32-byte service identifier that seeds the escrow PDA. */
+  readonly serviceId: Uint8Array;
+  /** Slot at which the escrow deposit expires (passed to the on-chain instruction). */
+  readonly expirySlot: number;
+  /** Recent blockhash (raw 32 bytes) from `getLatestBlockhash`. */
+  readonly recentBlockhash: Uint8Array;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the Anchor instruction discriminator: `sha256("global:<name>")[..8]`.
+ */
+export function anchorDiscriminator(name: string): Uint8Array {
+  return new Uint8Array(createHash('sha256').update(`global:${name}`).digest().subarray(0, 8));
+}
+
+/**
+ * Reject a non-integer, non-positive, or precision-unsafe atomic amount.
+ *
+ * JavaScript numbers are IEEE-754 doubles: only integers up to
+ * `Number.MAX_SAFE_INTEGER` (2^53 - 1) round-trip faithfully, and a u64 amount
+ * field above that cannot be represented exactly. A float would be silently
+ * truncated into the on-chain u64 and mis-charge the agent. Fail closed at the
+ * boundary — parity with the canonical SDKs' `assertValidAmount`.
+ */
+function assertValidAmount(amount: number): void {
+  if (!Number.isInteger(amount)) {
+    throw new SigningError('deposit amount must be an integer number of atomic USDC units');
+  }
+  if (amount <= 0) {
+    throw new SigningError('deposit amount must be greater than zero');
+  }
+  if (amount > Number.MAX_SAFE_INTEGER) {
+    throw new SigningError('deposit amount exceeds the safe-integer range (cannot encode as u64)');
+  }
+}
+
+/**
+ * Reject a non-integer, non-finite, or non-positive expiry slot.
+ *
+ * `expiry_slot` is encoded directly into the on-chain `u64` via {@link u64LE}.
+ * An `expirySlot` of 0 silently encodes a dead-on-arrival deposit, and
+ * `NaN`/`Infinity`/`-1` make `BigInt(value)` throw a raw untyped error rather
+ * than a `SigningError`. Fail closed here, parallel to {@link assertValidAmount}.
+ */
+function assertValidExpirySlot(expirySlot: number): void {
+  if (!Number.isInteger(expirySlot)) {
+    throw new SigningError('expiry_slot must be a positive integer');
+  }
+  if (expirySlot <= 0) {
+    throw new SigningError('expiry_slot must be a positive integer');
+  }
+}
+
+/** Encode a non-negative safe-integer as 8 little-endian bytes (u64). */
+function u64LE(value: number): Uint8Array {
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64LE(BigInt(value));
+  return new Uint8Array(buf);
+}
+
+/**
+ * Decode a base58 pubkey into 32 raw bytes, wrapping any failure in a
+ * SigningError that names the offending field but never echoes secret material.
+ */
+function decodeBs58Pubkey(field: string, b58: string): Uint8Array {
+  let key: PublicKey;
+  try {
+    key = new PublicKey(b58);
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new SigningError(`invalid address for ${field}: ${reason}`);
+  }
+  const bytes = key.toBytes();
+  if (bytes.length !== PUBKEY_LENGTH) {
+    throw new SigningError(`invalid address for ${field}: expected 32 bytes, got ${bytes.length}`);
+  }
+  return bytes;
+}
+
+/**
+ * Sign raw message bytes with the keypair's Ed25519 key, returning the 64-byte
+ * detached signature. The 32-byte seed is imported into an in-process Node
+ * `KeyObject` (PKCS#8) and used for the signature only — it is never logged.
+ * Mirrors the canonical SDK `Wallet.signMessage`.
+ */
+function signMessage(keypair: Keypair, message: Uint8Array): Uint8Array {
+  const seed = keypair.secretKey.slice(0, 32);
+  const pkcs8 = Buffer.concat([ED25519_PKCS8_PREFIX, Buffer.from(seed)]);
+  const keyObject = createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+  return new Uint8Array(edSign(null, Buffer.from(message), keyObject));
+}
+
+// ---------------------------------------------------------------------------
+// Legacy message serializer (manual — must match the Rust byte layout exactly).
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a Solana legacy transaction message.
+ *
+ * Layout: `header(3) || acct_count(u8) || N*32 keys (+ program key) ||
+ * blockhash(32) || ix_count(u8)=1 || program_id_index(u8) || ix_acct_count(u8)
+ * || ix_acct_indices || data_len(u8) || data`.
+ *
+ * Length prefixes are emitted as a single byte — the correct compact-u16
+ * encoding only for lengths <= 127. Larger values are rejected (not truncated),
+ * mirroring the Rust/Go/Python/TS builders.
+ */
+function buildLegacyMessage(
+  header: readonly [number, number, number],
+  accounts: readonly Uint8Array[],
+  programId: Uint8Array,
+  recentBlockhash: Uint8Array,
+  programIdIndex: number,
+  ixAccountIndices: Uint8Array,
+  ixData: Uint8Array,
+): Uint8Array {
+  const totalAccounts = accounts.length + 1; // +1 for the appended program key
+  if (totalAccounts > COMPACT_U16_SINGLE_BYTE_MAX) {
+    throw new SigningError(
+      `account count ${totalAccounts} exceeds the 127-byte compact-u16 single-byte limit`,
+    );
+  }
+  if (ixAccountIndices.length > COMPACT_U16_SINGLE_BYTE_MAX) {
+    throw new SigningError(
+      `instruction account count ${ixAccountIndices.length} exceeds the 127-byte compact-u16 single-byte limit`,
+    );
+  }
+  if (ixData.length > COMPACT_U16_SINGLE_BYTE_MAX) {
+    throw new SigningError(
+      `instruction data length ${ixData.length} exceeds the 127-byte compact-u16 single-byte limit`,
+    );
+  }
+
+  const parts: Uint8Array[] = [];
+  parts.push(Uint8Array.from(header));
+  parts.push(Uint8Array.from([totalAccounts]));
+  for (const acc of accounts) {
+    parts.push(acc);
+  }
+  parts.push(programId); // program key is the last account
+  parts.push(recentBlockhash);
+  parts.push(Uint8Array.from([1])); // instruction count
+  parts.push(Uint8Array.from([programIdIndex]));
+  parts.push(Uint8Array.from([ixAccountIndices.length]));
+  parts.push(ixAccountIndices);
+  parts.push(Uint8Array.from([ixData.length]));
+  parts.push(ixData);
+
+  return new Uint8Array(Buffer.concat(parts.map((p) => Buffer.from(p))));
+}
+
+// ---------------------------------------------------------------------------
+// Public builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a signed escrow `deposit` transaction, base64-encoded (standard
+ * alphabet).
+ *
+ * Returns a wire-format Solana legacy transaction ready for the gateway /
+ * `sendTransaction`. Pure with respect to the network (no I/O): for fixed
+ * inputs it always produces the same bytes, which is what lets
+ * {@link GOLDEN_VECTOR_B64} pin the wire layout.
+ *
+ * @throws SigningError on a zero/negative/float/out-of-range amount, a
+ *   non-positive/non-integer/non-finite expiry_slot, a malformed
+ *   provider/mint/program address, a wrong-length service_id/blockhash, a
+ *   PDA/ATA derivation failure, or a message-too-long length prefix.
+ */
+export function buildEscrowDepositTx(params: EscrowDepositParams): string {
+  // Step 1: fail-closed amount + expiry-slot guards, BEFORE any derivation.
+  assertValidAmount(params.amount);
+  assertValidExpirySlot(params.expirySlot);
+
+  // Step 2: validate the injected fixed-size fields.
+  if (params.serviceId.length !== PUBKEY_LENGTH) {
+    throw new SigningError(`service_id must be 32 bytes, got ${params.serviceId.length}`);
+  }
+  if (params.recentBlockhash.length !== PUBKEY_LENGTH) {
+    throw new SigningError(`recent_blockhash must be 32 bytes, got ${params.recentBlockhash.length}`);
+  }
+
+  // Step 3: agent pubkey that seeds the escrow PDA and signs the deposit.
+  const agentPubkey = params.keypair.publicKey.toBytes();
+
+  // Step 4: parse all addresses.
+  const provider = decodeBs58Pubkey('provider_wallet', params.providerWalletB58);
+  const usdcMint = decodeBs58Pubkey('usdc_mint', params.usdcMintB58);
+  const escrowProgram = decodeBs58Pubkey('escrow_program_id', params.escrowProgramIdB58);
+  const tokenProgram = decodeBs58Pubkey('token_program', TOKEN_PROGRAM_ID);
+  const ataProgram = decodeBs58Pubkey('ata_program', ATA_PROGRAM_ID);
+  const systemProgram = decodeBs58Pubkey('system_program', SYSTEM_PROGRAM_ID);
+
+  // Step 5: derive escrow PDA, agent ATA, and vault ATA. We use the canonical
+  // web3.js / spl-token primitives; the golden vector is the arbiter that they
+  // reproduce the on-chain layout. The vault ATA's owner is the escrow PDA
+  // (off-curve), so `allowOwnerOffCurve` must be true.
+  const escrowProgramKey = new PublicKey(escrowProgram);
+  const usdcMintKey = new PublicKey(usdcMint);
+  let escrowPda: PublicKey;
+  try {
+    [escrowPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from('escrow'), Buffer.from(agentPubkey), Buffer.from(params.serviceId)],
+      escrowProgramKey,
+    );
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new SigningError(`failed to derive escrow PDA: ${reason}`);
+  }
+
+  let agentAta: Uint8Array;
+  let vaultAta: Uint8Array;
+  try {
+    agentAta = getAssociatedTokenAddressSync(
+      usdcMintKey,
+      new PublicKey(agentPubkey),
+      false,
+      SPL_TOKEN_PROGRAM_ID,
+      SPL_ATA_PROGRAM_ID,
+    ).toBytes();
+    vaultAta = getAssociatedTokenAddressSync(
+      usdcMintKey,
+      escrowPda,
+      true, // escrow PDA owner is off-curve
+      SPL_TOKEN_PROGRAM_ID,
+      SPL_ATA_PROGRAM_ID,
+    ).toBytes();
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new SigningError(`failed to derive ATA: ${reason}`);
+  }
+
+  // Step 6: account list sorted by writability (writable signer, writable
+  // non-signers, readonly non-signers). The program key is appended last
+  // (index 9) inside the message serializer.
+  const accounts: Uint8Array[] = [
+    agentPubkey, // 0: signer, writable
+    escrowPda.toBytes(), // 1: writable, non-signer
+    agentAta, // 2: writable, non-signer
+    vaultAta, // 3: writable, non-signer
+    provider, // 4: readonly
+    usdcMint, // 5: readonly
+    tokenProgram, // 6: readonly
+    ataProgram, // 7: readonly
+    systemProgram, // 8: readonly
+  ];
+
+  // Step 7: instruction data = discriminator || amount(LE u64) || service_id ||
+  // expiry_slot(LE u64) = 8 + 8 + 32 + 8 = 56 bytes.
+  const ixData = new Uint8Array(
+    Buffer.concat([
+      Buffer.from(anchorDiscriminator('deposit')),
+      Buffer.from(u64LE(params.amount)),
+      Buffer.from(params.serviceId),
+      Buffer.from(u64LE(params.expirySlot)),
+    ]),
+  );
+  if (ixData.length !== IX_DATA_LENGTH) {
+    throw new SigningError(`deposit ix_data must be 56 bytes, got ${ixData.length}`);
+  }
+
+  // Anchor program account order remapped into the writability-sorted layout.
+  const ixAccountIndices = Uint8Array.from([0, 4, 5, 1, 2, 3, 6, 7, 8]);
+
+  // Step 8: legacy message. Header [1, 0, 6]; program_id_index = 9 (last).
+  const msg = buildLegacyMessage(
+    [1, 0, 6],
+    accounts,
+    escrowProgram,
+    params.recentBlockhash,
+    9, // program_id_index = 9 (last account)
+    ixAccountIndices,
+    ixData,
+  );
+
+  // Step 9: sign the raw message bytes with the agent keypair (ed25519).
+  const signature = signMessage(params.keypair, msg);
+  if (signature.length !== SIGNATURE_LENGTH) {
+    throw new SigningError(
+      `unexpected ed25519 signature length ${signature.length} (want ${SIGNATURE_LENGTH})`,
+    );
+  }
+
+  // Step 10: assemble wire tx: compact-u16(1) || signature(64) || message.
+  const wire = Buffer.concat([Buffer.from([1]), Buffer.from(signature), Buffer.from(msg)]);
+
+  return wire.toString('base64');
+}

--- a/sdks/signer-core/src/index.ts
+++ b/sdks/signer-core/src/index.ts
@@ -28,6 +28,17 @@ export type {
   PaymentExpectations,
 } from './types.js';
 export { createPaymentHeader, decodePaymentHeader, SigningError } from './sign.js';
+export {
+  buildEscrowDepositTx,
+  escrowExpirySlot,
+  assertPlausibleSlot,
+  anchorDiscriminator,
+  GOLDEN_VECTOR_B64,
+  MIN_ESCROW_EXPIRY_SLOTS_AHEAD,
+  MAX_ESCROW_EXPIRY_SLOTS_AHEAD,
+  MIN_PLAUSIBLE_SLOT,
+  type EscrowDepositParams,
+} from './escrow.js';
 export { parse402 } from './parse-402.js';
 export { filterAccepts } from './scheme-filter.js';
 export { isStubHeader, isStubTransaction } from './stub-guard.js';

--- a/sdks/signer-core/src/schema.ts
+++ b/sdks/signer-core/src/schema.ts
@@ -78,7 +78,17 @@ export const PaymentAcceptSchema = object({
   amount: decimalAmount,
   asset: pipe(string(), nonEmpty()),
   pay_to: pipe(string(), nonEmpty()),
-  max_timeout_seconds: pipe(number(), finite(), minValue(0)),
+  // FINDING A (audit 2026-06-08): `integer()` (not just `finite()`) so a
+  // fractional `max_timeout_seconds` is rejected at the parse boundary. The
+  // canonical wire type is integer-only — Rust deserializes it as `u64`
+  // (crates/protocol/src/payment.rs) and Go as `int` (sdks/go/types.go), so a
+  // JSON `30.5` fails to decode in both; the canonical TS signer rejects it with
+  // `!Number.isInteger`. Tightening the schema here (rather than accepting +
+  // flooring) keeps signer-core consistent with those three and mirrors their
+  // structural integer constraint. `sign.ts`'s `buildEscrowDeposit` keeps its
+  // own `!Number.isInteger` guard as defense-in-depth for callers that bypass
+  // the parser.
+  max_timeout_seconds: pipe(number(), integer(), minValue(0)),
   escrow_program_id: optional(string()),
 });
 

--- a/sdks/signer-core/src/sign.ts
+++ b/sdks/signer-core/src/sign.ts
@@ -28,14 +28,10 @@ import {
   Connection,
   Keypair,
   PublicKey,
-  SystemProgram,
   TransactionMessage,
   VersionedTransaction,
-  type TransactionInstruction,
 } from '@solana/web3.js';
 import {
-  ASSOCIATED_TOKEN_PROGRAM_ID,
-  TOKEN_PROGRAM_ID,
   createTransferCheckedInstruction,
   getAssociatedTokenAddress,
 } from '@solana/spl-token';
@@ -43,6 +39,11 @@ import bs58 from 'bs58';
 
 import type { PaymentAccept, PaymentExpectations, PaymentRequired } from './types.js';
 import { X402_VERSION_CLIENT } from './schema.js';
+import {
+  buildEscrowDepositTx,
+  escrowExpirySlot,
+  assertPlausibleSlot,
+} from './escrow.js';
 
 
 // X402_VERSION lives in schema.ts so parse-402.ts can compare incoming
@@ -268,7 +269,22 @@ async function buildEscrowDeposit(
   serviceId: Buffer,
   maxTimeoutSeconds: number,
 ): Promise<{ depositTx: string; agentPubkey: string }> {
-  const amount = parsePositiveAmount(amountStr, 'Escrow deposit');
+  // Validate amount BEFORE any RPC/key work. `parsePositiveAmount` enforces an
+  // integer atomic-unit string; the canonical `buildEscrowDepositTx` re-checks
+  // the safe-integer u64 range. amount is a small USDC atomic count, so the
+  // Number() conversion is exact for any plausible value (the builder rejects
+  // anything above Number.MAX_SAFE_INTEGER).
+  const amountBig = parsePositiveAmount(amountStr, 'Escrow deposit');
+  const amount = Number(amountBig);
+
+  // `max_timeout_seconds` comes straight from the untrusted 402 with no
+  // parse-boundary validation. Reject a non-finite/non-integer value here so it
+  // can't propagate a NaN through `escrowExpirySlot` into the on-chain u64. A
+  // negative finite integer is intentionally allowed — `escrowExpirySlot` floors
+  // it to 0 then clamps to the 150-slot floor (parity with the canonical SDKs).
+  if (!Number.isInteger(maxTimeoutSeconds)) {
+    throw new SigningError('max_timeout_seconds must be a finite integer number of seconds');
+  }
 
   let secretKey: Uint8Array | null = null;
   try {
@@ -276,70 +292,45 @@ async function buildEscrowDeposit(
     const payer = Keypair.fromSecretKey(secretKey);
     const agentPubkey = payer.publicKey.toBase58();
 
-    const providerPubkey = new PublicKey(providerWallet);
-    const programId = new PublicKey(programIdStr);
-
-    // Escrow PDA seeds: ["escrow", agent, serviceId]
-    const [escrowPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('escrow'), payer.publicKey.toBuffer(), serviceId],
-      programId,
-    );
-
-    const agentAta = await getAssociatedTokenAddress(USDC_MINT, payer.publicKey);
-    const vaultAta = await getAssociatedTokenAddress(USDC_MINT, escrowPda, true);
-
     const connection = mustConnection();
     const [{ blockhash }, currentSlot] = await Promise.all([
       connection.getLatestBlockhash('finalized'),
       connection.getSlot('confirmed'),
     ]);
 
-    // Solana ~400ms/slot; floor to integer; minimum 10 slots.
-    const timeoutSlots = Math.max(Math.floor((maxTimeoutSeconds * 1000) / 400), 10);
-    const expirySlot = BigInt(currentSlot + timeoutSlots);
+    // Fail closed on a stub/genesis/reset node before computing an expiry from a
+    // near-zero base slot (which would be a dead-on-arrival deposit the gateway
+    // bounces — and the MCP standalone-deposit path would broadcast on-chain
+    // first). Parity with the canonical SDK `fetchCurrentSlot` MIN_PLAUSIBLE_SLOT
+    // check.
+    assertPlausibleSlot(currentSlot);
 
-    // Anchor instruction discriminator: sha256("global:deposit")[0:8]
-    const discriminator = createHash('sha256')
-      .update(Buffer.from('global:deposit', 'utf-8'))
-      .digest()
-      .subarray(0, 8);
+    // Expiry-slot bounds in lockstep with the four canonical SDKs and the
+    // gateway verifier: clamp the offset into [150, 10000] slots. The old
+    // signer-core code used a 10-slot floor with no upper clamp, which produced
+    // a dead-on-arrival escrow for any maxTimeoutSeconds < ~20 (the gateway
+    // rejects expiry_slot - current_slot < MIN_EXPIRY_BUFFER_SLOTS = 50).
+    const expirySlot = escrowExpirySlot(currentSlot, maxTimeoutSeconds);
 
-    const data = Buffer.concat([
-      discriminator,
-      u64LE(amount),
-      serviceId,
-      u64LE(expirySlot),
-    ]);
+    // bs58.decode returns the raw 32-byte blockhash the canonical builder needs
+    // (NOT the base58 string).
+    const recentBlockhash = bs58.decode(blockhash);
 
-    const ix: TransactionInstruction = {
-      programId,
-      keys: [
-        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
-        { pubkey: providerPubkey, isSigner: false, isWritable: false },
-        { pubkey: USDC_MINT, isSigner: false, isWritable: false },
-        { pubkey: escrowPda, isSigner: false, isWritable: true },
-        { pubkey: agentAta, isSigner: false, isWritable: true },
-        { pubkey: vaultAta, isSigner: false, isWritable: true },
-        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
-        { pubkey: ASSOCIATED_TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
-        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
-      ],
-      data,
-    };
+    // Byte-exact, golden-vector-pinned legacy-message builder (canonical layout
+    // the gateway verifier expects). NO v0 VersionedTransaction, NO raw
+    // instruction-order accounts — those were the wire-drift bug this replaces.
+    const depositTx = buildEscrowDepositTx({
+      keypair: payer,
+      providerWalletB58: providerWallet,
+      usdcMintB58: USDC_MINT.toBase58(),
+      escrowProgramIdB58: programIdStr,
+      amount,
+      serviceId: new Uint8Array(serviceId),
+      expirySlot,
+      recentBlockhash,
+    });
 
-    const message = new TransactionMessage({
-      payerKey: payer.publicKey,
-      recentBlockhash: blockhash,
-      instructions: [ix],
-    }).compileToV0Message();
-
-    const tx = new VersionedTransaction(message);
-    tx.sign([payer]);
-
-    return {
-      depositTx: Buffer.from(tx.serialize()).toString('base64'),
-      agentPubkey,
-    };
+    return { depositTx, agentPubkey };
   } catch (err) {
     if (err instanceof SigningError) throw err;
     throw new SigningError(
@@ -430,14 +421,4 @@ function mustConnection(): Connection {
     );
   }
   return new Connection(rpcUrl, 'confirmed');
-}
-
-/** Encode a u64 as 8-byte little-endian. Avoids `BigInt64Array` for older Node. */
-function u64LE(value: bigint): Buffer {
-  const buf = Buffer.allocUnsafe(8);
-  const low = Number(value & 0xffffffffn);
-  const high = Number((value >> 32n) & 0xffffffffn);
-  buf.writeUInt32LE(low, 0);
-  buf.writeUInt32LE(high, 4);
-  return buf;
 }

--- a/sdks/signer-core/tests/escrow.test.ts
+++ b/sdks/signer-core/tests/escrow.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Golden-vector + expiry-clamp tests for signer-core's escrow deposit builder.
+ *
+ * signer-core is the shared signer behind the MCP server, OpenClaw provider,
+ * and AI SDK provider. Before this test existed it built a v0
+ * VersionedTransaction with raw instruction-order accounts — which does NOT
+ * match the byte-exact, writability-sorted legacy-message layout the gateway
+ * verifier expects (and that the canonical Rust/Go/Python/TS SDKs pin).
+ *
+ * Golden-vector parity IS the contract: `buildEscrowDepositTx` MUST reproduce
+ * `crates/escrow-tx/src/deposit.rs`'s GOLDEN_VECTOR_B64 byte-for-byte for the
+ * fixed input. If it diverges, the on-chain layout disagreement is a
+ * fund-misdirection bug — fix the builder, NEVER edit the expected golden
+ * value (the Rust/on-chain value is ground truth). Mirrors
+ * sdks/typescript/tests/unit/escrow.test.ts, sdks/go/escrow_test.go, and
+ * sdks/python/tests/unit/test_escrow.py.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { Keypair } from '@solana/web3.js';
+
+import {
+  buildEscrowDepositTx,
+  escrowExpirySlot,
+  anchorDiscriminator,
+  GOLDEN_VECTOR_B64,
+  MIN_ESCROW_EXPIRY_SLOTS_AHEAD,
+  MAX_ESCROW_EXPIRY_SLOTS_AHEAD,
+  MIN_PLAUSIBLE_SLOT,
+  assertPlausibleSlot,
+  type EscrowDepositParams,
+} from '../src/escrow.ts';
+import { SigningError } from '../src/sign.ts';
+
+// ---------------------------------------------------------------------------
+// Golden fixture — identical to the Rust/Go/Python/TS golden vector input.
+// Agent keypair from seed [42; 32], provider
+// 9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM, USDC mint
+// EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v, program
+// 9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU, service_id=[7; 32],
+// expiry_slot=1_000_750, recent_blockhash=[0xAB; 32], amount=2625.
+// ---------------------------------------------------------------------------
+
+const GOLDEN_PROVIDER = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
+const GOLDEN_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const GOLDEN_ESCROW_PROGRAM = '9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU';
+
+function goldenKeypair(): Keypair {
+  return Keypair.fromSeed(new Uint8Array(32).fill(42));
+}
+
+function goldenParams(): EscrowDepositParams {
+  return {
+    keypair: goldenKeypair(),
+    providerWalletB58: GOLDEN_PROVIDER,
+    usdcMintB58: GOLDEN_USDC_MINT,
+    escrowProgramIdB58: GOLDEN_ESCROW_PROGRAM,
+    amount: 2625,
+    serviceId: new Uint8Array(32).fill(7),
+    expirySlot: 1_000_750,
+    recentBlockhash: new Uint8Array(32).fill(0xab),
+  };
+}
+
+describe('signer-core escrow deposit golden vector (byte-exact parity)', () => {
+  it('reproduces the canonical Rust/Go/Python/TS golden vector byte-for-byte', () => {
+    const out = buildEscrowDepositTx(goldenParams());
+    // NEVER edit GOLDEN_VECTOR_B64 to match this output. The on-chain layout is
+    // ground truth — if this diverges, the fix is in the builder.
+    assert.equal(out, GOLDEN_VECTOR_B64);
+  });
+
+  it('is deterministic for identical fixed input (no nonce, no clock)', () => {
+    assert.equal(buildEscrowDepositTx(goldenParams()), buildEscrowDepositTx(goldenParams()));
+  });
+
+  it('decodes to compact-u16(1) || sig(64) || message', () => {
+    const raw = Buffer.from(GOLDEN_VECTOR_B64, 'base64');
+    assert.equal(raw[0], 0x01);
+    assert.ok(raw.length > 1 + 64);
+  });
+});
+
+describe('signer-core escrow golden vector drift guard', () => {
+  // The signer-core escrow golden constant MUST equal the Rust source of truth.
+  // If the Rust GOLDEN_VECTOR_B64 ever changes, the on-chain wire layout changed
+  // and this test fails loudly, forcing a resync rather than silent divergence.
+  it('signer-core escrow golden constant matches the Rust source of truth', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // tests/escrow.test.ts -> worktree root is ../../../ from here.
+    const rustSrc = resolve(here, '../../../crates/escrow-tx/src/deposit.rs');
+    const text = readFileSync(rustSrc, 'utf-8');
+    const m = text.match(/GOLDEN_VECTOR_B64:\s*&str\s*=\s*"([^"]+)"/);
+    assert.ok(m, 'could not locate GOLDEN_VECTOR_B64 in crates/escrow-tx/src/deposit.rs');
+    assert.equal(m![1], GOLDEN_VECTOR_B64);
+  });
+});
+
+describe('signer-core escrow deposit derivation parity', () => {
+  it('anchorDiscriminator is deterministic and distinct per instruction', () => {
+    assert.deepEqual(anchorDiscriminator('deposit'), anchorDiscriminator('deposit'));
+    assert.notDeepEqual(anchorDiscriminator('deposit'), anchorDiscriminator('claim'));
+  });
+
+  it('the deposit tx embeds the deposit discriminator', () => {
+    const raw = Buffer.from(buildEscrowDepositTx(goldenParams()), 'base64');
+    const disc = Buffer.from(anchorDiscriminator('deposit'));
+    assert.ok(raw.includes(disc));
+  });
+
+  it('the deposit tx embeds the agent pubkey', () => {
+    const params = goldenParams();
+    const agentPubkey = Buffer.from(params.keypair.publicKey.toBytes());
+    const raw = Buffer.from(buildEscrowDepositTx(params), 'base64');
+    assert.ok(raw.includes(agentPubkey));
+  });
+});
+
+describe('signer-core escrow deposit fail-closed amount guards', () => {
+  it('rejects zero amount', () => {
+    assert.throws(() => buildEscrowDepositTx({ ...goldenParams(), amount: 0 }), SigningError);
+  });
+
+  it('rejects a negative amount', () => {
+    assert.throws(() => buildEscrowDepositTx({ ...goldenParams(), amount: -1 }), /greater than zero|integer/);
+  });
+
+  it('rejects a non-integer (float) amount', () => {
+    assert.throws(() => buildEscrowDepositTx({ ...goldenParams(), amount: 2625.5 }), /integer/);
+  });
+
+  it('rejects a NaN amount', () => {
+    assert.throws(() => buildEscrowDepositTx({ ...goldenParams(), amount: Number.NaN }), /integer/);
+  });
+
+  it('rejects an amount above the safe-integer range', () => {
+    assert.throws(
+      () => buildEscrowDepositTx({ ...goldenParams(), amount: Number.MAX_SAFE_INTEGER + 2 }),
+      /safe-integer|integer/,
+    );
+  });
+});
+
+describe('signer-core escrow deposit fail-closed expiry-slot guards', () => {
+  it('rejects a zero expiry slot', () => {
+    assert.throws(() => buildEscrowDepositTx({ ...goldenParams(), expirySlot: 0 }), SigningError);
+  });
+
+  it('rejects a negative expiry slot', () => {
+    assert.throws(() => buildEscrowDepositTx({ ...goldenParams(), expirySlot: -1 }), /integer/);
+  });
+
+  it('rejects a non-integer expiry slot', () => {
+    assert.throws(() => buildEscrowDepositTx({ ...goldenParams(), expirySlot: 1.5 }), /integer/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expiry clamp parity with the four canonical SDKs (FINDING 2).
+// [MIN_ESCROW_EXPIRY_SLOTS_AHEAD=150, MAX_ESCROW_EXPIRY_SLOTS_AHEAD=10000]
+// floor/cap, MIN_PLAUSIBLE_SLOT=1_000_000 fail-closed plausibility check.
+// Ported verbatim from sdks/typescript/src/signer.ts (and rust/go/python).
+// ---------------------------------------------------------------------------
+
+describe('signer-core escrowExpirySlot clamp (parity with canonical SDKs)', () => {
+  it('exposes the canonical constants', () => {
+    assert.equal(MIN_ESCROW_EXPIRY_SLOTS_AHEAD, 150);
+    assert.equal(MAX_ESCROW_EXPIRY_SLOTS_AHEAD, 10_000);
+    assert.equal(MIN_PLAUSIBLE_SLOT, 1_000_000);
+  });
+
+  it('clamps a below-floor timeout up to the 150-slot floor', () => {
+    // maxTimeoutSeconds = 10 -> 10*1000/400 = 25 slots -> floored to 150.
+    const slot = escrowExpirySlot(5_000_000, 10);
+    assert.equal(slot, 5_000_000 + MIN_ESCROW_EXPIRY_SLOTS_AHEAD);
+  });
+
+  it('floors a tiny timeout (< floor) — the dead-on-arrival case the old code shipped', () => {
+    // maxTimeoutSeconds = 1 -> 2 slots in the old signer-core code (Math.max(.., 10)
+    // would even give 10) — both below the gateway's 50-slot reject threshold.
+    // The canonical clamp lifts it to 150.
+    assert.equal(escrowExpirySlot(5_000_000, 1), 5_000_000 + MIN_ESCROW_EXPIRY_SLOTS_AHEAD);
+  });
+
+  it('caps an above-ceiling timeout down to the 10000-slot ceiling', () => {
+    // maxTimeoutSeconds = 100000 -> 250000 slots -> capped to 10000.
+    const slot = escrowExpirySlot(5_000_000, 100_000);
+    assert.equal(slot, 5_000_000 + MAX_ESCROW_EXPIRY_SLOTS_AHEAD);
+  });
+
+  it('uses the raw offset when it falls inside the band', () => {
+    // maxTimeoutSeconds = 1000 -> 2500 slots, within [150, 10000].
+    const slot = escrowExpirySlot(5_000_000, 1000);
+    assert.equal(slot, 5_000_000 + 2500);
+  });
+
+  it('floors a negative timeout to 0 then clamps to the 150-slot floor', () => {
+    assert.equal(escrowExpirySlot(5_000_000, -42), 5_000_000 + MIN_ESCROW_EXPIRY_SLOTS_AHEAD);
+  });
+});
+
+describe('signer-core escrow slot plausibility (fail-closed)', () => {
+  it('accepts a plausible mainnet slot', () => {
+    assert.doesNotThrow(() => assertPlausibleSlot(5_000_000));
+  });
+
+  it('rejects a slot below MIN_PLAUSIBLE_SLOT (stub/genesis node)', () => {
+    assert.throws(() => assertPlausibleSlot(42), /implausibly low slot|MIN_PLAUSIBLE_SLOT|refusing/);
+  });
+
+  it('rejects a slot exactly one below the floor', () => {
+    assert.throws(() => assertPlausibleSlot(MIN_PLAUSIBLE_SLOT - 1), SigningError);
+  });
+
+  it('accepts a slot exactly at the floor', () => {
+    assert.doesNotThrow(() => assertPlausibleSlot(MIN_PLAUSIBLE_SLOT));
+  });
+
+  it('rejects a NaN / non-finite slot', () => {
+    assert.throws(() => assertPlausibleSlot(Number.NaN), SigningError);
+  });
+});

--- a/sdks/signer-core/tests/escrow.test.ts
+++ b/sdks/signer-core/tests/escrow.test.ts
@@ -158,6 +158,35 @@ describe('signer-core escrow deposit fail-closed expiry-slot guards', () => {
   it('rejects a non-integer expiry slot', () => {
     assert.throws(() => buildEscrowDepositTx({ ...goldenParams(), expirySlot: 1.5 }), /integer/);
   });
+
+  // FINDING B (audit 2026-06-08): a non-finite expiry_slot must fail closed as a
+  // SigningError, not leak a raw `RangeError: The number ... cannot be converted
+  // to a BigInt` out of `BigInt(Infinity)`/`BigInt(NaN)` in `u64LE`. The guard is
+  // in `assertValidExpirySlot` (Number.isSafeInteger rejects both).
+  it('rejects an Infinity expiry slot (fail closed, not a raw BigInt RangeError)', () => {
+    assert.throws(
+      () => buildEscrowDepositTx({ ...goldenParams(), expirySlot: Number.POSITIVE_INFINITY }),
+      SigningError,
+    );
+  });
+
+  it('rejects a NaN expiry slot', () => {
+    assert.throws(
+      () => buildEscrowDepositTx({ ...goldenParams(), expirySlot: Number.NaN }),
+      SigningError,
+    );
+  });
+
+  // FINDING C (audit 2026-06-08): expiry_slot parity with assertValidAmount —
+  // values above MAX_SAFE_INTEGER don't round-trip through an IEEE-754 double and
+  // cannot encode faithfully into the on-chain u64, so reject them like the amount
+  // guard does (Number.isSafeInteger, not Number.isInteger).
+  it('rejects an expiry slot above MAX_SAFE_INTEGER (safe-integer parity with amount)', () => {
+    assert.throws(
+      () => buildEscrowDepositTx({ ...goldenParams(), expirySlot: Number.MAX_SAFE_INTEGER + 2 }),
+      /safe-integer|integer/,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -201,6 +230,26 @@ describe('signer-core escrowExpirySlot clamp (parity with canonical SDKs)', () =
 
   it('floors a negative timeout to 0 then clamps to the 150-slot floor', () => {
     assert.equal(escrowExpirySlot(5_000_000, -42), 5_000_000 + MIN_ESCROW_EXPIRY_SLOTS_AHEAD);
+  });
+
+  // FINDING B (audit 2026-06-08): escrowExpirySlot is a public export. Before the
+  // guard it silently returned NaN for a NaN timeout (Math.max(NaN, 0) = NaN) and
+  // silently clamped Infinity to the 10000-slot ceiling — both hiding a real input
+  // error on a value path. Fail closed on a non-finite timeout instead. The
+  // canonical signers never feed it a non-integer (Rust u64 / Go int reject at
+  // deserialization, the canonical TS signer rejects with !Number.isInteger), so
+  // this guard only ever fires on a genuinely malformed input.
+  it('throws on a NaN timeout (was: silently returned NaN)', () => {
+    assert.throws(() => escrowExpirySlot(5_000_000, Number.NaN), SigningError);
+  });
+
+  it('throws on an Infinity timeout (was: silently clamped to the ceiling)', () => {
+    assert.throws(() => escrowExpirySlot(5_000_000, Number.POSITIVE_INFINITY), SigningError);
+  });
+
+  it('throws on a non-finite currentSlot', () => {
+    assert.throws(() => escrowExpirySlot(Number.NaN, 300), SigningError);
+    assert.throws(() => escrowExpirySlot(Number.POSITIVE_INFINITY, 300), SigningError);
   });
 });
 

--- a/sdks/signer-core/tests/parse-402.test.ts
+++ b/sdks/signer-core/tests/parse-402.test.ts
@@ -146,6 +146,30 @@ describe('parse402', () => {
       }
     });
 
+    // FINDING A (audit 2026-06-08): `max_timeout_seconds` is integer-only on the
+    // wire — Rust deserializes it as `u64`, Go as `int`, so a fractional value
+    // never reaches those signers. The valibot schema now enforces `integer()`
+    // so signer-core rejects it at the same parse boundary rather than relying
+    // solely on the downstream signer guard.
+    it('throws on a fractional max_timeout_seconds (integer-only wire field)', () => {
+      const body = {
+        ...validDirectBody,
+        accepts: [{ ...validDirectBody.accepts[0], max_timeout_seconds: 30.5 }],
+      };
+      assert.throws(
+        () => parse402(JSON.stringify(body)),
+        /accepts\[0\]/,
+      );
+    });
+
+    it('accepts an integer max_timeout_seconds (the canonical wire value)', () => {
+      const body = {
+        ...validDirectBody,
+        accepts: [{ ...validDirectBody.accepts[0], max_timeout_seconds: 60 }],
+      };
+      assert.doesNotThrow(() => parse402(JSON.stringify(body)));
+    });
+
     it('reports the index of the first invalid accepts element', () => {
       const body = {
         ...validDirectBody,

--- a/sdks/signer-core/tests/sign.test.ts
+++ b/sdks/signer-core/tests/sign.test.ts
@@ -10,6 +10,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
+import { Keypair } from '@solana/web3.js';
+import bs58 from 'bs58';
+
 import {
   createPaymentHeader,
   decodePaymentHeader,
@@ -173,6 +176,62 @@ describe('createPaymentHeader (escrow, stub mode)', () => {
     // 32 bytes -> 44 base64 chars with padding
     assert.equal(serviceId.length, 44);
     assert.match(serviceId, /^[A-Za-z0-9+/]+={0,2}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Header construction (escrow scheme, real-key — max_timeout_seconds boundary)
+//
+// FINDING A (audit 2026-06-08): `buildEscrowDeposit` validates the untrusted
+// `max_timeout_seconds` from the 402 with `!Number.isInteger`. We REJECT a
+// fractional timeout to stay consistent with the four canonical SDK signers:
+//   - Rust: `PaymentAccept.max_timeout_seconds: u64` — a JSON 30.5 fails serde
+//     deserialization, never reaching the signer (integer-only at the wire).
+//   - Go:   `MaxTimeoutSeconds int` — a JSON 30.5 fails json.Unmarshal into int.
+//   - TS (canonical, sdks/typescript/src/signer.ts): explicit
+//     `if (!Number.isInteger(accepted.maxTimeoutSeconds)) throw`.
+// (Python alone tolerates a float only via an unenforced `: int` annotation — an
+// unintended latent gap, NOT the contract.) Accepting + flooring a fractional
+// timeout here would make signer-core a fourth, divergent behavior; rejecting is
+// the canonical-consistent, fail-closed choice. The valibot schema additionally
+// rejects a non-integer `max_timeout_seconds` at the parse boundary (see
+// schema.test.ts), mirroring the Rust/Go structural integer constraint; this
+// signer-side guard is defense-in-depth for callers that bypass the parser.
+//
+// The check runs BEFORE any RPC/key work, so this test needs no SOLANA_RPC_URL:
+// the timeout rejection fires before `mustConnection()`.
+// ---------------------------------------------------------------------------
+
+describe('createPaymentHeader (escrow, real-key max_timeout_seconds boundary)', () => {
+  // A real, well-formed bs58 secret key — required to reach `buildEscrowDeposit`
+  // (the privateKey-supplied path). No secret material of value: a throwaway
+  // keypair generated per run.
+  const privateKeyB58 = bs58.encode(Keypair.generate().secretKey);
+
+  it('rejects a fractional max_timeout_seconds (parity with Rust u64 / Go int / canonical TS)', async () => {
+    const fractional: PaymentRequired = {
+      ...escrowPaymentRequired,
+      accepts: [{ ...escrowPaymentRequired.accepts[0], max_timeout_seconds: 30.5 }],
+    };
+    await assert.rejects(
+      () => createPaymentHeader(fractional, RESOURCE_URL, privateKeyB58, '{}'),
+      (err: unknown) => {
+        assert.ok(err instanceof SigningError, 'must be a SigningError');
+        assert.match((err as SigningError).message, /finite integer|max_timeout_seconds/);
+        return true;
+      },
+    );
+  });
+
+  it('rejects a NaN max_timeout_seconds (fail closed before RPC)', async () => {
+    const nan: PaymentRequired = {
+      ...escrowPaymentRequired,
+      accepts: [{ ...escrowPaymentRequired.accepts[0], max_timeout_seconds: Number.NaN }],
+    };
+    await assert.rejects(
+      () => createPaymentHeader(nan, RESOURCE_URL, privateKeyB58, '{}'),
+      SigningError,
+    );
   });
 });
 


### PR DESCRIPTION
## What

Fixes two confirmed **HIGH** money-path findings from the 2026-06-08 security audit (Scope 5) in `@solvela/signer-core` — the shared signer used by the `mcp`, `openclaw-provider`, and `ai-sdk-provider` JS consumers. Both made escrow deposits **silently undeliverable** (built wrong / dead-on-arrival, broadcast anyway).

1. **Wire drift** — `buildEscrowDeposit` built a **v0 `VersionedTransaction`** with accounts in raw instruction order. web3.js re-derives its own ordering, so the bytes did not match the canonical writability-sorted **legacy** message the gateway verifier expects (the layout the Rust/Go/Python/TS SDKs pin to `GOLDEN_VECTOR_B64`). signer-core had **no golden-vector test**, so the drift was invisible.
2. **Expiry drift** — expiry used a 10-slot floor, no cap, no plausibility check. The gateway rejects `expiry_slot − current_slot < 50`, so any `maxTimeoutSeconds < ~20` was dead-on-arrival — and the mcp standalone-deposit path broadcasts on-chain *before* the gateway bounces it.

## Fix

- **`src/escrow.ts` (new)** — faithful port of the canonical builder from `sdks/typescript/src/escrow.ts`: manual writability-sorted legacy message (account order `[0,4,5,1,2,3,6,7,8]`, header `[1,0,6]`), raw-ed25519 signing over the serialized message bytes. Plus `escrowExpirySlot` (`[150, 10000]` clamp) + `MIN_PLAUSIBLE_SLOT = 1_000_000` + `assertPlausibleSlot`, ported verbatim from `sdks/typescript/src/signer.ts`.
- **`src/sign.ts`** — escrow path now uses the canonical builder, runs `assertPlausibleSlot(currentSlot)` (fail-closed), and clamps expiry. The v0/raw-account inline builder is removed.
- **Ported, not imported** — signer-core is deliberately self-contained (no `@solvela/sdk` dep, to avoid a dead workspace dep on the wire-incompatible published SDK). A **drift-guard test** against `crates/escrow-tx/src/deposit.rs` is the forcing function against future skew.

## Tests

`tests/escrow.test.ts` — 26 cases: **byte-exact golden-vector parity** (matches the canonical Rust/Go/Python/TS `Ad449R7…` vector), drift guard vs the Rust source of truth, expiry-clamp boundaries, fail-closed slot/amount guards. Full suite **115/115**, `tsc --noEmit` clean.

## Review

Two-round money-path gate — `typescript-reviewer` + `silent-failure-hunter`, both **SHIP-WITH-NITS**, no Critical/High. The two original silent-failure bugs are confirmed fixed and fail-closed.

## Follow-ups (NOT in this PR — logged to the audit register)

- **LOW** defense-in-depth: add an explicit `> MAX_SAFE_INTEGER` bigint guard before the `Number()` amount conversion in `buildEscrowDeposit` so the error surfaces at the parse boundary (already caught downstream by `assertValidAmount`; this is purely about *where* it throws).
- **MED, pre-existing** (`createPaymentHeader`, not touched here): when an escrow `accept` has a falsy `escrow_program_id`, selection silently falls through to exact instead of erroring — needs verification against the "no silent scheme fallback" invariant.

## ⚠️ Before merge

Run the **cross-repo staging smoke matrix** — this changes byte-level escrow wire format for three downstream JS packages; the golden-vector test proves parity against the pinned vector, but an end-to-end deposit→verify against a live gateway is the final gate.