### PR TITLE
test(gateway): OpenAPI drift guard — validate live responses against docs/openapi.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +453,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -890,6 +917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1232,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastembed"
 version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1303,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1424,6 +1498,7 @@ dependencies = [
  "hex",
  "hmac",
  "http-body-util",
+ "jsonschema",
  "lru",
  "metrics",
  "metrics-exporter-prometheus",
@@ -2080,6 +2155,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,6 +2440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2592,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +2614,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -2525,6 +2653,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2664,6 +2803,12 @@ dependencies = [
  "lzma-rust2",
  "ureq",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -3157,6 +3302,43 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -4401,6 +4583,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,6 +4733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "v_frame"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4572,6 +4770,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "want"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -78,3 +78,8 @@ http-body-util = "0.1"
 ed25519-dalek = { workspace = true }
 bs58 = { workspace = true }
 tokio-stream = "0.1"
+# OpenAPI drift guard (tests/openapi_contract.rs): validates live responses
+# against docs/openapi.json (OpenAPI 3.1 schemas = JSON Schema 2020-12).
+# Default features are disabled — they pull in network/file `$ref` resolution,
+# which the self-contained spec never needs.
+jsonschema = { version = "0.46", default-features = false }

--- a/crates/gateway/tests/openapi_contract.rs
+++ b/crates/gateway/tests/openapi_contract.rs
@@ -1,0 +1,531 @@
+//! OpenAPI contract drift guard.
+//!
+//! `docs/openapi.json` is the canonical machine-readable contract for the
+//! public API (and the pay.sh catalog sidecar), but nothing else in CI
+//! validates it against what the gateway actually serves — the repo's
+//! documented failure mode is "declared-but-unenforced quality gates"
+//! (see `.claude/plan/solvela.md` doc-audit notes). These tests pin live
+//! responses — driven in-process via `tower::ServiceExt::oneshot`, no live
+//! server (CLAUDE.md rule #10) — against the spec's JSON Schemas, so either
+//! side drifting fails CI with a diagnosable error.
+//!
+//! OpenAPI 3.1 schemas are JSON Schema draft 2020-12. To validate against a
+//! component schema whose internal `$ref`s point at
+//! `#/components/schemas/...`, each validator is built from the FULL spec
+//! document with a top-level `"$ref"` injected — internal references then
+//! resolve against the root document.
+//!
+//! The 402 challenge is the money-path wire contract: these tests encode the
+//! CURRENT contract. If a live response genuinely fails the spec, the fix is
+//! a reviewed change to whichever side is wrong — never a quiet edit of the
+//! expected schema to match output.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+use gateway::config::AppConfig;
+use gateway::middleware::rate_limit::{
+    FreeTierGlobalCap, RateLimitConfig, RateLimiter, FREE_TIER_GLOBAL_RPM_DEFAULT,
+};
+use gateway::providers::health::{CircuitBreakerConfig, ProviderHealthTracker};
+use gateway::providers::{ChatStream, LLMProvider, ProviderRegistry};
+use gateway::services::ServiceRegistry;
+use gateway::{build_router, AppState};
+use solvela_protocol::{ChatChoice, ChatMessage, ChatResponse, ModelRegistration, Role, Usage};
+use solvela_router::models::ModelRegistry;
+use solvela_x402::traits::{Error as X402Error, PaymentVerifier};
+use solvela_x402::types::{
+    PayloadData, PaymentAccept, PaymentPayload, Resource, SettlementResult, SolanaPayload,
+    VerificationResult, SOLANA_NETWORK, USDC_MINT,
+};
+
+/// The canonical spec, pinned at compile time — same pattern as the
+/// `models.toml` guards in `crates/gateway/src/providers/fallback.rs`
+/// (`every_fallback_chain_id_is_registered`).
+const OPENAPI_JSON: &str = include_str!("../../../docs/openapi.json");
+
+/// Recipient wallet used for the test AppState and payment headers.
+const TEST_RECIPIENT_WALLET: &str = "GatewayRecipientWallet111111111111111111111111";
+
+/// Payment amount (atomic USDC) exceeding any test model cost estimate.
+const TEST_PAYMENT_AMOUNT: &str = "1000000";
+
+/// One PAID model so the no-payment request exercises the 402 challenge path.
+const TEST_MODELS_TOML: &str = r#"
+[models.openai-gpt-4o]
+provider = "openai"
+model_id = "gpt-4o"
+display_name = "GPT-4o"
+input_cost_per_million = 2.50
+output_cost_per_million = 10.00
+context_window = 128000
+supports_streaming = true
+supports_tools = true
+supports_vision = true
+"#;
+
+// ---------------------------------------------------------------------------
+// Spec / schema helpers
+// ---------------------------------------------------------------------------
+
+/// Parse the spec, failing loudly on a malformed `docs/openapi.json` edit.
+fn spec_value() -> Value {
+    serde_json::from_str(OPENAPI_JSON).expect("docs/openapi.json must parse as JSON")
+}
+
+/// Compile a draft 2020-12 validator from `root`, failing the test (not
+/// silently passing) if the schema itself does not compile.
+fn validator_for(root: &Value, what: &str) -> jsonschema::Validator {
+    jsonschema::draft202012::options()
+        .build(root)
+        .unwrap_or_else(|e| panic!("{what}: schema failed to compile: {e}"))
+}
+
+/// Build a validator for `#/components/schemas/<name>` by injecting a
+/// top-level `$ref` into the full spec document, so internal `$ref`s in the
+/// component resolve against the root document.
+fn component_validator(name: &str) -> jsonschema::Validator {
+    let mut root = spec_value();
+    assert!(
+        root.pointer(&format!("/components/schemas/{name}"))
+            .is_some(),
+        "docs/openapi.json has no #/components/schemas/{name}"
+    );
+    root.as_object_mut()
+        .expect("spec root must be a JSON object")
+        .insert(
+            "$ref".to_string(),
+            json!(format!("#/components/schemas/{name}")),
+        );
+    validator_for(&root, name)
+}
+
+/// Assert `instance` conforms to `validator`, printing the validation errors
+/// AND the actual response body so drift is diagnosable from CI logs alone.
+fn assert_conforms(validator: &jsonschema::Validator, instance: &Value, what: &str) {
+    let errors: Vec<String> = validator
+        .iter_errors(instance)
+        .map(|err| format!("  - {err} (instance path: `{}`)", err.instance_path()))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "{what} drifted from docs/openapi.json.\nvalidation errors:\n{}\nactual response body:\n{}",
+        errors.join("\n"),
+        serde_json::to_string_pretty(instance).unwrap_or_else(|_| instance.to_string()),
+    );
+}
+
+/// Collect a response body and parse it as JSON, panicking with the raw bytes
+/// on a non-JSON body.
+async fn response_json(response: axum::response::Response) -> Value {
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        panic!(
+            "response body is not JSON ({e}): {}",
+            String::from_utf8_lossy(&bytes)
+        )
+    })
+}
+
+// ---------------------------------------------------------------------------
+// In-process app fixtures (mirrors `tests/integration.rs` — full router via
+// `build_router`, mock verifier/provider, no network)
+// ---------------------------------------------------------------------------
+
+/// A mock verifier that accepts all structurally-valid `exact` payloads, so
+/// the paid 200 path can be exercised without a live Solana RPC connection.
+struct AlwaysPassVerifier;
+
+#[async_trait]
+impl PaymentVerifier for AlwaysPassVerifier {
+    fn network(&self) -> &str {
+        SOLANA_NETWORK
+    }
+
+    fn scheme(&self) -> &str {
+        "exact"
+    }
+
+    async fn verify_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<VerificationResult, X402Error> {
+        Ok(VerificationResult {
+            valid: true,
+            reason: None,
+            verified_amount: Some(2625),
+        })
+    }
+
+    async fn settle_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<SettlementResult, X402Error> {
+        Ok(SettlementResult {
+            success: true,
+            tx_signature: Some("MockSettledTxSig123".to_string()),
+            network: SOLANA_NETWORK.to_string(),
+            error: None,
+            verified_amount: None,
+            failure_kind: None,
+        })
+    }
+}
+
+/// A mock LLM provider returning a canned non-streaming completion.
+struct MockProvider;
+
+#[async_trait]
+impl LLMProvider for MockProvider {
+    fn name(&self) -> &str {
+        "openai"
+    }
+
+    fn supported_models(&self) -> Vec<ModelRegistration> {
+        vec![]
+    }
+
+    async fn chat_completion(
+        &self,
+        req: solvela_protocol::ChatRequest,
+    ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(ChatResponse {
+            id: "mock-chatcmpl-001".to_string(),
+            object: "chat.completion".to_string(),
+            created: 1_700_000_000,
+            model: req.model,
+            choices: vec![ChatChoice {
+                index: 0,
+                message: ChatMessage {
+                    role: Role::Assistant,
+                    content: "[mock response]".into(),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: Some(Usage {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                total_tokens: 15,
+            }),
+        })
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _req: solvela_protocol::ChatRequest,
+    ) -> Result<ChatStream, Box<dyn std::error::Error + Send + Sync>> {
+        Err("streaming is not exercised by the OpenAPI contract tests".into())
+    }
+}
+
+/// Build the full router with a caller-supplied provider registry.
+fn contract_app(providers: ProviderRegistry) -> axum::Router {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).expect("test models toml");
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(ServiceRegistry::empty()),
+        providers,
+        facilitator,
+        usage: gateway::usage::UsageTracker::noop(),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: None,
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: None,
+        api_key_hmac_secret: None,
+        prometheus_handle: None,
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
+    });
+    build_router(state, RateLimiter::new(RateLimitConfig::default()))
+}
+
+/// App with NO providers configured — exercises the 402 quote path.
+fn quote_app() -> axum::Router {
+    contract_app(ProviderRegistry::from_env(reqwest::Client::new()))
+}
+
+/// App with a mock provider so a paid request returns a 200 completion.
+fn paid_app() -> axum::Router {
+    let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+    providers.insert("openai".to_string(), Arc::new(MockProvider));
+    contract_app(ProviderRegistry::from_providers(providers))
+}
+
+/// Build a minimal valid `exact` PaymentPayload header (base64 JSON).
+fn valid_payment_header(resource_url: &str) -> String {
+    let payload = PaymentPayload {
+        x402_version: 2,
+        resource: Resource {
+            url: resource_url.to_string(),
+            method: "POST".to_string(),
+        },
+        accepted: PaymentAccept {
+            scheme: "exact".to_string(),
+            network: SOLANA_NETWORK.to_string(),
+            amount: TEST_PAYMENT_AMOUNT.to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: TEST_RECIPIENT_WALLET.to_string(),
+            max_timeout_seconds: 300,
+            escrow_program_id: None,
+        },
+        payload: PayloadData::Direct(SolanaPayload {
+            transaction: base64::engine::general_purpose::STANDARD.encode(b"mock_signed_tx_bytes"),
+        }),
+    };
+    let json = serde_json::to_vec(&payload).expect("serialize payment payload");
+    base64::engine::general_purpose::STANDARD.encode(&json)
+}
+
+/// POST a chat completion request, optionally with a `PAYMENT-SIGNATURE`.
+async fn post_chat(
+    app: axum::Router,
+    body: &Value,
+    payment_header: Option<String>,
+) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json");
+    if let Some(header) = payment_header {
+        builder = builder.header("PAYMENT-SIGNATURE", header);
+    }
+    app.oneshot(
+        builder
+            .body(Body::from(serde_json::to_vec(body).expect("request body")))
+            .expect("build request"),
+    )
+    .await
+    .expect("oneshot")
+}
+
+fn chat_body(model: &str) -> Value {
+    json!({
+        "model": model,
+        "messages": [{"role": "user", "content": "What is 2+2?"}],
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Spec self-checks — a malformed spec edit must FAIL, not silently pass
+// ---------------------------------------------------------------------------
+
+#[test]
+fn spec_parses_and_every_component_schema_compiles() {
+    let spec = spec_value();
+    let schemas = spec
+        .pointer("/components/schemas")
+        .and_then(Value::as_object)
+        .expect("docs/openapi.json must have components.schemas");
+    assert!(!schemas.is_empty(), "components.schemas must not be empty");
+    for name in schemas.keys() {
+        // `component_validator` panics with the schema name on a compile failure.
+        let _ = component_validator(name);
+    }
+
+    // The /health 200 schema is inline (not a component) — compile it too.
+    let health_schema = spec
+        .pointer("/paths/~1health/get/responses/200/content/application~1json/schema")
+        .expect("docs/openapi.json must define the inline /health 200 schema");
+    let _ = validator_for(health_schema, "inline /health 200 schema");
+}
+
+/// Guards against the whole suite becoming vacuous (e.g. a refactor that
+/// makes every validator accept anything): the strict `PaymentRequired`
+/// validator must reject obviously non-conforming bodies.
+#[test]
+fn payment_required_validator_rejects_nonconforming_bodies() {
+    let validator = component_validator("PaymentRequired");
+    assert!(
+        !validator.is_valid(&json!({})),
+        "PaymentRequired validator accepted an empty object — validation is vacuous"
+    );
+    assert!(
+        !validator.is_valid(&json!({
+            "x402_version": "2",
+            "resource": {"url": "/v1/chat/completions", "method": "POST"},
+            "accepts": [],
+            "cost_breakdown": {},
+            "error": "Payment required"
+        })),
+        "PaymentRequired validator accepted a body with wrong types and empty accepts"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Live-response contract checks
+// ---------------------------------------------------------------------------
+
+/// POST /v1/chat/completions on a PAID model with no `PAYMENT-SIGNATURE` →
+/// HTTP 402, body conforms to the strict `PaymentRequired` challenge schema.
+/// The spec's 402 content is `anyOf [PaymentRequired, Error]`; the challenge
+/// form must match the stricter arm — that is the drift signal.
+#[tokio::test]
+async fn chat_402_challenge_conforms_to_payment_required_schema() {
+    let response = post_chat(quote_app(), &chat_body("openai/gpt-4o"), None).await;
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let body = response_json(response).await;
+    assert_conforms(
+        &component_validator("PaymentRequired"),
+        &body,
+        "POST /v1/chat/completions 402 challenge body",
+    );
+    // The challenge must actually quote at least one scheme (an empty
+    // `accepts` would be schema-invalid too via minItems, but assert the
+    // money-relevant field explicitly for a clearer failure).
+    assert!(
+        body["accepts"]
+            .as_array()
+            .is_some_and(|accepts| !accepts.is_empty()),
+        "402 challenge quoted no payment schemes: {body}"
+    );
+}
+
+/// POST with a PAYMENT-SIGNATURE that cannot be decoded → HTTP 402 with the
+/// standard error envelope — the `Error` arm of the spec's 402 `anyOf`.
+#[tokio::test]
+async fn chat_402_invalid_payment_envelope_conforms_to_error_schema() {
+    let response = post_chat(
+        quote_app(),
+        &chat_body("openai/gpt-4o"),
+        Some("!!!not-base64-not-json!!!".to_string()),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let body = response_json(response).await;
+    assert_conforms(
+        &component_validator("Error"),
+        &body,
+        "POST /v1/chat/completions 402 invalid-payment error body",
+    );
+    assert_eq!(
+        body["error"]["type"], "invalid_payment",
+        "spec documents `invalid_payment` for an undecodable payment header: {body}"
+    );
+}
+
+/// GET /v1/models → 200, body conforms to `ModelList`.
+#[tokio::test]
+async fn models_response_conforms_to_model_list_schema() {
+    let response = quote_app()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/models")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("oneshot");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response_json(response).await;
+    // An empty `data` array would conform vacuously — require at least one
+    // model so the per-item schema is actually exercised.
+    assert!(
+        body["data"].as_array().is_some_and(|data| !data.is_empty()),
+        "GET /v1/models returned no models; per-item schema not exercised: {body}"
+    );
+    assert_conforms(
+        &component_validator("ModelList"),
+        &body,
+        "GET /v1/models 200 body",
+    );
+}
+
+/// GET /health → 200, body conforms to the spec's inline response schema
+/// (extracted from the parsed spec, not duplicated here).
+#[tokio::test]
+async fn health_response_conforms_to_inline_schema() {
+    let response = quote_app()
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("oneshot");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let spec = spec_value();
+    let health_schema = spec
+        .pointer("/paths/~1health/get/responses/200/content/application~1json/schema")
+        .expect("docs/openapi.json must define the inline /health 200 schema");
+    let validator = validator_for(health_schema, "inline /health 200 schema");
+
+    let body = response_json(response).await;
+    assert_conforms(&validator, &body, "GET /health 200 body");
+}
+
+/// A paid request through the full route (mock provider + always-pass
+/// verifier) → 200, body conforms to `ChatCompletionResponse`.
+#[tokio::test]
+async fn paid_chat_completion_conforms_to_chat_completion_response_schema() {
+    let response = post_chat(
+        paid_app(),
+        &chat_body("openai/gpt-4o"),
+        Some(valid_payment_header("/v1/chat/completions")),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response_json(response).await;
+    assert_conforms(
+        &component_validator("ChatCompletionResponse"),
+        &body,
+        "POST /v1/chat/completions 200 completion body",
+    );
+}
+
+/// Unknown model → HTTP 404 with the standard error envelope (`Error`).
+#[tokio::test]
+async fn unknown_model_404_conforms_to_error_schema() {
+    let response = post_chat(quote_app(), &chat_body("no-such/model"), None).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = response_json(response).await;
+    assert_conforms(
+        &component_validator("Error"),
+        &body,
+        "POST /v1/chat/completions 404 unknown-model body",
+    );
+    assert_eq!(
+        body["error"]["type"], "model_not_found",
+        "spec documents `model_not_found` for an unknown model: {body}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the drift-guard finding deferred from #535: `docs/openapi.json` is the canonical API contract (and the pay.sh catalog sidecar source), but nothing in CI validated it against the live responses — the repo's documented "declared-but-unenforced quality gate" failure mode. This adds the proportionate guard agreed in the review: a single integration-test binary using the existing `tower::ServiceExt::oneshot` + `build_router` infrastructure, with the spec pinned at compile time via `include_str!` — the same pattern as the `models.toml` registry guards.

## What it guards

New `crates/gateway/tests/openapi_contract.rs`, 8 tests:

- the spec parses and **every component schema compiles** (a malformed spec edit fails CI)
- an anti-vacuousness test proving the validators actually reject non-conforming bodies
- `POST /v1/chat/completions` without payment → 402 body validates against `PaymentRequired` (strict — not the `anyOf` Error arm), `accepts` non-empty
- 402 with an undecodable payment header → validates against the `Error` arm with `error.type = invalid_payment` (the dual-402 contract documented in #535)
- `GET /v1/models` → `ModelList` (with non-empty `data` so per-item schemas are exercised)
- `GET /health` → the inline schema extracted from the parsed spec (not duplicated)
- a real paid 200 completion (mock provider + always-pass verifier) → `ChatCompletionResponse`
- unknown model → 404 `Error` with `error.type = model_not_found`

Validation failures print the actual body plus instance-path errors, so drift is diagnosable from CI logs.

## Dependency

`jsonschema = { version = "0.46", default-features = false }` as a **dev-dependency** of the gateway only (OpenAPI 3.1 schemas are JSON Schema 2020-12; default features disabled to drop network/file `$ref` resolution the self-contained spec never needs). MIT, crates.io, `cargo deny check` green (advisories/bans/licenses/sources).

## Verification

- `cargo test -p gateway --test openapi_contract`: 8 passed
- `cargo test -p gateway --test integration`: 207 passed (unchanged)
- `cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings`: clean
- No spec-vs-live mismatches found — all five response surfaces conform to the current spec
- No production code touched; tests-first via `solvela-money-path-engineer` with the `solvela-x402`/`solvela-fintech` skills

With this, the pay-skills sidecar sync invariant has a mechanical backstop: any gateway change that breaks the published contract fails CI here before it can drift the catalog entry.