### PR TITLE
feat(gateway): aggregate free-tier rate cap (protect shared upstream key)

### DIFF
--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -120,6 +120,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         })
     }
 

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -879,6 +879,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         })
     }
 
@@ -1373,6 +1376,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         })
     }
 
@@ -1429,6 +1435,9 @@ supports_vision = false
             dev_bypass_payment: true,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
         })
     }
@@ -1784,6 +1793,9 @@ supports_vision = false
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
         });
         Some((state, redis_client))

--- a/crates/gateway/src/a2a/jsonrpc.rs
+++ b/crates/gateway/src/a2a/jsonrpc.rs
@@ -126,6 +126,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         });
 
         axum::Router::new()

--- a/crates/gateway/src/cache/mod.rs
+++ b/crates/gateway/src/cache/mod.rs
@@ -44,6 +44,16 @@ const CACHE_KEY_PREFIX: &str = "solvela:cache:";
 /// Redis key prefix for transaction replay-protection entries.
 const REPLAY_KEY_PREFIX: &str = "solvela:txn:";
 
+/// Redis key prefix for the cross-instance aggregate free-tier RPM counter.
+/// The full key is `free_tier:global_rpm:<epoch_minute>` (see
+/// [`ResponseCache::incr_global_free_window`]).
+const FREE_TIER_GLOBAL_RPM_PREFIX: &str = "free_tier:global_rpm:";
+
+/// TTL (seconds) applied to a free-tier RPM window key on its first increment.
+/// Longer than the 60s window so the key outlives its own minute; old windows
+/// self-expire rather than accumulating.
+const FREE_TIER_GLOBAL_WINDOW_TTL_SECS: u64 = 120;
+
 /// Cache configuration.
 #[derive(Debug, Clone)]
 pub struct CacheConfig {
@@ -240,6 +250,58 @@ impl ResponseCache {
                 }
             }
         }
+    }
+
+    /// Increment the global free-tier fixed-window counter for `epoch_minute`
+    /// and return the post-increment count.
+    ///
+    /// Backs the cross-instance aggregate free-tier rate cap (PR B). Multiple
+    /// gateway instances share one upstream provider API key whose free-tier
+    /// quota is a SINGLE shared ceiling (Google's free Gemini tier: ~15 RPM
+    /// across the whole key). A per-instance in-memory counter × N instances
+    /// would collectively blow past that ceiling, so the authoritative counter
+    /// MUST live in Redis when Redis is configured.
+    ///
+    /// Fixed-window counter: `INCR free_tier:global_rpm:<epoch_minute>`, with a
+    /// short TTL set on the FIRST increment so stale window keys self-expire.
+    /// The TTL (120s) comfortably outlives the 60s window — the window key is
+    /// only read during its own minute, and the extra slack absorbs clock skew
+    /// without ever letting two live windows share a key.
+    ///
+    /// Returns `Err(CacheError::Operation)` on any Redis error. The caller
+    /// (`FreeTierGlobalCap`) DEGRADES to its in-memory counter on `Err` rather
+    /// than failing the request — an infra blip must not hard-fail free traffic,
+    /// and the upstream provider's own 429 remains the ultimate backstop.
+    pub async fn incr_global_free_window(&self, epoch_minute: u64) -> Result<u64, CacheError> {
+        let key = format!("{FREE_TIER_GLOBAL_RPM_PREFIX}{epoch_minute}");
+        let mut conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| CacheError::Operation(e.to_string()))?;
+
+        // INCR is atomic and returns the new value. Redis creates the key at 0
+        // then increments, so a return of exactly 1 means we just created the
+        // window key — set its TTL only then (avoids resetting the TTL on every
+        // increment, which would keep a hot key alive indefinitely).
+        let count: u64 = redis::cmd("INCR")
+            .arg(&key)
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| CacheError::Operation(e.to_string()))?;
+
+        if count == 1 {
+            // Best-effort TTL on first sight. If EXPIRE fails the counter still
+            // bounds the current minute correctly; the key would just linger,
+            // and Redis key eviction / a later window's own EXPIRE bounds that.
+            let _: Result<i64, redis::RedisError> = redis::cmd("EXPIRE")
+                .arg(&key)
+                .arg(FREE_TIER_GLOBAL_WINDOW_TTL_SECS)
+                .query_async(&mut conn)
+                .await;
+        }
+
+        Ok(count)
     }
 
     /// Get a raw string value by key.
@@ -466,5 +528,69 @@ mod tests {
             lru.get(&format!("sig_{}", cap - 1)).is_some(),
             "recent entries should remain in LRU cache"
         );
+    }
+
+    /// The Redis-backed aggregate free-tier window counter increments
+    /// monotonically within one window and sets a TTL on first sight.
+    ///
+    /// Gated on a reachable Redis (skips cleanly if down). Uses a unique
+    /// per-run epoch_minute key so concurrent test runs don't collide. Cleans
+    /// the key up afterward.
+    #[tokio::test]
+    async fn incr_global_free_window_counts_and_sets_ttl() {
+        let redis_url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+        let client = match redis::Client::open(redis_url.clone()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skipping: cannot open Redis client ({e})");
+                return;
+            }
+        };
+        let mut conn = match client.get_multiplexed_async_connection().await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skipping: Redis unreachable ({e})");
+                return;
+            }
+        };
+
+        let cache = ResponseCache::new(&redis_url, CacheConfig::default())
+            .expect("client creation should not connect");
+
+        // Unique window id so this test is isolated from real traffic and other
+        // runs. Derived from nanos to avoid collisions.
+        let minute = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let key = format!("{FREE_TIER_GLOBAL_RPM_PREFIX}{minute}");
+
+        // First increment → 1, and a TTL must now be set on the key.
+        let c1 = cache
+            .incr_global_free_window(minute)
+            .await
+            .expect("redis incr should succeed");
+        assert_eq!(c1, 1, "first increment of a fresh window returns 1");
+
+        let ttl: i64 = redis::cmd("TTL")
+            .arg(&key)
+            .query_async(&mut conn)
+            .await
+            .expect("TTL query");
+        assert!(
+            ttl > 0 && ttl as u64 <= FREE_TIER_GLOBAL_WINDOW_TTL_SECS,
+            "first increment must set a positive TTL (<= {FREE_TIER_GLOBAL_WINDOW_TTL_SECS}s), got {ttl}"
+        );
+
+        // Subsequent increments keep counting up in the same window.
+        let c2 = cache.incr_global_free_window(minute).await.unwrap();
+        let c3 = cache.incr_global_free_window(minute).await.unwrap();
+        assert_eq!(c2, 2);
+        assert_eq!(c3, 3);
+
+        // Cleanup.
+        let _: Result<i64, redis::RedisError> =
+            redis::cmd("DEL").arg(&key).query_async(&mut conn).await;
     }
 }

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -43,7 +43,7 @@ use crate::services::ServiceRegistry;
 use solvela_router::models::ModelRegistry;
 use solvela_x402::facilitator::Facilitator;
 
-use crate::middleware::rate_limit::RateLimiter;
+use crate::middleware::rate_limit::{FreeTierGlobalCap, RateLimiter};
 use crate::middleware::request_id::RequestIdLayer;
 use crate::providers::ProviderRegistry;
 use crate::routes::escrow::SlotCache;
@@ -114,6 +114,19 @@ pub struct AppState {
     /// `SOLVELA_FREE_TIER_RATE_LIMIT`. Keyed on the TCP peer IP (never a
     /// client-supplied header — GHSA-6ggq-cvwx-4f67).
     pub free_rate_limiter: RateLimiter,
+    /// Aggregate (global, all-clients-combined) free-tier rate cap.
+    ///
+    /// Complements [`free_rate_limiter`](Self::free_rate_limiter): the per-IP
+    /// limiter rejects single-IP spammers cheaply, but cannot protect the
+    /// upstream provider's SHARED free-tier ceiling (Google's free Gemini tier
+    /// ~15 RPM across the whole API key) — many distinct IPs each under their
+    /// per-IP cap can still collectively exceed it. This cap bounds the COMBINED
+    /// free throughput so the gateway 429s before the provider does. Backed by
+    /// Redis (cross-instance) when `cache` is `Some`, degrading to an in-memory
+    /// per-instance counter otherwise. Default
+    /// [`FREE_TIER_GLOBAL_RPM_DEFAULT`](crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT);
+    /// override via `SOLVELA_FREE_TIER_GLOBAL_RPM`.
+    pub free_global_cap: FreeTierGlobalCap,
 }
 
 impl AppState {

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -28,7 +28,9 @@ use gateway::services::ServiceRegistry;
 use gateway::{
     balance_monitor::BalanceMonitor,
     build_router, cache, config,
-    middleware::rate_limit::{RateLimitConfig, RateLimiter},
+    middleware::rate_limit::{
+        FreeTierGlobalCap, RateLimitConfig, RateLimiter, FREE_TIER_GLOBAL_RPM_DEFAULT,
+    },
     providers::ProviderRegistry,
     AppState,
 };
@@ -545,6 +547,46 @@ async fn main() -> anyhow::Result<()> {
         };
     let free_rate_limiter = RateLimiter::new(free_rate_limit_config);
 
+    // ── Aggregate (global) free-tier rate cap ──────────────────────────────────
+    //
+    // Caps TOTAL free-model throughput across ALL clients per minute, BELOW the
+    // upstream provider's shared free-tier ceiling (Google's free Gemini tier
+    // ~15 RPM across the whole API key). The per-IP limiter above can't protect
+    // that shared ceiling — many distinct IPs each under their per-IP cap can
+    // collectively exceed it. Default FREE_TIER_GLOBAL_RPM_DEFAULT (12, below
+    // 15); override via SOLVELA_FREE_TIER_GLOBAL_RPM (RCR_ fallback for parity
+    // with the other rate-limit env vars). Backed by Redis (cross-instance) when
+    // a cache is configured; degrades to an in-memory per-instance counter
+    // otherwise (bounds a single instance — adequate for single-instance/dev).
+    let free_global_rpm =
+        match env_with_fallback("SOLVELA_FREE_TIER_GLOBAL_RPM", "RCR_FREE_TIER_GLOBAL_RPM") {
+            Ok(val) => match val.parse::<u32>() {
+                Ok(0) => {
+                    tracing::warn!(
+                        "SOLVELA_FREE_TIER_GLOBAL_RPM=0 disables ALL free-tier access \
+                         (every free request would be rejected); using default instead"
+                    );
+                    FREE_TIER_GLOBAL_RPM_DEFAULT
+                }
+                Ok(max) => {
+                    tracing::info!(
+                        global_rpm = max,
+                        "Aggregate free-tier global RPM override from env"
+                    );
+                    max
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        value = %val,
+                        "Invalid SOLVELA_FREE_TIER_GLOBAL_RPM, using default"
+                    );
+                    FREE_TIER_GLOBAL_RPM_DEFAULT
+                }
+            },
+            Err(_) => FREE_TIER_GLOBAL_RPM_DEFAULT,
+        };
+    let free_global_cap = FreeTierGlobalCap::new(free_global_rpm);
+
     // Build shared state
     let state = Arc::new(AppState {
         config: app_config.clone(),
@@ -595,6 +637,7 @@ async fn main() -> anyhow::Result<()> {
         prometheus_handle,
         dev_bypass_payment,
         free_rate_limiter: free_rate_limiter.clone(),
+        free_global_cap,
     });
 
     // ── Shutdown signal for background tasks ────────────────────────────────

--- a/crates/gateway/src/middleware/api_key.rs
+++ b/crates/gateway/src/middleware/api_key.rs
@@ -230,6 +230,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         })
     }
 

--- a/crates/gateway/src/middleware/rate_limit.rs
+++ b/crates/gateway/src/middleware/rate_limit.rs
@@ -212,6 +212,145 @@ impl RateLimiter {
     }
 }
 
+/// Default aggregate (global, all-clients-combined) free-tier requests-per-minute
+/// cap.
+///
+/// This MUST stay BELOW the upstream provider's SHARED free-tier ceiling. The
+/// free model is served on Google's free Gemini API tier, whose hard limit is
+/// ~15 requests/min SHARED across the whole gateway API key. The per-IP free
+/// limiter ([`RateLimitConfig::free_default`]) cannot protect that shared
+/// ceiling — many distinct IPs each under their per-IP cap can still collectively
+/// exceed 15 RPM, making Google 429 the gateway and surfacing as errors for ALL
+/// free users. 12 leaves headroom below 15 so the gateway returns its OWN clean
+/// 429 before Google's leaks through. Override via `SOLVELA_FREE_TIER_GLOBAL_RPM`.
+pub const FREE_TIER_GLOBAL_RPM_DEFAULT: u32 = 12;
+
+/// In-memory fixed-window state for the aggregate free-tier cap.
+///
+/// A single shared counter (NOT per-client): `(epoch_minute, count)`. Used as
+/// the backing store when Redis is absent, AND as the degradation fallback when
+/// a configured Redis errors at runtime. Per-instance only — acceptable for
+/// single-instance/dev; multi-instance deployments rely on the Redis path so the
+/// counter is shared across instances (see [`FreeTierGlobalCap::check`]).
+#[derive(Debug, Default)]
+struct GlobalWindow {
+    epoch_minute: u64,
+    count: u64,
+}
+
+/// Aggregate (global) free-tier rate cap — total free-model throughput across
+/// ALL clients per 1-minute fixed window, kept below the upstream provider's
+/// shared ceiling.
+///
+/// Distinct from [`RateLimiter`], which is per-client. This caps the COMBINED
+/// free traffic so the gateway 429s before the upstream provider does. Backing
+/// store is Redis when configured (cross-instance: every instance increments one
+/// shared key), degrading to an in-memory per-instance counter when Redis is
+/// absent or errors at runtime.
+#[derive(Debug, Clone)]
+pub struct FreeTierGlobalCap {
+    /// Max free requests allowed across all clients per window.
+    cap: u32,
+    /// In-memory fallback counter (Redis-absent and Redis-error paths).
+    window: Arc<std::sync::Mutex<GlobalWindow>>,
+}
+
+impl FreeTierGlobalCap {
+    /// Window length in seconds. Fixed 1-minute window to match the provider's
+    /// per-minute (RPM) ceiling and the `retry-after` advertised on rejection.
+    pub const WINDOW_SECS: u64 = 60;
+
+    /// Create a cap with the given per-minute limit.
+    pub fn new(cap: u32) -> Self {
+        Self {
+            cap,
+            window: Arc::new(std::sync::Mutex::new(GlobalWindow::default())),
+        }
+    }
+
+    /// The configured per-minute cap.
+    pub fn cap(&self) -> u32 {
+        self.cap
+    }
+
+    /// Current wall-clock epoch minute (UTC). The fixed-window bucket id shared
+    /// by Redis and the in-memory fallback so both agree on window boundaries.
+    fn epoch_minute() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() / Self::WINDOW_SECS)
+            .unwrap_or(0)
+    }
+
+    /// Increment the in-memory fixed-window counter for `minute` and return the
+    /// post-increment count. Resets the window when the minute rolls over.
+    ///
+    /// GHSA-wc9q-wc6q-gwmq pattern: recover from a poisoned lock rather than
+    /// panicking, so one panicking task can't wedge the free path for everyone.
+    fn incr_in_memory(&self, minute: u64) -> u64 {
+        let mut w = self
+            .window
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if w.epoch_minute != minute {
+            w.epoch_minute = minute;
+            w.count = 0;
+        }
+        w.count += 1;
+        w.count
+    }
+
+    /// Check (and consume one slot of) the aggregate free-tier budget.
+    ///
+    /// Returns `Ok(())` when the request is under the cap, `Err(())` when the
+    /// aggregate window is exhausted (caller emits the shared 429).
+    ///
+    /// Store selection:
+    /// - `cache = Some` (Redis configured): increment the shared Redis window
+    ///   key so the counter is cross-instance. On a Redis ERROR, DEGRADE to the
+    ///   in-memory per-instance counter and `warn!` — an infra blip must not
+    ///   hard-fail free traffic (fail-open to in-memory, NOT fail-open to
+    ///   unbounded), and the provider's own 429 is the ultimate backstop.
+    /// - `cache = None` (no Redis): use the in-memory per-instance counter.
+    pub async fn check(&self, cache: Option<&crate::cache::ResponseCache>) -> Result<(), ()> {
+        let minute = Self::epoch_minute();
+
+        let count = match cache {
+            Some(c) => match c.incr_global_free_window(minute).await {
+                Ok(n) => n,
+                Err(e) => {
+                    // Degrade to in-memory rather than failing the request. We do
+                    // NOT go unbounded: the in-memory counter still bounds this
+                    // instance for the current window.
+                    warn!(
+                        error = %e,
+                        "free-tier aggregate cap: Redis INCR failed — degrading to in-memory counter for this request"
+                    );
+                    self.incr_in_memory(minute)
+                }
+            },
+            None => self.incr_in_memory(minute),
+        };
+
+        if count > self.cap as u64 {
+            Err(())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Build a [`RateLimitConfig`] describing this cap, so the shared
+    /// [`rate_limited_response`] emits a correct `x-ratelimit-limit` /
+    /// `retry-after` for the 1-minute aggregate window.
+    pub fn as_rate_limit_config(&self) -> RateLimitConfig {
+        RateLimitConfig {
+            max_requests: self.cap,
+            window: Duration::from_secs(Self::WINDOW_SECS),
+            unknown_max_requests: self.cap,
+        }
+    }
+}
+
 /// Paths that are exempt from rate limiting.
 ///
 /// These are operational/monitoring endpoints that must remain accessible even
@@ -554,6 +693,87 @@ mod tests {
             RATE_LIMIT_SKIP_PATHS.contains(&"/metrics"),
             "metrics endpoint must be exempt from rate limiting"
         );
+    }
+
+    #[tokio::test]
+    async fn test_free_global_cap_blocks_after_cap_in_memory() {
+        // No Redis → in-memory counter. Cap of 3: first 3 OK, 4th rejected.
+        let cap = FreeTierGlobalCap::new(3);
+        assert!(cap.check(None).await.is_ok(), "1st under cap");
+        assert!(cap.check(None).await.is_ok(), "2nd under cap");
+        assert!(cap.check(None).await.is_ok(), "3rd at cap");
+        assert!(
+            cap.check(None).await.is_err(),
+            "4th must be rejected — aggregate cap exceeded"
+        );
+        // Still rejected on subsequent calls within the same window.
+        assert!(cap.check(None).await.is_err());
+    }
+
+    #[test]
+    fn test_free_global_cap_default_below_google_ceiling() {
+        // The aggregate default MUST stay strictly below Google's shared 15 RPM
+        // free-tier ceiling, or the gateway leaks Google's 429 instead of its own.
+        assert_eq!(FREE_TIER_GLOBAL_RPM_DEFAULT, 12);
+        // Compile-time guard: a future bump to >= 15 fails the build, not just a
+        // test run. (clippy::assertions_on_constants wants the const block form.)
+        const _: () = assert!(
+            FREE_TIER_GLOBAL_RPM_DEFAULT < 15,
+            "aggregate default must stay below Google's 15 RPM shared ceiling"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_free_global_cap_window_resets() {
+        // Drive the in-memory counter directly across a window rollover: an
+        // exhausted minute must not bleed into the next minute's budget.
+        let cap = FreeTierGlobalCap::new(2);
+        assert_eq!(cap.incr_in_memory(100), 1);
+        assert_eq!(cap.incr_in_memory(100), 2);
+        assert_eq!(cap.incr_in_memory(100), 3); // over cap (count > 2)
+                                                // New minute → counter resets to 1.
+        assert_eq!(
+            cap.incr_in_memory(101),
+            1,
+            "window rollover must reset the aggregate counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_free_global_cap_degrades_to_in_memory_on_redis_error() {
+        // A configured-but-unreachable Redis must NOT 500 the request: the cap
+        // degrades to its in-memory counter and still bounds traffic. Point at a
+        // closed port so every INCR errors, then assert the in-memory counter is
+        // what enforces the cap (cap=2 → 3rd rejected).
+        let cache = crate::cache::ResponseCache::new(
+            "redis://127.0.0.1:1",
+            crate::cache::CacheConfig::default(),
+        )
+        .expect("client open does not connect");
+        let cap = FreeTierGlobalCap::new(2);
+
+        assert!(
+            cap.check(Some(&cache)).await.is_ok(),
+            "1st must serve via in-memory degradation, not error"
+        );
+        assert!(cap.check(Some(&cache)).await.is_ok(), "2nd at cap");
+        assert!(
+            cap.check(Some(&cache)).await.is_err(),
+            "3rd must be rejected by the in-memory fallback counter — degradation is bounded, not unbounded"
+        );
+    }
+
+    #[test]
+    fn test_free_global_cap_as_rate_limit_config() {
+        let cap = FreeTierGlobalCap::new(12);
+        let cfg = cap.as_rate_limit_config();
+        assert_eq!(cfg.max_requests, 12);
+        assert_eq!(cfg.window, Duration::from_secs(60));
+        // The shared 429 builder must advertise a 60s retry-after for the
+        // 1-minute aggregate window.
+        let resp = rate_limited_response(&cfg);
+        assert_eq!(resp.headers().get("x-ratelimit-limit").unwrap(), "12");
+        assert_eq!(resp.headers().get("retry-after").unwrap(), "60");
     }
 
     #[tokio::test]

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -406,6 +406,36 @@ pub async fn chat_completions(
                 ));
             }
 
+            // Gate order on the free path is deliberate:
+            //   1. per-IP free check (above) — cheap, in-memory, rejects a single
+            //      spamming IP without a Redis round-trip.
+            //   2. aggregate cap (here) — global across ALL clients, bounds total
+            //      free throughput below the upstream provider's SHARED ceiling
+            //      (the per-IP check can't: many distinct IPs each under their
+            //      per-IP cap can still collectively exceed Google's ~15 RPM).
+            //   3. prompt guard → provider (below).
+            // Both rate gates run BEFORE any provider call so a rejected request
+            // never reaches the upstream free-tier quota. The cap uses Redis when
+            // configured (cross-instance) and degrades to in-memory on Redis error
+            // (it never goes unbounded); see `FreeTierGlobalCap::check`.
+            if state
+                .free_global_cap
+                .check(state.cache.as_ref())
+                .await
+                .is_err()
+            {
+                counter!("solvela_payments_total", "status" => "free_global_rate_limited")
+                    .increment(1);
+                warn!(
+                    model = %req.model,
+                    cap = state.free_global_cap.cap(),
+                    "free-tier aggregate (global) rate cap exceeded — returning gateway 429 before upstream provider 429s"
+                );
+                return Ok(crate::middleware::rate_limit::rate_limited_response(
+                    &state.free_global_cap.as_rate_limit_config(),
+                ));
+            }
+
             counter!("solvela_payments_total", "status" => "free").increment(1);
             info!(model = %req.model, "zero-cost model — serving free-tier request without payment");
 

--- a/crates/gateway/src/routes/health.rs
+++ b/crates/gateway/src/routes/health.rs
@@ -165,6 +165,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         })
     }
 
@@ -240,6 +243,9 @@ supports_vision = false
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
         })
     }

--- a/crates/gateway/src/routes/orgs/api_keys.rs
+++ b/crates/gateway/src/routes/orgs/api_keys.rs
@@ -254,6 +254,9 @@ mod tests {
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         });
 
         let ctx = OrgContext {

--- a/crates/gateway/src/routes/orgs/mod.rs
+++ b/crates/gateway/src/routes/orgs/mod.rs
@@ -404,6 +404,9 @@ supports_vision = true
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         });
 
         Router::new()
@@ -569,6 +572,9 @@ mod tests {
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         };
 
         let mut headers = HeaderMap::new();
@@ -616,6 +622,9 @@ mod tests {
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
         };
 
@@ -667,6 +676,9 @@ mod tests {
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
         };
 

--- a/crates/gateway/src/routes/orgs/teams.rs
+++ b/crates/gateway/src/routes/orgs/teams.rs
@@ -432,6 +432,9 @@ mod tests {
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
         });
 
         let ctx = OrgContext {

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -955,6 +955,7 @@ mod tests {
             prometheus_handle: None,
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(crate::middleware::rate_limit::RateLimitConfig::free_default()),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT),
         });
 
         let app = axum::Router::new()
@@ -1088,6 +1089,9 @@ mod tests {
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
         })
     }

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -17,7 +17,9 @@ use tokio::sync::RwLock;
 use tower::ServiceExt;
 
 use gateway::config::AppConfig;
-use gateway::middleware::rate_limit::{RateLimitConfig, RateLimiter};
+use gateway::middleware::rate_limit::{
+    FreeTierGlobalCap, RateLimitConfig, RateLimiter, FREE_TIER_GLOBAL_RPM_DEFAULT,
+};
 use gateway::providers::health::{CircuitBreakerConfig, ProviderHealthTracker};
 use gateway::providers::{ChatStream, LLMProvider, ProviderRegistry};
 use gateway::services::ServiceRegistry;
@@ -469,6 +471,7 @@ fn test_app_with_state() -> (axum::Router, Arc<AppState>) {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
         Arc::clone(&state),
@@ -707,6 +710,7 @@ fn test_app_with_provider_registry_and_exact_verifier(
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
         Arc::clone(&state),
@@ -788,6 +792,7 @@ fn app_with_semantic_cache(sem: Arc<gateway::cache::semantic::SemanticCache>) ->
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: true,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -1098,6 +1103,7 @@ fn app_with_semantic_cache_and_escrow(
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -1757,6 +1763,7 @@ fn test_app_with_provider_registry_and_escrow_verifier(
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -1828,6 +1835,7 @@ fn test_app_with_escrow() -> axum::Router {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -2257,6 +2265,7 @@ async fn test_chat_enforced_wallet_unprovisioned_tenant_returns_400_e2e() {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
         Arc::clone(&state),
@@ -4166,6 +4175,7 @@ fn test_app_with_nonce_pool() -> axum::Router {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     gateway::build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -6198,6 +6208,7 @@ fn test_app_with_escrow_metrics() -> axum::Router {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -6362,6 +6373,7 @@ async fn test_escrow_health_reflects_incremented_metrics() {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
 
     // Simulate claim processing by incrementing metrics atomically
@@ -6596,6 +6608,7 @@ async fn test_escrow_health_status_down_without_claimer() {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
 
     let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
@@ -6984,6 +6997,7 @@ async fn test_proxy_require_tenant_wallet_rejected_before_settlement() {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
         Arc::clone(&state),
@@ -7933,6 +7947,7 @@ async fn test_admin_stats_returns_404_when_admin_token_not_configured() {
         api_key_hmac_secret: None,
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
         Arc::clone(&state),
@@ -8543,6 +8558,10 @@ fn test_app_with_free_limit(free_max: u32) -> axum::Router {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(free_cfg),
+        // Generous aggregate cap by default so the PER-IP tests above are not
+        // accidentally tripped by the global cap; the aggregate-cap tests build
+        // their own app via `test_app_with_global_cap`.
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -8792,6 +8811,9 @@ async fn dev_bypass_still_works() {
             window: std::time::Duration::from_secs(60),
             unknown_max_requests: 0,
         }),
+        // Aggregate cap also set to 0 — if the dev-bypass branch were ever
+        // (incorrectly) routed through the free gates, this PAID model would 429.
+        free_global_cap: FreeTierGlobalCap::new(0),
     });
     let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
 
@@ -8810,5 +8832,225 @@ async fn dev_bypass_still_works() {
             .get("x-solvela-payment-status")
             .and_then(|v| v.to_str().ok()),
         Some("dev_bypass"),
+    );
+}
+
+// ===========================================================================
+// PR B — Aggregate (global, all-clients-combined) free-tier rate cap
+// ===========================================================================
+
+/// Build a mock-provider app whose AGGREGATE (global) free-tier cap is
+/// `global_cap` requests/min, with a GENEROUS per-IP free limit so the per-IP
+/// gate never trips first — isolating the aggregate cap under test. No Redis →
+/// the cap uses its in-memory counter (deterministic for tests).
+fn test_app_with_global_cap(global_cap: u32) -> axum::Router {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+
+    // Per-IP free limit set high so it never gates before the aggregate cap.
+    let free_cfg = RateLimitConfig {
+        max_requests: 10_000,
+        window: std::time::Duration::from_secs(60),
+        unknown_max_requests: 10_000,
+    };
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: mock_provider_registry(),
+        facilitator,
+        usage: gateway::usage::UsageTracker::noop(),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: None,
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(free_cfg),
+        free_global_cap: FreeTierGlobalCap::new(global_cap),
+    });
+    build_router(state, RateLimiter::new(RateLimitConfig::default()))
+}
+
+/// The aggregate cap trips on COMBINED free traffic even from DISTINCT IPs —
+/// proving it is global, not per-IP. With a generous per-IP limit, three
+/// requests from three different IPs against a global cap of 2 must yield two
+/// 200s then a 429.
+#[tokio::test]
+async fn free_global_cap_trips_across_distinct_ips() {
+    let app = test_app_with_global_cap(2);
+
+    // Two distinct IPs, each well under the (generous) per-IP limit.
+    let r1 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, "203.0.113.1"))
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::OK, "1st (global) under cap");
+
+    let r2 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, "203.0.113.2"))
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::OK, "2nd (global) at cap");
+
+    // Third request from yet another distinct IP — each IP is under its OWN
+    // per-IP limit, so only the GLOBAL cap can reject this. If the cap were
+    // per-IP this would be a 200.
+    let r3 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, "203.0.113.3"))
+        .await
+        .unwrap();
+    assert_eq!(
+        r3.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "aggregate cap must reject the 3rd request from a 3rd distinct IP (proves it is global, not per-IP)"
+    );
+
+    // The 429 advertises the AGGREGATE limit (2) and a 60s retry-after.
+    assert_eq!(
+        r3.headers().get("x-ratelimit-limit").unwrap(),
+        "2",
+        "aggregate 429 must carry the global cap (2)"
+    );
+    assert_eq!(r3.headers().get("x-ratelimit-remaining").unwrap(), "0");
+    assert_eq!(
+        r3.headers().get("retry-after").unwrap(),
+        "60",
+        "aggregate cap window is 1 minute"
+    );
+    let bytes = r3.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["error"]["type"], "rate_limit_exceeded");
+}
+
+/// Under the aggregate cap → served. A single request against a generous global
+/// cap must be served normally.
+#[tokio::test]
+async fn free_global_cap_under_cap_is_served() {
+    let app = test_app_with_global_cap(5);
+    let resp = app
+        .oneshot(free_chat_request(FREE_MODEL, "198.51.100.5"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a free request under the aggregate cap must be served"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-solvela-payment-status")
+            .and_then(|v| v.to_str().ok()),
+        Some("free"),
+    );
+}
+
+/// The per-IP limit and the aggregate cap are INDEPENDENT gates: a single IP
+/// hammering returns the PER-IP 429 (smaller limit) before the aggregate cap is
+/// even consulted (per-IP runs first). Build an app where the per-IP limit (1) is
+/// tighter than the global cap (100): the 2nd request from one IP must be 429'd
+/// by the per-IP gate, carrying the per-IP limit header (1), not the global (100).
+#[tokio::test]
+async fn free_per_ip_and_global_cap_are_independent() {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+    let free_cfg = RateLimitConfig {
+        max_requests: 1,
+        window: std::time::Duration::from_secs(60),
+        unknown_max_requests: 1,
+    };
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: mock_provider_registry(),
+        facilitator,
+        usage: gateway::usage::UsageTracker::noop(),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: None,
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(free_cfg),
+        // Global cap deliberately LOOSER than the per-IP limit.
+        free_global_cap: FreeTierGlobalCap::new(100),
+    });
+    let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
+
+    let ip = "192.0.2.50";
+    let r1 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, ip))
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+
+    // 2nd from the same IP → rejected by the PER-IP gate (runs first), carrying
+    // the per-IP limit (1), NOT the global cap (100).
+    let r2 = app
+        .clone()
+        .oneshot(free_chat_request(FREE_MODEL, ip))
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        r2.headers().get("x-ratelimit-limit").unwrap(),
+        "1",
+        "per-IP gate must reject first (limit=1), not the looser global cap (100)"
+    );
+}
+
+/// Paid models are unaffected by the aggregate cap. With a global cap of 0 (which
+/// would reject every FREE request), a PAID model with no payment header must
+/// still take its own 402 path — the aggregate cap only gates the free branch.
+#[tokio::test]
+async fn paid_model_unaffected_by_global_cap() {
+    let app = test_app_with_global_cap(0);
+    let resp = app
+        .oneshot(free_chat_request("openai/gpt-4o", "198.51.100.6"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "a paid model must 402, never be gated by the free aggregate cap"
     );
 }

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -88,6 +88,9 @@ fn router_with_pool(pool: PgPool) -> Router {
         free_rate_limiter: gateway::middleware::rate_limit::RateLimiter::new(
             gateway::middleware::rate_limit::RateLimitConfig::free_default(),
         ),
+        free_global_cap: gateway::middleware::rate_limit::FreeTierGlobalCap::new(
+            gateway::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+        ),
     });
 
     Router::new()

--- a/crates/gateway/tests/stats_http_redis.rs
+++ b/crates/gateway/tests/stats_http_redis.rs
@@ -24,7 +24,9 @@ use tokio::sync::RwLock;
 use tower::ServiceExt;
 
 use gateway::config::AppConfig;
-use gateway::middleware::rate_limit::{RateLimitConfig, RateLimiter};
+use gateway::middleware::rate_limit::{
+    FreeTierGlobalCap, RateLimitConfig, RateLimiter, FREE_TIER_GLOBAL_RPM_DEFAULT,
+};
 use gateway::providers::health::{CircuitBreakerConfig, ProviderHealthTracker};
 use gateway::providers::ProviderRegistry;
 use gateway::services::ServiceRegistry;
@@ -96,6 +98,7 @@ fn stats_router(usage: UsageTracker, db_pool: Option<PgPool>) -> axum::Router {
         prometheus_handle: None,
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(
         Arc::clone(&state),


### PR DESCRIPTION
## What

**PR B** of the free-tier work. Adds a **global** (all-clients-combined) rate cap on the free tier so total free-model throughput stays **below Google's free Gemini tier's ~15 RPM ceiling**, which is shared across the gateway's single API key.

### Why (the gap PR A left)
PR A's per-IP limit can't protect a shared upstream key: many distinct IPs, each under their per-IP limit, can collectively blow past Google's 15 RPM → Google 429s the gateway → errors for **all** free users. This cap makes the gateway return its own clean 429 first.

## Design

- **Default 12 RPM** (strictly `< 15`, enforced by a `const` compile-time guard). Env: `SOLVELA_FREE_TIER_GLOBAL_RPM` (`RCR_` fallback; `0`/invalid → default + warn).
- **Fixed-window** counter, key `free_tier:global_rpm:<epoch_minute>`, `retry-after` = 60s.
- **Backing store:**
  - Redis configured → shared key (`INCR` + first-increment `EXPIRE 120s`) → **cross-instance** (N instances share one counter vs Google's one key).
  - Redis absent → in-memory per-instance counter.
  - Redis **error** at runtime → degrade to in-memory + `warn!` (**fail-open to bounded, never unbounded**; provider's own 429 is the backstop).
- **Free-path gate order:** per-IP check (cheap, in-memory) → aggregate cap → prompt guard → provider. Both gates run before any provider call; the cap is reachable **only** on the zero-cost path (paid requests never enter it).
- 429 reuses the shared `rate_limited_response` with a distinct `status="free_global_rate_limited"` metric + warn.

## Tests
6 unit (in-memory cap, window reset, `<15` guard, **Redis-error degradation**, config) + 1 live-Redis cache unit (INCR/EXPIRE/TTL actually exercised on this box) + 4 integration (**global cap trips across DISTINCT IPs**, under-cap served, per-IP vs global independent, paid unaffected). fmt/clippy clean; gateway lib **733**, integration **183**.

## Independent review (focused, fail-open class)

`ecc:silent-failure-hunter` — gate order, paid-path isolation, and 429 shape all **clean**; no unconditional-Ok / unbounded path; lock-poison/time/overflow clean. Two findings, both **accepted by design**:

- **MEDIUM** — during a *sustained multi-minute Redis outage*, the in-memory fallback resets per minute, so it enforces 12/min **per instance** instead of globally. This is the inherent consequence of losing the shared store; per-minute rate per instance is preserved and Google's 429 backstops. Documented in code.
- **LOW** — if `EXPIRE` fails on key creation the key lingers with no TTL (negligible; epoch-minute wrap is ~17M years). Could be hardened later with an atomic `SET … EX`.

## Scope
Aggregate cap only. PR A's deferred follow-ups (free-model-with-payment-header, unknown-bucket DoS doc, zero-cost Redis round-trips, `unknown_max_requests` env, warn throttling) are untouched.