### PR TITLE
docs(openapi): fix contract errors in the gateway API spec (review follow-up to #534)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4,7 +4,7 @@
     "title": "Solvela Gateway",
     "description": "Solana-native AI agent payment gateway. OpenAI-compatible LLM chat completions paid per request in USDC-SPL over the x402 protocol — no API key, no account, just a wallet. A rule-based smart router selects a model per request, an exact-match response cache returns prior answers at zero upstream cost, and a trustless on-chain escrow scheme is available for prepaid sessions.",
     "version": "0.1.0",
-    "license": { "name": "Apache-2.0", "url": "https://www.apache.org/licenses/LICENSE-2.0" }
+    "license": { "name": "BUSL-1.1", "identifier": "BUSL-1.1" }
   },
   "servers": [
     { "url": "https://solvela-gateway.fly.dev", "description": "Production" }
@@ -14,7 +14,8 @@
       "post": {
         "operationId": "createChatCompletion",
         "summary": "Create an OpenAI-compatible chat completion",
-        "description": "OpenAI-compatible chat completion. Without a `PAYMENT-SIGNATURE` header the gateway returns HTTP 402 with an x402 challenge: a legacy JSON body plus a canonical x402 v2 challenge in the `PAYMENT-REQUIRED` response header, both quoting the USDC cost on Solana mainnet. Sign the quoted `exact` payment with your wallet and resubmit to receive the completion.",
+        "description": "OpenAI-compatible chat completion. Without a `PAYMENT-SIGNATURE` header the gateway returns HTTP 402 with an x402 challenge: a legacy snake_case JSON body plus a canonical x402 v2 challenge (camelCase) in the `PAYMENT-REQUIRED` response header, both quoting the USDC cost on Solana mainnet. Sign the quoted `exact` (or `escrow`) payment with your wallet and resubmit the same request with the signed payment payload in the `PAYMENT-SIGNATURE` header to receive the completion.",
+        "security": [{}, { "x402Payment": [] }],
         "requestBody": {
           "required": true,
           "content": {
@@ -42,21 +43,48 @@
             }
           },
           "402": {
-            "description": "Payment required. Body is the x402 challenge; the `PAYMENT-REQUIRED` response header carries the canonical x402 v2 challenge (base64-encoded JSON).",
+            "description": "Payment required. Two distinct bodies share this status: (1) the x402 **challenge** (`PaymentRequired`, snake_case fields) when the request carries no `PAYMENT-SIGNATURE` header — sign and resubmit; (2) the standard **error envelope** (`Error`, with `error.type` of `payment_required` or `invalid_payment`) when a payment header was present but could not be decoded or verified — do not blindly retry. The `PAYMENT-REQUIRED` response header accompanies the challenge form.",
             "headers": {
               "PAYMENT-REQUIRED": {
-                "description": "Base64-encoded canonical x402 v2 challenge (camelCase).",
+                "description": "Base64-encoded canonical x402 v2 challenge as camelCase JSON (`x402Version`, `accepts[].payTo`, `accepts[].maxTimeoutSeconds`, …) — note the JSON *body* uses snake_case; the two casings are intentional and must not be mixed. Carries only `exact` scheme entries, each with `extra: {\"decimals\": 6}`. Present whenever an `exact` scheme is offered (i.e., on every challenge).",
                 "schema": { "type": "string" }
               }
             },
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PaymentRequired" }
+                "schema": {
+                  "anyOf": [
+                    { "$ref": "#/components/schemas/PaymentRequired" },
+                    { "$ref": "#/components/schemas/Error" }
+                  ]
+                }
               }
             }
           },
           "400": {
-            "description": "Invalid request.",
+            "description": "Invalid request (`error.type`: `bad_request`).",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+          },
+          "404": {
+            "description": "Unknown model ID, alias, or profile (`error.type`: `model_not_found`).",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+          },
+          "415": {
+            "description": "Image content sent to a model without vision capability (`error.type`: `unsupported_media_type`).",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+          },
+          "429": {
+            "description": "Rate limited (`error.type`: `rate_limit_exceeded` or `rate_limited`). Honor `retry-after` before retrying.",
+            "headers": {
+              "retry-after": { "description": "Seconds until the rate-limit window resets.", "schema": { "type": "integer" } },
+              "x-ratelimit-limit": { "description": "Requests allowed per window.", "schema": { "type": "integer" } },
+              "x-ratelimit-remaining": { "description": "Requests remaining in the current window (always 0 on a 429).", "schema": { "type": "integer" } },
+              "x-ratelimit-reset": { "description": "Seconds until the window resets.", "schema": { "type": "integer" } }
+            },
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+          },
+          "5XX": {
+            "description": "Upstream or gateway failure: 502 (`provider_error`), 503 (`upstream_unavailable` — all providers down), 500 (`settlement_failed`, `internal_error`).",
             "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
           }
         }
@@ -67,6 +95,7 @@
         "operationId": "listModels",
         "summary": "List available models with pricing and capabilities",
         "description": "Returns the model catalog with per-token pricing and capabilities. No payment required.",
+        "security": [],
         "responses": {
           "200": {
             "description": "Model list.",
@@ -84,6 +113,7 @@
         "operationId": "health",
         "summary": "Report gateway and dependency health status",
         "description": "Liveness/readiness probe. No payment required.",
+        "security": [],
         "responses": {
           "200": {
             "description": "Service status.",
@@ -102,6 +132,14 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 payment payload: JSON (raw or base64-encoded) of the form `{ x402_version, resource: {url, method}, accepted: <one entry from the 402 challenge's accepts[]>, payload: { transaction } | { deposit_tx, service_id, agent_pubkey } }`, where `transaction`/`deposit_tx` is a base64-encoded signed Solana versioned transaction. Omit the header to receive the 402 challenge quoting the price."
+      }
+    },
     "schemas": {
       "ChatCompletionRequest": {
         "type": "object",
@@ -128,40 +166,65 @@
       },
       "ChatMessage": {
         "type": "object",
-        "required": ["role", "content"],
+        "required": ["role"],
         "properties": {
           "role": { "type": "string", "enum": ["system", "user", "assistant", "tool", "developer"] },
           "content": {
-            "description": "Plain string, or an array of content parts (text and image_url) for vision-capable models.",
+            "description": "Plain string, an array of content parts (text and image_url) for vision-capable models, or null/absent on assistant turns that carry only `tool_calls`. The gateway maps absent and null content to the empty string on input.",
             "anyOf": [
               { "type": "string" },
-              { "type": "array", "items": { "type": "object" } }
+              { "type": "array", "items": { "type": "object" } },
+              { "type": "null" }
             ]
           },
           "name": { "type": "string" },
+          "tool_calls": {
+            "type": "array",
+            "description": "Tool calls requested by the model (assistant messages only). Reply with a `role: tool` message carrying the matching `tool_call_id`.",
+            "items": { "$ref": "#/components/schemas/ToolCall" }
+          },
           "tool_call_id": { "type": "string" }
+        }
+      },
+      "ToolCall": {
+        "type": "object",
+        "required": ["id", "type", "function"],
+        "properties": {
+          "id": { "type": "string" },
+          "type": { "type": "string", "example": "function" },
+          "function": {
+            "type": "object",
+            "required": ["name", "arguments"],
+            "properties": {
+              "name": { "type": "string" },
+              "arguments": { "type": "string", "description": "JSON-encoded function arguments." }
+            }
+          }
         }
       },
       "ChatCompletionResponse": {
         "type": "object",
+        "required": ["id", "object", "created", "model", "choices"],
         "properties": {
           "id": { "type": "string" },
-          "object": { "type": "string", "example": "text_completion" },
+          "object": { "type": "string", "example": "chat.completion" },
           "created": { "type": "integer" },
           "model": { "type": "string" },
           "choices": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": ["index", "message"],
               "properties": {
                 "index": { "type": "integer" },
                 "message": { "$ref": "#/components/schemas/ChatMessage" },
-                "finish_reason": { "type": "string" }
+                "finish_reason": { "type": ["string", "null"] }
               }
             }
           },
           "usage": {
-            "type": "object",
+            "type": ["object", "null"],
+            "required": ["prompt_tokens", "completion_tokens", "total_tokens"],
             "properties": {
               "prompt_tokens": { "type": "integer" },
               "completion_tokens": { "type": "integer" },
@@ -172,11 +235,13 @@
       },
       "PaymentRequired": {
         "type": "object",
-        "description": "x402 challenge returned with HTTP 402.",
+        "description": "x402 challenge returned with HTTP 402 when no `PAYMENT-SIGNATURE` header is present. Field names are snake_case; the canonical camelCase rendering travels in the `PAYMENT-REQUIRED` response header.",
+        "required": ["x402_version", "resource", "accepts", "cost_breakdown", "error"],
         "properties": {
           "x402_version": { "type": "integer", "example": 2 },
           "resource": {
             "type": "object",
+            "required": ["url", "method"],
             "properties": {
               "url": { "type": "string", "example": "/v1/chat/completions" },
               "method": { "type": "string", "example": "POST" }
@@ -184,20 +249,24 @@
           },
           "accepts": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "type": "object",
+              "required": ["scheme", "network", "amount", "asset", "pay_to", "max_timeout_seconds"],
               "properties": {
                 "scheme": { "type": "string", "enum": ["exact", "escrow"] },
                 "network": { "type": "string", "example": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" },
                 "amount": { "type": "string", "description": "Atomic units (USDC has 6 decimals)." },
                 "asset": { "type": "string", "description": "USDC SPL mint address." },
                 "pay_to": { "type": "string", "description": "Recipient wallet address." },
-                "max_timeout_seconds": { "type": "integer", "example": 300 }
+                "max_timeout_seconds": { "type": "integer", "example": 300 },
+                "escrow_program_id": { "type": "string", "description": "Escrow program ID. Present only on `scheme: escrow` entries; absent otherwise." }
               }
             }
           },
           "cost_breakdown": {
             "type": "object",
+            "required": ["provider_cost", "platform_fee", "total", "currency", "fee_percent"],
             "properties": {
               "provider_cost": { "type": "string" },
               "platform_fee": { "type": "string" },
@@ -211,12 +280,14 @@
       },
       "ModelList": {
         "type": "object",
+        "required": ["object", "data"],
         "properties": {
           "object": { "type": "string", "example": "list" },
           "data": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": ["id", "object", "provider", "display_name", "context_window", "capabilities", "pricing"],
               "properties": {
                 "id": { "type": "string" },
                 "object": { "type": "string", "example": "model" },
@@ -225,6 +296,7 @@
                 "context_window": { "type": "integer" },
                 "capabilities": {
                   "type": "object",
+                  "required": ["streaming", "tools", "vision", "reasoning"],
                   "properties": {
                     "streaming": { "type": "boolean" },
                     "tools": { "type": "boolean" },
@@ -234,6 +306,7 @@
                 },
                 "pricing": {
                   "type": "object",
+                  "required": ["input_per_million", "output_per_million", "currency", "fee_percent"],
                   "properties": {
                     "input_per_million": { "type": "number" },
                     "output_per_million": { "type": "number" },
@@ -248,11 +321,17 @@
       },
       "Error": {
         "type": "object",
+        "required": ["error"],
         "properties": {
           "error": {
             "type": "object",
+            "required": ["type", "message"],
             "properties": {
-              "type": { "type": "string" },
+              "type": {
+                "type": "string",
+                "description": "Machine-readable error kind. Known values: `bad_request`, `model_not_found`, `payment_required`, `invalid_payment`, `settlement_failed`, `forbidden`, `unsupported_media_type`, `rate_limited`, `rate_limit_exceeded`, `provider_error`, `upstream_unavailable`, `internal_error`. New values may be added; treat unknown values as retriable-or-not by HTTP status.",
+                "example": "invalid_payment"
+              },
               "message": { "type": "string" }
             }
           }


### PR DESCRIPTION
## Summary

Follow-up to #534 (merged while under review). A multi-agent review of the spec against the live wire format (`crates/protocol` + gateway source) found three contract errors and several material gaps; this PR fixes all of them. Docs-only — no code changes.

### Contract errors (a client generated from the old spec breaks)

- **`ChatMessage` couldn't represent a tool-call response**: added `tool_calls` (new `ToolCall` schema mirroring `crates/protocol/src/tools.rs`), allowed `null`/absent `content` (the gateway maps both to empty — `chat.rs` `deserialize_content`), and dropped `content` from `required`. The spec advertised `tools`/`tool_choice` on the request side while strict clients failed to deserialize the very responses that feature produces.
- **`object` example was `"text_completion"`** — the legacy non-chat completions value. The gateway emits `"chat.completion"` everywhere (providers, cache paths).
- **License said Apache-2.0** — the gateway is **BUSL-1.1** (`crates/gateway/Cargo.toml`, root `LICENSE`); Apache-2.0 covers only the library crates.

### Material gaps

- **`securitySchemes.x402Payment`**: the `PAYMENT-SIGNATURE` request header is now machine-readable (was prose-only); chat op takes `security: [{}, {x402Payment}]`, free GETs explicitly `security: []`.
- **402 dual body documented**: challenge (`PaymentRequired`) vs error envelope (`invalid_payment`/`payment_required`) — clients must not blindly retry the latter. Header description now spells out snake_case body vs camelCase `PAYMENT-REQUIRED` header, exact-only entries, and `extra: {"decimals": 6}`.
- **`accepts[].escrow_program_id`** documented (present on `scheme: escrow` entries — `payment.rs`).
- **Reachable status codes added**: 404 (`model_not_found`), 415 (`unsupported_media_type`), 429 with `retry-after`/`x-ratelimit-*` headers (`rate_limit.rs`), and `5XX` (502/503/500). Known `error.type` values enumerated in the `Error` schema description.
- **`required` pinned on all response schemas** (402 challenge invariants, `ChatCompletionResponse`, `ModelList`, `Error`) so codegen stops rendering every field Optional — matching the serde `skip_serializing_if` reality of the Rust types.

## Validation

- `redocly lint`: 0 errors (2 pre-existing style warnings: no-4xx-response on the free GETs)
- `@seriousme/openapi-schema-validator` (official OpenAPI 3.1 meta-schema): valid
- Every field change was verified against the Rust source before editing.

## Note

The review also flagged (not addressed here, candidate follow-up): no CI guard validates `docs/openapi.json` against the live responses — a single tower-oneshot integration test using `include_str!` + the `jsonschema` crate would close the drift gap, same pattern as the `models.toml` guards.