### PR TITLE
chore(deps): remove four unused dependencies flagged by cargo-machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,7 +3636,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "solvela-router",
  "solvela-x402",
  "tempfile",
  "thiserror",
@@ -3674,7 +3673,6 @@ name = "solvela-router"
 version = "0.2.0"
 dependencies = [
  "serde",
- "serde_json",
  "solvela-protocol",
  "thiserror",
  "toml",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 
 [dependencies]
 solvela-x402 = { workspace = true }
-solvela-router = { workspace = true }
 
 clap = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["api-bindings"]
 solvela-protocol = { workspace = true }
 
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 toml = { workspace = true }

--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -3360,7 +3360,6 @@ dependencies = [
  "solvela-client-cli-args",
  "solvela-protocol",
  "tokio",
- "tracing",
  "tracing-subscriber",
 ]
 
@@ -3384,7 +3383,6 @@ dependencies = [
  "axum",
  "clap",
  "reqwest",
- "serde",
  "serde_json",
  "solana-sdk",
  "solvela-client",

--- a/sdks/rust/crates/solvela-client-cli/Cargo.toml
+++ b/sdks/rust/crates/solvela-client-cli/Cargo.toml
@@ -24,7 +24,6 @@ reqwest = { workspace = true }
 clap = { workspace = true }
 rpassword = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
 futures = { workspace = true }

--- a/sdks/rust/crates/solvela-client-proxy/Cargo.toml
+++ b/sdks/rust/crates/solvela-client-proxy/Cargo.toml
@@ -28,7 +28,6 @@ axum = { workspace = true }
 tower-http = { workspace = true }
 reqwest = { workspace = true }
 clap = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
## Summary

Dead-dependency cleanup (`/refactor-clean` pass). `cargo-machete` flagged four unused dependencies; each was verified by source grep before removal — no imports, no derive-macro usage, no feature-gated paths:

| Crate | Removed dep | Why it's dead |
|---|---|---|
| `solvela-cli` | `solvela-router` | CLI talks to the gateway over HTTP; never imports the router |
| `solvela-router` | `serde_json` | Model registry is TOML; only `serde` + `toml` are used |
| `solvela-client-cli` (SDK) | `tracing` | Only `tracing-subscriber` is referenced (`init_tracing`) |
| `solvela-client-proxy` (SDK) | `serde` | Only `serde_json` is used; no `Serialize`/`Deserialize` derives in src |

No source changes — Cargo.toml + lockfile entries only. SDK crates' public APIs are untouched (a removed unused dep is not an API change).

Other findings triaged and skipped as false positives: dashboard `depcheck` flagged `tailwindcss`/`@tailwindcss/postcss`, but both are consumed via `postcss.config.mjs` + CSS `@import 'tailwindcss'`. Clippy dead-code surface was already zero (CI enforces `-D warnings`).

## Test plan

- [x] Baseline tests green before each removal; affected crate re-tested after each (196 cli / 22 router / 27 client-cli / 9 client-proxy)
- [x] Full main-workspace `cargo test`: 750 passed; the only 12 failures are escrow-claim persistence tests that need a live PostgreSQL and fail identically on pristine main (docker compose down)
- [x] Full SDK-workspace `cargo test`: 203 passed, 0 failed
- [x] `cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean on both workspaces