### PR TITLE
docs: remove license quick-reference block

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,14 +473,6 @@ Solvela uses a **per-component license split**. Pick the license of the piece yo
 | **SDKs** (`sdks/*`) | [Apache-2.0](./LICENSE-APACHE) | Client libraries. The patent grant matters here — the SDKs build and broadcast USDC transactions. |
 | **Dashboard / docs site** (`dashboard/`) | [Apache-2.0](./LICENSE-APACHE) | Front-end. |
 
-### Quick reference
-
-- **You're a developer using Solvela's hosted gateway at `api.solvela.ai`** → no license obligations on you, just use it.
-- **You're self-hosting the gateway internally for your own product** → free under the Additional Use Grant if your gross annual revenue attributable to the gateway is under USD $1M.
-- **You're building a competing managed gateway service from this code** → you need a commercial license. Contact `partnerships@solvela.ai`.
-- **Your annual revenue derived from the gateway will exceed USD $1M** → you need a commercial license. Contact `partnerships@solvela.ai`.
-- **You're embedding the SDK or building on top of the protocol/router crates** → standard Apache-2.0 obligations apply (preserve copyright/NOTICE attribution, state significant changes, no warranty). You receive an explicit patent grant. No payment to Solvela required.
-
 ### Trademark
 
 "Solvela" and the Solvela logo are trademarks of the Solvela Contributors. The licenses above grant code rights only — they do not grant trademark rights. If you fork the gateway and run it yourself, please rename it.

--- a/dashboard/content/docs/enterprise/commercial-license.mdx
+++ b/dashboard/content/docs/enterprise/commercial-license.mdx
@@ -20,7 +20,7 @@ The **Solvela Gateway** (the `gateway` crate and the `solvela-gateway` binary) i
 
 ## You **do** need a commercial license if…
 
-- You offer the gateway, or a derivative of it, as a **hosted, managed, or software-as-a-service offering to third parties**. (Building a competing managed gateway service from this code is the textbook BSL trigger.)
+- You offer the gateway, or a derivative of it, as a **hosted, managed, or software-as-a-service offering to third parties**.
 - Your gross annual revenue derived from or attributable to the gateway exceeds **USD $1,000,000**.
 - You want to remove or modify the BSL terms before the [Change Date](https://github.com/solvela-ai/solvela/blob/main/LICENSE) (2030-05-02 for v0.2.x, after which the gateway becomes MIT automatically).
 


### PR DESCRIPTION
## What

Removes the informal license-guidance restatements, leaving the authoritative license table and BSL terms intact.

- **README.md** — drops the entire `### Quick reference` section (5 bullets: hosted-user, internal self-host under \$1M, competing managed service, >\$1M revenue, SDK/Apache embedding).
- **dashboard/content/docs/enterprise/commercial-license.mdx** — drops the parenthetical "(Building a competing managed gateway service from this code is the textbook BSL trigger.)" from the "You **do** need a commercial license if…" bullet.

## Why

Per request — remove the restated quick-reference licensing guidance from the repo. The license table, the Additional Use Grant, and the BSL rule bullets are unchanged; only the informal duplicated guidance is removed.

## Scope

Docs-only. No code, config, or license-text changes.