### PR TITLE
feat(router): make Gemini 3.1 Flash-Lite the free-tier model

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ The 402 response includes a `cost_breakdown` with per-token pricing, estimated t
 
 All prices are provider cost in USDC. A 5% platform fee is applied on top. See `config/models.toml` for the full registry or query `GET /pricing` at runtime.
 
+> **Free-tier data-use notice.** `gemini-3.1-flash-lite` is the `free` profile's model and is served via Google's **free** Gemini API tier. On that tier Google may use submitted prompts and generated responses to improve its products, and human reviewers may read, annotate, and process them — do not send sensitive data through the free tier. The free tier is also rate-limited (~15 requests/min, shared per gateway key), so treat it as a demo/evaluation tier rather than a model to build production load on. Paid models on this list are not subject to that data-use policy.
+
 ---
 
 ## API Endpoints

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The 402 response includes a `cost_breakdown` with per-token pricing, estimated t
 | Anthropic | `claude-sonnet-4-6` | $3.00 | $15.00 | 200K |
 | Anthropic | `claude-sonnet-4-5-20250929` | $3.00 | $15.00 | 200K |
 | Anthropic | `claude-haiku-4-5-20251001` | $1.00 | $5.00 | 200K |
+| Google | `gemini-3.1-flash-lite` | Free | Free | 1M |
 | Google | `gemini-3.1-pro` | $2.00 | $12.00 | 1M |
 | Google | `gemini-2.5-flash` | $0.30 | $2.50 | 1M |
 | Google | `gemini-2.5-flash-lite` | $0.10 | $0.40 | 1M |

--- a/config/models.toml
+++ b/config/models.toml
@@ -120,6 +120,17 @@ output_cost_per_million = 0.40
 context_window = 1000000
 supports_streaming = true
 
+[models.google-gemini-3-1-flash-lite]
+provider = "google"
+model_id = "gemini-3.1-flash-lite"
+display_name = "Gemini 3.1 Flash-Lite (Free)"
+input_cost_per_million = 0.0
+output_cost_per_million = 0.0
+context_window = 1000000
+supports_streaming = true
+supports_tools = true
+supports_vision = true
+
 # --- DeepSeek ---
 
 [models.deepseek-chat]

--- a/crates/router/src/profiles.rs
+++ b/crates/router/src/profiles.rs
@@ -77,10 +77,10 @@ pub fn resolve_model(profile: Profile, tier: Tier) -> &'static str {
         (Profile::Premium, Tier::Reasoning) => "openai/o3",
 
         // FREE: only free-tier models
-        (Profile::Free, Tier::Simple) => "openai/gpt-oss-120b",
-        (Profile::Free, Tier::Medium) => "openai/gpt-oss-120b",
-        (Profile::Free, Tier::Complex) => "openai/gpt-oss-120b",
-        (Profile::Free, Tier::Reasoning) => "openai/gpt-oss-120b",
+        (Profile::Free, Tier::Simple) => "google/gemini-3.1-flash-lite",
+        (Profile::Free, Tier::Medium) => "google/gemini-3.1-flash-lite",
+        (Profile::Free, Tier::Complex) => "google/gemini-3.1-flash-lite",
+        (Profile::Free, Tier::Reasoning) => "google/gemini-3.1-flash-lite",
     }
 }
 
@@ -101,7 +101,7 @@ pub fn resolve_alias(alias: &str) -> Option<&'static str> {
         "grok" | "grok-fast" => Some("xai/grok-4-fast-reasoning"),
         "deepseek" | "ds" => Some("deepseek/deepseek-chat"),
         "deepseek-r" | "reasoner" => Some("deepseek/deepseek-reasoner"),
-        "free" | "oss" => Some("openai/gpt-oss-120b"),
+        "free" | "oss" => Some("google/gemini-3.1-flash-lite"),
         "o3-mini" | "o3mini" => Some("openai/o3-mini"),
         "o4-mini" | "o4mini" => Some("openai/o4-mini"),
         "gpt4.1" | "gpt-4.1" | "gpt41" => Some("openai/gpt-4.1"),
@@ -143,7 +143,7 @@ mod tests {
     fn test_resolve_model() {
         assert_eq!(
             resolve_model(Profile::Free, Tier::Reasoning),
-            "openai/gpt-oss-120b"
+            "google/gemini-3.1-flash-lite"
         );
         assert_eq!(
             resolve_model(Profile::Premium, Tier::Reasoning),
@@ -152,6 +152,51 @@ mod tests {
         assert_eq!(
             resolve_model(Profile::Auto, Tier::Simple),
             "google/gemini-2.5-flash"
+        );
+    }
+
+    /// The free tier maps EVERY complexity tier to the canonical Gemini 3.1
+    /// Flash-Lite key. Pins the 2026-06 repoint off `openai/gpt-oss-120b`
+    /// (which was never served free by OpenAI's API) onto Google's free-tier
+    /// model. The companion `every_alias_and_profile_tier_resolves_to_a_registered_model`
+    /// test guarantees this key is registered in `config/models.toml`.
+    #[test]
+    fn free_profile_every_tier_resolves_to_gemini_flash_lite() {
+        for tier in [Tier::Simple, Tier::Medium, Tier::Complex, Tier::Reasoning] {
+            assert_eq!(
+                resolve_model(Profile::Free, tier),
+                "google/gemini-3.1-flash-lite",
+                "Profile::Free tier {tier:?} must route to the free Gemini model"
+            );
+        }
+    }
+
+    /// The `free` / `oss` aliases resolve to the same canonical free-tier key
+    /// as `Profile::Free`. Guards against the alias and the profile drifting
+    /// apart (which would silently route alias users to a different model).
+    #[test]
+    fn free_and_oss_aliases_resolve_to_gemini_flash_lite() {
+        assert_eq!(resolve_alias("free"), Some("google/gemini-3.1-flash-lite"));
+        assert_eq!(resolve_alias("oss"), Some("google/gemini-3.1-flash-lite"));
+        // Alias and profile must agree on the free-tier target.
+        assert_eq!(
+            resolve_alias("free"),
+            Some(resolve_model(Profile::Free, Tier::Simple))
+        );
+    }
+
+    /// The free-tier model key MUST exist in the production `config/models.toml`
+    /// registry. A repoint that named an unregistered model would 500 every
+    /// free-tier request at the registry lookup (the same class of bug the
+    /// `haiku` alias previously had).
+    #[test]
+    fn free_tier_model_is_registered_in_models_toml() {
+        let toml_str = include_str!("../../../config/models.toml");
+        let registry = crate::models::ModelRegistry::from_toml(toml_str)
+            .expect("config/models.toml must parse");
+        assert!(
+            registry.get("google/gemini-3.1-flash-lite").is_some(),
+            "the free-tier model google/gemini-3.1-flash-lite must be in models.toml"
         );
     }
 


### PR DESCRIPTION
## What

Repoints Solvela's free tier from `openai/gpt-oss-120b` to **`google/gemini-3.1-flash-lite`** — Google's genuinely-\$0 free-tier model, served through the existing Google adapter (no new provider code).

- `Profile::Free` (all four tiers) → `google/gemini-3.1-flash-lite`
- `free` / `oss` aliases → same canonical key
- New `[models.google-gemini-3-1-flash-lite]` registry entry (0.0/0.0, 1M context, streaming/tools/vision)
- README model table row added

## Why

`openai/gpt-oss-120b` was priced 0.0/0.0 with `provider = "openai"`, but **OpenAI does not serve gpt-oss free via its API** — so the free tier was either silently failing or silently subsidizing inference from the gateway wallet. Gemini 3.1 Flash-Lite is genuinely \$0 on Google's free tier and reachable via the adapter we already ship.

## gpt-oss-120b entry: retained, not removed

It's referenced by SDK codegen drift guards (`sdks/ai-sdk-provider` byte-identical drift test + `EXPECTED_COUNT`, `sdks/openclaw-provider`, `sdks/rust`). Removing it is a 4-package cross-repo change (exactly the wire-contract drift the project guards against), so it's deferred to a separate scoped PR. It's no longer the free default — only reachable by explicit model id, which neutralizes the silent-subsidy/silent-fail concern.

## Money path

\$0 pricing verified clean: `5% of 0 = 0`, no divide-by-zero / NaN / fail-closed rejection (the only division is by the literal `1_000_000`). Pinned by existing zero-token cost tests.

## Tests

Adds 3 router guard tests (every Free tier → new key; free/oss aliases agree with profile; key registered in `config/models.toml`). The pre-existing alias↔registry cross-check now exercises the new key.

- `cargo fmt --all`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test -p solvela-router`: 22 passed
- `cargo test -p gateway --lib`: 720 passed (1 ignored)
- `cargo test -p gateway --test integration`: 173 passed

## ⚠️ Operator notes (not blocking, follow-ups)

1. **Data-use caveat:** Gemini's free tier may use submitted prompts/responses to improve Google products, and human reviewers may read them. There's no field in `ModelRegistration`/`ModelInfo` to surface this — needs a docs note or a schema-field decision (the latter touches SDK codegen).
2. **Rate limit:** free tier is ~15 RPM, shared per API key. This is a demo/taste tier, not a scalable serving tier; per-request rate limiting for the free model should land before promoting it widely.