### PR TITLE
fix(gateway): quote and validate payment asset from configured mint, not compile-time constant

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -3,32 +3,57 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
 use solvela_x402::types::{
-    PaymentAccept, PaymentPayload, PaymentRequired, Resource, SolanaPayload,
+    PaymentAccept, PaymentPayload, PaymentRequired, Resource, SolanaPayload, SOLANA_NETWORK,
+    USDC_MINT,
 };
 use zeroize::Zeroizing;
 
 use crate::commands::wallet::load_wallet;
 
+/// Returns true if an accept entry is payable by this CLI: the canonical
+/// Solana network AND the canonical USDC mint.
+///
+/// The CLI pins both client-side (matching all four SDK signers) so a
+/// malicious or misconfigured gateway advertising a foreign asset or network
+/// can never steer the wallet into signing a transfer of the wrong token —
+/// fail closed, never fall back to "first advertised entry".
+fn is_payable_accept(accept: &PaymentAccept) -> bool {
+    accept.network == SOLANA_NETWORK && accept.asset == USDC_MINT
+}
+
 /// Select the preferred payment scheme from the accepts list.
 ///
-/// If `override_scheme` is `Some`, the scheme with that name must be present in
-/// `accepts` or an error is returned. Otherwise the default preference is used:
-/// "escrow" (when a program ID is advertised) over "exact".
+/// Only entries on the canonical Solana network with the canonical USDC mint
+/// are eligible (see [`is_payable_accept`]). If `override_scheme` is `Some`,
+/// an eligible entry with that scheme name must be present or an error is
+/// returned. Otherwise the default preference is used: "escrow" (when a
+/// program ID is advertised) over "exact".
 fn select_payment_scheme<'a>(
     accepts: &'a [PaymentAccept],
     override_scheme: Option<&str>,
 ) -> Result<&'a PaymentAccept> {
     if let Some(scheme) = override_scheme {
-        return accepts
-            .iter()
-            .find(|a| a.scheme == scheme)
-            .with_context(|| format!("requested scheme '{scheme}' not advertised by gateway"));
+        let mut candidates = accepts.iter().filter(|a| a.scheme == scheme).peekable();
+        if candidates.peek().is_none() {
+            anyhow::bail!("requested scheme '{scheme}' not advertised by gateway");
+        }
+        return candidates.find(|a| is_payable_accept(a)).with_context(|| {
+            format!(
+                "requested scheme '{scheme}' is only advertised with an unsupported \
+                 network/asset (expected Solana USDC mint {USDC_MINT}); refusing to sign"
+            )
+        });
     }
     accepts
         .iter()
-        .find(|a| a.scheme == "escrow" && a.escrow_program_id.is_some())
-        .or_else(|| accepts.first())
-        .context("gateway returned no accepted payment methods")
+        .find(|a| is_payable_accept(a) && a.scheme == "escrow" && a.escrow_program_id.is_some())
+        .or_else(|| accepts.iter().find(|a| is_payable_accept(a)))
+        .with_context(|| {
+            format!(
+                "gateway advertised no payment method on the Solana USDC mint {USDC_MINT}; \
+                 refusing to sign"
+            )
+        })
 }
 
 /// Generate a unique 32-byte service_id by hashing the request body + random nonce.
@@ -702,6 +727,82 @@ mod tests {
         assert!(
             result.unwrap_err().to_string().contains("escrow"),
             "error should mention the requested scheme"
+        );
+    }
+
+    /// An exact accept whose `asset` is NOT the canonical USDC mint (wSOL here).
+    /// A malicious or buggy gateway advertising this first must never have it
+    /// selected — the CLI pins the canonical Solana network + USDC mint
+    /// client-side, matching the four SDK signers.
+    fn make_foreign_asset_accept() -> PaymentAccept {
+        PaymentAccept {
+            asset: "So11111111111111111111111111111111111111112".to_string(),
+            ..make_exact_accept()
+        }
+    }
+
+    /// An exact accept on a foreign network (Ethereum mainnet CAIP-2 id).
+    fn make_foreign_network_accept() -> PaymentAccept {
+        PaymentAccept {
+            network: "eip155:1".to_string(),
+            ..make_exact_accept()
+        }
+    }
+
+    #[test]
+    fn test_select_payment_scheme_skips_foreign_mint_first_entry() {
+        let accepts = vec![make_foreign_asset_accept(), make_exact_accept()];
+        let selected = select_payment_scheme(&accepts, None).expect("valid USDC entry exists");
+        assert_eq!(
+            selected.asset, USDC_MINT,
+            "foreign-mint entry listed first must be skipped in favor of the USDC entry"
+        );
+    }
+
+    #[test]
+    fn test_select_payment_scheme_skips_foreign_network_first_entry() {
+        let accepts = vec![make_foreign_network_accept(), make_exact_accept()];
+        let selected = select_payment_scheme(&accepts, None).expect("valid USDC entry exists");
+        assert_eq!(selected.network, SOLANA_NETWORK);
+    }
+
+    #[test]
+    fn test_select_payment_scheme_prefers_escrow_among_valid_entries() {
+        // Escrow preference is kept, but only among canonical-mint entries.
+        let accepts = vec![
+            make_foreign_asset_accept(),
+            make_exact_accept(),
+            make_escrow_accept(),
+        ];
+        let selected = select_payment_scheme(&accepts, None).expect("valid entries exist");
+        assert_eq!(selected.scheme, "escrow");
+        assert_eq!(selected.asset, USDC_MINT);
+    }
+
+    #[test]
+    fn test_select_payment_scheme_all_foreign_errors() {
+        let mut foreign_escrow = make_escrow_accept();
+        foreign_escrow.asset = "So11111111111111111111111111111111111111112".to_string();
+        let accepts = vec![make_foreign_asset_accept(), foreign_escrow];
+        let result = select_payment_scheme(&accepts, None);
+        assert!(
+            result.is_err(),
+            "no canonical USDC entry must be a hard error, never a fallback selection"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains(USDC_MINT),
+            "error should name the expected USDC mint"
+        );
+    }
+
+    #[test]
+    fn test_select_payment_scheme_override_foreign_mint_errors() {
+        // --scheme exact, but the only exact entry carries a foreign mint.
+        let accepts = vec![make_foreign_asset_accept(), make_escrow_accept()];
+        let result = select_payment_scheme(&accepts, Some("exact"));
+        assert!(
+            result.is_err(),
+            "--scheme override must not select a foreign-mint entry"
         );
     }
 

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -34,6 +34,10 @@ fn select_payment_scheme<'a>(
 ) -> Result<&'a PaymentAccept> {
     if let Some(scheme) = override_scheme {
         let mut candidates = accepts.iter().filter(|a| a.scheme == scheme).peekable();
+        // `peek()` does NOT consume: the subsequent `find` still scans from the
+        // first scheme-matching entry. The two-step shape exists to keep the
+        // two distinct errors apart — "scheme not advertised at all" vs
+        // "advertised only with an unsupported network/asset".
         if candidates.peek().is_none() {
             anyhow::bail!("requested scheme '{scheme}' not advertised by gateway");
         }
@@ -803,6 +807,25 @@ mod tests {
         assert!(
             result.is_err(),
             "--scheme override must not select a foreign-mint entry"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains(USDC_MINT),
+            "error should name the expected USDC mint"
+        );
+    }
+
+    #[test]
+    fn test_select_payment_scheme_empty_accepts_errors() {
+        // A gateway advertising NO payment options must produce a clear,
+        // mint-naming error — never a panic or a silent default.
+        let result = select_payment_scheme(&[], None);
+        assert!(
+            result.is_err(),
+            "empty accepts list must be a hard error, never a selection"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains(USDC_MINT),
+            "error should name the expected USDC mint"
         );
     }
 

--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -43,7 +43,7 @@ pub async fn agent_card(State(state): State<Arc<AppState>>) -> impl IntoResponse
                         "network": "solana",
                         // The CONFIGURED mint (what the verifier enforces),
                         // never the compile-time constant.
-                        "asset": state.config.solana.usdc_mint.clone(),
+                        "asset": &state.config.solana.usdc_mint,
                         "schemes": schemes
                     }
                 }

--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -41,7 +41,9 @@ pub async fn agent_card(State(state): State<Arc<AppState>>) -> impl IntoResponse
                     "required": true,
                     "params": {
                         "network": "solana",
-                        "asset": solvela_protocol::USDC_MINT,
+                        // The CONFIGURED mint (what the verifier enforces),
+                        // never the compile-time constant.
+                        "asset": state.config.solana.usdc_mint.clone(),
                         "schemes": schemes
                     }
                 }
@@ -80,8 +82,12 @@ mod tests {
     use solvela_x402::facilitator::Facilitator;
 
     fn make_state() -> Arc<AppState> {
+        make_state_with_config(AppConfig::default())
+    }
+
+    fn make_state_with_config(config: AppConfig) -> Arc<AppState> {
         Arc::new(AppState {
-            config: AppConfig::default(),
+            config,
             model_registry: ModelRegistry::from_toml(
                 r#"
 [models.test-model]
@@ -186,6 +192,71 @@ supports_vision = false
         assert_eq!(extensions.len(), 2);
         assert_eq!(extensions[0]["uri"], AP2_EXTENSION_URI);
         assert_eq!(extensions[1]["uri"], X402_EXTENSION_URI);
+    }
+
+    /// With a NON-default configured USDC mint, the AgentCard's x402 extension
+    /// advertises the configured mint — an A2A agent following the card must
+    /// build a payment the verifier will actually accept.
+    #[tokio::test]
+    async fn test_agent_card_advertises_configured_usdc_mint() {
+        let devnet_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let mut config = AppConfig::default();
+        config.solana.usdc_mint = devnet_mint.to_string();
+        let state = make_state_with_config(config);
+        let app = axum::Router::new()
+            .route(
+                "/.well-known/agent.json",
+                axum::routing::get(super::agent_card),
+            )
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                http::Request::builder()
+                    .method("GET")
+                    .uri("/.well-known/agent.json")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("request should succeed");
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096)
+            .await
+            .expect("read body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+
+        assert_eq!(
+            json["capabilities"]["extensions"][1]["params"]["asset"], devnet_mint,
+            "agent card must advertise the configured mint"
+        );
+    }
+
+    /// Default-config wire stability: with no mint override, the AgentCard
+    /// advertises the mainnet USDC mint exactly (pinned as a literal).
+    #[tokio::test]
+    async fn test_agent_card_advertises_default_usdc_mint() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                http::Request::builder()
+                    .method("GET")
+                    .uri("/.well-known/agent.json")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("request should succeed");
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096)
+            .await
+            .expect("read body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+
+        assert_eq!(
+            json["capabilities"]["extensions"][1]["params"]["asset"],
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        );
     }
 
     #[tokio::test]

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -124,12 +124,16 @@ async fn handle_new_request(
         data: None,
     })?;
 
-    // Build PaymentRequired (same structure as chat route)
+    // Build PaymentRequired (same structure as chat route). Quote the
+    // CONFIGURED mint — the one the verifier enforces — never the compile-time
+    // constant. The stored offer is also what `validate_submitted_against_offer`
+    // matches the submitted payment against, so quote and validation stay
+    // aligned by construction.
     let mut accepts = vec![solvela_x402::types::PaymentAccept {
         scheme: "exact".to_string(),
         network: solvela_x402::types::SOLANA_NETWORK.to_string(),
         amount: atomic_amount.clone(),
-        asset: solvela_x402::types::USDC_MINT.to_string(),
+        asset: state.config.solana.usdc_mint.clone(),
         pay_to: state.config.solana.recipient_wallet.clone(),
         max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
         escrow_program_id: None,
@@ -140,7 +144,7 @@ async fn handle_new_request(
             scheme: "escrow".to_string(),
             network: solvela_x402::types::SOLANA_NETWORK.to_string(),
             amount: atomic_amount,
-            asset: solvela_x402::types::USDC_MINT.to_string(),
+            asset: state.config.solana.usdc_mint.clone(),
             pay_to: state.config.solana.recipient_wallet.clone(),
             max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
             escrow_program_id: state.config.solana.escrow_program_id.clone(),
@@ -1329,6 +1333,13 @@ supports_vision = false
     /// `new_task_id()` so task keys are unique and never collide across
     /// parallel runs.
     fn test_state_with_redis() -> Arc<AppState> {
+        test_state_with_redis_config(AppConfig::default())
+    }
+
+    /// Like [`test_state_with_redis`] but with a caller-supplied `AppConfig`,
+    /// so tests can override payment-relevant config (e.g. a non-default
+    /// `solana.usdc_mint`).
+    fn test_state_with_redis_config(config: AppConfig) -> Arc<AppState> {
         use crate::cache::{CacheConfig, ResponseCache};
 
         let redis_client =
@@ -1337,7 +1348,7 @@ supports_vision = false
             .expect("ResponseCache::from_client should not connect");
 
         Arc::new(AppState {
-            config: AppConfig::default(),
+            config,
             model_registry: ModelRegistry::from_toml(
                 r#"
 [models.test-model]
@@ -1481,6 +1492,57 @@ supports_vision = false
             result["id"].as_str().map(str::len).unwrap_or(0) > 0,
             "task id must be set"
         );
+    }
+
+    /// With a NON-default configured USDC mint, the A2A payment-required
+    /// metadata quotes the configured mint as `asset` — not the compile-time
+    /// mainnet constant (which the verifier would never accept on that
+    /// deployment).
+    #[tokio::test]
+    async fn new_request_payment_required_quotes_configured_usdc_mint() {
+        let devnet_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let mut config = AppConfig::default();
+        config.solana.usdc_mint = devnet_mint.to_string();
+        let state = test_state_with_redis_config(config);
+        let params = user_msg_with_text("Hello world", Some("test-model"));
+
+        let result = handle_new_request(&state, &params)
+            .await
+            .expect("happy path must succeed with Redis");
+
+        let accepts = result["status"]["message"]["metadata"][x402_meta::REQUIRED_KEY]["accepts"]
+            .as_array()
+            .expect("accepts must be an array");
+        assert!(!accepts.is_empty());
+        for accept in accepts {
+            assert_eq!(
+                accept["asset"], devnet_mint,
+                "A2A payment quote must use the configured mint"
+            );
+        }
+    }
+
+    /// Default-config wire stability: with no mint override, the A2A payment
+    /// quote carries the mainnet USDC mint exactly (pinned as a literal).
+    #[tokio::test]
+    async fn new_request_payment_required_quotes_default_usdc_mint() {
+        let state = test_state_with_redis();
+        let params = user_msg_with_text("Hello world", Some("test-model"));
+
+        let result = handle_new_request(&state, &params)
+            .await
+            .expect("happy path must succeed with Redis");
+
+        let accepts = result["status"]["message"]["metadata"][x402_meta::REQUIRED_KEY]["accepts"]
+            .as_array()
+            .expect("accepts must be an array");
+        assert!(!accepts.is_empty());
+        for accept in accepts {
+            assert_eq!(
+                accept["asset"], "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "default config must quote the mainnet USDC mint byte-identically"
+            );
+        }
     }
 
     /// New request through the public dispatcher with a Redis-backed state.

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -174,6 +174,15 @@ async fn handle_new_request(
     // without this, the agent paid for ≤max_tokens output but the provider
     // would be invoked with max_tokens=None and could return an unbounded
     // response, leaving the gateway to absorb the overrun.
+    //
+    // KNOWN WINDOW (stale offer across a mint-config change): the stored
+    // `payment_required` snapshot lives in Redis for TASK_TTL (600s). If the
+    // operator changes `solana.usdc_mint` and restarts within that window, a
+    // pre-change offer still validates against the OLD mint in
+    // `validate_submitted_against_offer`, then fails opaquely at the verifier
+    // (which enforces the NEW configured mint). Accepted: the window is short,
+    // mint changes are rare operator events, and the failure is a denial (no
+    // mis-charge). Revisit if offers ever become long-lived.
     let task_id = new_task_id();
     let record = TaskRecord {
         id: task_id.clone(),
@@ -1734,6 +1743,86 @@ supports_vision = false
         assert!(
             !err.message.contains("verifier"),
             "must not leak verifier internals: {}",
+            err.message
+        );
+    }
+
+    /// FULL two-step A2A flow under a NON-default configured mint: step 1
+    /// quotes the devnet mint; a step-2 submission echoing that devnet mint as
+    /// `accepted.asset` must get PAST `validate_submitted_against_offer`
+    /// (reaching facilitator verification — the empty facilitator then fails
+    /// with the sanitized verification message), NOT be rejected as an
+    /// offer mismatch. Every other payment_submitted test hardcodes the
+    /// mainnet constant, so without this test the offer-match path is
+    /// unguarded against the compile-time constant creeping back in.
+    #[tokio::test]
+    async fn payment_submitted_with_configured_devnet_mint_passes_offer_validation() {
+        let devnet_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let mut config = AppConfig::default();
+        config.solana.usdc_mint = devnet_mint.to_string();
+        let state = test_state_with_redis_config(config);
+
+        // Step 1: new request → input-required task carrying the devnet offer.
+        let new_params = user_msg_with_text("test", Some("test-model"));
+        let task_value = handle_new_request(&state, &new_params).await.expect("task");
+        let task_id = task_value["id"].as_str().expect("id").to_string();
+
+        // Build the submission from the OFFER itself (scheme/network/asset/
+        // pay_to/amount), the way a compliant agent would.
+        let offer = task_value["status"]["message"]["metadata"][x402_meta::REQUIRED_KEY]["accepts"]
+            [0]
+        .clone();
+        assert_eq!(
+            offer["asset"], devnet_mint,
+            "offer must quote the configured mint"
+        );
+
+        let tx_raw = format!("test_tx_{}", uuid::Uuid::new_v4().simple());
+        let payload = json!({
+            "x402_version": solvela_x402::types::X402_VERSION,
+            "resource": {"url": "/v1/chat/completions", "method": "POST"},
+            "accepted": {
+                "scheme": offer["scheme"],
+                "network": offer["network"],
+                "amount": offer["amount"],
+                "asset": offer["asset"],
+                "pay_to": offer["pay_to"],
+                "max_timeout_seconds": offer["max_timeout_seconds"],
+            },
+            "payload": { "transaction": tx_raw }
+        });
+
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            x402_meta::STATUS_KEY.to_string(),
+            json!(x402_meta::PAYMENT_SUBMITTED),
+        );
+        metadata.insert(x402_meta::PAYLOAD_KEY.to_string(), payload);
+
+        let params = MessageSendParams {
+            message: Message {
+                role: MessageRole::User,
+                parts: vec![Part::Text {
+                    text: "pay".to_string(),
+                }],
+                metadata: Some(metadata),
+            },
+            task_id: Some(task_id.clone()),
+        };
+
+        let err = handle_payment_submitted(&state, &HeaderMap::new(), &task_id, &params)
+            .await
+            .expect_err("empty facilitator must fail verification");
+        assert_eq!(err.code, ERR_PAYMENT_FAILED);
+        assert!(
+            !err.message.contains("does not match any offered"),
+            "devnet-mint submission must NOT be rejected at offer validation; got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("verification failed"),
+            "submission must reach facilitator verification (past the offer \
+             match); got: {}",
             err.message
         );
     }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -87,8 +87,21 @@ async fn main() -> anyhow::Result<()> {
     }) {
         app_config.solana.recipient_wallet = val;
     }
-    if let Ok(val) = env_with_fallback("SOLVELA_SOLANA__USDC_MINT", "RCR_SOLANA__USDC_MINT") {
-        app_config.solana.usdc_mint = val;
+    if let Ok(val) = env_with_fallback("SOLVELA_SOLANA__USDC_MINT", "RCR_SOLANA__USDC_MINT")
+        .or_else(|_| env_with_fallback("SOLVELA_SOLANA_USDC_MINT", "RCR_SOLANA_USDC_MINT"))
+    {
+        // Ignore an empty/whitespace-only override and keep the default —
+        // same pattern as SOLVELA_ADMIN_TOKEN / SOLVELA_API_KEY_HMAC_SECRET
+        // below. An empty mint would otherwise replace a valid default and
+        // fail the startup validation further down.
+        if val.trim().is_empty() {
+            warn!(
+                "SOLVELA_SOLANA__USDC_MINT is set but empty — ignoring the \
+                 override and keeping the configured/default USDC mint"
+            );
+        } else {
+            app_config.solana.usdc_mint = val;
+        }
     }
     if let Ok(val) = env_with_fallback(
         "SOLVELA_SOLANA__ESCROW_PROGRAM_ID",
@@ -116,6 +129,22 @@ async fn main() -> anyhow::Result<()> {
             app_config.server.port = port;
         }
     }
+
+    // The configured USDC mint is quoted in every 402 challenge and enforced
+    // by every payment verifier, but `EscrowVerifier` only Pubkey-parses its
+    // mint at first payment — a malformed value would otherwise boot fine and
+    // then fail every payment opaquely. Validate ONCE here, after all env
+    // overrides, so every consumer (402 quote builders, SolanaVerifier,
+    // EscrowVerifier/Claimer, balance monitor, discovery surfaces) is covered.
+    // Fatal in ALL modes, same spirit as the migration rule (arch rule #15):
+    // never serve traffic against a broken money-path config.
+    validate_usdc_mint(&app_config.solana.usdc_mint).map_err(|e| {
+        error!(error = %e, "FATAL: configured USDC mint is not a valid Solana pubkey");
+        anyhow::anyhow!(
+            "invalid USDC mint configuration (SOLVELA_SOLANA__USDC_MINT / \
+             [solana].usdc_mint): {e}"
+        )
+    })?;
 
     // Load model registry from config file
     let models_toml = std::fs::read_to_string("config/models.toml")
@@ -965,6 +994,20 @@ fn redact_connection_url(url: &str) -> String {
     url.to_string()
 }
 
+/// Validate that the configured USDC mint parses as a Solana `Pubkey`
+/// (base58, exactly 32 bytes).
+///
+/// Pure startup-time seam: called once from `main()` after all env overrides
+/// are applied, so a typo'd/truncated/garbage mint refuses to boot instead of
+/// surfacing as an opaque verification failure on the first real payment.
+fn validate_usdc_mint(mint: &str) -> anyhow::Result<()> {
+    use std::str::FromStr;
+
+    solvela_x402::solana_types::Pubkey::from_str(mint)
+        .map_err(|e| anyhow::anyhow!("'{mint}' is not a valid Solana pubkey: {e}"))?;
+    Ok(())
+}
+
 /// Generate a random 32-byte secret using two UUIDv4 values.
 ///
 /// UUIDv4 provides 122 bits of randomness per call (backed by the OS CSPRNG),
@@ -1142,6 +1185,43 @@ mod tests {
             "redis_connect failure path must increment the startup-failure counter; \
              a typo in the metric name or a missing counter! call would slip past this test"
         );
+    }
+
+    /// Startup mint validation accepts both the mainnet default and a valid
+    /// non-default (devnet) mint — the configured-mint feature must not be
+    /// blocked by the validator.
+    #[test]
+    fn validate_usdc_mint_accepts_valid_pubkeys() {
+        // Mainnet USDC (the compile-time default).
+        validate_usdc_mint("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")
+            .expect("mainnet USDC mint must validate");
+        // Devnet USDC (the canonical non-default deployment).
+        validate_usdc_mint("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU")
+            .expect("devnet USDC mint must validate");
+        // The shipped default config value must always pass — otherwise a
+        // default deployment could not boot.
+        validate_usdc_mint(&config::AppConfig::default().solana.usdc_mint)
+            .expect("default config mint must validate");
+    }
+
+    /// Startup mint validation fails closed on every malformed shape: empty,
+    /// whitespace, non-base58, and wrong-length base58. Any of these reaching
+    /// the verifiers would fail every payment opaquely at runtime instead.
+    #[test]
+    fn validate_usdc_mint_rejects_malformed_values() {
+        for bad in [
+            "",                                              // empty
+            "   ",                                           // whitespace
+            "not-a-pubkey",                                  // non-base58 ('-')
+            "0OIl",                                          // base58-forbidden chars
+            "abc",                                           // too short (decodes < 32 bytes)
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1vEPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // too long
+        ] {
+            assert!(
+                validate_usdc_mint(bad).is_err(),
+                "malformed mint {bad:?} must fail startup validation"
+            );
+        }
     }
 
     /// Lock the exhaustive set of reason labels for the startup-failure

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -536,11 +536,15 @@ pub async fn chat_completions(
         counter!("solvela_payments_total", "status" => "none").increment(1);
         info!(model = %req.model, "no payment signature, returning 402");
 
+        // Quote the CONFIGURED mint — the same one `SolanaVerifier`/
+        // `EscrowVerifier` enforce — never the compile-time constant, so a
+        // deployment with a non-default mint (e.g. devnet) quotes an asset it
+        // will actually accept.
         let mut accepts = vec![solvela_x402::types::PaymentAccept {
             scheme: "exact".to_string(),
             network: solvela_x402::types::SOLANA_NETWORK.to_string(),
             amount: atomic_amount.clone(),
-            asset: solvela_x402::types::USDC_MINT.to_string(),
+            asset: state.config.solana.usdc_mint.clone(),
             pay_to: state.config.solana.recipient_wallet.clone(),
             max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
             escrow_program_id: None,
@@ -552,7 +556,7 @@ pub async fn chat_completions(
                 scheme: "escrow".to_string(),
                 network: solvela_x402::types::SOLANA_NETWORK.to_string(),
                 amount: atomic_amount,
-                asset: solvela_x402::types::USDC_MINT.to_string(),
+                asset: state.config.solana.usdc_mint.clone(),
                 pay_to: state.config.solana.recipient_wallet.clone(),
                 max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
                 escrow_program_id: state.config.solana.escrow_program_id.clone(),
@@ -655,11 +659,12 @@ pub async fn chat_completions(
                 ));
             }
 
-            // Verify asset is USDC-SPL mint
-            if payload.accepted.asset != solvela_x402::types::USDC_MINT {
+            // Verify asset is the CONFIGURED USDC-SPL mint — the same one the
+            // verifier enforces — not the compile-time constant.
+            if payload.accepted.asset != state.config.solana.usdc_mint {
                 warn!(
                     asset = %payload.accepted.asset,
-                    expected = %solvela_x402::types::USDC_MINT,
+                    expected = %state.config.solana.usdc_mint,
                     "payment asset mismatch"
                 );
                 return Err(GatewayError::BadRequest(

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -662,8 +662,13 @@ pub async fn chat_completions(
             // Verify asset is the CONFIGURED USDC-SPL mint — the same one the
             // verifier enforces — not the compile-time constant.
             if payload.accepted.asset != state.config.solana.usdc_mint {
+                // GHSA-cgqx-mg48-949v posture: `asset` is client-controlled —
+                // cap to the max base58 pubkey length (44 chars) before
+                // logging (mirrors the tx_prefix truncation in a2a/handler.rs;
+                // chars-based so a multibyte boundary can never panic).
+                let asset_prefix: String = payload.accepted.asset.chars().take(44).collect();
                 warn!(
-                    asset = %payload.accepted.asset,
+                    asset = %asset_prefix,
                     expected = %state.config.solana.usdc_mint,
                     "payment asset mismatch"
                 );

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -284,9 +284,14 @@ pub async fn proxy_service(
     // Validate asset is the CONFIGURED USDC-SPL mint — the same one the
     // verifier enforces — not the compile-time constant.
     if payload.accepted.asset != state.config.solana.usdc_mint {
+        // GHSA-cgqx-mg48-949v posture: `asset` is client-controlled — cap to
+        // the max base58 pubkey length (44 chars) before echoing/logging
+        // (mirrors the tx_prefix truncation in a2a/handler.rs; chars-based so
+        // a multibyte boundary can never panic).
+        let asset_prefix: String = payload.accepted.asset.chars().take(44).collect();
         return Err(GatewayError::BadRequest(format!(
-            "payment asset must be USDC mint '{}', got '{}'",
-            state.config.solana.usdc_mint, payload.accepted.asset
+            "payment asset must be USDC mint '{}', got '{asset_prefix}'",
+            state.config.solana.usdc_mint
         )));
     }
 

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -17,7 +17,7 @@ use tracing::{info, warn};
 
 use solvela_x402::types::{
     CostBreakdown, PaymentAccept, PaymentRequired, Resource, PLATFORM_FEE_PERCENT, SOLANA_NETWORK,
-    USDC_MINT, X402_VERSION,
+    X402_VERSION,
 };
 
 use crate::error::GatewayError;
@@ -215,7 +215,9 @@ pub async fn proxy_service(
                 scheme: "exact".to_string(),
                 network: SOLANA_NETWORK.to_string(),
                 amount: expected_atomic.to_string(),
-                asset: USDC_MINT.to_string(),
+                // Quote the CONFIGURED mint (what the verifier enforces),
+                // never the compile-time constant.
+                asset: state.config.solana.usdc_mint.clone(),
                 pay_to: state.config.solana.recipient_wallet.clone(),
                 max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
                 escrow_program_id: None,
@@ -279,11 +281,12 @@ pub async fn proxy_service(
         )));
     }
 
-    // Validate asset is USDC-SPL mint
-    if payload.accepted.asset != USDC_MINT {
+    // Validate asset is the CONFIGURED USDC-SPL mint — the same one the
+    // verifier enforces — not the compile-time constant.
+    if payload.accepted.asset != state.config.solana.usdc_mint {
         return Err(GatewayError::BadRequest(format!(
-            "payment asset must be USDC mint '{USDC_MINT}', got '{}'",
-            payload.accepted.asset
+            "payment asset must be USDC mint '{}', got '{}'",
+            state.config.solana.usdc_mint, payload.accepted.asset
         )));
     }
 
@@ -646,6 +649,7 @@ pub async fn proxy_service(
 mod tests {
     use super::*;
     use crate::payment_util::extract_signer_from_base64_tx;
+    use solvela_x402::types::USDC_MINT;
 
     /// Convenience: total atomic cost only — most existing tests only care
     /// about the total, not the full breakdown.

--- a/crates/gateway/src/routes/supported.rs
+++ b/crates/gateway/src/routes/supported.rs
@@ -78,7 +78,12 @@ mod tests {
         assert_eq!(resp.kinds[0].x402_version, X402_VERSION);
         assert_eq!(resp.kinds[0].scheme, "exact");
         assert_eq!(resp.kinds[0].network, SOLANA_NETWORK);
-        assert_eq!(resp.kinds[0].asset, USDC_MINT);
+        // Pin the LITERAL mainnet mint, not the constant against itself —
+        // this is the wire-stability guarantee for default deployments.
+        assert_eq!(
+            resp.kinds[0].asset,
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        );
         assert_eq!(resp.gateway, "Solvela");
     }
 

--- a/crates/gateway/src/routes/supported.rs
+++ b/crates/gateway/src/routes/supported.rs
@@ -4,10 +4,15 @@
 //! Follows the OpenFacilitator `/supported` standard so Solvela
 //! is discoverable by x402 ecosystem tooling and dashboards.
 
+use std::sync::Arc;
+
+use axum::extract::State;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
-use solvela_x402::types::{SOLANA_NETWORK, USDC_MINT, X402_VERSION};
+use solvela_x402::types::{SOLANA_NETWORK, X402_VERSION};
+
+use crate::AppState;
 
 /// A supported payment kind (scheme + network combination).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -33,30 +38,41 @@ pub struct SupportedResponse {
     pub pricing_url: &'static str,
 }
 
-/// GET /v1/supported
+/// Build the `/v1/supported` response for a given accepted USDC mint.
 ///
-/// Returns x402 payment schemes and networks supported by this gateway.
-/// Compatible with the OpenFacilitator discovery standard.
-pub async fn supported() -> Json<SupportedResponse> {
-    Json(SupportedResponse {
+/// The mint is the CONFIGURED one (`config.solana.usdc_mint`) — the same mint
+/// the payment verifiers enforce — never the compile-time constant, so a
+/// deployment with a non-default mint advertises an asset it will actually
+/// accept.
+fn supported_response(usdc_mint: &str) -> SupportedResponse {
+    SupportedResponse {
         kinds: vec![SupportedKind {
             x402_version: X402_VERSION,
             scheme: "exact".to_string(),
             network: SOLANA_NETWORK.to_string(),
-            asset: USDC_MINT.to_string(),
+            asset: usdc_mint.to_string(),
         }],
         gateway: "Solvela",
         pricing_url: "/v1/models",
-    })
+    }
+}
+
+/// GET /v1/supported
+///
+/// Returns x402 payment schemes and networks supported by this gateway.
+/// Compatible with the OpenFacilitator discovery standard.
+pub async fn supported(State(state): State<Arc<AppState>>) -> Json<SupportedResponse> {
+    Json(supported_response(&state.config.solana.usdc_mint))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solvela_x402::types::USDC_MINT;
 
-    #[tokio::test]
-    async fn test_supported_response() {
-        let Json(resp) = supported().await;
+    #[test]
+    fn test_supported_response_default_mint() {
+        let resp = supported_response(USDC_MINT);
 
         assert_eq!(resp.kinds.len(), 1);
         assert_eq!(resp.kinds[0].x402_version, X402_VERSION);
@@ -64,5 +80,12 @@ mod tests {
         assert_eq!(resp.kinds[0].network, SOLANA_NETWORK);
         assert_eq!(resp.kinds[0].asset, USDC_MINT);
         assert_eq!(resp.gateway, "Solvela");
+    }
+
+    #[test]
+    fn test_supported_response_reports_configured_mint() {
+        let devnet_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let resp = supported_response(devnet_mint);
+        assert_eq!(resp.kinds[0].asset, devnet_mint);
     }
 }

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -48,6 +48,11 @@ const TEST_PAYMENT_AMOUNT: &str = "1000000";
 /// Admin token for escrow health endpoint tests.
 const TEST_ADMIN_TOKEN: &str = "test-admin-token-for-integration-tests";
 
+/// A non-default USDC mint (devnet USDC) used to prove that 402 quotes and
+/// inbound asset validation follow `config.solana.usdc_mint` rather than the
+/// compile-time mainnet constant.
+const TEST_DEVNET_USDC_MINT: &str = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+
 /// Returns a shared `PrometheusHandle` for all integration tests.
 ///
 /// The global `metrics` recorder can only be installed once per process, so
@@ -478,6 +483,61 @@ fn test_app_with_state() -> (axum::Router, Arc<AppState>) {
         RateLimiter::new(RateLimitConfig::default()),
     );
     (router, state)
+}
+
+/// Build a test app with a NON-default configured USDC mint and a
+/// caller-supplied provider registry.
+///
+/// Mirrors [`test_app_with_state`] except `config.solana.usdc_mint` is
+/// overridden — used to prove the 402 quote and the inbound asset validation
+/// follow the configured mint (what the verifiers enforce), not the
+/// compile-time mainnet constant.
+fn test_app_with_usdc_mint_and_providers(mint: &str, providers: ProviderRegistry) -> axum::Router {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+    config.solana.usdc_mint = mint.to_string();
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers,
+        facilitator,
+        usage: gateway::usage::UsageTracker::noop(),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: None,
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
+    });
+    build_router(state, RateLimiter::new(RateLimitConfig::default()))
+}
+
+/// [`test_app_with_usdc_mint_and_providers`] with no providers configured —
+/// for exercising the 402 quote path.
+fn test_app_with_usdc_mint(mint: &str) -> axum::Router {
+    test_app_with_usdc_mint_and_providers(mint, ProviderRegistry::from_env(reqwest::Client::new()))
 }
 
 // ---------------------------------------------------------------------------
@@ -1770,6 +1830,13 @@ fn test_app_with_provider_registry_and_escrow_verifier(
 
 /// Build a test app with escrow support enabled.
 fn test_app_with_escrow() -> axum::Router {
+    test_app_with_escrow_and_usdc_mint(USDC_MINT)
+}
+
+/// Build a test app with escrow support enabled and a caller-supplied
+/// configured USDC mint, so escrow-scheme 402 quotes can be checked against a
+/// non-default mint.
+fn test_app_with_escrow_and_usdc_mint(mint: &str) -> axum::Router {
     let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
     let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
 
@@ -1783,6 +1850,7 @@ fn test_app_with_escrow() -> axum::Router {
     config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
     config.solana.escrow_program_id =
         Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string());
+    config.solana.usdc_mint = mint.to_string();
 
     // Create a dummy claimer — won't actually submit claims in tests
     // We need a valid 64-byte key. Use a test keypair.
@@ -1842,6 +1910,13 @@ fn test_app_with_escrow() -> axum::Router {
 
 /// Build a minimal valid PaymentPayload base64-encoded header for a given model path.
 fn valid_payment_header(resource_url: &str) -> String {
+    valid_payment_header_with(resource_url, USDC_MINT, TEST_RECIPIENT_WALLET)
+}
+
+/// Like [`valid_payment_header`] but with caller-supplied `asset` and `pay_to`,
+/// so tests can probe the inbound `accepted` field validation (e.g. a payload
+/// echoing the configured non-default mint vs. the mainnet constant).
+fn valid_payment_header_with(resource_url: &str, asset: &str, pay_to: &str) -> String {
     let payload = PaymentPayload {
         x402_version: 2,
         resource: Resource {
@@ -1852,8 +1927,8 @@ fn valid_payment_header(resource_url: &str) -> String {
             scheme: "exact".to_string(),
             network: SOLANA_NETWORK.to_string(),
             amount: TEST_PAYMENT_AMOUNT.to_string(),
-            asset: USDC_MINT.to_string(),
-            pay_to: TEST_RECIPIENT_WALLET.to_string(),
+            asset: asset.to_string(),
+            pay_to: pay_to.to_string(),
             max_timeout_seconds: 300,
             escrow_program_id: None,
         },
@@ -3698,6 +3773,16 @@ async fn test_402_offers_escrow_when_configured() {
         accepts[1]["escrow_program_id"].is_string(),
         "escrow accept should include escrow_program_id"
     );
+    // Default-config wire stability: with no usdc_mint override, both accepts
+    // entries carry the mainnet USDC mint exactly (pinned as a literal).
+    assert_eq!(
+        accepts[0]["asset"],
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    );
+    assert_eq!(
+        accepts[1]["asset"],
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    );
 }
 
 #[tokio::test]
@@ -3730,6 +3815,296 @@ async fn test_402_no_escrow_when_not_configured() {
     let accepts = pr["accepts"].as_array().unwrap();
     assert_eq!(accepts.len(), 1, "should only offer exact scheme");
     assert_eq!(accepts[0]["scheme"], "exact");
+}
+
+// ---------------------------------------------------------------------------
+// Configured (non-default) USDC mint — 402 quote and inbound asset validation
+// must follow `config.solana.usdc_mint` (what the on-chain verifiers enforce),
+// never the compile-time mainnet constant.
+// ---------------------------------------------------------------------------
+
+/// With a non-default configured mint, the chat 402 quote advertises the
+/// configured mint as `asset` — not the compile-time mainnet constant.
+#[tokio::test]
+async fn test_chat_402_quotes_configured_usdc_mint() {
+    let app = test_app_with_usdc_mint(TEST_DEVNET_USDC_MINT);
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let pr: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let accepts = pr["accepts"].as_array().unwrap();
+    assert!(!accepts.is_empty());
+    for accept in accepts {
+        assert_eq!(
+            accept["asset"], TEST_DEVNET_USDC_MINT,
+            "402 must quote the configured mint, not the compile-time constant"
+        );
+    }
+}
+
+/// Same as above with escrow configured: BOTH accepts entries (exact + escrow)
+/// quote the configured mint.
+#[tokio::test]
+async fn test_chat_402_escrow_accept_quotes_configured_usdc_mint() {
+    let app = test_app_with_escrow_and_usdc_mint(TEST_DEVNET_USDC_MINT);
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let pr: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let accepts = pr["accepts"].as_array().unwrap();
+    assert_eq!(
+        accepts.len(),
+        2,
+        "should offer both exact and escrow schemes"
+    );
+    assert_eq!(accepts[0]["asset"], TEST_DEVNET_USDC_MINT);
+    assert_eq!(accepts[1]["asset"], TEST_DEVNET_USDC_MINT);
+}
+
+/// The services proxy 402 quote also advertises the configured mint.
+#[tokio::test]
+async fn test_proxy_402_quotes_configured_usdc_mint() {
+    let app = test_app_with_usdc_mint(TEST_DEVNET_USDC_MINT);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/web-search/proxy")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let pr: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let accepts = pr["accepts"].as_array().unwrap();
+    assert!(!accepts.is_empty());
+    assert_eq!(accepts[0]["asset"], TEST_DEVNET_USDC_MINT);
+}
+
+/// The /v1/supported discovery endpoint reports the configured mint.
+#[tokio::test]
+async fn test_supported_reports_configured_usdc_mint() {
+    let app = test_app_with_usdc_mint(TEST_DEVNET_USDC_MINT);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/supported")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let kinds = json["kinds"].as_array().unwrap();
+    assert!(!kinds.is_empty());
+    assert_eq!(kinds[0]["asset"], TEST_DEVNET_USDC_MINT);
+}
+
+/// Inbound validation under a non-default configured mint: a payment payload
+/// echoing the CONFIGURED mint passes the asset check end-to-end (the
+/// always-pass verifier and mock provider then complete the request).
+#[tokio::test]
+async fn test_chat_payment_with_configured_mint_passes_asset_validation() {
+    let app =
+        test_app_with_usdc_mint_and_providers(TEST_DEVNET_USDC_MINT, mock_provider_registry());
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header_with(
+                        "/v1/chat/completions",
+                        TEST_DEVNET_USDC_MINT,
+                        TEST_RECIPIENT_WALLET,
+                    ),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "payment echoing the configured mint must pass asset validation"
+    );
+}
+
+/// Inbound validation under a non-default configured mint: a payment payload
+/// echoing the mainnet CONSTANT is rejected with the asset-mismatch error —
+/// it no longer matches what the verifier enforces.
+#[tokio::test]
+async fn test_chat_payment_with_default_mint_rejected_under_configured_mint() {
+    let app =
+        test_app_with_usdc_mint_and_providers(TEST_DEVNET_USDC_MINT, mock_provider_registry());
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header_with(
+                        "/v1/chat/completions",
+                        USDC_MINT,
+                        TEST_RECIPIENT_WALLET,
+                    ),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("Payment asset is unsupported"),
+        "rejection must be the asset-mismatch error, got: {body_str}"
+    );
+}
+
+/// Proxy inbound validation: a payload echoing the configured mint gets PAST
+/// the asset check (the deliberately-wrong pay_to then triggers the LATER
+/// pay_to-mismatch rejection, proving the asset gate was cleared).
+#[tokio::test]
+async fn test_proxy_payment_with_configured_mint_passes_asset_validation() {
+    let app = test_app_with_usdc_mint(TEST_DEVNET_USDC_MINT);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/web-search/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header_with(
+                        "/v1/services/web-search/proxy",
+                        TEST_DEVNET_USDC_MINT,
+                        "WrongRecipientWallet11111111111111111111111111",
+                    ),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("pay_to"),
+        "error must be the pay_to mismatch (past the asset check), got: {body_str}"
+    );
+}
+
+/// Proxy inbound validation: a payload echoing the mainnet constant under a
+/// non-default configured mint is rejected at the asset check.
+#[tokio::test]
+async fn test_proxy_payment_with_default_mint_rejected_under_configured_mint() {
+    let app = test_app_with_usdc_mint(TEST_DEVNET_USDC_MINT);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/web-search/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header_with(
+                        "/v1/services/web-search/proxy",
+                        USDC_MINT,
+                        TEST_RECIPIENT_WALLET,
+                    ),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("payment asset must be"),
+        "rejection must be the asset-mismatch error, got: {body_str}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

The 402 payment quotes, the inbound `accepted.asset` validation, and the discovery surfaces (`/v1/supported`, A2A agent card) all compared against the compile-time `USDC_MINT` constant, while the on-chain verifiers (`SolanaVerifier`, `EscrowVerifier`) enforce the **configured** mint (`SOLVELA_SOLANA__USDC_MINT`). Any deployment with a non-default mint quoted one asset and verified another — payments for the configured mint were rejected at the asset gate before verification. This PR makes `config.solana.usdc_mint` the single source of truth for quote → validate → verify.

## Changes

- **402 quotes** (`routes/chat`, `routes/proxy`, `a2a/handler`) and **inbound asset checks** (`routes/chat`, `routes/proxy` — proxy had its own constant-bound check) now use the configured mint. A2A inbound validation aligns by construction (`validate_submitted_against_offer` matches the stored offer).
- **Discovery surfaces** (`/v1/supported`, A2A agent card x402 extension) advertise the configured mint.
- **Startup fail-fast**: the configured mint is validated as a base58 Pubkey after all env overrides, in all modes; empty/whitespace env values are ignored with a warning (keeping the default) instead of propagating `asset: ""` into quotes.
- **Env fallback gap**: `SOLVELA_SOLANA_USDC_MINT` (single-underscore legacy form) is now honored, matching every other Solana config key as documented in CLAUDE.md.
- **CLI hardening**: `solvela chat` payment-scheme selection now only signs entries matching the canonical Solana network + mainnet USDC mint (fail-closed, including under `--scheme`), instead of falling back to `accepts.first()`.
- **Log-injection cap**: client-controlled asset strings are truncated to 44 chars in warn logs (GHSA-cgqx-mg48-949v posture).

**Behavior contract**: byte-identical responses under default config (pinned by literal-string tests on chat, proxy, a2a, `/supported`, agent card). No amount, fee, or settlement logic touched.

## Tests

22 new tests: configured-mint quoting across all five surfaces, full-route payment acceptance under a configured mint + rejection of the mainnet constant under a non-default config (chat and proxy), full two-step A2A flow (new request → payment submitted) under a devnet mint, startup mint validation, and 6 CLI selection tests (foreign mint/network skipped, all-foreign errors, `--scheme` override fail-closed, empty accepts). Full workspace-relevant suites green: 1296 passed, 0 failed (with local Postgres). fmt + clippy `-D warnings` clean.

## Review

Two-round money-path review: round 1 = rust-reviewer, security-reviewer, silent-failure-hunter, pr-test-analyzer (all findings addressed in 22acf92d, including a Critical empty-env-var split-brain and missing startup validation); round 2 = independent fresh-eyes pass — APPROVE, zero findings.

## Deferred (intentionally out of scope)

- `a2a/task_store.rs` `load_task` returns `Ok(None)` when Redis is absent, masking infra failure as "task not found" (pre-existing) — follow-up issue.
- Dev-mode fallback `SolanaVerifier` (main.rs) hardcodes the mainnet mint; pre-existing, dev-only, unreachable in production (panics first). Candidate for the same unification in a follow-up.
- Proxy full-200 integration test under a configured mint (needs mock upstream harness).