### PR TITLE
docs(readme): reference solvela-pg Postgres app (was solvela-db)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Solvela is deployed on Fly.io:
 | Resource | URL / Name |
 |----------|------------|
 | Gateway | `api.solvela.ai` (Fly app: `solvela-gateway`) |
-| PostgreSQL | `solvela-db` (Fly Postgres 17.2) |
+| PostgreSQL | `solvela-pg` (Fly Postgres 17.2) |
 | Redis | `solvela-cache` (Upstash, ord + iad) |
 
 ```bash


### PR DESCRIPTION
## Summary
- The production Postgres app was migrated to a new Fly.io org and is now named `solvela-pg` (Postgres can't move between orgs, so it was dump/restored into a fresh cluster). Update the deployment table to match the live app name.

## Test plan
- [x] `grep -n solvela-db README.md` returns no remaining references