### PR TITLE
feat(gateway): canonical x402 v2 wire-compat layer (pay CLI interop)

### DIFF
--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -1,7 +1,10 @@
-use axum::http::StatusCode;
+use axum::http::{HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
+use base64::Engine;
 use serde_json::json;
-use solvela_x402::types::PaymentRequired;
+use solvela_x402::types::{
+    CanonicalPaymentRequired, PaymentRequired, CANONICAL_PAYMENT_REQUIRED_HEADER,
+};
 
 /// Gateway-level errors returned as HTTP responses.
 ///
@@ -107,11 +110,18 @@ impl IntoResponse for GatewayError {
         // envelope), so it bypasses the (status, error_type, message)
         // tuple machinery the other variants share. See variant docs.
         if let GatewayError::PaymentChallenge(payment_required) = &self {
-            return (
+            let mut response = (
                 StatusCode::PAYMENT_REQUIRED,
                 axum::Json(payment_required.as_ref()),
             )
                 .into_response();
+            // Canonical x402 wire-compat: the same 402 additionally carries
+            // the canonical v2 challenge in the `PAYMENT-REQUIRED` header so
+            // standard x402 clients (e.g. the solana-foundation `pay` CLI,
+            // which checks this header BEFORE body parsing) can pay, while
+            // legacy SDKs keep parsing the unchanged snake_case body.
+            attach_canonical_challenge_header(&mut response, payment_required);
+            return response;
         }
 
         let (status, error_type, message) = match &self {
@@ -183,6 +193,50 @@ impl IntoResponse for GatewayError {
         });
 
         (status, axum::Json(body)).into_response()
+    }
+}
+
+/// Attach the canonical x402 v2 challenge header to a 402 response.
+///
+/// The header value is `base64(standard)` of the camelCase
+/// [`CanonicalPaymentRequired`] envelope projected from the legacy body —
+/// exact-scheme entries only (escrow never crosses the canonical surface).
+///
+/// Additive by design: the legacy snake_case body remains the authoritative
+/// challenge for published SDKs. When the legacy challenge offers no `exact`
+/// scheme there is nothing a canonical client could pay, so NO header is
+/// emitted (fail closed — never advertise an unsatisfiable challenge). A
+/// serialization/encoding failure likewise skips the header with a `warn!`
+/// rather than failing the 402 for legacy clients; canonical clients then see
+/// no challenge at all (a loud failure on their side), never a wrong one.
+fn attach_canonical_challenge_header(response: &mut Response, payment_required: &PaymentRequired) {
+    let Some(canonical) = CanonicalPaymentRequired::from_payment_required(payment_required) else {
+        return;
+    };
+    let json = match serde_json::to_vec(&canonical) {
+        Ok(json) => json,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "failed to serialize canonical x402 challenge — 402 sent without PAYMENT-REQUIRED header"
+            );
+            return;
+        }
+    };
+    let encoded = base64::engine::general_purpose::STANDARD.encode(json);
+    match HeaderValue::from_str(&encoded) {
+        Ok(value) => {
+            response.headers_mut().insert(
+                HeaderName::from_static(CANONICAL_PAYMENT_REQUIRED_HEADER),
+                value,
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "failed to encode canonical x402 challenge header — 402 sent without PAYMENT-REQUIRED header"
+            );
+        }
     }
 }
 

--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -218,6 +218,7 @@ fn attach_canonical_challenge_header(response: &mut Response, payment_required: 
         Err(e) => {
             tracing::warn!(
                 error = %e,
+                resource = %payment_required.resource.url,
                 "failed to serialize canonical x402 challenge — 402 sent without PAYMENT-REQUIRED header"
             );
             return;
@@ -234,6 +235,7 @@ fn attach_canonical_challenge_header(response: &mut Response, payment_required: 
         Err(e) => {
             tracing::warn!(
                 error = %e,
+                resource = %payment_required.resource.url,
                 "failed to encode canonical x402 challenge header — 402 sent without PAYMENT-REQUIRED header"
             );
         }
@@ -474,10 +476,22 @@ mod tests {
     /// that "uniformizes" the response shape is loud.
     #[tokio::test]
     async fn test_payment_challenge_emits_top_level_payment_required() {
-        let (status, json) = error_response(GatewayError::PaymentChallenge(Box::new(
-            build_test_payment_required(),
-        )))
-        .await;
+        let response =
+            GatewayError::PaymentChallenge(Box::new(build_test_payment_required())).into_response();
+        let status = response.status();
+
+        // The same 402 must ALSO carry the canonical x402 v2 challenge in the
+        // PAYMENT-REQUIRED header (the legacy body offers `exact`, so the
+        // canonical projection exists).
+        assert!(
+            response
+                .headers()
+                .contains_key(CANONICAL_PAYMENT_REQUIRED_HEADER),
+            "402 challenge must carry the canonical PAYMENT-REQUIRED header"
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(status, StatusCode::PAYMENT_REQUIRED);
 
@@ -500,6 +514,30 @@ mod tests {
             !json["error"].is_object(),
             "PaymentChallenge must NOT wrap the PaymentRequired in the OpenAI envelope; \
              got top-level `error` as object: {json}"
+        );
+    }
+
+    /// When the legacy challenge offers NO `exact` scheme (escrow-only), the
+    /// canonical PAYMENT-REQUIRED header must be ABSENT — never advertise a
+    /// challenge canonical clients cannot satisfy (fail closed). Pinned at
+    /// the `IntoResponse` boundary because that is where header emission is
+    /// decided; the chat route today always offers `exact`, so no real route
+    /// can produce an exact-less challenge.
+    #[tokio::test]
+    async fn test_payment_challenge_escrow_only_omits_canonical_header() {
+        let mut payment_required = build_test_payment_required();
+        for accept in &mut payment_required.accepts {
+            accept.scheme = "escrow".to_string();
+        }
+
+        let response = GatewayError::PaymentChallenge(Box::new(payment_required)).into_response();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(
+            !response
+                .headers()
+                .contains_key(CANONICAL_PAYMENT_REQUIRED_HEADER),
+            "an exact-less 402 must NOT carry the canonical PAYMENT-REQUIRED header"
         );
     }
 

--- a/crates/gateway/src/middleware/x402.rs
+++ b/crates/gateway/src/middleware/x402.rs
@@ -8,7 +8,7 @@ use axum::{
 use base64::Engine;
 use tracing::{info, warn};
 
-use solvela_x402::types::PaymentPayload;
+use solvela_x402::types::{CanonicalPaymentEnvelope, PaymentPayload};
 
 use crate::AppState;
 
@@ -103,17 +103,27 @@ pub async fn extract_payment(
 
 /// Decode a PAYMENT-SIGNATURE header value.
 ///
-/// The header is base64-encoded JSON containing a `PaymentPayload`.
-/// Some clients may send raw JSON (not base64-encoded), so we try both.
+/// The header is base64-encoded JSON containing either the legacy Solvela
+/// `PaymentPayload` (snake_case — what the published SDKs send) or a
+/// canonical x402 v2 `PaymentSignatureEnvelope` (camelCase — what standard
+/// x402 clients like the solana-foundation `pay` CLI send). Some clients may
+/// send raw JSON (not base64-encoded), so we try both encodings.
+///
+/// The legacy shape is always tried FIRST and is unchanged; the two shapes
+/// are mutually unparseable (legacy uses `deny_unknown_fields` and the
+/// canonical envelope requires `x402Version`), so neither can shadow the
+/// other. A canonical envelope that parses but fails the fail-closed mapping
+/// (escrow scheme, signature proof, non-v2 version, missing fields) returns
+/// that specific error — it is never silently retried as something else.
 ///
 /// Returns `Ok(payload)` on success, `Err(reason)` if the header cannot be decoded.
-/// Used by both the extraction middleware and the chat route handler.
+/// Used by the extraction middleware and the chat/proxy route handlers.
 pub fn decode_payment_header(header: &str) -> Result<PaymentPayload, String> {
     // Try standard base64 decode first
     if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(header) {
         if let Ok(json_str) = String::from_utf8(decoded) {
-            if let Ok(payload) = serde_json::from_str::<PaymentPayload>(&json_str) {
-                return Ok(payload);
+            if let Some(result) = parse_payment_json(&json_str) {
+                return result;
             }
         }
     }
@@ -121,18 +131,43 @@ pub fn decode_payment_header(header: &str) -> Result<PaymentPayload, String> {
     // Try URL-safe base64
     if let Ok(decoded) = base64::engine::general_purpose::URL_SAFE.decode(header) {
         if let Ok(json_str) = String::from_utf8(decoded) {
-            if let Ok(payload) = serde_json::from_str::<PaymentPayload>(&json_str) {
-                return Ok(payload);
+            if let Some(result) = parse_payment_json(&json_str) {
+                return result;
             }
         }
     }
 
     // Try raw JSON
-    if let Ok(payload) = serde_json::from_str::<PaymentPayload>(header) {
-        return Ok(payload);
+    if let Some(result) = parse_payment_json(header) {
+        return result;
     }
 
     Err("unable to decode payment header: not valid base64 or JSON".to_string())
+}
+
+/// Parse a candidate JSON string as a payment payload.
+///
+/// Returns:
+/// - `None` — the string is neither shape; the caller falls through to the
+///   next decoding attempt.
+/// - `Some(Ok(_))` — a legacy `PaymentPayload`, or a canonical v2 envelope
+///   successfully mapped into one.
+/// - `Some(Err(_))` — a canonical v2 envelope that parsed but was REJECTED by
+///   the fail-closed mapping (escrow scheme, signature proof, unsupported
+///   version, missing accepted/resource). Surfaced as a hard error so a
+///   money-relevant rejection is never masked by further decode attempts.
+fn parse_payment_json(json_str: &str) -> Option<Result<PaymentPayload, String>> {
+    if let Ok(payload) = serde_json::from_str::<PaymentPayload>(json_str) {
+        return Some(Ok(payload));
+    }
+    if let Ok(envelope) = serde_json::from_str::<CanonicalPaymentEnvelope>(json_str) {
+        return Some(
+            envelope
+                .into_payment_payload()
+                .map_err(|e| format!("canonical x402 payment rejected: {e}")),
+        );
+    }
+    None
 }
 
 #[cfg(test)]
@@ -221,6 +256,100 @@ mod tests {
             PayloadData::Direct(p) => assert_eq!(p.transaction, "base64encodedtx"),
             PayloadData::Escrow(_) => panic!("expected Direct variant"),
         }
+    }
+
+    /// Build a canonical x402 v2 envelope JSON (pay-CLI shape) with the given
+    /// scheme and proof object. Field names are literals so these tests pin
+    /// the wire contract independently of the serde derives.
+    fn canonical_envelope_json(scheme: &str, proof: serde_json::Value) -> String {
+        serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": scheme,
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "amount": "2625",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "RecipientWallet123",
+                "maxTimeoutSeconds": 300,
+                "extra": { "decimals": 6 }
+            },
+            "resource": { "url": "/v1/chat/completions", "description": "API access" },
+            "payload": proof
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_decode_canonical_v2_envelope_base64() {
+        let json =
+            canonical_envelope_json("exact", serde_json::json!({ "transaction": "dGVzdA==" }));
+        let encoded = base64::engine::general_purpose::STANDARD.encode(json.as_bytes());
+
+        let decoded = decode_payment_header(&encoded).expect("canonical envelope must decode");
+        assert_eq!(decoded.x402_version, 2);
+        assert_eq!(decoded.accepted.scheme, "exact");
+        assert_eq!(decoded.accepted.pay_to, "RecipientWallet123");
+        assert_eq!(decoded.resource.url, "/v1/chat/completions");
+        assert_eq!(decoded.resource.method, "POST");
+        match &decoded.payload {
+            PayloadData::Direct(p) => assert_eq!(p.transaction, "dGVzdA=="),
+            PayloadData::Escrow(_) => panic!("canonical payment must map to Direct"),
+        }
+    }
+
+    #[test]
+    fn test_decode_canonical_v2_envelope_raw_json() {
+        let json =
+            canonical_envelope_json("exact", serde_json::json!({ "transaction": "dGVzdA==" }));
+        let decoded = decode_payment_header(&json).expect("raw canonical JSON must decode");
+        assert_eq!(decoded.accepted.scheme, "exact");
+    }
+
+    /// A canonical envelope selecting escrow must be a hard error with the
+    /// canonical-rejection message — never silently retried or defaulted.
+    #[test]
+    fn test_decode_canonical_escrow_scheme_is_hard_error() {
+        let json =
+            canonical_envelope_json("escrow", serde_json::json!({ "transaction": "dGVzdA==" }));
+        let encoded = base64::engine::general_purpose::STANDARD.encode(json.as_bytes());
+
+        let err = decode_payment_header(&encoded).expect_err("escrow must be rejected");
+        assert!(
+            err.contains("canonical x402 payment rejected"),
+            "error must surface the canonical rejection: {err}"
+        );
+        assert!(
+            err.contains("exact"),
+            "error must name the accepted scheme: {err}"
+        );
+    }
+
+    /// A canonical client-broadcast `signature` proof must be a hard error —
+    /// the gateway controls broadcast (deferred settlement, #486).
+    #[test]
+    fn test_decode_canonical_signature_proof_is_hard_error() {
+        let json = canonical_envelope_json(
+            "exact",
+            serde_json::json!({ "signature": "5wZ2UM8fFakeSignature" }),
+        );
+        let encoded = base64::engine::general_purpose::STANDARD.encode(json.as_bytes());
+
+        let err = decode_payment_header(&encoded).expect_err("signature proof must be rejected");
+        assert!(err.contains("canonical x402 payment rejected"), "{err}");
+    }
+
+    /// The legacy payload must still decode FIRST and unchanged — the
+    /// canonical path is additive only.
+    #[test]
+    fn test_decode_legacy_payload_unchanged_alongside_canonical() {
+        let payload = sample_payload();
+        let json = serde_json::to_string(&payload).unwrap();
+        let encoded = base64::engine::general_purpose::STANDARD.encode(json.as_bytes());
+
+        let decoded = decode_payment_header(&encoded).expect("legacy payload must still decode");
+        assert_eq!(decoded.x402_version, 2);
+        assert_eq!(decoded.resource.method, "POST");
+        assert_eq!(decoded.accepted.pay_to, "RecipientWallet123");
     }
 
     /// Regression: `Debug` on `PaymentInfo` must redact the raw signed

--- a/crates/gateway/src/middleware/x402.rs
+++ b/crates/gateway/src/middleware/x402.rs
@@ -328,8 +328,8 @@ mod tests {
             "error must surface the canonical rejection: {err}"
         );
         assert!(
-            err.contains("exact"),
-            "error must name the accepted scheme: {err}"
+            err.contains("escrow"),
+            "error must name the rejected scheme: {err}"
         );
     }
 

--- a/crates/gateway/src/middleware/x402.rs
+++ b/crates/gateway/src/middleware/x402.rs
@@ -6,7 +6,7 @@ use axum::{
     response::Response,
 };
 use base64::Engine;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use solvela_x402::types::{CanonicalPaymentEnvelope, PaymentPayload};
 
@@ -92,7 +92,16 @@ pub async fn extract_payment(
                 Err(e) => {
                     // If header is present but invalid, still let the request through.
                     // The route handler will see no PaymentInfo and return 402.
-                    warn!(error = %e, "failed to decode payment signature header");
+                    //
+                    // The decode-failure detail can embed (length-capped)
+                    // attacker-controlled bytes — e.g. the canonical
+                    // envelope's rejected scheme — so the indexed warn! stays
+                    // a fixed string and the detail is demoted to debug!. The
+                    // paying routes (routes/chat, routes/proxy) log the same
+                    // failure WITH its reason at warn! when they hard-fail
+                    // the request, so the reason is never lost.
+                    warn!("failed to decode payment signature header");
+                    debug!(error = %e, "payment signature decode failure detail");
                 }
             }
         }

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -636,8 +636,13 @@ pub async fn chat_completions(
 
             // Verify the resource URL matches this endpoint
             if payload.resource.url != "/v1/chat/completions" {
+                // `resource.url` is client-controlled and unbounded (up to the
+                // 50KB header guard), so log a truncated copy server-side —
+                // mirrors the proxy-route truncation (chars-based so a
+                // multibyte boundary can never panic).
+                let resource_url: String = payload.resource.url.chars().take(256).collect();
                 warn!(
-                    resource_url = %payload.resource.url,
+                    resource_url = %resource_url,
                     "payment resource URL mismatch"
                 );
                 return Err(GatewayError::InvalidPayment(
@@ -647,8 +652,11 @@ pub async fn chat_completions(
 
             // Verify the resource method is POST
             if !payload.resource.method.eq_ignore_ascii_case("POST") {
+                // `resource.method` is client-controlled — truncate defensively
+                // before logging (same posture as `resource.url` above).
+                let method: String = payload.resource.method.chars().take(16).collect();
                 warn!(
-                    method = %payload.resource.method,
+                    method = %method,
                     "payment resource method mismatch"
                 );
                 return Err(GatewayError::BadRequest(

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -587,7 +587,21 @@ pub async fn chat_completions(
     run_prompt_guard(&req.messages)?;
 
     // Step 4: Payment present — try to decode and verify via Facilitator
-    let payment_payload = decode_payment_from_header(payment_header.unwrap());
+    let payment_payload = match decode_payment_from_header(payment_header.unwrap()) {
+        Ok(payload) => Some(payload),
+        Err(reason) => {
+            // Canonical-surface rejections (unsupported scheme / proof /
+            // version, missing accepted/resource) and garbled headers are
+            // distinct, money-relevant failures — log the SPECIFIC reason
+            // server-side so they are never silently conflated. The client
+            // receives only the fixed string in the `None` arm below
+            // (GHSA-cgqx-mg48-949v: never reflect the parse error; the only
+            // attacker-controlled bytes in `reason` are the 32-char-capped
+            // scheme echo from `CanonicalPaymentError::UnsupportedScheme`).
+            warn!(error = %reason, "PAYMENT-SIGNATURE header decode failed");
+            None
+        }
+    };
 
     // Track escrow-specific info for post-response claim
     let payment_scheme: PaymentScheme;

--- a/crates/gateway/src/routes/chat/payment.rs
+++ b/crates/gateway/src/routes/chat/payment.rs
@@ -14,16 +14,21 @@ use crate::middleware::x402::decode_payment_header;
 use crate::payment_util::extract_payer_wallet;
 use crate::AppState;
 
-/// Try to decode a `PaymentPayload` from the `PAYMENT-SIGNATURE` header.
+/// Decode a `PaymentPayload` from the `PAYMENT-SIGNATURE` header.
 ///
-/// Returns `None` if decoding fails -- this is intentional for backwards
-/// compatibility with raw string headers used in tests (e.g., "fake-payment-for-testing").
+/// Returns the specific decode-failure reason on `Err` so the route can log
+/// it server-side: canonical-surface rejections (unsupported scheme / proof /
+/// version, missing `accepted`/`resource`) are distinct, money-relevant
+/// errors that must never be swallowed into a silent `None` and become
+/// indistinguishable from a garbled header. The client-facing message stays
+/// a FIXED string at the call site (GHSA-cgqx-mg48-949v: never reflect the
+/// parse error).
 ///
 /// Delegates to the shared `decode_payment_header` in the x402 middleware.
 pub(crate) fn decode_payment_from_header(
     header: &str,
-) -> Option<solvela_x402::types::PaymentPayload> {
-    decode_payment_header(header).ok()
+) -> Result<solvela_x402::types::PaymentPayload, String> {
+    decode_payment_header(header)
 }
 
 /// Extract wallet address and transaction signature from the payment header.
@@ -34,7 +39,7 @@ pub(crate) fn decode_payment_from_header(
 /// (fee payer). Falls back to "unknown" if extraction fails.
 pub(crate) fn extract_payment_info(header: &str) -> (String, Option<String>) {
     match decode_payment_from_header(header) {
-        Some(payload) => {
+        Ok(payload) => {
             let wallet = extract_payer_wallet(&payload);
             let tx_sig = match &payload.payload {
                 solvela_x402::types::PayloadData::Direct(p) => Some(p.transaction.clone()),
@@ -42,7 +47,11 @@ pub(crate) fn extract_payment_info(header: &str) -> (String, Option<String>) {
             };
             (wallet, tx_sig)
         }
-        None => ("unknown".to_string(), None),
+        // Attribution-only fallback: this function feeds the spend log /
+        // metrics labels, and the route has already hard-failed any header
+        // that does not decode — so `Err` is unreachable on the paid path
+        // and "unknown" can never mask a billing decision.
+        Err(_) => ("unknown".to_string(), None),
     }
 }
 
@@ -247,7 +256,7 @@ mod tests {
         let encoded = base64::engine::general_purpose::STANDARD.encode(&json);
 
         let result = decode_payment_from_header(&encoded);
-        assert!(result.is_some());
+        assert!(result.is_ok());
         let decoded = result.unwrap();
         assert_eq!(decoded.x402_version, 2);
         assert_eq!(decoded.accepted.scheme, "exact");
@@ -277,14 +286,50 @@ mod tests {
         let json_str = serde_json::to_string(&payload).unwrap();
 
         let result = decode_payment_from_header(&json_str);
-        assert!(result.is_some());
+        assert!(result.is_ok());
     }
 
     #[test]
-    fn test_decode_payment_from_header_invalid_returns_none() {
-        assert!(decode_payment_from_header("garbage-data").is_none());
-        assert!(decode_payment_from_header("").is_none());
-        assert!(decode_payment_from_header("fake-payment-for-testing").is_none());
+    fn test_decode_payment_from_header_invalid_returns_err() {
+        assert!(decode_payment_from_header("garbage-data").is_err());
+        assert!(decode_payment_from_header("").is_err());
+        assert!(decode_payment_from_header("fake-payment-for-testing").is_err());
+    }
+
+    /// A canonical v2 envelope that the fail-closed mapping REJECTS (here:
+    /// escrow scheme) must surface as a hard `Err` carrying the specific
+    /// canonical rejection reason — never the generic garbled-header message,
+    /// and never a silent `None`-equivalent. The route logs this reason at
+    /// `warn!` before returning its fixed client-facing 402.
+    #[test]
+    fn test_decode_payment_from_header_canonical_rejection_surfaces_reason() {
+        use base64::Engine;
+        let envelope = serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": "escrow",
+                "network": solvela_x402::types::SOLANA_NETWORK,
+                "amount": "2625",
+                "asset": solvela_x402::types::USDC_MINT,
+                "payTo": "TestWallet",
+                "maxTimeoutSeconds": 300
+            },
+            "resource": { "url": "/v1/chat/completions" },
+            "payload": { "transaction": "dGVzdA==" }
+        });
+        let encoded =
+            base64::engine::general_purpose::STANDARD.encode(envelope.to_string().as_bytes());
+
+        let err = decode_payment_from_header(&encoded)
+            .expect_err("canonical escrow selection must be a hard error");
+        assert!(
+            err.contains("canonical x402 payment rejected"),
+            "rejection reason must be surfaced, got: {err}"
+        );
+        assert!(
+            !err.contains("not valid base64 or JSON"),
+            "must be distinguishable from a garbled header: {err}"
+        );
     }
 
     // =========================================================================

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -255,10 +255,20 @@ pub async fn proxy_service(
     // Validate resource URL matches this proxy endpoint
     let expected_url = format!("/v1/services/{service_id}/proxy");
     if payload.resource.url != expected_url {
-        return Err(GatewayError::InvalidPayment(format!(
-            "payment resource '{}' does not match this endpoint",
-            payload.resource.url
-        )));
+        // GHSA-cgqx-mg48-949v posture: `resource.url` is client-controlled
+        // and unbounded (the canonical envelope imposes no length cap on it),
+        // so it is never reflected to the client. Log a truncated copy
+        // server-side; the client gets a fixed string — the 402 challenge
+        // already tells it the correct resource.
+        let got: String = payload.resource.url.chars().take(256).collect();
+        warn!(
+            expected = %expected_url,
+            got = %got,
+            "payment resource URL mismatch (proxy)"
+        );
+        return Err(GatewayError::InvalidPayment(
+            "Payment resource does not match this endpoint.".to_string(),
+        ));
     }
 
     // Validate resource method is POST

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -32,7 +32,8 @@ use solvela_router::models::ModelRegistry;
 use solvela_x402::traits::{Error as X402Error, PaymentVerifier};
 use solvela_x402::types::{
     EscrowPayload, PayloadData, PaymentAccept, PaymentPayload, Resource, SettlementResult,
-    SolanaPayload, VerificationResult, SOLANA_NETWORK, USDC_MINT,
+    SolanaPayload, VerificationResult, CANONICAL_PAYMENT_REQUIRED_HEADER, SOLANA_NETWORK,
+    USDC_MINT,
 };
 
 // ---------------------------------------------------------------------------
@@ -9556,10 +9557,6 @@ async fn paid_model_unaffected_by_global_cap() {
 // remain byte-for-byte unchanged for the published SDKs.
 // ---------------------------------------------------------------------------
 
-/// The canonical x402 v2 challenge header name (lowercase; HTTP header names
-/// are case-insensitive and the pay client matches ignore-case).
-const CANONICAL_PAYMENT_REQUIRED_HEADER: &str = "payment-required";
-
 /// Issue a no-payment chat request and return the full 402 response.
 async fn chat_402_response(app: axum::Router) -> axum::response::Response {
     let body = serde_json::json!({
@@ -9597,13 +9594,25 @@ fn decode_canonical_challenge(response: &axum::response::Response) -> serde_json
 /// `PaymentSignatureEnvelope`. Field names are written as literals here so the
 /// test pins the wire shape independently of any gateway-side serde derive.
 fn canonical_payment_signature_header(scheme: &str, payload: serde_json::Value) -> String {
+    canonical_payment_signature_header_with(scheme, SOLANA_NETWORK, USDC_MINT, payload)
+}
+
+/// Like [`canonical_payment_signature_header`] but with caller-supplied
+/// `network` and `asset`, so tests can prove canonical inbound payments hit
+/// the same downstream accepted-field validation as legacy ones.
+fn canonical_payment_signature_header_with(
+    scheme: &str,
+    network: &str,
+    asset: &str,
+    payload: serde_json::Value,
+) -> String {
     let envelope = serde_json::json!({
         "x402Version": 2,
         "accepted": {
             "scheme": scheme,
-            "network": SOLANA_NETWORK,
+            "network": network,
             "amount": TEST_PAYMENT_AMOUNT,
-            "asset": USDC_MINT,
+            "asset": asset,
             "payTo": TEST_RECIPIENT_WALLET,
             "maxTimeoutSeconds": 300,
             "extra": { "decimals": 6 }
@@ -9854,7 +9863,7 @@ impl PaymentVerifier for PayloadRecordingVerifier {
 #[tokio::test]
 async fn test_chat_canonical_payment_reaches_exact_verifier_with_mapped_payload() {
     let seen: Arc<std::sync::Mutex<Option<PaymentPayload>>> = Arc::new(std::sync::Mutex::new(None));
-    let (app, _state) =
+    let (app, state) =
         test_app_with_mock_provider_and_exact_verifier(Arc::new(PayloadRecordingVerifier {
             seen: seen.clone(),
         }));
@@ -9891,6 +9900,16 @@ async fn test_chat_canonical_payment_reaches_exact_verifier_with_mapped_payload(
     assert_eq!(payload.accepted.network, SOLANA_NETWORK);
     assert_eq!(payload.accepted.asset, USDC_MINT);
     assert_eq!(payload.accepted.pay_to, TEST_RECIPIENT_WALLET);
+    // The mapped payload must bind to the CONFIGURED mint and recipient —
+    // the same values the route validation and the verifier enforce.
+    assert_eq!(
+        payload.accepted.asset, state.config.solana.usdc_mint,
+        "mapped asset must equal the configured mint"
+    );
+    assert_eq!(
+        payload.accepted.pay_to, state.config.solana.recipient_wallet,
+        "mapped pay_to must equal the configured recipient wallet"
+    );
     assert_eq!(payload.accepted.amount, TEST_PAYMENT_AMOUNT);
     assert_eq!(payload.accepted.escrow_program_id, None);
     assert_eq!(payload.resource.url, "/v1/chat/completions");
@@ -10044,4 +10063,154 @@ async fn test_chat_legacy_payment_signature_still_succeeds_alongside_canonical()
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["object"], "chat.completion");
+}
+
+/// Replay: the SAME canonical PAYMENT-SIGNATURE envelope submitted twice
+/// through the real route against shared `AppState` must be rejected on the
+/// second attempt. The replay gate keys on the transaction string, which the
+/// canonical→legacy mapping carries verbatim — canonical payments get exactly
+/// the same replay protection as legacy ones.
+#[tokio::test]
+async fn test_chat_canonical_payment_replay_rejected() {
+    let app = test_app_with_mock_provider();
+
+    let tx_b64 = base64::engine::general_purpose::STANDARD.encode(b"canonical_replay_tx_bytes");
+    let header =
+        canonical_payment_signature_header("exact", serde_json::json!({ "transaction": tx_b64 }));
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let make_request = || {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("payment-signature", header.clone())
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap()
+    };
+
+    let first = app.clone().oneshot(make_request()).await.unwrap();
+    assert_eq!(
+        first.status(),
+        StatusCode::OK,
+        "first canonical submission must succeed"
+    );
+
+    let second = app.oneshot(make_request()).await.unwrap();
+    assert_eq!(
+        second.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "replayed canonical envelope must be rejected"
+    );
+    let body = second.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "invalid_payment");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("already been used"),
+        "second submission must hit the replay gate: {json}"
+    );
+}
+
+/// A canonical envelope quoting the WRONG mint must be rejected by the same
+/// downstream asset validation (H2) legacy payments hit — canonical inbound
+/// payments cannot bypass accepted-field validation. The chat route returns
+/// 400 `bad_request` for accepted-field mismatches (same as legacy; only
+/// resource/verification failures use 402).
+#[tokio::test]
+async fn test_chat_canonical_wrong_asset_rejected() {
+    let app = test_app_with_mock_provider();
+
+    let tx_b64 = base64::engine::general_purpose::STANDARD.encode(b"mock_signed_tx_bytes");
+    let header = canonical_payment_signature_header_with(
+        "exact",
+        SOLANA_NETWORK,
+        TEST_DEVNET_USDC_MINT, // config quotes the mainnet constant
+        serde_json::json!({ "transaction": tx_b64 }),
+    );
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("payment-signature", header)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "wrong mint must be rejected, never verified"
+    );
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "bad_request");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Payment asset is unsupported"),
+        "must hit the asset validation: {json}"
+    );
+}
+
+/// A canonical envelope quoting the WRONG network must be rejected by the
+/// same downstream network validation legacy payments hit.
+#[tokio::test]
+async fn test_chat_canonical_wrong_network_rejected() {
+    let app = test_app_with_mock_provider();
+
+    let tx_b64 = base64::engine::general_purpose::STANDARD.encode(b"mock_signed_tx_bytes");
+    let header = canonical_payment_signature_header_with(
+        "exact",
+        "eip155:8453", // Base — not the advertised Solana CAIP-2 network
+        USDC_MINT,
+        serde_json::json!({ "transaction": tx_b64 }),
+    );
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("payment-signature", header)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "wrong network must be rejected, never verified"
+    );
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "bad_request");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Payment network is unsupported"),
+        "must hit the network validation: {json}"
+    );
 }

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -9727,15 +9727,18 @@ async fn test_chat_402_legacy_body_shape_unchanged() {
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let legacy: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    // `serde_json::Value` maps iterate alphabetically (no `preserve_order`
-    // feature in this workspace), so pin the exact KEY SETS — any addition,
-    // removal, or rename still fails here.
-    let top_keys: Vec<&str> = legacy
+    // JSON object key order is not part of the wire contract, and
+    // `serde_json::Value` iteration order flips between alphabetical and
+    // declaration order depending on whether the `preserve_order` feature is
+    // unified into the build — so pin the exact KEY SETS order-insensitively
+    // (sorted) — any addition, removal, or rename still fails here.
+    let mut top_keys: Vec<&str> = legacy
         .as_object()
         .unwrap()
         .keys()
         .map(|k| k.as_str())
         .collect();
+    top_keys.sort_unstable();
     assert_eq!(
         top_keys,
         vec![
@@ -9747,19 +9750,21 @@ async fn test_chat_402_legacy_body_shape_unchanged() {
         ],
         "legacy 402 top-level keys must not change"
     );
-    let resource_keys: Vec<&str> = legacy["resource"]
+    let mut resource_keys: Vec<&str> = legacy["resource"]
         .as_object()
         .unwrap()
         .keys()
         .map(|k| k.as_str())
         .collect();
+    resource_keys.sort_unstable();
     assert_eq!(resource_keys, vec!["method", "url"]);
-    let accept_keys: Vec<&str> = legacy["accepts"][0]
+    let mut accept_keys: Vec<&str> = legacy["accepts"][0]
         .as_object()
         .unwrap()
         .keys()
         .map(|k| k.as_str())
         .collect();
+    accept_keys.sort_unstable();
     assert_eq!(
         accept_keys,
         vec![

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -9538,3 +9538,510 @@ async fn paid_model_unaffected_by_global_cap() {
         "a paid model must 402, never be gated by the free aggregate cap"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Canonical x402 wire-compat (solana-foundation/pay CLI interop)
+//
+// Golden shapes in this section are pinned to the `pay` CLI's x402 client
+// (solana-foundation/pay rust/crates/core/src/client/x402.rs, backed by the
+// solana-foundation/pay-kit `solana-x402` crate):
+//   - the v2 challenge lives in a `PAYMENT-REQUIRED` response header carrying
+//     base64(JSON envelope) with camelCase fields (`x402Version`, `accepts[]`
+//     entries with `payTo` / `maxTimeoutSeconds` / `asset` / `amount`), checked
+//     BEFORE any body parsing;
+//   - the client replies in the existing `PAYMENT-SIGNATURE` header with a
+//     canonical v2 envelope `{x402Version, accepted, resource, payload:
+//     {transaction}}`.
+// The legacy snake_case 402 body and legacy PAYMENT-SIGNATURE payload must
+// remain byte-for-byte unchanged for the published SDKs.
+// ---------------------------------------------------------------------------
+
+/// The canonical x402 v2 challenge header name (lowercase; HTTP header names
+/// are case-insensitive and the pay client matches ignore-case).
+const CANONICAL_PAYMENT_REQUIRED_HEADER: &str = "payment-required";
+
+/// Issue a no-payment chat request and return the full 402 response.
+async fn chat_402_response(app: axum::Router) -> axum::response::Response {
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
+/// Decode the canonical challenge header from a 402 response into JSON.
+fn decode_canonical_challenge(response: &axum::response::Response) -> serde_json::Value {
+    let header = response
+        .headers()
+        .get(CANONICAL_PAYMENT_REQUIRED_HEADER)
+        .expect("402 must carry the canonical PAYMENT-REQUIRED header")
+        .to_str()
+        .expect("header must be ASCII");
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(header)
+        .expect("canonical challenge header must be standard base64");
+    serde_json::from_slice(&decoded).expect("canonical challenge must be JSON")
+}
+
+/// Build a canonical x402 v2 `PAYMENT-SIGNATURE` value exactly as the pay
+/// client's `build_payment_header` emits it: base64(standard) of a camelCase
+/// `PaymentSignatureEnvelope`. Field names are written as literals here so the
+/// test pins the wire shape independently of any gateway-side serde derive.
+fn canonical_payment_signature_header(scheme: &str, payload: serde_json::Value) -> String {
+    let envelope = serde_json::json!({
+        "x402Version": 2,
+        "accepted": {
+            "scheme": scheme,
+            "network": SOLANA_NETWORK,
+            "amount": TEST_PAYMENT_AMOUNT,
+            "asset": USDC_MINT,
+            "payTo": TEST_RECIPIENT_WALLET,
+            "maxTimeoutSeconds": 300,
+            "extra": { "decimals": 6 }
+        },
+        "resource": {
+            "url": "/v1/chat/completions",
+            "description": "API access"
+        },
+        "payload": payload
+    });
+    base64::engine::general_purpose::STANDARD.encode(envelope.to_string())
+}
+
+/// The 402 response must carry the canonical v2 challenge in the
+/// `PAYMENT-REQUIRED` header with the exact camelCase field names the pay
+/// client's parser consumes — alongside the unchanged legacy body.
+#[tokio::test]
+async fn test_chat_402_carries_canonical_payment_required_header() {
+    let response = chat_402_response(test_app()).await;
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let canonical = decode_canonical_challenge(&response);
+
+    assert_eq!(canonical["x402Version"], 2, "canonical version field");
+    assert_eq!(canonical["resource"]["url"], "/v1/chat/completions");
+
+    let accepts = canonical["accepts"].as_array().expect("accepts array");
+    assert_eq!(accepts.len(), 1, "exact only (no escrow configured)");
+    let exact = &accepts[0];
+    assert_eq!(exact["scheme"], "exact");
+    assert_eq!(exact["network"], SOLANA_NETWORK);
+    assert_eq!(exact["asset"], USDC_MINT);
+    assert_eq!(exact["payTo"], TEST_RECIPIENT_WALLET);
+    assert_eq!(exact["maxTimeoutSeconds"], 300);
+    assert_eq!(exact["extra"]["decimals"], 6);
+    assert!(
+        exact["amount"].is_string(),
+        "amount must be an atomic-unit string"
+    );
+
+    // feePayer is DELIBERATELY absent: the gateway's exact verifier requires
+    // signatures[0] to verify against account_keys[0] and broadcasts without
+    // countersigning, so a server-fee-payer tx (empty fee-payer sig slot)
+    // would be rejected. Omitting it makes the pay client self-pay the SOL fee
+    // and produce a fully-signed tx the existing verifier accepts.
+    assert!(
+        exact["extra"].get("feePayer").is_none(),
+        "canonical challenge must not advertise a feePayer"
+    );
+
+    // No snake_case bleed-through into the canonical surface.
+    assert!(exact.get("pay_to").is_none());
+    assert!(exact.get("max_timeout_seconds").is_none());
+    assert!(canonical.get("x402_version").is_none());
+    assert!(canonical.get("cost_breakdown").is_none());
+
+    // The canonical body amount mirrors the legacy quote exactly.
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let legacy: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        canonical["accepts"][0]["amount"], legacy["accepts"][0]["amount"],
+        "canonical and legacy must quote the same atomic amount"
+    );
+}
+
+/// The escrow scheme must NOT be exposed through the canonical surface even
+/// when the gateway offers it on the legacy body.
+#[tokio::test]
+async fn test_chat_402_canonical_header_excludes_escrow() {
+    let response = chat_402_response(test_app_with_escrow()).await;
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let canonical = decode_canonical_challenge(&response);
+    let accepts = canonical["accepts"].as_array().expect("accepts array");
+    assert_eq!(
+        accepts.len(),
+        1,
+        "canonical surface must advertise exact only"
+    );
+    assert_eq!(accepts[0]["scheme"], "exact");
+
+    // Legacy body still advertises both schemes — unchanged.
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let legacy: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let legacy_accepts = legacy["accepts"].as_array().unwrap();
+    assert_eq!(legacy_accepts.len(), 2, "legacy keeps exact + escrow");
+    assert_eq!(legacy_accepts[1]["scheme"], "escrow");
+}
+
+/// Canonical challenge must quote the CONFIGURED mint (PR #531), never the
+/// compile-time constant.
+#[tokio::test]
+async fn test_chat_402_canonical_header_quotes_configured_mint() {
+    let response = chat_402_response(test_app_with_usdc_mint(TEST_DEVNET_USDC_MINT)).await;
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let canonical = decode_canonical_challenge(&response);
+    assert_eq!(
+        canonical["accepts"][0]["asset"], TEST_DEVNET_USDC_MINT,
+        "canonical asset must follow config.solana.usdc_mint"
+    );
+}
+
+/// Legacy-regression pin: the snake_case 402 body shape must stay EXACTLY as
+/// the published SDKs parse it — same top-level keys, same nested keys, no
+/// additions. The canonical layer is header-only.
+#[tokio::test]
+async fn test_chat_402_legacy_body_shape_unchanged() {
+    let response = chat_402_response(test_app()).await;
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let legacy: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // `serde_json::Value` maps iterate alphabetically (no `preserve_order`
+    // feature in this workspace), so pin the exact KEY SETS — any addition,
+    // removal, or rename still fails here.
+    let top_keys: Vec<&str> = legacy
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(|k| k.as_str())
+        .collect();
+    assert_eq!(
+        top_keys,
+        vec![
+            "accepts",
+            "cost_breakdown",
+            "error",
+            "resource",
+            "x402_version"
+        ],
+        "legacy 402 top-level keys must not change"
+    );
+    let resource_keys: Vec<&str> = legacy["resource"]
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(|k| k.as_str())
+        .collect();
+    assert_eq!(resource_keys, vec!["method", "url"]);
+    let accept_keys: Vec<&str> = legacy["accepts"][0]
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(|k| k.as_str())
+        .collect();
+    assert_eq!(
+        accept_keys,
+        vec![
+            "amount",
+            "asset",
+            "max_timeout_seconds",
+            "network",
+            "pay_to",
+            "scheme"
+        ],
+        "legacy accepts[] entry keys must not change"
+    );
+    assert_eq!(legacy["x402_version"], 2);
+}
+
+/// A pay-shaped canonical `PAYMENT-SIGNATURE` (v2 envelope, camelCase,
+/// payload.transaction) must decode, map into the legacy verification
+/// pipeline, and serve the request end-to-end through the real route.
+#[tokio::test]
+async fn test_chat_with_canonical_payment_signature_succeeds() {
+    let app = test_app_with_mock_provider();
+
+    let tx_b64 = base64::engine::general_purpose::STANDARD.encode(b"mock_signed_tx_bytes");
+    let header =
+        canonical_payment_signature_header("exact", serde_json::json!({ "transaction": tx_b64 }));
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("payment-signature", header)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["object"], "chat.completion");
+    assert_eq!(json["choices"][0]["message"]["content"], "[mock response]");
+}
+
+/// An `exact`-scheme verifier that records the payload it was asked to verify,
+/// so tests can assert exactly what the canonical→legacy mapping handed to the
+/// verification pipeline.
+struct PayloadRecordingVerifier {
+    seen: Arc<std::sync::Mutex<Option<PaymentPayload>>>,
+}
+
+#[async_trait::async_trait]
+impl PaymentVerifier for PayloadRecordingVerifier {
+    fn network(&self) -> &str {
+        SOLANA_NETWORK
+    }
+
+    fn scheme(&self) -> &str {
+        "exact"
+    }
+
+    async fn verify_payment(
+        &self,
+        payload: &PaymentPayload,
+    ) -> Result<VerificationResult, X402Error> {
+        *self
+            .seen
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(payload.clone());
+        Ok(VerificationResult {
+            valid: true,
+            reason: None,
+            verified_amount: Some(2625),
+        })
+    }
+
+    async fn settle_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<SettlementResult, X402Error> {
+        Ok(SettlementResult {
+            success: true,
+            tx_signature: Some("MockSettledTxSig123".to_string()),
+            network: SOLANA_NETWORK.to_string(),
+            error: None,
+            verified_amount: None,
+            failure_kind: None,
+        })
+    }
+}
+
+/// The canonical inbound payload must reach the existing verifier mapped into
+/// the legacy `PaymentPayload` shape: scheme `exact`, `Direct` transaction
+/// carried verbatim, accepted fields and resource bound for route validation.
+#[tokio::test]
+async fn test_chat_canonical_payment_reaches_exact_verifier_with_mapped_payload() {
+    let seen: Arc<std::sync::Mutex<Option<PaymentPayload>>> = Arc::new(std::sync::Mutex::new(None));
+    let (app, _state) =
+        test_app_with_mock_provider_and_exact_verifier(Arc::new(PayloadRecordingVerifier {
+            seen: seen.clone(),
+        }));
+
+    let tx_b64 = base64::engine::general_purpose::STANDARD.encode(b"mock_signed_tx_bytes");
+    let header =
+        canonical_payment_signature_header("exact", serde_json::json!({ "transaction": tx_b64 }));
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("payment-signature", header)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let payload = seen
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+        .expect("verifier must have been reached with the mapped payload");
+    assert_eq!(payload.x402_version, 2);
+    assert_eq!(payload.accepted.scheme, "exact");
+    assert_eq!(payload.accepted.network, SOLANA_NETWORK);
+    assert_eq!(payload.accepted.asset, USDC_MINT);
+    assert_eq!(payload.accepted.pay_to, TEST_RECIPIENT_WALLET);
+    assert_eq!(payload.accepted.amount, TEST_PAYMENT_AMOUNT);
+    assert_eq!(payload.accepted.escrow_program_id, None);
+    assert_eq!(payload.resource.url, "/v1/chat/completions");
+    assert_eq!(payload.resource.method, "POST");
+    match &payload.payload {
+        PayloadData::Direct(p) => assert_eq!(p.transaction, tx_b64),
+        PayloadData::Escrow(_) => panic!("canonical payment must map to Direct"),
+    }
+}
+
+/// The escrow scheme must be rejected on the canonical inbound surface — a
+/// canonical client cannot select escrow, and the gateway must fail closed
+/// rather than route it anywhere.
+#[tokio::test]
+async fn test_chat_canonical_escrow_scheme_rejected() {
+    let app = test_app_with_mock_provider();
+
+    let tx_b64 = base64::engine::general_purpose::STANDARD.encode(b"mock_signed_tx_bytes");
+    let header =
+        canonical_payment_signature_header("escrow", serde_json::json!({ "transaction": tx_b64 }));
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("payment-signature", header)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "canonical escrow selection must be rejected, never served"
+    );
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "invalid_payment");
+}
+
+/// A canonical signature-proof payload (`payload.signature`, client-broadcast
+/// model) must be rejected: the gateway's exact flow requires the signed
+/// transaction so IT controls broadcast (deferred settlement, #486).
+#[tokio::test]
+async fn test_chat_canonical_signature_proof_rejected() {
+    let app = test_app_with_mock_provider();
+
+    let header = canonical_payment_signature_header(
+        "exact",
+        serde_json::json!({ "signature": "5wZ2UM8fFakeBase58Signature1111111111111111" }),
+    );
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("payment-signature", header)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "invalid_payment");
+}
+
+/// A v1 canonical envelope (x402Version: 1) must be rejected — the gateway
+/// only advertises and accepts the v2 canonical surface.
+#[tokio::test]
+async fn test_chat_canonical_v1_envelope_rejected() {
+    let app = test_app_with_mock_provider();
+
+    let tx_b64 = base64::engine::general_purpose::STANDARD.encode(b"mock_signed_tx_bytes");
+    // V1 X-PAYMENT shape per the pay client: scheme/network at the top level,
+    // no accepted/resource.
+    let envelope = serde_json::json!({
+        "x402Version": 1,
+        "scheme": "exact",
+        "network": "solana",
+        "payload": { "transaction": tx_b64 }
+    });
+    let header = base64::engine::general_purpose::STANDARD.encode(envelope.to_string());
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("payment-signature", header)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "invalid_payment");
+}
+
+/// Legacy regression: the existing snake_case PAYMENT-SIGNATURE payload must
+/// keep working bit-for-bit alongside the canonical inbound path.
+#[tokio::test]
+async fn test_chat_legacy_payment_signature_still_succeeds_alongside_canonical() {
+    let app = test_app_with_mock_provider();
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["object"], "chat.completion");
+}

--- a/crates/protocol/src/canonical.rs
+++ b/crates/protocol/src/canonical.rs
@@ -1,0 +1,616 @@
+//! Canonical x402 v2 wire-compatibility types.
+//!
+//! Solvela's native 402 body and `PAYMENT-SIGNATURE` payload predate the
+//! canonical x402 v2 wire format and use a snake_case dialect that the
+//! published SDKs (`@solvela/sdk`, `solvela-sdk` PyPI, Go, `solvela-client`)
+//! parse byte-for-byte. Those shapes are frozen — see [`crate::payment`].
+//!
+//! This module adds the CANONICAL x402 v2 shapes alongside them, pinned to
+//! what the `pay` CLI (solana-foundation/pay, backed by the
+//! solana-foundation/pay-kit `solana-x402` crate) actually parses and emits:
+//!
+//! - **Outbound challenge** — [`CanonicalPaymentRequired`], serialized as
+//!   camelCase JSON, base64-encoded into the `PAYMENT-REQUIRED` response
+//!   header ([`CANONICAL_PAYMENT_REQUIRED_HEADER`]) on the same 402 response
+//!   that carries the unchanged legacy body. The pay client checks this
+//!   header BEFORE any body parsing and treats its presence as x402 v2.
+//! - **Inbound payment** — [`CanonicalPaymentEnvelope`], the v2
+//!   `PaymentSignatureEnvelope` the pay client base64-encodes into the
+//!   `PAYMENT-SIGNATURE` request header:
+//!   `{ x402Version: 2, accepted, resource, payload: { transaction } }`.
+//!   [`CanonicalPaymentEnvelope::into_payment_payload`] maps it (fail-closed)
+//!   into the legacy [`PaymentPayload`] so the existing verification pipeline
+//!   runs unchanged.
+//!
+//! Money-path rules enforced here:
+//! - Only scheme `"exact"` crosses the canonical surface — escrow is never
+//!   advertised on it and is rejected inbound ([`CanonicalPaymentError`]).
+//! - Only a signed `transaction` proof is accepted (the gateway controls the
+//!   broadcast; a client-broadcast `signature` proof is a different trust
+//!   model and is rejected).
+//! - `extra.feePayer` is deliberately NEVER advertised: the gateway's exact
+//!   verifier requires `signatures[0]` to verify against `account_keys[0]`
+//!   and broadcasts without countersigning, so a server-fee-payer transaction
+//!   (empty fee-payer signature slot) would always be rejected. With the
+//!   field absent the pay client self-pays the SOL fee and submits a
+//!   fully-signed transaction the existing verifier accepts.
+//!
+//! Unlike the legacy types, the inbound canonical types do NOT use
+//! `deny_unknown_fields`: the x402 v2 spec (§5.1.2) lets clients echo and
+//! append envelope fields, and the mapping below copies ONLY the validated,
+//! known fields into [`PaymentPayload`] — unknown keys are dropped at the
+//! boundary and can never propagate into gateway logic.
+
+use serde::{Deserialize, Serialize};
+
+use crate::constants::X402_VERSION;
+use crate::payment::{
+    PayloadData, PaymentAccept, PaymentPayload, PaymentRequired, Resource, SolanaPayload,
+};
+
+/// Canonical x402 v2 challenge response header (lowercase for
+/// `HeaderName::from_static`; HTTP header names are case-insensitive and the
+/// pay client matches ignore-case). The pay-kit constant is
+/// `PAYMENT_REQUIRED_HEADER = "PAYMENT-REQUIRED"`.
+pub const CANONICAL_PAYMENT_REQUIRED_HEADER: &str = "payment-required";
+
+/// The canonical x402 protocol version this surface speaks (`x402Version`).
+pub const CANONICAL_X402_VERSION: u64 = 2;
+
+/// USDC token decimals, advertised in `accepts[].extra.decimals` so canonical
+/// clients build `TransferChecked` with the decimals the verifier expects.
+/// Solvela prices everything in 6-decimal atomic USDC units.
+const USDC_DECIMALS: u8 = 6;
+
+/// Maximum characters of a client-supplied scheme echoed into an error
+/// message (GHSA-cgqx-mg48-949v posture: never reflect unbounded
+/// attacker-controlled bytes).
+const MAX_ECHOED_SCHEME_CHARS: usize = 32;
+
+/// Why a canonical inbound payment envelope was rejected.
+///
+/// These messages may be logged server-side; the route handlers return their
+/// own fixed client-facing strings, so nothing here is reflected verbatim to
+/// clients beyond the (length-capped) scheme.
+#[derive(Debug, thiserror::Error)]
+pub enum CanonicalPaymentError {
+    #[error("unsupported x402Version {0}; this gateway accepts canonical x402 version 2")]
+    UnsupportedVersion(u64),
+
+    #[error("canonical payment envelope is missing the `accepted` object")]
+    MissingAccepted,
+
+    #[error(
+        "canonical payment envelope is missing the `resource` object; \
+         echo the resource from the PAYMENT-REQUIRED challenge"
+    )]
+    MissingResource,
+
+    #[error("unsupported scheme '{0}' on the canonical x402 surface; only 'exact' is accepted")]
+    UnsupportedScheme(String),
+
+    #[error(
+        "unsupported payment proof: only a signed `transaction` is accepted \
+         (the gateway broadcasts after delivery; client-broadcast `signature` \
+         proofs are not supported)"
+    )]
+    UnsupportedProof,
+}
+
+/// Canonical v2 resource metadata (`resource` on both envelopes).
+/// Mirrors pay-kit `ResourceInfo`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanonicalResource {
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+}
+
+/// One canonical `accepts[]` entry / the echoed `accepted` object.
+///
+/// Field names are the v2 wire contract the pay client parses:
+/// `scheme`, `network` (CAIP-2), `amount` (atomic-unit string), `asset`
+/// (mint address), `payTo` (recipient wallet), `maxTimeoutSeconds`, `extra`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanonicalAccept {
+    pub scheme: String,
+    pub network: String,
+    pub amount: String,
+    pub asset: String,
+    pub pay_to: String,
+    pub max_timeout_seconds: u64,
+    /// Scheme-specific extras (`decimals`, never `feePayer` — see module
+    /// docs). Echoed back by clients; ignored on the inbound mapping.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<serde_json::Value>,
+}
+
+/// Canonical v2 challenge envelope carried (base64-encoded) in the
+/// `PAYMENT-REQUIRED` response header. Mirrors pay-kit
+/// `PaymentRequiredEnvelope`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanonicalPaymentRequired {
+    pub x402_version: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<CanonicalResource>,
+    pub accepts: Vec<CanonicalAccept>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl CanonicalPaymentRequired {
+    /// Project the legacy 402 body onto the canonical v2 challenge.
+    ///
+    /// Copies the already-quoted atomic amount strings verbatim — no amount
+    /// math happens here. Only `exact` entries cross the canonical surface;
+    /// returns `None` when the legacy challenge offers no `exact` scheme, in
+    /// which case the caller must NOT emit a canonical header (fail closed —
+    /// never advertise a challenge canonical clients cannot satisfy).
+    pub fn from_payment_required(legacy: &PaymentRequired) -> Option<Self> {
+        let accepts: Vec<CanonicalAccept> = legacy
+            .accepts
+            .iter()
+            .filter(|accept| accept.scheme == "exact")
+            .map(|accept| CanonicalAccept {
+                scheme: accept.scheme.clone(),
+                network: accept.network.clone(),
+                amount: accept.amount.clone(),
+                asset: accept.asset.clone(),
+                pay_to: accept.pay_to.clone(),
+                max_timeout_seconds: accept.max_timeout_seconds,
+                // decimals only — NEVER feePayer (see module docs).
+                extra: Some(serde_json::json!({ "decimals": USDC_DECIMALS })),
+            })
+            .collect();
+
+        if accepts.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            x402_version: CANONICAL_X402_VERSION,
+            resource: Some(CanonicalResource {
+                url: legacy.resource.url.clone(),
+                description: None,
+                mime_type: None,
+            }),
+            accepts,
+            error: Some(legacy.error.clone()),
+        })
+    }
+}
+
+/// Canonical payment proof — mirrors pay-kit `PaymentProof` (untagged).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CanonicalProof {
+    /// Client sends signed transaction bytes for the gateway to broadcast.
+    Transaction {
+        /// Base64-encoded serialized signed transaction.
+        transaction: String,
+    },
+    /// Client broadcast itself and sends the confirmed signature. NOT
+    /// accepted by the mapping below (the gateway must control broadcast).
+    Signature {
+        /// Base58-encoded transaction signature.
+        signature: String,
+    },
+}
+
+/// Canonical v2 payment envelope carried (base64-encoded) in the
+/// `PAYMENT-SIGNATURE` request header. Mirrors pay-kit
+/// `PaymentSignatureEnvelope`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanonicalPaymentEnvelope {
+    /// Top-level scheme — only set by v1 clients; ignored (v2 carries the
+    /// scheme inside `accepted`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<String>,
+    /// Top-level network — only set by v1 clients; ignored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<String>,
+    pub x402_version: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted: Option<CanonicalAccept>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<CanonicalResource>,
+    pub payload: CanonicalProof,
+    /// Echoed v2 extensions — ignored (Solvela advertises none).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<serde_json::Value>,
+}
+
+impl CanonicalPaymentEnvelope {
+    /// Map a canonical v2 payment envelope into the legacy [`PaymentPayload`]
+    /// the existing verification pipeline consumes. Fail-closed: every
+    /// rejection is an explicit error, never a default.
+    ///
+    /// The legacy `resource.method` has no canonical equivalent; it is set to
+    /// `"POST"` because every payment-gated Solvela endpoint is POST-only and
+    /// the route handlers independently require POST.
+    pub fn into_payment_payload(self) -> Result<PaymentPayload, CanonicalPaymentError> {
+        if self.x402_version != CANONICAL_X402_VERSION {
+            return Err(CanonicalPaymentError::UnsupportedVersion(self.x402_version));
+        }
+
+        let accepted = self
+            .accepted
+            .ok_or(CanonicalPaymentError::MissingAccepted)?;
+        if accepted.scheme != "exact" {
+            let scheme: String = accepted
+                .scheme
+                .chars()
+                .take(MAX_ECHOED_SCHEME_CHARS)
+                .collect();
+            return Err(CanonicalPaymentError::UnsupportedScheme(scheme));
+        }
+
+        let resource = self
+            .resource
+            .ok_or(CanonicalPaymentError::MissingResource)?;
+
+        let transaction = match self.payload {
+            CanonicalProof::Transaction { transaction } => transaction,
+            CanonicalProof::Signature { .. } => {
+                return Err(CanonicalPaymentError::UnsupportedProof);
+            }
+        };
+
+        Ok(PaymentPayload {
+            x402_version: X402_VERSION,
+            resource: Resource {
+                url: resource.url,
+                method: "POST".to_string(),
+            },
+            accepted: PaymentAccept {
+                scheme: accepted.scheme,
+                network: accepted.network,
+                amount: accepted.amount,
+                asset: accepted.asset,
+                pay_to: accepted.pay_to,
+                max_timeout_seconds: accepted.max_timeout_seconds,
+                escrow_program_id: None,
+            },
+            payload: PayloadData::Direct(SolanaPayload { transaction }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{MAX_TIMEOUT_SECONDS, SOLANA_NETWORK, USDC_MINT};
+    use crate::cost::CostBreakdown;
+
+    fn legacy_payment_required(accepts: Vec<PaymentAccept>) -> PaymentRequired {
+        PaymentRequired {
+            x402_version: X402_VERSION,
+            resource: Resource {
+                url: "/v1/chat/completions".to_string(),
+                method: "POST".to_string(),
+            },
+            accepts,
+            cost_breakdown: CostBreakdown {
+                provider_cost: "0.002500".to_string(),
+                platform_fee: "0.000125".to_string(),
+                total: "0.002625".to_string(),
+                currency: "USDC".to_string(),
+                fee_percent: 5,
+            },
+            error: "Payment required".to_string(),
+        }
+    }
+
+    fn exact_accept() -> PaymentAccept {
+        PaymentAccept {
+            scheme: "exact".to_string(),
+            network: SOLANA_NETWORK.to_string(),
+            amount: "2625".to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC".to_string(),
+            max_timeout_seconds: MAX_TIMEOUT_SECONDS,
+            escrow_program_id: None,
+        }
+    }
+
+    fn escrow_accept() -> PaymentAccept {
+        PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: SOLANA_NETWORK.to_string(),
+            amount: "2625".to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC".to_string(),
+            max_timeout_seconds: MAX_TIMEOUT_SECONDS,
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
+        }
+    }
+
+    /// Golden vector (outbound): the serialized canonical challenge must use
+    /// exactly the field names/casing the pay client's
+    /// `PaymentRequiredEnvelope`/`PaymentRequirements` parser consumes
+    /// (pay-kit rust/crates/x402 — `x402Version`, `accepts[].payTo`,
+    /// `maxTimeoutSeconds`, CAIP-2 `network`, mint `asset`, atomic-string
+    /// `amount`).
+    #[test]
+    fn canonical_challenge_serializes_to_pay_client_shape() {
+        let canonical =
+            CanonicalPaymentRequired::from_payment_required(&legacy_payment_required(vec![
+                exact_accept(),
+            ]))
+            .expect("exact accept must produce a canonical challenge");
+
+        let value = serde_json::to_value(&canonical).unwrap();
+        let expected = serde_json::json!({
+            "x402Version": 2,
+            "resource": {
+                "url": "/v1/chat/completions"
+            },
+            "accepts": [{
+                "scheme": "exact",
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "amount": "2625",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC",
+                "maxTimeoutSeconds": 300,
+                "extra": { "decimals": 6 }
+            }],
+            "error": "Payment required"
+        });
+        assert_eq!(value, expected, "canonical challenge wire shape drifted");
+    }
+
+    /// The canonical challenge never advertises escrow, and never a feePayer.
+    #[test]
+    fn canonical_challenge_excludes_escrow_and_fee_payer() {
+        let canonical =
+            CanonicalPaymentRequired::from_payment_required(&legacy_payment_required(vec![
+                exact_accept(),
+                escrow_accept(),
+            ]))
+            .expect("exact accept present");
+
+        assert_eq!(canonical.accepts.len(), 1);
+        assert_eq!(canonical.accepts[0].scheme, "exact");
+        let extra = canonical.accepts[0].extra.as_ref().unwrap();
+        assert!(
+            extra.get("feePayer").is_none(),
+            "feePayer must never be advertised (verifier requires a fully-signed tx)"
+        );
+    }
+
+    /// No exact entry → no canonical challenge (fail closed: do not advertise
+    /// a surface canonical clients cannot pay on).
+    #[test]
+    fn canonical_challenge_none_without_exact_scheme() {
+        let canonical =
+            CanonicalPaymentRequired::from_payment_required(&legacy_payment_required(vec![
+                escrow_accept(),
+            ]));
+        assert!(canonical.is_none());
+    }
+
+    /// Golden vector (inbound): a `PAYMENT-SIGNATURE` envelope shaped exactly
+    /// like the pay client's `build_payment_header` output — accepted object
+    /// taken verbatim from the pay client's own V2 test fixture
+    /// (solana-foundation/pay x402.rs::parse_v2_payment_required_header_…),
+    /// including the `extra.feePayer` echo — must map into the legacy
+    /// `PaymentPayload`.
+    #[test]
+    fn pay_client_v2_envelope_maps_to_legacy_payment_payload() {
+        let envelope_json = serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": "exact",
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "amount": "10000",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC",
+                "maxTimeoutSeconds": 300,
+                "extra": {
+                    "feePayer": "AepWpq3GQwL8CeKMtZyKtKPa7W91Coygh3ropAJapVdU",
+                    "decimals": 6
+                }
+            },
+            "resource": {
+                "url": "https://api.example.com/v1/test",
+                "description": "API access"
+            },
+            "payload": { "transaction": "dGVzdA==" }
+        });
+
+        let envelope: CanonicalPaymentEnvelope =
+            serde_json::from_value(envelope_json).expect("pay-shaped envelope must parse");
+        let payload = envelope
+            .into_payment_payload()
+            .expect("pay-shaped envelope must map");
+
+        assert_eq!(payload.x402_version, 2);
+        assert_eq!(payload.resource.url, "https://api.example.com/v1/test");
+        assert_eq!(payload.resource.method, "POST");
+        assert_eq!(payload.accepted.scheme, "exact");
+        assert_eq!(
+            payload.accepted.network,
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+        );
+        assert_eq!(payload.accepted.amount, "10000");
+        assert_eq!(
+            payload.accepted.asset,
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        );
+        assert_eq!(
+            payload.accepted.pay_to,
+            "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC"
+        );
+        assert_eq!(payload.accepted.max_timeout_seconds, 300);
+        assert_eq!(payload.accepted.escrow_program_id, None);
+        match payload.payload {
+            PayloadData::Direct(p) => assert_eq!(p.transaction, "dGVzdA=="),
+            PayloadData::Escrow(_) => panic!("must map to Direct"),
+        }
+    }
+
+    /// Round trip: the accepted entry the gateway advertises, echoed verbatim
+    /// (as the pay client does), maps back to identical legacy fields.
+    #[test]
+    fn advertised_accept_echo_round_trips() {
+        let canonical =
+            CanonicalPaymentRequired::from_payment_required(&legacy_payment_required(vec![
+                exact_accept(),
+            ]))
+            .unwrap();
+        let advertised = serde_json::to_value(&canonical.accepts[0]).unwrap();
+
+        let envelope_json = serde_json::json!({
+            "x402Version": 2,
+            "accepted": advertised,
+            "resource": serde_json::to_value(canonical.resource.as_ref().unwrap()).unwrap(),
+            "payload": { "transaction": "dGVzdA==" }
+        });
+        let envelope: CanonicalPaymentEnvelope = serde_json::from_value(envelope_json).unwrap();
+        let payload = envelope.into_payment_payload().unwrap();
+
+        let original = exact_accept();
+        assert_eq!(payload.accepted.scheme, original.scheme);
+        assert_eq!(payload.accepted.network, original.network);
+        assert_eq!(payload.accepted.amount, original.amount);
+        assert_eq!(payload.accepted.asset, original.asset);
+        assert_eq!(payload.accepted.pay_to, original.pay_to);
+        assert_eq!(
+            payload.accepted.max_timeout_seconds,
+            original.max_timeout_seconds
+        );
+        assert_eq!(payload.resource.url, "/v1/chat/completions");
+    }
+
+    #[test]
+    fn envelope_rejects_non_v2_version() {
+        let envelope_json = serde_json::json!({
+            "x402Version": 1,
+            "scheme": "exact",
+            "network": "solana",
+            "payload": { "transaction": "dGVzdA==" }
+        });
+        let envelope: CanonicalPaymentEnvelope = serde_json::from_value(envelope_json).unwrap();
+        let err = envelope.into_payment_payload().unwrap_err();
+        assert!(matches!(err, CanonicalPaymentError::UnsupportedVersion(1)));
+    }
+
+    #[test]
+    fn envelope_rejects_missing_accepted() {
+        let envelope_json = serde_json::json!({
+            "x402Version": 2,
+            "resource": { "url": "/v1/chat/completions" },
+            "payload": { "transaction": "dGVzdA==" }
+        });
+        let envelope: CanonicalPaymentEnvelope = serde_json::from_value(envelope_json).unwrap();
+        let err = envelope.into_payment_payload().unwrap_err();
+        assert!(matches!(err, CanonicalPaymentError::MissingAccepted));
+    }
+
+    #[test]
+    fn envelope_rejects_missing_resource() {
+        let envelope_json = serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": "exact",
+                "network": SOLANA_NETWORK,
+                "amount": "2625",
+                "asset": USDC_MINT,
+                "payTo": "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC",
+                "maxTimeoutSeconds": 300
+            },
+            "payload": { "transaction": "dGVzdA==" }
+        });
+        let envelope: CanonicalPaymentEnvelope = serde_json::from_value(envelope_json).unwrap();
+        let err = envelope.into_payment_payload().unwrap_err();
+        assert!(matches!(err, CanonicalPaymentError::MissingResource));
+    }
+
+    /// Escrow must never enter through the canonical surface, and the echoed
+    /// scheme in the error is length-capped (reflected-injection posture).
+    #[test]
+    fn envelope_rejects_non_exact_scheme_with_capped_echo() {
+        let long_scheme = "escrow".to_string() + &"x".repeat(200);
+        let envelope_json = serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": long_scheme,
+                "network": SOLANA_NETWORK,
+                "amount": "2625",
+                "asset": USDC_MINT,
+                "payTo": "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC",
+                "maxTimeoutSeconds": 300
+            },
+            "resource": { "url": "/v1/chat/completions" },
+            "payload": { "transaction": "dGVzdA==" }
+        });
+        let envelope: CanonicalPaymentEnvelope = serde_json::from_value(envelope_json).unwrap();
+        match envelope.into_payment_payload().unwrap_err() {
+            CanonicalPaymentError::UnsupportedScheme(scheme) => {
+                assert!(scheme.starts_with("escrow"));
+                assert!(
+                    scheme.chars().count() <= MAX_ECHOED_SCHEME_CHARS,
+                    "echoed scheme must be length-capped"
+                );
+            }
+            other => panic!("expected UnsupportedScheme, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn envelope_rejects_signature_proof() {
+        let envelope_json = serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": "exact",
+                "network": SOLANA_NETWORK,
+                "amount": "2625",
+                "asset": USDC_MINT,
+                "payTo": "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC",
+                "maxTimeoutSeconds": 300
+            },
+            "resource": { "url": "/v1/chat/completions" },
+            "payload": { "signature": "5wZ2UM8fFakeSignature" }
+        });
+        let envelope: CanonicalPaymentEnvelope = serde_json::from_value(envelope_json).unwrap();
+        let err = envelope.into_payment_payload().unwrap_err();
+        assert!(matches!(err, CanonicalPaymentError::UnsupportedProof));
+    }
+
+    /// A legacy Solvela `PaymentPayload` JSON must NOT parse as a canonical
+    /// envelope (it lacks `x402Version`), so the two surfaces can never be
+    /// confused by an inbound decoder that tries both.
+    #[test]
+    fn legacy_payload_json_does_not_parse_as_canonical_envelope() {
+        let legacy = PaymentPayload {
+            x402_version: 2,
+            resource: Resource {
+                url: "/v1/chat/completions".to_string(),
+                method: "POST".to_string(),
+            },
+            accepted: exact_accept(),
+            payload: PayloadData::Direct(SolanaPayload {
+                transaction: "dGVzdA==".to_string(),
+            }),
+        };
+        let json = serde_json::to_string(&legacy).unwrap();
+        assert!(
+            serde_json::from_str::<CanonicalPaymentEnvelope>(&json).is_err(),
+            "legacy snake_case payload must not be parseable as a canonical envelope"
+        );
+    }
+
+    /// Header constant pin — the pay client looks for `PAYMENT-REQUIRED`
+    /// (case-insensitive).
+    #[test]
+    fn canonical_header_constant_pinned() {
+        assert_eq!(CANONICAL_PAYMENT_REQUIRED_HEADER, "payment-required");
+        assert!(CANONICAL_PAYMENT_REQUIRED_HEADER.eq_ignore_ascii_case("PAYMENT-REQUIRED"));
+    }
+}

--- a/crates/protocol/src/canonical.rs
+++ b/crates/protocol/src/canonical.rs
@@ -35,11 +35,15 @@
 //!   field absent the pay client self-pays the SOL fee and submits a
 //!   fully-signed transaction the existing verifier accepts.
 //!
-//! Unlike the legacy types, the inbound canonical types do NOT use
+//! Unlike the legacy types, the inbound canonical ENVELOPE types do NOT use
 //! `deny_unknown_fields`: the x402 v2 spec (§5.1.2) lets clients echo and
 //! append envelope fields, and the mapping below copies ONLY the validated,
 //! known fields into [`PaymentPayload`] — unknown keys are dropped at the
-//! boundary and can never propagate into gateway logic.
+//! boundary and can never propagate into gateway logic. The one exception is
+//! the `payload` proof object: its variants ([`CanonicalTransactionProof`],
+//! [`CanonicalSignatureProof`]) DO use `deny_unknown_fields` so an ambiguous
+//! proof carrying both `transaction` and `signature` fails the parse instead
+//! of silently resolving to one variant (see [`CanonicalProof`]).
 
 use serde::{Deserialize, Serialize};
 
@@ -136,8 +140,10 @@ pub struct CanonicalAccept {
 #[serde(rename_all = "camelCase")]
 pub struct CanonicalPaymentRequired {
     pub x402_version: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resource: Option<CanonicalResource>,
+    /// Always populated on the outbound challenge (the pay client binds its
+    /// payment to it). Only the INBOUND envelope ([`CanonicalPaymentEnvelope`])
+    /// legitimately treats resource as optional.
+    pub resource: CanonicalResource,
     pub accepts: Vec<CanonicalAccept>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -173,33 +179,67 @@ impl CanonicalPaymentRequired {
         }
 
         Some(Self {
+            // The canonical surface is pinned to v2 regardless of the legacy
+            // `X402_VERSION` constant: this field is the canonical protocol
+            // version the pay client negotiates on, not Solvela's legacy
+            // wire-format version, and the two evolve independently.
             x402_version: CANONICAL_X402_VERSION,
-            resource: Some(CanonicalResource {
+            resource: CanonicalResource {
                 url: legacy.resource.url.clone(),
                 description: None,
                 mime_type: None,
-            }),
+            },
             accepts,
-            error: Some(legacy.error.clone()),
+            // Deliberately None: the pay client never parses `error`, and the
+            // legacy body's gateway prose ("Payment required") doesn't belong
+            // in the canonical header. The legacy body keeps carrying it.
+            error: None,
         })
     }
 }
 
+/// Transaction proof body (`payload.transaction`).
+///
+/// `deny_unknown_fields` is load-bearing: serde cannot apply it to inline
+/// struct variants of an untagged enum, so each [`CanonicalProof`] variant
+/// wraps a dedicated struct instead (mirroring the legacy
+/// [`crate::payment::EscrowPayload`]/[`crate::payment::SolanaPayload`]
+/// disambiguation). An ambiguous payload carrying BOTH `transaction` and
+/// `signature` then fails BOTH variants — and therefore the whole envelope
+/// parse — instead of silently deserializing as `Transaction` and dropping
+/// the `signature` key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalTransactionProof {
+    /// Base64-encoded serialized signed transaction.
+    pub transaction: String,
+}
+
+/// Signature proof body (`payload.signature`) — the client-broadcast trust
+/// model. Parsed so it can be rejected with a precise error; see
+/// [`CanonicalProof`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalSignatureProof {
+    /// Base58-encoded transaction signature.
+    pub signature: String,
+}
+
 /// Canonical payment proof — mirrors pay-kit `PaymentProof` (untagged).
+///
+/// Variant ORDER is load-bearing: `#[serde(untagged)]` tries variants in
+/// declaration order, and `Transaction` (the only proof the gateway accepts)
+/// must be tried before `Signature`. Both inner structs carry
+/// `deny_unknown_fields`, so the ambiguous both-keys payload fails both
+/// variants rather than resolving by order.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CanonicalProof {
     /// Client sends signed transaction bytes for the gateway to broadcast.
-    Transaction {
-        /// Base64-encoded serialized signed transaction.
-        transaction: String,
-    },
+    Transaction(CanonicalTransactionProof),
     /// Client broadcast itself and sends the confirmed signature. NOT
     /// accepted by the mapping below (the gateway must control broadcast).
-    Signature {
-        /// Base58-encoded transaction signature.
-        signature: String,
-    },
+    Signature(CanonicalSignatureProof),
 }
 
 /// Canonical v2 payment envelope carried (base64-encoded) in the
@@ -256,13 +296,18 @@ impl CanonicalPaymentEnvelope {
             .ok_or(CanonicalPaymentError::MissingResource)?;
 
         let transaction = match self.payload {
-            CanonicalProof::Transaction { transaction } => transaction,
-            CanonicalProof::Signature { .. } => {
+            CanonicalProof::Transaction(proof) => proof.transaction,
+            CanonicalProof::Signature(_) => {
                 return Err(CanonicalPaymentError::UnsupportedProof);
             }
         };
 
         Ok(PaymentPayload {
+            // Deliberately the legacy constant, NOT echoed from the inbound
+            // envelope: the legacy field is u8 while the canonical one is
+            // u64, and the version gate above guarantees only v2 envelopes
+            // reach this point — echoing would just be a lossy cast of a
+            // value already proven equal to 2.
             x402_version: X402_VERSION,
             resource: Resource {
                 url: resource.url,
@@ -359,8 +404,10 @@ mod tests {
                 "payTo": "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC",
                 "maxTimeoutSeconds": 300,
                 "extra": { "decimals": 6 }
-            }],
-            "error": "Payment required"
+            }]
+            // NOTE: no `error` key — the pay client never parses it and the
+            // legacy body's prose stays out of the canonical header
+            // (`from_payment_required` sets `error: None`).
         });
         assert_eq!(value, expected, "canonical challenge wire shape drifted");
     }
@@ -469,7 +516,7 @@ mod tests {
         let envelope_json = serde_json::json!({
             "x402Version": 2,
             "accepted": advertised,
-            "resource": serde_json::to_value(canonical.resource.as_ref().unwrap()).unwrap(),
+            "resource": serde_json::to_value(&canonical.resource).unwrap(),
             "payload": { "transaction": "dGVzdA==" }
         });
         let envelope: CanonicalPaymentEnvelope = serde_json::from_value(envelope_json).unwrap();
@@ -561,6 +608,62 @@ mod tests {
             }
             other => panic!("expected UnsupportedScheme, got {other:?}"),
         }
+    }
+
+    /// An ambiguous proof carrying BOTH `transaction` and `signature` must
+    /// fail to parse outright — at the proof level and therefore at the
+    /// envelope level — never silently drop one key and pick a variant.
+    /// (`deny_unknown_fields` on both proof structs makes each variant reject
+    /// the other's key; mirrors the legacy `EscrowPayload`/`SolanaPayload`
+    /// disambiguation in `crate::payment`.)
+    #[test]
+    fn ambiguous_proof_with_both_keys_fails_to_parse() {
+        let ambiguous = serde_json::json!({ "transaction": "a", "signature": "b" });
+        assert!(
+            serde_json::from_value::<CanonicalProof>(ambiguous.clone()).is_err(),
+            "a proof with both `transaction` and `signature` must not parse"
+        );
+
+        let envelope_json = serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": "exact",
+                "network": SOLANA_NETWORK,
+                "amount": "2625",
+                "asset": USDC_MINT,
+                "payTo": "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC",
+                "maxTimeoutSeconds": 300
+            },
+            "resource": { "url": "/v1/chat/completions" },
+            "payload": ambiguous
+        });
+        assert!(
+            serde_json::from_value::<CanonicalPaymentEnvelope>(envelope_json).is_err(),
+            "an envelope with an ambiguous proof must fail at the envelope parse"
+        );
+    }
+
+    /// Future canonical versions must be rejected too — the v2 gate is an
+    /// equality check, not a lower bound (`envelope_rejects_non_v2_version`
+    /// covers the v1 side).
+    #[test]
+    fn envelope_rejects_future_version() {
+        let envelope_json = serde_json::json!({
+            "x402Version": 3,
+            "accepted": {
+                "scheme": "exact",
+                "network": SOLANA_NETWORK,
+                "amount": "2625",
+                "asset": USDC_MINT,
+                "payTo": "6cvgmdrsVxyiuPzqMCSBnS7fAmA5Mk2VG4BcfVhC8jdC",
+                "maxTimeoutSeconds": 300
+            },
+            "resource": { "url": "/v1/chat/completions" },
+            "payload": { "transaction": "dGVzdA==" }
+        });
+        let envelope: CanonicalPaymentEnvelope = serde_json::from_value(envelope_json).unwrap();
+        let err = envelope.into_payment_payload().unwrap_err();
+        assert!(matches!(err, CanonicalPaymentError::UnsupportedVersion(3)));
     }
 
     #[test]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod canonical;
 pub mod chat;
 pub mod constants;
 pub mod cost;
@@ -10,6 +11,7 @@ pub mod vision;
 
 // Flat re-exports so consumers write:
 //   use solvela_protocol::{ChatRequest, PaymentRequired, CostBreakdown};
+pub use canonical::*;
 pub use chat::*;
 pub use constants::*;
 pub use cost::*;

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -11,7 +11,14 @@ pub mod vision;
 
 // Flat re-exports so consumers write:
 //   use solvela_protocol::{ChatRequest, PaymentRequired, CostBreakdown};
-pub use canonical::*;
+// Canonical x402 v2 wire-compat items are re-exported EXPLICITLY (not glob)
+// so the canonical surface that crosses the crate boundary stays auditable;
+// supporting types (CanonicalAccept, CanonicalResource, CanonicalProof, …)
+// remain reachable via `solvela_protocol::canonical::`.
+pub use canonical::{
+    CanonicalPaymentEnvelope, CanonicalPaymentError, CanonicalPaymentRequired,
+    CANONICAL_PAYMENT_REQUIRED_HEADER, CANONICAL_X402_VERSION,
+};
 pub use chat::*;
 pub use constants::*;
 pub use cost::*;

--- a/sdks/ai-sdk-provider/package-lock.json
+++ b/sdks/ai-sdk-provider/package-lock.json
@@ -49,7 +49,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.9.1",
-        "tsx": "^4.22.3",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3"
       }
     },

--- a/sdks/ai-sdk-provider/src/generated/models.ts
+++ b/sdks/ai-sdk-provider/src/generated/models.ts
@@ -11,6 +11,7 @@ export type SolvelaModelId =
   | "deepseek-reasoner"
   | "google-gemini-2-5-flash"
   | "google-gemini-2-5-flash-lite"
+  | "google-gemini-3-1-flash-lite"
   | "google-gemini-3-1-pro"
   | "openai-gpt-4-1"
   | "openai-gpt-4-1-mini"
@@ -153,6 +154,20 @@ export const MODELS = [
     supportsStreaming: true,
     supportsTools: false,
     supportsVision: false,
+    reasoning: false,
+    supportsStructuredOutput: false,
+  },
+  {
+    id: "google-gemini-3-1-flash-lite",
+    provider: "google",
+    modelId: "gemini-3.1-flash-lite",
+    displayName: "Gemini 3.1 Flash-Lite (Free)",
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    contextWindow: 1000000,
+    supportsStreaming: true,
+    supportsTools: true,
+    supportsVision: true,
     reasoning: false,
     supportsStructuredOutput: false,
   },

--- a/sdks/ai-sdk-provider/tests/unit/codegen.test.ts
+++ b/sdks/ai-sdk-provider/tests/unit/codegen.test.ts
@@ -65,6 +65,7 @@ const KNOWN_MODEL_IDS: readonly string[] = [
   "deepseek-reasoner",
   "google-gemini-2-5-flash",
   "google-gemini-2-5-flash-lite",
+  "google-gemini-3-1-flash-lite",
   "google-gemini-3-1-pro",
   "openai-gpt-4-1",
   "openai-gpt-4-1-mini",
@@ -82,7 +83,7 @@ const KNOWN_MODEL_IDS: readonly string[] = [
   "xai-grok-code-fast-1",
 ] as const;
 
-const EXPECTED_COUNT = 24;
+const EXPECTED_COUNT = 25;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/sdks/openclaw-provider/src/models.generated.ts
+++ b/sdks/openclaw-provider/src/models.generated.ts
@@ -184,6 +184,20 @@ export const SOLVELA_MODELS: SolvelaModel[] = [
     "reasoning": false
   },
   {
+    "id": "solvela/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash-Lite (Free)",
+    "provider": "google",
+    "contextWindow": 1000000,
+    "maxTokens": 32768,
+    "inputCostPerMillion": 0,
+    "outputCostPerMillion": 0,
+    "supportsStreaming": true,
+    "supportsTools": true,
+    "supportsVision": true,
+    "supportsStructuredOutput": false,
+    "reasoning": false
+  },
+  {
     "id": "solvela/deepseek-chat",
     "name": "DeepSeek V3.2 Chat",
     "provider": "deepseek",
@@ -367,4 +381,4 @@ export const SOLVELA_MODELS: SolvelaModel[] = [
   }
 ];
 
-export const MODEL_COUNT = 24;
+export const MODEL_COUNT = 25;


### PR DESCRIPTION
## Summary

Adds a canonical-x402 v2 compatibility layer so standard x402 clients — specifically the Solana Foundation `pay` CLI — can discover, decode, and pay Solvela's 402 challenges. This is the prerequisite for listing Solvela in the [pay.sh provider catalog](https://github.com/solana-foundation/pay-skills), and it makes the gateway payable by any spec-conformant x402 client (Cloudflare Agents SDK, CDP tooling), not just our own SDKs.

## Design — dual-stack on one 402 response

- **Outbound:** the legacy snake_case 402 JSON body is unchanged byte-for-byte (published SDKs depend on it). The canonical camelCase challenge (`x402Version`, `accepts[].payTo/maxTimeoutSeconds/asset/amount`, CAIP-2 network) is added as a base64 `PAYMENT-REQUIRED` response header — the pay client checks that header before falling back to body parsing (verified in its source, not assumed).
- **Inbound:** `decode_payment_header` tries the legacy `PaymentPayload` shape first, then the canonical v2 envelope (sent by pay in `PAYMENT-SIGNATURE` after a V2 challenge), mapped fail-closed into the legacy type before replay protection, accepted-field validation, budget gating, and facilitator verification. Legacy and canonical payments share the same replay key.
- **Scheme surface:** `exact` only. Escrow is excluded outbound and hard-rejected inbound; client-broadcast `signature` proofs are hard-rejected (gateway must control broadcast). `extra.feePayer` is deliberately omitted so pay signs as its own fee payer — a server-fee-payer tx would always fail our verifier's `signatures[0]` check.
- Asset/mint comes from runtime config per #531; no exact `accepts` entry → no canonical header (fail closed, legacy challenge stays authoritative).
- Mutual unparseability between the two dialects is proven by test (`deny_unknown_fields` asymmetry is deliberate and documented in the module docs).

## Wire-contract provenance

Field names, casing, header names, and version-detection behavior are pinned to the actual pay client source (`solana-foundation/pay` `rust/crates/core/src/client/x402.rs` + the pay-kit `solana-x402` crate). The inbound golden vector uses the pay client's own V2 test fixture verbatim (including the `extra.feePayer` echo).

## Review

Full money-path review process: 5-agent specialized stack (rust, security, silent-failure, type-design, test-coverage) → round-1 fixes (`e5436512`: canonical rejection reasons no longer swallowed by `.ok()`, `CanonicalProof` ambiguous-payload hard-fail via `deny_unknown_fields` wrappers, proxy URL reflection fixed, log-echo posture tightened, replay/wrong-mint/wrong-network/header-absence tests added) → independent second-pass review (APPROVE-WITH-NITS; nits applied in `6209e361`). Security pass came back clean on parser-differential, escrow leakage, amount/asset/recipient confusion, resource binding, header injection, and grant-before-settle categories.

## Tests

- protocol: 68 passed (12 new: outbound/inbound golden vectors, rejections, mutual-unparseability, header-constant pin)
- gateway lib: 746 passed (canonical decode, hard-error, header-omission units)
- gateway integration: 207 passed (14 new through the real router: canonical header on 402, configured-mint quoting, escrow exclusion, end-to-end canonical payment to a recording verifier with asset/pay_to assertions, replay rejection, wrong asset/network, legacy regression pins)
- fmt + clippy (`-D warnings`) clean

## Follow-ups (not this PR)

- Live verification against the real `pay` CLI (devnet first, then a small mainnet probe) before the pay.sh catalog submission
- OpenAPI spec + `providers/solvela/*` PAY.md for the pay-skills catalog PR
- Deferred by review (documented): `CanonicalScheme` enum, `deserialize_with` amount validation, legacy `x402_version` u8→u64