### PR TITLE
feat(gateway): zero-cost free-tier bypass + per-IP anti-abuse rate limit

### DIFF
--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -117,6 +117,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         })
     }
 

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -876,6 +876,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         })
     }
 
@@ -1367,6 +1370,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         })
     }
 
@@ -1421,6 +1427,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: true,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         })
     }
 
@@ -1773,6 +1782,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         });
         Some((state, redis_client))
     }

--- a/crates/gateway/src/a2a/jsonrpc.rs
+++ b/crates/gateway/src/a2a/jsonrpc.rs
@@ -123,6 +123,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         });
 
         axum::Router::new()

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -104,6 +104,16 @@ pub struct AppState {
     /// When `true`, skip payment verification for chat requests (dev mode only).
     /// Always `false` in production — set via `SOLVELA_DEV_BYPASS_PAYMENT=true` (RCR_DEV_BYPASS_PAYMENT accepted as deprecated fallback).
     pub dev_bypass_payment: bool,
+    /// Per-client (IP) rate limiter for the **anonymous free-tier bypass** path.
+    ///
+    /// Distinct from the global outer-layer limiter (wired in `build_router`):
+    /// the outer limiter runs BEFORE model resolution and cannot know a request
+    /// is free, so the free-tier cap is enforced inside the chat handler on the
+    /// zero-cost branch only. Stricter default than the paid limit
+    /// ([`RateLimitConfig::free_default`]); override via
+    /// `SOLVELA_FREE_TIER_RATE_LIMIT`. Keyed on the TCP peer IP (never a
+    /// client-supplied header — GHSA-6ggq-cvwx-4f67).
+    pub free_rate_limiter: RateLimiter,
 }
 
 impl AppState {

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -527,10 +527,18 @@ async fn main() -> anyhow::Result<()> {
                     );
                     RateLimitConfig::free_default().max_requests
                 });
-                tracing::info!(max_requests = max, "Free-tier rate limit override from env");
-                RateLimitConfig {
-                    max_requests: max,
-                    ..RateLimitConfig::free_default()
+                if max == 0 {
+                    tracing::warn!(
+                        "SOLVELA_FREE_TIER_RATE_LIMIT=0 disables ALL free-tier access \
+                         (every free request would be rejected); using free-tier default instead"
+                    );
+                    RateLimitConfig::free_default()
+                } else {
+                    tracing::info!(max_requests = max, "Free-tier rate limit override from env");
+                    RateLimitConfig {
+                        max_requests: max,
+                        ..RateLimitConfig::free_default()
+                    }
                 }
             }
             Err(_) => RateLimitConfig::free_default(),

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -510,6 +510,33 @@ async fn main() -> anyhow::Result<()> {
         enabled
     };
 
+    // ── Free-tier (anonymous zero-cost bypass) rate limiter ────────────────────
+    //
+    // Enforced INSIDE the chat handler on the zero-cost branch only (the global
+    // outer-layer limiter runs before model resolution and can't tell a request
+    // is free). Stricter default than the paid limit; keyed on the TCP peer IP.
+    // Overridable via SOLVELA_FREE_TIER_RATE_LIMIT (RCR_ fallback for parity with
+    // the other rate-limit env vars).
+    let free_rate_limit_config =
+        match env_with_fallback("SOLVELA_FREE_TIER_RATE_LIMIT", "RCR_FREE_TIER_RATE_LIMIT") {
+            Ok(val) => {
+                let max: u32 = val.parse().unwrap_or_else(|_| {
+                    tracing::warn!(
+                        value = %val,
+                        "Invalid SOLVELA_FREE_TIER_RATE_LIMIT, using free-tier default"
+                    );
+                    RateLimitConfig::free_default().max_requests
+                });
+                tracing::info!(max_requests = max, "Free-tier rate limit override from env");
+                RateLimitConfig {
+                    max_requests: max,
+                    ..RateLimitConfig::free_default()
+                }
+            }
+            Err(_) => RateLimitConfig::free_default(),
+        };
+    let free_rate_limiter = RateLimiter::new(free_rate_limit_config);
+
     // Build shared state
     let state = Arc::new(AppState {
         config: app_config.clone(),
@@ -559,6 +586,7 @@ async fn main() -> anyhow::Result<()> {
         slot_cache: gateway::routes::escrow::new_slot_cache(),
         prometheus_handle,
         dev_bypass_payment,
+        free_rate_limiter: free_rate_limiter.clone(),
     });
 
     // ── Shutdown signal for background tasks ────────────────────────────────
@@ -754,6 +782,26 @@ async fn main() -> anyhow::Result<()> {
                 }
                 _ = rl_shutdown_rx.changed() => {
                     info!("rate limiter cleanup shutting down gracefully");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Periodic cleanup for the free-tier limiter (held in AppState). Same
+    // fixed-window eviction + graceful-shutdown contract as the paid limiter
+    // above, so the free-tier IP HashMap also stays bounded.
+    let mut free_rl_shutdown_rx = shutdown_rx.clone();
+    let free_rl_clone = free_rate_limiter.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    free_rl_clone.cleanup().await;
+                }
+                _ = free_rl_shutdown_rx.changed() => {
+                    info!("free-tier rate limiter cleanup shutting down gracefully");
                     break;
                 }
             }

--- a/crates/gateway/src/middleware/api_key.rs
+++ b/crates/gateway/src/middleware/api_key.rs
@@ -227,6 +227,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         })
     }
 

--- a/crates/gateway/src/middleware/rate_limit.rs
+++ b/crates/gateway/src/middleware/rate_limit.rs
@@ -1,15 +1,45 @@
 use std::collections::HashMap;
+use std::convert::Infallible;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::{
-    extract::Request,
+    extract::{ConnectInfo, FromRequestParts, Request},
+    http::request::Parts,
     http::StatusCode,
     middleware::Next,
     response::{IntoResponse, Response},
 };
 use tokio::sync::Mutex;
 use tracing::warn;
+
+/// Infallible extractor for the TCP peer address, for use in route handlers that
+/// need the actual connection IP (e.g. free-tier rate limiting) WITHOUT 500-ing
+/// when `ConnectInfo` is absent.
+///
+/// axum 0.8's `ConnectInfo<T>` only implements `FromRequestParts` (not
+/// `OptionalFromRequestParts`), so `Option<ConnectInfo<_>>` is not a valid
+/// extractor and a bare `ConnectInfo` would reject every request that lacks the
+/// extension — exactly the `oneshot` test path and any proxy-misconfig. This
+/// wrapper reads the same extension the middleware reads
+/// (`request.extensions().get::<ConnectInfo<SocketAddr>>()`) and yields `None`
+/// instead of failing. Pair with [`connect_info_client_id`] for keying.
+#[derive(Debug, Clone, Copy)]
+pub struct PeerAddr(pub Option<SocketAddr>);
+
+impl<S: Send + Sync> FromRequestParts<S> for PeerAddr {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(PeerAddr(
+            parts
+                .extensions
+                .get::<ConnectInfo<SocketAddr>>()
+                .map(|ci| ci.0),
+        ))
+    }
+}
 
 /// Configuration for the rate limiter.
 #[derive(Debug, Clone)]
@@ -43,6 +73,24 @@ impl RateLimitConfig {
             ..Self::default()
         }
     }
+
+    /// Default rate-limit budget for the anonymous **free-tier** bypass path.
+    ///
+    /// The zero-cost bypass serves requests with NO payer wallet, so abuse can
+    /// only be bounded by client IP. This default is intentionally STRICTER than
+    /// the paid `max_requests` (60/min): free requests get 5 per 60s window. The
+    /// `unknown` bucket (no `ConnectInfo`) is stricter still, matching the
+    /// default policy.
+    ///
+    /// Overridable via `SOLVELA_FREE_TIER_RATE_LIMIT` — see
+    /// [`with_max_requests`](Self::with_max_requests).
+    pub fn free_default() -> Self {
+        Self {
+            max_requests: 5,
+            window: Duration::from_secs(60),
+            unknown_max_requests: 2,
+        }
+    }
 }
 
 /// Per-client rate limit state.
@@ -70,6 +118,14 @@ impl RateLimiter {
             entries: Arc::new(Mutex::new(HashMap::new())),
             last_emergency_cleanup: Arc::new(tokio::sync::Mutex::new(None)),
         }
+    }
+
+    /// Read-only access to this limiter's config.
+    ///
+    /// Used by the free-tier in-handler path to build a matching 429 response
+    /// (limit/window headers) via [`rate_limited_response`].
+    pub fn config(&self) -> &RateLimitConfig {
+        &self.config
     }
 
     /// Check if a request from the given client should be allowed.
@@ -198,29 +254,7 @@ pub async fn rate_limit(request: Request, next: Next) -> Response {
             }
             Err(()) => {
                 warn!(client_id, "rate limit exceeded");
-                let reset_secs = limiter.config.window.as_secs();
-                let mut response = (
-                    StatusCode::TOO_MANY_REQUESTS,
-                    axum::Json(serde_json::json!({
-                        "error": {
-                            "type": "rate_limit_exceeded",
-                            "message": "Too many requests. Please slow down.",
-                        }
-                    })),
-                )
-                    .into_response();
-                let headers = response.headers_mut();
-                if let Ok(limit_val) = limiter.config.max_requests.to_string().parse() {
-                    headers.insert("x-ratelimit-limit", limit_val);
-                }
-                if let Ok(remaining_val) = "0".parse() {
-                    headers.insert("x-ratelimit-remaining", remaining_val);
-                }
-                if let Ok(reset_val) = reset_secs.to_string().parse::<axum::http::HeaderValue>() {
-                    headers.insert("x-ratelimit-reset", reset_val.clone());
-                    headers.insert("retry-after", reset_val);
-                }
-                response
+                rate_limited_response(&limiter.config)
             }
         }
     } else {
@@ -281,6 +315,63 @@ fn extract_client_id(request: &Request) -> String {
            all unidentified clients share a single stricter rate limit"
     );
     "unknown".to_string()
+}
+
+/// Derive a rate-limit client id for the **anonymous free-tier path** from the
+/// Tower-injected peer socket address.
+///
+/// The free bypass has no payer wallet, so the only honest identity is the
+/// actual TCP peer IP (from `ConnectInfo`). When `ConnectInfo` is absent
+/// (`addr == None`, e.g. behind a misconfigured proxy or in `oneshot` tests),
+/// fall back to the shared stricter `"unknown"` bucket.
+///
+/// **GHSA-6ggq-cvwx-4f67 invariant:** this NEVER keys on a client-supplied
+/// header (`X-Forwarded-For` et al.) — only the cryptographically-/transport-
+/// grounded peer address — so a free client cannot spoof its way into a fresh
+/// bucket. Mirrors steps 2–3 of [`extract_client_id`].
+pub fn connect_info_client_id(addr: Option<std::net::SocketAddr>) -> String {
+    match addr {
+        Some(a) => a.ip().to_string(),
+        None => {
+            warn!(
+                "free-tier rate limiter falling back to shared 'unknown' bucket — ConnectInfo \
+                 not configured; all unidentified free clients share a single stricter limit"
+            );
+            "unknown".to_string()
+        }
+    }
+}
+
+/// Build the canonical 429 Too Many Requests response.
+///
+/// Single source of truth for the rate-limit-exceeded body + `x-ratelimit-*` /
+/// `retry-after` headers, shared by the global rate-limit middleware and the
+/// in-handler free-tier limiter so both emit byte-identical 429s. `remaining`
+/// is always `0` here (the request was rejected).
+pub fn rate_limited_response(config: &RateLimitConfig) -> Response {
+    let reset_secs = config.window.as_secs();
+    let mut response = (
+        StatusCode::TOO_MANY_REQUESTS,
+        axum::Json(serde_json::json!({
+            "error": {
+                "type": "rate_limit_exceeded",
+                "message": "Too many requests. Please slow down.",
+            }
+        })),
+    )
+        .into_response();
+    let headers = response.headers_mut();
+    if let Ok(limit_val) = config.max_requests.to_string().parse() {
+        headers.insert("x-ratelimit-limit", limit_val);
+    }
+    if let Ok(remaining_val) = "0".parse() {
+        headers.insert("x-ratelimit-remaining", remaining_val);
+    }
+    if let Ok(reset_val) = reset_secs.to_string().parse::<axum::http::HeaderValue>() {
+        headers.insert("x-ratelimit-reset", reset_val.clone());
+        headers.insert("retry-after", reset_val);
+    }
+    response
 }
 
 #[cfg(test)]
@@ -380,6 +471,54 @@ mod tests {
         assert_eq!(config.max_requests, 10000);
         assert_eq!(config.unknown_max_requests, 10); // unchanged from default
         assert_eq!(config.window, Duration::from_secs(60)); // unchanged
+    }
+
+    #[test]
+    fn test_free_default_is_stricter_than_paid() {
+        let free = RateLimitConfig::free_default();
+        let paid = RateLimitConfig::default();
+        assert!(
+            free.max_requests < paid.max_requests,
+            "free-tier limit ({}) must be stricter than the paid limit ({})",
+            free.max_requests,
+            paid.max_requests
+        );
+        assert_eq!(free.max_requests, 5);
+        assert_eq!(free.unknown_max_requests, 2);
+        assert_eq!(free.window, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_connect_info_client_id_uses_peer_ip() {
+        let addr: std::net::SocketAddr = "203.0.113.7:54321".parse().unwrap();
+        // The PORT must be dropped — keying must be per-IP, not per-connection,
+        // or each new TCP connection would escape into a fresh bucket.
+        assert_eq!(connect_info_client_id(Some(addr)), "203.0.113.7");
+    }
+
+    #[test]
+    fn test_connect_info_client_id_unknown_when_absent() {
+        // No ConnectInfo (e.g. oneshot tests / misconfigured proxy) → the shared
+        // stricter "unknown" bucket, never a per-request-spoofable value.
+        assert_eq!(connect_info_client_id(None), "unknown");
+    }
+
+    #[tokio::test]
+    async fn test_rate_limited_response_shape_and_headers() {
+        let config = RateLimitConfig::free_default();
+        let response = rate_limited_response(&config);
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let headers = response.headers();
+        assert_eq!(headers.get("x-ratelimit-limit").unwrap(), "5");
+        assert_eq!(headers.get("x-ratelimit-remaining").unwrap(), "0");
+        assert_eq!(headers.get("x-ratelimit-reset").unwrap(), "60");
+        assert_eq!(headers.get("retry-after").unwrap(), "60");
+
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "rate_limit_exceeded");
     }
 
     #[test]

--- a/crates/gateway/src/middleware/rate_limit.rs
+++ b/crates/gateway/src/middleware/rate_limit.rs
@@ -238,8 +238,21 @@ pub async fn rate_limit(request: Request, next: Next) -> Response {
         let limiter = limiter.clone();
         match limiter.check(&client_id).await {
             Ok(remaining) => {
-                let mut response = next.run(request).await;
-                // Add standard rate limit headers
+                let response = next.run(request).await;
+                // Do NOT overwrite rate-limit headers when the downstream handler
+                // already returned a 429. An in-handler free-tier limiter
+                // (built by `rate_limited_response`) produces its own
+                // authoritative `x-ratelimit-*` headers reflecting the FREE limit
+                // (e.g. 5/min). The outer limiter's success arm fired only
+                // because this request was under the (looser, e.g. 60/min) OUTER
+                // cap; re-inserting those values here would tell the client it
+                // has "40 remaining" alongside a 429, which would make it ignore
+                // `retry-after` and hammer. Preserve the inner 429's headers.
+                if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                    return response;
+                }
+                // Add standard rate limit headers (non-429 responses only).
+                let mut response = response;
                 let headers = response.headers_mut();
                 if let Ok(val) = limiter.config.max_requests.to_string().parse() {
                     headers.insert("x-ratelimit-limit", val);
@@ -348,6 +361,12 @@ pub fn connect_info_client_id(addr: Option<std::net::SocketAddr>) -> String {
 /// `retry-after` headers, shared by the global rate-limit middleware and the
 /// in-handler free-tier limiter so both emit byte-identical 429s. `remaining`
 /// is always `0` here (the request was rejected).
+///
+/// These headers are **authoritative** on the wire: the outer `rate_limit`
+/// middleware now preserves any 429 response's headers unchanged (it returns
+/// early on `StatusCode::TOO_MANY_REQUESTS` instead of re-inserting its own
+/// looser limit/remaining values), so a free-tier 429 built here reaches the
+/// client carrying the correct FREE limit and `remaining == 0`.
 pub fn rate_limited_response(config: &RateLimitConfig) -> Response {
     let reset_secs = config.window.as_secs();
     let mut response = (

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -437,6 +437,25 @@ fn usdc_atomic_amount(decimal_str: &str) -> String {
     usdc_atomic_amount_checked(decimal_str).unwrap_or_else(|_| "0".to_string())
 }
 
+/// Decide whether a request is **free** from its already-computed atomic-cost
+/// estimate — the SAME `atomic_amount` string the 402 challenge advertises in
+/// its `accepts[]` (the output of [`usdc_atomic_amount_checked`] over the
+/// registry `estimate_cost` total).
+///
+/// This is the single source of truth for free-ness on the no-payment path: a
+/// model is free **iff** its computed estimate atomic cost is exactly `0`. We do
+/// NOT separately inspect `input_cost_per_million`/`output_cost_per_million` —
+/// keying off the same estimate the 402 quotes guarantees a pricing change can
+/// never let a *paid* model silently bypass payment (and vice-versa).
+///
+/// **Fail-closed:** a non-numeric atomic string (which should be impossible here
+/// — it is produced by `usdc_atomic_amount_checked`) is treated as NOT free, so
+/// an unparseable amount can never open the zero-cost bypass. Returning `false`
+/// keeps the paid 402 path, which is the safe default.
+pub(crate) fn is_free_estimate(atomic_amount: &str) -> bool {
+    matches!(atomic_amount.trim().parse::<u64>(), Ok(0))
+}
+
 /// Pricing for a semantic-cache hit, in atomic USDC units.
 ///
 /// The normal path (cache miss / exact-match hit) is represented by the absence
@@ -655,6 +674,33 @@ mod tests {
     #[test]
     fn test_usdc_atomic_max_precision() {
         assert_eq!(usdc_atomic_amount("0.000001"), "1");
+    }
+
+    #[test]
+    fn test_is_free_estimate_zero_is_free() {
+        // The exact string a free (0.0/0.0) model's 402 quote carries.
+        assert!(is_free_estimate("0"));
+        assert!(is_free_estimate(" 0 ")); // tolerate incidental whitespace
+    }
+
+    #[test]
+    fn test_is_free_estimate_nonzero_is_not_free() {
+        // Smallest billable amount (1 micro-USDC) must NOT be treated as free.
+        assert!(!is_free_estimate("1"));
+        assert!(!is_free_estimate("2625"));
+        assert!(!is_free_estimate("1000000"));
+    }
+
+    #[test]
+    fn test_is_free_estimate_fails_closed_on_garbage() {
+        // A non-numeric / malformed atomic string must fail CLOSED (not free),
+        // so an unparseable amount can never open the zero-cost bypass for a
+        // paid request. Defense-in-depth: the producer is
+        // `usdc_atomic_amount_checked`, which never emits these.
+        assert!(!is_free_estimate(""));
+        assert!(!is_free_estimate("abc"));
+        assert!(!is_free_estimate("0.0")); // atomic units are integers, not decimals
+        assert!(!is_free_estimate("-1"));
     }
 
     #[test]

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -33,8 +33,8 @@ use crate::AppState;
 
 use cost::{
     cap_usage_to_request_limits, completion_token_ceiling, compute_actual_atomic_cost,
-    estimate_input_tokens, estimated_atomic_cost, scheme_realized_discount, spend_cost_atomic,
-    usdc_atomic_amount_checked, usdc_f64_to_atomic_safe, PaymentScheme,
+    estimate_input_tokens, estimated_atomic_cost, is_free_estimate, scheme_realized_discount,
+    spend_cost_atomic, usdc_atomic_amount_checked, usdc_f64_to_atomic_safe, PaymentScheme,
 };
 use payment::{decode_payment_from_header, extract_payment_info, fire_escrow_claim};
 use provider::{ProviderCallContext, ProviderCallError, ProviderCallResult};
@@ -78,6 +78,10 @@ const MAX_TOKENS_LIMIT: u32 = 128_000;
 /// 5. Support both JSON and SSE streaming responses
 pub async fn chat_completions(
     State(state): State<Arc<AppState>>,
+    // Infallible peer-address extractor. Yields `None` when `ConnectInfo` is
+    // absent (e.g. `oneshot` integration tests, proxy misconfig) so the free-tier
+    // path degrades to the stricter "unknown" bucket rather than 500-ing.
+    peer_addr: crate::middleware::rate_limit::PeerAddr,
     headers: HeaderMap,
     Json(mut req): Json<ChatRequest>,
 ) -> Result<Response, GatewayError> {
@@ -346,10 +350,12 @@ pub async fn chat_completions(
     }
 
     if payment_header.is_none() {
-        // Return 402 with pricing info
-        counter!("solvela_payments_total", "status" => "none").increment(1);
-        info!(model = %req.model, "no payment signature, returning 402");
-
+        // Compute the upfront cost estimate ONCE. This same `atomic_amount` is the
+        // single source of truth for two decisions below:
+        //   1. free-ness (is_free_estimate → zero-cost bypass), and
+        //   2. the amount advertised in the 402 `accepts[]` for a paid model.
+        // Deriving both from one estimate means a pricing change can never make a
+        // paid model silently bypass payment (or a free model wrongly 402).
         let cost = state
             .model_registry
             .estimate_cost(
@@ -368,6 +374,104 @@ pub async fn chat_completions(
                 req.model, e
             ))
         })?;
+
+        // ── Zero-cost (free-tier) bypass ──────────────────────────────────────
+        //
+        // A model is free IFF its computed estimate atomic cost is exactly 0
+        // (e.g. a 0.0/0.0-priced model). Such a request must be SERVED, not 402'd
+        // for a $0 payment. A paid model (atomic > 0) falls through to the 402
+        // below unchanged — `is_free_estimate` fails closed on any non-"0" value.
+        if is_free_estimate(&atomic_amount) {
+            // Anti-abuse: the free path is anonymous (no payer wallet), so it is
+            // rate-limited per client IP, STRICTER than the paid limit. Enforced
+            // BEFORE any provider work so a limited free request never reaches the
+            // upstream provider quota. Keyed on the TCP peer IP (never a
+            // client-supplied header — GHSA-6ggq-cvwx-4f67); absent ConnectInfo
+            // falls back to the shared stricter "unknown" bucket.
+            let free_client_id = crate::middleware::rate_limit::connect_info_client_id(peer_addr.0);
+            if state
+                .free_rate_limiter
+                .check(&free_client_id)
+                .await
+                .is_err()
+            {
+                counter!("solvela_payments_total", "status" => "free_rate_limited").increment(1);
+                warn!(
+                    client_id = %free_client_id,
+                    model = %req.model,
+                    "free-tier rate limit exceeded"
+                );
+                return Ok(crate::middleware::rate_limit::rate_limited_response(
+                    state.free_rate_limiter.config(),
+                ));
+            }
+
+            counter!("solvela_payments_total", "status" => "free").increment(1);
+            info!(model = %req.model, "zero-cost model — serving free-tier request without payment");
+
+            // Free requests reach a provider, so they must run the guard (same as
+            // the dev-bypass and paid paths).
+            run_prompt_guard(&req.messages)?;
+
+            let ctx = ProviderCallContext {
+                state: &state,
+                req: &req,
+                model_info,
+                headers: &headers,
+                debug_enabled,
+                request_start,
+                routing_tier: &routing_tier,
+                routing_score,
+                routing_profile: &routing_profile,
+                session_id: &session_id,
+                payment_status: PaymentStatus::Free,
+            };
+
+            return match provider::execute_provider_call(&ctx).await {
+                Ok(result) => {
+                    // Log spend at $0 via the existing fire-and-forget path so the
+                    // free tier still shows up in usage/observability. `cost_usdc`
+                    // is 0.0 and `estimated_cost_usdc` is None, so `log_spend`
+                    // increments counters by 0 (no divide-by-zero / no fail-closed
+                    // path is reachable for a zero amount). Anonymous: there is no
+                    // payer wallet, so a sentinel marks the row as free-tier.
+                    let usage = result
+                        .usage
+                        .as_ref()
+                        .map(|u| cap_usage_to_request_limits(u, &req, model_info));
+                    state.usage.log_spend(SpendLogEntry {
+                        wallet_address: "free-tier".to_string(),
+                        model: req.model.clone(),
+                        provider: result
+                            .actual_provider
+                            .unwrap_or_else(|| model_info.provider.clone()),
+                        input_tokens: usage.as_ref().map(|u| u.prompt_tokens).unwrap_or(0),
+                        output_tokens: usage.as_ref().map(|u| u.completion_tokens).unwrap_or(0),
+                        cost_usdc: 0.0,
+                        tx_signature: None,
+                        request_id: request_id.clone(),
+                        session_id: session_id.clone(),
+                        tenant: tenant.clone(),
+                        tenant_enforced: false,
+                        estimated_cost_usdc: None,
+                    });
+                    Ok(result.response)
+                }
+                Err(e) => Err(match e {
+                    ProviderCallError::AllProvidersFailed { model, error, .. } => {
+                        GatewayError::Internal(format!(
+                            "all providers failed for free model '{}': {}",
+                            model, error
+                        ))
+                    }
+                    ProviderCallError::Internal(msg) => GatewayError::Internal(msg),
+                }),
+            };
+        }
+
+        // Return 402 with pricing info (paid model, no payment header)
+        counter!("solvela_payments_total", "status" => "none").increment(1);
+        info!(model = %req.model, "no payment signature, returning 402");
 
         let mut accepts = vec![solvela_x402::types::PaymentAccept {
             scheme: "exact".to_string(),

--- a/crates/gateway/src/routes/health.rs
+++ b/crates/gateway/src/routes/health.rs
@@ -162,6 +162,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         })
     }
 
@@ -235,6 +238,9 @@ supports_vision = false
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         })
     }
 

--- a/crates/gateway/src/routes/orgs/api_keys.rs
+++ b/crates/gateway/src/routes/orgs/api_keys.rs
@@ -251,6 +251,9 @@ mod tests {
             prometheus_handle: None,
             api_key_hmac_secret: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         });
 
         let ctx = OrgContext {

--- a/crates/gateway/src/routes/orgs/mod.rs
+++ b/crates/gateway/src/routes/orgs/mod.rs
@@ -401,6 +401,9 @@ supports_vision = true
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         });
 
         Router::new()
@@ -563,6 +566,9 @@ mod tests {
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         };
 
         let mut headers = HeaderMap::new();
@@ -608,6 +614,9 @@ mod tests {
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         };
 
         let org_id = uuid::Uuid::new_v4();
@@ -656,6 +665,9 @@ mod tests {
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         };
 
         let headers = HeaderMap::new();

--- a/crates/gateway/src/routes/orgs/teams.rs
+++ b/crates/gateway/src/routes/orgs/teams.rs
@@ -429,6 +429,9 @@ mod tests {
             prometheus_handle: None,
             api_key_hmac_secret: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         });
 
         let ctx = OrgContext {

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -954,6 +954,7 @@ mod tests {
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(crate::middleware::rate_limit::RateLimitConfig::free_default()),
         });
 
         let app = axum::Router::new()
@@ -1085,6 +1086,9 @@ mod tests {
             api_key_hmac_secret: None,
             prometheus_handle: None,
             dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
         })
     }
 

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -8644,20 +8644,26 @@ async fn free_path_rate_limited_per_ip() {
         StatusCode::TOO_MANY_REQUESTS,
         "exceeding the per-IP free limit must 429"
     );
-    // NOTE: the in-handler free 429 sets x-ratelimit-limit=2 / remaining=0, but
-    // the response bubbles back up through the GLOBAL rate-limit middleware whose
-    // success arm re-inserts its own (60) limit/remaining headers, overwriting
-    // them. That is correct layering — the outermost limit header reflects the
-    // global cap. The load-bearing free-tier contract that survives is: 429
-    // status, retry-after, and the rate_limit_exceeded body. Both rate-limit
-    // headers are still present (their VALUE just reflects the outer limiter).
-    assert!(
-        resp.headers().get("x-ratelimit-limit").is_some(),
-        "429 must carry x-ratelimit-limit"
+    // The in-handler free 429 sets x-ratelimit-limit=2 (the FREE limit) /
+    // remaining=0. The response bubbles back up through the GLOBAL rate-limit
+    // middleware, whose success arm now returns 429 responses UNCHANGED (it no
+    // longer re-inserts its own looser 60-limit headers). So the FREE-tier
+    // limit/remaining headers survive intact — a client sees a 429 alongside the
+    // free limit and remaining=0, never "40 remaining", and will honour
+    // retry-after instead of hammering.
+    assert_eq!(
+        resp.headers()
+            .get("x-ratelimit-limit")
+            .expect("429 must carry x-ratelimit-limit"),
+        "2",
+        "429 must carry the FREE limit (2), not the outer global limit (60)"
     );
-    assert!(
-        resp.headers().get("x-ratelimit-remaining").is_some(),
-        "429 must carry x-ratelimit-remaining"
+    assert_eq!(
+        resp.headers()
+            .get("x-ratelimit-remaining")
+            .expect("429 must carry x-ratelimit-remaining"),
+        "0",
+        "a rejected request must report 0 remaining"
     );
     assert!(
         resp.headers().get("retry-after").is_some(),

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -407,6 +407,15 @@ context_window = 200000
 supports_streaming = true
 supports_tools = true
 supports_vision = true
+
+[models.google-gemini-flash-lite]
+provider = "google"
+model_id = "gemini-3.1-flash-lite"
+display_name = "Gemini 3.1 Flash Lite (Free)"
+input_cost_per_million = 0.0
+output_cost_per_million = 0.0
+context_window = 1000000
+supports_streaming = true
 "#;
 
 /// Build a test app with the test model config (no real provider API keys).
@@ -459,6 +468,7 @@ fn test_app_with_state() -> (axum::Router, Arc<AppState>) {
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     let router = build_router(
         Arc::clone(&state),
@@ -608,6 +618,7 @@ fn mock_provider_registry() -> ProviderRegistry {
         "deepseek".to_string(),
         Arc::new(MockProvider::new("deepseek")),
     );
+    providers.insert("google".to_string(), Arc::new(MockProvider::new("google")));
     ProviderRegistry::from_providers(providers)
 }
 
@@ -695,6 +706,7 @@ fn test_app_with_provider_registry_and_exact_verifier(
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     let router = build_router(
         Arc::clone(&state),
@@ -775,6 +787,7 @@ fn app_with_semantic_cache(sem: Arc<gateway::cache::semantic::SemanticCache>) ->
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: true,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -1084,6 +1097,7 @@ fn app_with_semantic_cache_and_escrow(
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -1742,6 +1756,7 @@ fn test_app_with_provider_registry_and_escrow_verifier(
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -1812,6 +1827,7 @@ fn test_app_with_escrow() -> axum::Router {
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -1960,7 +1976,9 @@ async fn test_models_endpoint() {
     assert_eq!(json["object"], "list");
 
     let data = json["data"].as_array().unwrap();
-    assert_eq!(data.len(), 3);
+    // 4 models in TEST_MODELS_TOML: gpt-4o, deepseek-chat, claude-sonnet, and
+    // the free google/gemini-3.1-flash-lite (added for the free-tier tests).
+    assert_eq!(data.len(), 4);
 
     // Lock in the full wire shape. The route serializes
     // `solvela_protocol::ModelInfo`, whose nested layout is the contract the
@@ -2238,6 +2256,7 @@ async fn test_chat_enforced_wallet_unprovisioned_tenant_returns_400_e2e() {
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     let app = build_router(
         Arc::clone(&state),
@@ -4146,6 +4165,7 @@ fn test_app_with_nonce_pool() -> axum::Router {
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     gateway::build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -6177,6 +6197,7 @@ fn test_app_with_escrow_metrics() -> axum::Router {
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -6340,6 +6361,7 @@ async fn test_escrow_health_reflects_incremented_metrics() {
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
 
     // Simulate claim processing by incrementing metrics atomically
@@ -6573,6 +6595,7 @@ async fn test_escrow_health_status_down_without_claimer() {
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
 
     let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
@@ -6960,6 +6983,7 @@ async fn test_proxy_require_tenant_wallet_rejected_before_settlement() {
         api_key_hmac_secret: None,
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     let app = build_router(
         Arc::clone(&state),
@@ -7908,6 +7932,7 @@ async fn test_admin_stats_returns_404_when_admin_token_not_configured() {
         prometheus_handle: Some(test_prometheus_handle()),
         api_key_hmac_secret: None,
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     let app = build_router(
         Arc::clone(&state),
@@ -8462,5 +8487,322 @@ async fn reservation_provided_max_tokens_is_unchanged() {
     assert!(
         reserved < ceiling_quote,
         "a provided max_tokens=256 must reserve less than the 8192 ceiling"
+    );
+}
+
+// ===========================================================================
+// PR A — Free-tier zero-cost bypass + per-client anti-abuse rate limit
+// ===========================================================================
+
+/// Free model id present in TEST_MODELS_TOML, priced 0.0/0.0 → zero atomic cost.
+const FREE_MODEL: &str = "google/gemini-3.1-flash-lite";
+
+/// Build a mock-provider app whose FREE-tier limiter uses `free_max` requests
+/// per (named-IP) window. The paid (outer) limiter stays at its generous
+/// default so the two limiters can be shown not to cross-contaminate.
+fn test_app_with_free_limit(free_max: u32) -> axum::Router {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+
+    // Stricter free-tier config: `free_max` for NAMED ip buckets, and the same
+    // for the "unknown" bucket so a no-ConnectInfo test is deterministic.
+    let free_cfg = RateLimitConfig {
+        max_requests: free_max,
+        window: std::time::Duration::from_secs(60),
+        unknown_max_requests: free_max,
+    };
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: mock_provider_registry(),
+        facilitator,
+        usage: gateway::usage::UsageTracker::noop(),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: None,
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(free_cfg),
+    });
+    build_router(state, RateLimiter::new(RateLimitConfig::default()))
+}
+
+/// Build a chat request for `model` with a fixed `ConnectInfo` peer IP so the
+/// free-tier limiter keys on a NAMED bucket (not the shared "unknown" one).
+fn free_chat_request(model: &str, ip: &str) -> Request<Body> {
+    let body = format!(r#"{{"model":"{model}","messages":[{{"role":"user","content":"hello"}}]}}"#);
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .header("x-solvela-debug", "true")
+        .body(Body::from(body))
+        .unwrap();
+    let addr: std::net::SocketAddr = format!("{ip}:40000").parse().unwrap();
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo(addr));
+    req
+}
+
+/// A zero-cost model with NO payment header is SERVED (200), not 402'd, and the
+/// debug header reports payment-status = free.
+#[tokio::test]
+async fn free_model_no_payment_is_served_not_402() {
+    let app = test_app_with_free_limit(5);
+    let resp = app
+        .oneshot(free_chat_request(FREE_MODEL, "198.51.100.10"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a zero-cost model must be served without payment, not 402'd"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-solvela-payment-status")
+            .and_then(|v| v.to_str().ok()),
+        Some("free"),
+        "payment status must be reported as free"
+    );
+
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(
+        v["id"], "mock-chatcmpl-001",
+        "free request must reach the (mock) provider and return its response"
+    );
+}
+
+/// A PAID model with NO payment header still returns 402 (unchanged behavior).
+/// Guards that the zero-cost bypass is reachable ONLY when cost == 0.
+#[tokio::test]
+async fn paid_model_no_payment_still_402() {
+    let app = test_app_with_free_limit(5);
+    let resp = app
+        .oneshot(free_chat_request("openai/gpt-4o", "198.51.100.11"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "a paid model with no payment header must still 402"
+    );
+}
+
+/// The free path is rate-limited per client IP: under the limit → served; over
+/// the limit → 429 with the standard rate-limit headers.
+#[tokio::test]
+async fn free_path_rate_limited_per_ip() {
+    let app = test_app_with_free_limit(2);
+    let ip = "203.0.113.42";
+
+    // First 2 requests from this IP succeed.
+    for i in 0..2 {
+        let resp = app
+            .clone()
+            .oneshot(free_chat_request(FREE_MODEL, ip))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "request {i} should be served"
+        );
+    }
+
+    // The 3rd exceeds the free limit → 429 with headers.
+    let resp = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, ip))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "exceeding the per-IP free limit must 429"
+    );
+    // NOTE: the in-handler free 429 sets x-ratelimit-limit=2 / remaining=0, but
+    // the response bubbles back up through the GLOBAL rate-limit middleware whose
+    // success arm re-inserts its own (60) limit/remaining headers, overwriting
+    // them. That is correct layering — the outermost limit header reflects the
+    // global cap. The load-bearing free-tier contract that survives is: 429
+    // status, retry-after, and the rate_limit_exceeded body. Both rate-limit
+    // headers are still present (their VALUE just reflects the outer limiter).
+    assert!(
+        resp.headers().get("x-ratelimit-limit").is_some(),
+        "429 must carry x-ratelimit-limit"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-remaining").is_some(),
+        "429 must carry x-ratelimit-remaining"
+    );
+    assert!(
+        resp.headers().get("retry-after").is_some(),
+        "429 must carry retry-after"
+    );
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["error"]["type"], "rate_limit_exceeded");
+}
+
+/// Two different IPs get independent free-tier buckets (per-IP keying).
+#[tokio::test]
+async fn free_path_independent_ip_buckets() {
+    let app = test_app_with_free_limit(1);
+
+    // IP A uses its single allowance, then is limited.
+    let a1 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, "192.0.2.1"))
+        .await
+        .unwrap();
+    assert_eq!(a1.status(), StatusCode::OK);
+    let a2 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, "192.0.2.1"))
+        .await
+        .unwrap();
+    assert_eq!(a2.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // IP B still has its full (separate) allowance.
+    let b1 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, "192.0.2.2"))
+        .await
+        .unwrap();
+    assert_eq!(
+        b1.status(),
+        StatusCode::OK,
+        "a different IP must have an independent free bucket"
+    );
+}
+
+/// A free request and a PAID request from the same client must not share a
+/// bucket: the free limiter is dedicated to the free path. Exhaust the free
+/// bucket, then prove the paid model still reaches its own (402) path rather
+/// than being 429'd by the free limiter.
+#[tokio::test]
+async fn free_and_paid_do_not_cross_contaminate() {
+    let app = test_app_with_free_limit(1);
+    let ip = "198.51.100.77";
+
+    // Exhaust the free bucket for this IP.
+    let f1 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, ip))
+        .await
+        .unwrap();
+    assert_eq!(f1.status(), StatusCode::OK);
+    let f2 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, ip))
+        .await
+        .unwrap();
+    assert_eq!(
+        f2.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "free bucket should now be exhausted for this IP"
+    );
+
+    // A PAID model from the SAME IP must still hit its own 402 path — the free
+    // limiter must not block it.
+    let paid = app
+        .clone()
+        .oneshot(free_chat_request("openai/gpt-4o", ip))
+        .await
+        .unwrap();
+    assert_eq!(
+        paid.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "paid request must not be 429'd by the free-tier limiter"
+    );
+}
+
+/// The dev-bypass path still works (regression guard for the restructured
+/// no-payment block).
+#[tokio::test]
+async fn dev_bypass_still_works() {
+    // `app_with_semantic_cache` builds an app with dev_bypass_payment = true.
+    // Reuse the dev-bypass app builder if available; otherwise build inline.
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: mock_provider_registry(),
+        facilitator,
+        usage: gateway::usage::UsageTracker::noop(),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: None,
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: true,
+        // Free limiter intentionally set to 0 so that, if the dev-bypass branch
+        // were ever (incorrectly) routed through the free limiter, this PAID
+        // model would 429 — proving dev-bypass takes its own path.
+        free_rate_limiter: RateLimiter::new(RateLimitConfig {
+            max_requests: 0,
+            window: std::time::Duration::from_secs(60),
+            unknown_max_requests: 0,
+        }),
+    });
+    let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
+
+    // A PAID model with no payment header is served via dev-bypass (200), not 402.
+    let resp = app
+        .oneshot(free_chat_request("openai/gpt-4o", "198.51.100.99"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "dev-bypass must serve a paid model without payment"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-solvela-payment-status")
+            .and_then(|v| v.to_str().ok()),
+        Some("dev_bypass"),
     );
 }

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -85,6 +85,9 @@ fn router_with_pool(pool: PgPool) -> Router {
         api_key_hmac_secret: None,
         prometheus_handle: None,
         dev_bypass_payment: false,
+        free_rate_limiter: gateway::middleware::rate_limit::RateLimiter::new(
+            gateway::middleware::rate_limit::RateLimitConfig::free_default(),
+        ),
     });
 
     Router::new()

--- a/crates/gateway/tests/stats_http_redis.rs
+++ b/crates/gateway/tests/stats_http_redis.rs
@@ -95,6 +95,7 @@ fn stats_router(usage: UsageTracker, db_pool: Option<PgPool>) -> axum::Router {
         api_key_hmac_secret: None,
         prometheus_handle: None,
         dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
     });
     build_router(
         Arc::clone(&state),


### PR DESCRIPTION
## What

Makes \$0 (free-tier) models actually usable and guards the now-anonymous free path against abuse. This is **PR A** of the free-tier work (the aggregate "protect Google's shared ~15 RPM key" cap is a separate later PR).

### The bug this fixes
A free (`0.0/0.0`) model was unusable: the handler returned **402 for any request without a `payment-signature` header regardless of cost**, so the free tier asked agents to sign a payment for \$0.

## Component 1 — zero-cost payment bypass (money path)

- On the no-payment path, the cost estimate is computed **once**; if the request is free it's served directly instead of 402'd.
- Free-ness = `is_free_estimate(atomic_amount)` over the **same** atomic estimate the 402 advertises in `accepts[]` — a single source of truth, so a pricing change can never make a paid model silently bypass payment (or a free model wrongly 402). **Fails closed:** any non-`"0"`/unparseable amount → paid 402 path.
- Serves via `PaymentStatus::Free` (metric `solvela_payments_total{status="free"}`), runs the prompt guard, and logs spend at \$0 through the existing fire-and-forget path (anonymous → `wallet_address: "free-tier"` sentinel).
- **Paid models with no payment header still 402** (unchanged; covered by a test).

## Component 2 — per-client free-tier rate limit (anti-abuse)

- A second, **stricter** `RateLimiter` (default **5/60s**, unknown bucket 2) keyed on the **TCP peer IP** (never client-supplied headers — preserves GHSA-6ggq-cvwx-4f67), enforced **in-handler on the free path before any provider work** (the global outer limiter runs before model resolution and can't see free-ness).
- Configurable via **`SOLVELA_FREE_TIER_RATE_LIMIT`** (`RCR_` fallback). On exceed → shared 429 (`status="free_rate_limited"`).
- Factored shared helpers `connect_info_client_id` + `rate_limited_response`; the middleware's existing 429 arm now reuses the latter.
- Adds an infallible `PeerAddr` extractor (axum 0.8 `ConnectInfo` has no `Optional` extractor) so the path degrades to the stricter `unknown` bucket instead of 500-ing when `ConnectInfo` is absent (e.g. `oneshot` tests).

## Tests

- **Unit:** 3 free-ness predicate (zero/nonzero/fails-closed) + 4 rate-limit (free stricter than paid, IP keying present/absent, 429 shape).
- **Integration (oneshot + test_app):** free served not 402; paid still 402; free per-IP limit trips; independent IP buckets; free/paid bucket isolation; dev-bypass intact.
- `cargo fmt`/`clippy -D warnings` clean; gateway lib **727** pass, integration **179** pass.

## Reviewer notes

- **Header precedence:** an in-handler free 429 bubbles back through the global rate-limit middleware, whose success arm overwrites `x-ratelimit-*` with its own (60) values. The load-bearing contract that survives is the **429 status + `retry-after` + `rate_limit_exceeded` body** (asserted in tests). No money is mis-charged; documented in code + test.
- **Scope:** Components 1 + 2 only. No aggregate/global Google-quota cap, no Redis backing (PR B).