### PR TITLE
fix(gateway): free-tier hardening — 5 deferred findings

### DIFF
--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -867,6 +867,29 @@ async fn main() -> anyhow::Result<()> {
 
     info!(addr, models = model_count, "Solvela gateway started");
 
+    // FINDING 2: confirm ConnectInfo-based per-IP keying is in effect. The serve
+    // call below uses `into_make_service_with_connect_info::<SocketAddr>()`, so
+    // every free request keys on its real TCP peer IP rather than collapsing into
+    // the shared stricter "unknown" bucket. If a proxy/misconfig ever strips
+    // ConnectInfo, the `solvela_free_tier_unknown_bucket_total` metric (emitted on
+    // the free path) climbs — alert on it.
+    info!(
+        "free-tier rate limiting keys on the TCP peer IP (ConnectInfo enabled); \
+         the shared 'unknown' bucket is the fallback only when ConnectInfo is absent — \
+         watch solvela_free_tier_unknown_bucket_total to detect that misconfig"
+    );
+
+    // FINDING 4: `unknown_max_requests` (the shared 'unknown'-bucket limit) is
+    // FIXED at its default and is NOT env-overridable. `SOLVELA_FREE_TIER_RATE_LIMIT`
+    // overrides only `max_requests` (the per-IP free limit), consistent with the
+    // paid limiter's `with_max_requests` shape. Documented here so operators do not
+    // expect an env var to tune the unknown-bucket limit.
+    info!(
+        free_unknown_max_requests = free_rate_limiter.config().unknown_max_requests,
+        "free-tier 'unknown' bucket limit is fixed at its default and not env-overridable \
+         (SOLVELA_FREE_TIER_RATE_LIMIT tunes only the per-IP free limit)"
+    );
+
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<std::net::SocketAddr>(),

--- a/crates/gateway/src/middleware/rate_limit.rs
+++ b/crates/gateway/src/middleware/rate_limit.rs
@@ -12,7 +12,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use tokio::sync::Mutex;
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// Infallible extractor for the TCP peer address, for use in route handlers that
 /// need the actual connection IP (e.g. free-tier rate limiting) WITHOUT 500-ing
@@ -485,7 +485,12 @@ pub fn connect_info_client_id(addr: Option<std::net::SocketAddr>) -> String {
     match addr {
         Some(a) => a.ip().to_string(),
         None => {
-            warn!(
+            // FINDING 5: this used to `warn!` on EVERY ConnectInfo-absent request,
+            // spamming logs in a misconfigured deploy. Downgraded to `debug!`; the
+            // operator-facing signal is the `solvela_free_tier_unknown_bucket_total`
+            // metric emitted by the free path (Finding 2) and the one-time startup
+            // assertion in main.rs — both far lower noise than a per-request warn.
+            debug!(
                 "free-tier rate limiter falling back to shared 'unknown' bucket — ConnectInfo \
                  not configured; all unidentified free clients share a single stricter limit"
             );

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -349,156 +349,189 @@ pub async fn chat_completions(
             });
     }
 
-    if payment_header.is_none() {
-        // Compute the upfront cost estimate ONCE. This same `atomic_amount` is the
-        // single source of truth for two decisions below:
-        //   1. free-ness (is_free_estimate → zero-cost bypass), and
-        //   2. the amount advertised in the 402 `accepts[]` for a paid model.
-        // Deriving both from one estimate means a pricing change can never make a
-        // paid model silently bypass payment (or a free model wrongly 402).
-        let cost = state
-            .model_registry
-            .estimate_cost(
-                &req.model,
-                estimate_input_tokens(&req),
-                // #500: reserve for the SAME completion-token ceiling billing
-                // will cap to (not a flat 1000), so an omitted-max_tokens
-                // request can never bill above its reservation.
-                completion_token_ceiling(req.max_tokens, model_info),
-            )
-            .map_err(|e| GatewayError::Internal(e.to_string()))?;
+    // Compute the upfront cost estimate ONCE. This same `atomic_amount` is the
+    // single source of truth for two decisions below:
+    //   1. free-ness (is_free_estimate → zero-cost bypass), and
+    //   2. the amount advertised in the 402 `accepts[]` for a paid model.
+    // Deriving both from one estimate means a pricing change can never make a
+    // paid model silently bypass payment (or a free model wrongly 402).
+    //
+    // FINDING 1: the free-ness decision is hoisted ABOVE the `payment_header`
+    // branch so it is reachable whether or not a payment header is present. A
+    // free (estimate == 0) request must be SERVED at $0 regardless of any
+    // header — previously the bypass lived inside `if payment_header.is_none()`,
+    // so a free model carrying a (stray/legacy) payment header fell through to
+    // decode/verify and failed with InvalidPayment. The quoted amount for a free
+    // model is 0, so there is nothing to claim; a present header is simply
+    // ignored. `is_free_estimate` fails closed on any non-"0" value, so a paid
+    // model can never take this path.
+    let cost = state
+        .model_registry
+        .estimate_cost(
+            &req.model,
+            estimate_input_tokens(&req),
+            // #500: reserve for the SAME completion-token ceiling billing
+            // will cap to (not a flat 1000), so an omitted-max_tokens
+            // request can never bill above its reservation.
+            completion_token_ceiling(req.max_tokens, model_info),
+        )
+        .map_err(|e| GatewayError::Internal(e.to_string()))?;
 
-        let atomic_amount = usdc_atomic_amount_checked(&cost.total).map_err(|e| {
-            GatewayError::Internal(format!(
-                "failed to compute USDC atomic amount for model '{}': {}",
-                req.model, e
-            ))
-        })?;
+    let atomic_amount = usdc_atomic_amount_checked(&cost.total).map_err(|e| {
+        GatewayError::Internal(format!(
+            "failed to compute USDC atomic amount for model '{}': {}",
+            req.model, e
+        ))
+    })?;
 
-        // ── Zero-cost (free-tier) bypass ──────────────────────────────────────
-        //
-        // A model is free IFF its computed estimate atomic cost is exactly 0
-        // (e.g. a 0.0/0.0-priced model). Such a request must be SERVED, not 402'd
-        // for a $0 payment. A paid model (atomic > 0) falls through to the 402
-        // below unchanged — `is_free_estimate` fails closed on any non-"0" value.
-        if is_free_estimate(&atomic_amount) {
-            // Anti-abuse: the free path is anonymous (no payer wallet), so it is
-            // rate-limited per client IP, STRICTER than the paid limit. Enforced
-            // BEFORE any provider work so a limited free request never reaches the
-            // upstream provider quota. Keyed on the TCP peer IP (never a
-            // client-supplied header — GHSA-6ggq-cvwx-4f67); absent ConnectInfo
-            // falls back to the shared stricter "unknown" bucket.
-            let free_client_id = crate::middleware::rate_limit::connect_info_client_id(peer_addr.0);
-            if state
-                .free_rate_limiter
-                .check(&free_client_id)
-                .await
-                .is_err()
-            {
-                counter!("solvela_payments_total", "status" => "free_rate_limited").increment(1);
-                warn!(
-                    client_id = %free_client_id,
-                    model = %req.model,
-                    "free-tier rate limit exceeded"
-                );
-                return Ok(crate::middleware::rate_limit::rate_limited_response(
-                    state.free_rate_limiter.config(),
-                ));
-            }
-
-            // Gate order on the free path is deliberate:
-            //   1. per-IP free check (above) — cheap, in-memory, rejects a single
-            //      spamming IP without a Redis round-trip.
-            //   2. aggregate cap (here) — global across ALL clients, bounds total
-            //      free throughput below the upstream provider's SHARED ceiling
-            //      (the per-IP check can't: many distinct IPs each under their
-            //      per-IP cap can still collectively exceed Google's ~15 RPM).
-            //   3. prompt guard → provider (below).
-            // Both rate gates run BEFORE any provider call so a rejected request
-            // never reaches the upstream free-tier quota. The cap uses Redis when
-            // configured (cross-instance) and degrades to in-memory on Redis error
-            // (it never goes unbounded); see `FreeTierGlobalCap::check`.
-            if state
-                .free_global_cap
-                .check(state.cache.as_ref())
-                .await
-                .is_err()
-            {
-                counter!("solvela_payments_total", "status" => "free_global_rate_limited")
-                    .increment(1);
-                warn!(
-                    model = %req.model,
-                    cap = state.free_global_cap.cap(),
-                    "free-tier aggregate (global) rate cap exceeded — returning gateway 429 before upstream provider 429s"
-                );
-                return Ok(crate::middleware::rate_limit::rate_limited_response(
-                    &state.free_global_cap.as_rate_limit_config(),
-                ));
-            }
-
-            counter!("solvela_payments_total", "status" => "free").increment(1);
-            info!(model = %req.model, "zero-cost model — serving free-tier request without payment");
-
-            // Free requests reach a provider, so they must run the guard (same as
-            // the dev-bypass and paid paths).
-            run_prompt_guard(&req.messages)?;
-
-            let ctx = ProviderCallContext {
-                state: &state,
-                req: &req,
-                model_info,
-                headers: &headers,
-                debug_enabled,
-                request_start,
-                routing_tier: &routing_tier,
-                routing_score,
-                routing_profile: &routing_profile,
-                session_id: &session_id,
-                payment_status: PaymentStatus::Free,
-            };
-
-            return match provider::execute_provider_call(&ctx).await {
-                Ok(result) => {
-                    // Log spend at $0 via the existing fire-and-forget path so the
-                    // free tier still shows up in usage/observability. `cost_usdc`
-                    // is 0.0 and `estimated_cost_usdc` is None, so `log_spend`
-                    // increments counters by 0 (no divide-by-zero / no fail-closed
-                    // path is reachable for a zero amount). Anonymous: there is no
-                    // payer wallet, so a sentinel marks the row as free-tier.
-                    let usage = result
-                        .usage
-                        .as_ref()
-                        .map(|u| cap_usage_to_request_limits(u, &req, model_info));
-                    state.usage.log_spend(SpendLogEntry {
-                        wallet_address: "free-tier".to_string(),
-                        model: req.model.clone(),
-                        provider: result
-                            .actual_provider
-                            .unwrap_or_else(|| model_info.provider.clone()),
-                        input_tokens: usage.as_ref().map(|u| u.prompt_tokens).unwrap_or(0),
-                        output_tokens: usage.as_ref().map(|u| u.completion_tokens).unwrap_or(0),
-                        cost_usdc: 0.0,
-                        tx_signature: None,
-                        request_id: request_id.clone(),
-                        session_id: session_id.clone(),
-                        tenant: tenant.clone(),
-                        tenant_enforced: false,
-                        estimated_cost_usdc: None,
-                    });
-                    Ok(result.response)
-                }
-                Err(e) => Err(match e {
-                    ProviderCallError::AllProvidersFailed { model, error, .. } => {
-                        GatewayError::Internal(format!(
-                            "all providers failed for free model '{}': {}",
-                            model, error
-                        ))
-                    }
-                    ProviderCallError::Internal(msg) => GatewayError::Internal(msg),
-                }),
-            };
+    // ── Zero-cost (free-tier) bypass ──────────────────────────────────────────
+    //
+    // A model is free IFF its computed estimate atomic cost is exactly 0
+    // (e.g. a 0.0/0.0-priced model). Such a request must be SERVED, not 402'd
+    // for a $0 payment, and never reaches payment decode/verify/settlement —
+    // there is nothing to charge or claim at $0. A paid model (atomic > 0) falls
+    // through to the 402 / paid path below unchanged — `is_free_estimate` fails
+    // closed on any non-"0" value, so it is the single source of truth for
+    // free-ness and a paid request can never accidentally take this branch.
+    if is_free_estimate(&atomic_amount) {
+        // Anti-abuse: the free path is anonymous (no payer wallet), so it is
+        // rate-limited per client IP, STRICTER than the paid limit. Enforced
+        // BEFORE any provider work so a limited free request never reaches the
+        // upstream provider quota. Keyed on the TCP peer IP (never a
+        // client-supplied header — GHSA-6ggq-cvwx-4f67); absent ConnectInfo
+        // falls back to the shared stricter "unknown" bucket.
+        let free_client_id = crate::middleware::rate_limit::connect_info_client_id(peer_addr.0);
+        // FINDING 2: surface the `unknown` bucket collapse for operators. When
+        // ConnectInfo is absent every free client keys to one shared bucket
+        // (a trivial free-tier DoS under proxy misconfig). Production always
+        // sets ConnectInfo (`into_make_service_with_connect_info` in main.rs),
+        // so this counter staying at 0 confirms correct keying; a nonzero value
+        // is an alertable misconfiguration. This does NOT change the limiting
+        // behavior — only its observability.
+        if free_client_id == "unknown" {
+            counter!("solvela_free_tier_unknown_bucket_total").increment(1);
+        }
+        if state
+            .free_rate_limiter
+            .check(&free_client_id)
+            .await
+            .is_err()
+        {
+            counter!("solvela_payments_total", "status" => "free_rate_limited").increment(1);
+            warn!(
+                client_id = %free_client_id,
+                model = %req.model,
+                "free-tier rate limit exceeded"
+            );
+            return Ok(crate::middleware::rate_limit::rate_limited_response(
+                state.free_rate_limiter.config(),
+            ));
         }
 
+        // Gate order on the free path is deliberate:
+        //   1. per-IP free check (above) — cheap, in-memory, rejects a single
+        //      spamming IP without a Redis round-trip.
+        //   2. aggregate cap (here) — global across ALL clients, bounds total
+        //      free throughput below the upstream provider's SHARED ceiling
+        //      (the per-IP check can't: many distinct IPs each under their
+        //      per-IP cap can still collectively exceed Google's ~15 RPM).
+        //   3. prompt guard → provider (below).
+        // Both rate gates run BEFORE any provider call so a rejected request
+        // never reaches the upstream free-tier quota. The cap uses Redis when
+        // configured (cross-instance) and degrades to in-memory on Redis error
+        // (it never goes unbounded); see `FreeTierGlobalCap::check`.
+        if state
+            .free_global_cap
+            .check(state.cache.as_ref())
+            .await
+            .is_err()
+        {
+            counter!("solvela_payments_total", "status" => "free_global_rate_limited").increment(1);
+            warn!(
+                model = %req.model,
+                cap = state.free_global_cap.cap(),
+                "free-tier aggregate (global) rate cap exceeded — returning gateway 429 before upstream provider 429s"
+            );
+            return Ok(crate::middleware::rate_limit::rate_limited_response(
+                &state.free_global_cap.as_rate_limit_config(),
+            ));
+        }
+
+        counter!("solvela_payments_total", "status" => "free").increment(1);
+        // FINDING 1: a present payment header on a free model is ignored — the
+        // quoted amount is 0, so there is nothing to verify, settle, or claim.
+        // The request is served at $0 and never touches the payment path.
+        if payment_header.is_some() {
+            debug!(
+                model = %req.model,
+                "free model carried a payment header — ignored (quoted amount is 0, nothing to claim)"
+            );
+        }
+        info!(model = %req.model, "zero-cost model — serving free-tier request at $0");
+
+        // Free requests reach a provider, so they must run the guard (same as
+        // the dev-bypass and paid paths).
+        run_prompt_guard(&req.messages)?;
+
+        let ctx = ProviderCallContext {
+            state: &state,
+            req: &req,
+            model_info,
+            headers: &headers,
+            debug_enabled,
+            request_start,
+            routing_tier: &routing_tier,
+            routing_score,
+            routing_profile: &routing_profile,
+            session_id: &session_id,
+            payment_status: PaymentStatus::Free,
+        };
+
+        return match provider::execute_provider_call(&ctx).await {
+            Ok(result) => {
+                // Log spend at $0 via the existing fire-and-forget path so the
+                // free tier still shows up in usage/observability. `cost_usdc`
+                // is 0.0 and `estimated_cost_usdc` is None, so `log_spend`
+                // increments counters by 0 (no divide-by-zero / no fail-closed
+                // path is reachable for a zero amount). Anonymous: there is no
+                // payer wallet, so a sentinel marks the row as free-tier.
+                let usage = result
+                    .usage
+                    .as_ref()
+                    .map(|u| cap_usage_to_request_limits(u, &req, model_info));
+                state.usage.log_spend(SpendLogEntry {
+                    wallet_address: "free-tier".to_string(),
+                    model: req.model.clone(),
+                    provider: result
+                        .actual_provider
+                        .unwrap_or_else(|| model_info.provider.clone()),
+                    input_tokens: usage.as_ref().map(|u| u.prompt_tokens).unwrap_or(0),
+                    output_tokens: usage.as_ref().map(|u| u.completion_tokens).unwrap_or(0),
+                    cost_usdc: 0.0,
+                    tx_signature: None,
+                    request_id: request_id.clone(),
+                    session_id: session_id.clone(),
+                    tenant: tenant.clone(),
+                    tenant_enforced: false,
+                    estimated_cost_usdc: None,
+                });
+                Ok(result.response)
+            }
+            Err(e) => Err(match e {
+                ProviderCallError::AllProvidersFailed { model, error, .. } => {
+                    GatewayError::Internal(format!(
+                        "all providers failed for free model '{}': {}",
+                        model, error
+                    ))
+                }
+                ProviderCallError::Internal(msg) => GatewayError::Internal(msg),
+            }),
+        };
+    }
+
+    // Not free (estimate > 0). A paid model with NO payment header returns 402.
+    // (A paid model WITH a header falls through to decode/verify/settle below.)
+    if payment_header.is_none() {
         // Return 402 with pricing info (paid model, no payment header)
         counter!("solvela_payments_total", "status" => "none").increment(1);
         info!(model = %req.model, "no payment signature, returning 402");

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -431,7 +431,24 @@ impl UsageTracker {
         // be negative if actual usage came in under the estimate. If
         // `estimated_cost_usdc` is `None` no reservation was committed
         // (legacy / proxy / test paths), so we increment by the full cost.
+        // FINDING 3: skip the Redis spend-counter round-trip for a PURE zero-cost
+        // row — `cost_usdc == 0.0` AND `estimated_cost_usdc` is None (the free-tier
+        // $0 entry). With no reservation, the increment delta below is exactly 0.0,
+        // so the three `INCRBYFLOAT spend:* 0.0` (+ per-tenant) calls are pure no-op
+        // round-trips. We still write the DB row above for observability.
+        //
+        // This is safe per solvela-fintech (fail-closed / never-drop-a-real-spend):
+        // a real (nonzero) spend has `cost_usdc != 0.0`, and a reconciled spend has
+        // `estimated_cost_usdc == Some(_)` (where the delta `0.0 - reserved` is a
+        // REAL negative adjustment that MUST still post). Both of those keep BOTH
+        // conditions from holding, so neither is ever skipped here.
+        let is_zero_cost_no_reservation =
+            entry.cost_usdc == 0.0 && entry.estimated_cost_usdc.is_none();
+
         if let Some(client) = &self.redis_client {
+            if is_zero_cost_no_reservation {
+                return;
+            }
             let client = client.clone();
             let db_pool = self.db_pool.clone();
             let wallet = entry.wallet_address;

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -8766,6 +8766,115 @@ async fn free_and_paid_do_not_cross_contaminate() {
     );
 }
 
+/// Build a free-model chat request that ALSO carries a (dummy) payment header,
+/// with a fixed `ConnectInfo` peer IP. Used to prove a free model is served at
+/// $0 regardless of a stray/legacy payment header (Finding 1).
+fn free_chat_request_with_header(model: &str, ip: &str, header_val: &str) -> Request<Body> {
+    let mut req = free_chat_request(model, ip);
+    req.headers_mut().insert(
+        "payment-signature",
+        axum::http::HeaderValue::from_str(header_val).unwrap(),
+    );
+    req
+}
+
+/// FINDING 1 (the load-bearing case): a FREE model carrying a payment header must
+/// be SERVED at $0, NOT rejected with InvalidPayment. Before the fix the
+/// zero-cost bypass lived inside `if payment_header.is_none()`, so a free model
+/// with a header skipped the bypass, hit decode/verify, and 402'd
+/// (invalid_payment). The header is simply ignored (quoted amount is 0).
+#[tokio::test]
+async fn free_model_with_payment_header_is_served() {
+    let app = test_app_with_free_limit(5);
+    let resp = app
+        .oneshot(free_chat_request_with_header(
+            FREE_MODEL,
+            "198.51.100.30",
+            // A garbage header that would NOT decode as a PaymentPayload — on a
+            // paid model this yields InvalidPayment; on a free model it must be
+            // ignored entirely.
+            "not-a-valid-payment-payload",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a free model with a (stray) payment header must be served at $0, not InvalidPayment-rejected"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-solvela-payment-status")
+            .and_then(|v| v.to_str().ok()),
+        Some("free"),
+        "a free request remains payment-status = free even with a header present"
+    );
+}
+
+/// FINDING 1 corollary: the free path's per-IP rate limit still applies when a
+/// payment header is present — a header must not let a free client escape the
+/// anti-abuse gate.
+#[tokio::test]
+async fn free_model_with_header_still_rate_limited() {
+    let app = test_app_with_free_limit(1);
+    let ip = "198.51.100.31";
+
+    let first = app
+        .clone()
+        .oneshot(free_chat_request_with_header(
+            FREE_MODEL,
+            ip,
+            "dummy-header",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK, "first free request served");
+
+    let second = app
+        .clone()
+        .oneshot(free_chat_request_with_header(
+            FREE_MODEL,
+            ip,
+            "dummy-header",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        second.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "a free model with a header is still bound by the per-IP free limit"
+    );
+}
+
+/// FINDING 1 guard (unchanged paid behavior): a PAID model with a BAD (undecodable)
+/// payment header must STILL be rejected with invalid_payment (402) — the
+/// restructure must not let a paid request take the free path.
+#[tokio::test]
+async fn paid_model_bad_header_still_invalid_payment() {
+    let app = test_app_with_free_limit(5);
+    let resp = app
+        .oneshot(free_chat_request_with_header(
+            "openai/gpt-4o",
+            "198.51.100.32",
+            "not-a-valid-payment-payload",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "a paid model with a bad payment header must still be rejected"
+    );
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(
+        v["error"]["type"], "invalid_payment",
+        "an undecodable header on a paid model must map to invalid_payment, not be served free"
+    );
+}
+
 /// The dev-bypass path still works (regression guard for the restructured
 /// no-payment block).
 #[tokio::test]

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -152,6 +152,106 @@ async fn log_spend_accumulates_across_calls(pool: PgPool) {
     redis_del(&client, &[&day_key]).await;
 }
 
+/// FINDING 3: a PURE zero-cost row (`cost_usdc == 0.0` AND `estimated_cost_usdc`
+/// is None — the free-tier $0 entry) must write the DB row for observability but
+/// issue NO Redis spend-counter increment (the increment would be `INCRBYFLOAT 0.0`,
+/// a no-op round-trip). Proven by asserting the `spend:{wallet}:{day}` key NEVER
+/// materializes after a settling window, while a nonzero entry for the SAME wallet
+/// DOES create it.
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_zero_cost_no_reservation_skips_redis_but_writes_db(pool: PgPool) {
+    let client = redis_client();
+    let wallet = unique_wallet();
+    let now = Utc::now();
+    let day_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%d"));
+
+    let tracker = UsageTracker::new(Some(pool.clone()), Some(client.clone()));
+
+    // (a) Pure zero-cost free-tier entry: $0, no reservation.
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "google/gemini-3.1-flash-lite".to_string(),
+        provider: "google".to_string(),
+        input_tokens: 5,
+        output_tokens: 7,
+        cost_usdc: 0.0,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant: None,
+        tenant_enforced: false,
+        estimated_cost_usdc: None,
+    });
+
+    // The DB row must be written (observability). Poll for it.
+    let mut db_rows: i64 = 0;
+    for _ in 0..50 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        db_rows = sqlx::query_scalar("SELECT COUNT(*) FROM spend_logs WHERE wallet_address = $1")
+            .bind(&wallet)
+            .fetch_one(&pool)
+            .await
+            .expect("count spend_logs");
+        if db_rows >= 1 {
+            break;
+        }
+    }
+    assert_eq!(
+        db_rows, 1,
+        "a zero-cost free-tier entry must still write its DB row for observability"
+    );
+
+    // The Redis spend key must NOT exist — no INCRBYFLOAT was issued. Give the
+    // fire-and-forget spawn ample time to (not) write.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("conn");
+    let zero_cost_val: Option<String> = redis::cmd("GET")
+        .arg(&day_key)
+        .query_async(&mut conn)
+        .await
+        .expect("get day key");
+    assert!(
+        zero_cost_val.is_none(),
+        "a pure $0/no-reservation entry must NOT create a Redis spend counter, got {zero_cost_val:?}"
+    );
+
+    // (b) A NONZERO entry for the same wallet still increments Redis.
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: wallet.clone(),
+        model: "openai/gpt-4o".to_string(),
+        provider: "openai".to_string(),
+        input_tokens: 100,
+        output_tokens: 200,
+        cost_usdc: 0.0050,
+        tx_signature: None,
+        request_id: None,
+        session_id: None,
+        tenant: None,
+        tenant_enforced: false,
+        estimated_cost_usdc: None,
+    });
+    let day_val = wait_for_key(&client, &day_key)
+        .await
+        .expect("a nonzero entry must still create the Redis spend counter");
+    assert!(
+        (day_val.parse::<f64>().unwrap_or(0.0) - 0.005).abs() < 1e-9,
+        "nonzero spend counter must equal 0.005, got {day_val}"
+    );
+
+    redis_del(
+        &client,
+        &[
+            &day_key,
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H")),
+            &format!("spend:{}:{}", wallet, now.format("%Y-%m")),
+        ],
+    )
+    .await;
+}
+
 #[sqlx::test(migrations = "../../migrations")]
 async fn check_budget_passes_when_under_default_daily_limit(pool: PgPool) {
     let client = redis_client();


### PR DESCRIPTION
## What

Clears the five Low/operational findings deferred from the free-tier PRs (#524/#525/#526), logged on #525.

| # | Sev | Fix |
|---|-----|-----|
| **1** | Medium (money-path) | A free model carrying a payment header was wrongly rejected (`InvalidPayment`). The free-ness decision is **hoisted above** the `payment_header` branch: a free (`estimate==0`) request is served at $0 regardless of any header and never reaches decode/verify/settle. Paid path (`estimate>0`) byte-unchanged; `is_free_estimate` stays the fail-closed single source of truth. |
| **3** | Low (money-path) | `log_spend` skips the Redis spend-counter `INCRBYFLOAT` for a pure zero-cost row (`cost==0 && estimated==None`) while still writing the DB row. Both conditions required → no real or reconciled (negative-release) update is ever dropped. |
| **2** | Medium (ops) | Emit `solvela_free_tier_unknown_bucket_total` when the free path keys to the shared `unknown` bucket (proxy-misconfig DoS signal) + startup `info!` confirming ConnectInfo-based per-IP keying. Limiting behavior unchanged. |
| **5** | Low (ops) | Downgrade the per-request `connect_info_client_id` `warn!` → `debug!` (the Finding-2 metric is the operator signal now), killing log spam under misconfig. |
| **4** | Low (ops) | Startup `info!` documenting `unknown_max_requests` is fixed at its default and not env-overridable (consistent with the paid limiter; no new env var). |

## Tests
- `free_model_with_payment_header_is_served` — the new case → 200 at $0 (verified it **fails 402-vs-200 pre-change**, passes after).
- `free_model_with_header_still_rate_limited`, `paid_model_bad_header_still_invalid_payment` (paid unchanged).
- `log_spend_zero_cost_no_reservation_skips_redis_but_writes_db` — $0 row writes DB, no `spend:` key; nonzero still does.
- fmt/clippy clean; gateway lib **733**, integration **186**, +1 live `usage_redis`.

## Independent review
`ecc:silent-failure-hunter` on the Finding 1 restructure + Finding 3 skip — **all clean**: paid can't take the free path (fails closed), free path returns before any decode/verify/settle/escrow/budget, paid path byte-equivalent, dev-bypass first & unchanged, the Redis skip never drops a real/reconciled spend.

## Scope
Only these 5 findings. No wire-format / settlement-semantics changes; the paid path is unchanged.