### PR TITLE
docs(openapi): describe ToolCall required fields (pay catalog check)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -190,13 +190,14 @@
         "type": "object",
         "required": ["id", "type", "function"],
         "properties": {
-          "id": { "type": "string" },
+          "id": { "type": "string", "description": "Unique identifier for this tool call; echo it back as `tool_call_id` on the follow-up `role: tool` message." },
           "type": { "type": "string", "example": "function" },
           "function": {
             "type": "object",
+            "description": "The function the model wants invoked.",
             "required": ["name", "arguments"],
             "properties": {
-              "name": { "type": "string" },
+              "name": { "type": "string", "description": "Function name, matching a `tools[].function.name` from the request." },
               "arguments": { "type": "string", "description": "JSON-encoded function arguments." }
             }
           }


### PR DESCRIPTION
## Summary

`pay catalog check` requires every required request-body field to carry a description (or example/enum/etc.) so agents know what to send. The `ToolCall` schema added in #535 left `id`, `function`, and `function.name` bare — the catalog validator flagged them when syncing the spec to solana-foundation/pay-skills#136.

Adds the three descriptions (+3/-2 lines, docs-only). With this, `docs/openapi.json` is byte-identical to the pay.sh catalog sidecar, which now passes `pay catalog check` (`solvela/chat` clean; remaining catalog errors are a different provider's).

## Validation

- `redocly lint`: 0 errors
- OpenAPI 3.1 meta-schema: valid
- `pay catalog check`: `solvela/chat` passes