### PR TITLE
fix(gateway): paid streaming requests never wrote a spend_logs row

### DIFF
--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -596,6 +596,57 @@ pub(crate) fn spend_cost_atomic(
     }
 }
 
+/// Which spend-ledger arm fires for a delivered paid response.
+///
+/// Selection is pure so the four-way precedence is unit-testable in isolation
+/// from the route; the route's post-response logging block matches on this
+/// exhaustively, so a future variant is a compile error at the financial
+/// branch — never a silent fall-through. (That fall-through was a real bug:
+/// a delivered, settled STREAMING response has `usage == None` and no
+/// semantic-cost outcome, and the old three-arm `if/else` chain matched no
+/// logging arm at all — money collected on-chain never reached the spend
+/// ledger and the `check_budget` reservation was never reconciled.)
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SpendLogArm<'a> {
+    /// Post-delivery `exact` settle failed: payment was never collected and
+    /// the reservation was already released at the settle-failure branch.
+    /// Recording spend would charge the wallet's budget for an uncollected
+    /// payment.
+    SkipSettleFailed,
+    /// Provider reported usage — bill from the actual (capped) token counts.
+    ActualUsage(&'a Usage),
+    /// Usage-less semantic-cache hit (`cost_outcome` present): bill the
+    /// estimate, with the discount realised on escrow only
+    /// (`scheme_realized_discount`).
+    UsagelessSemanticHit,
+    /// Delivered + settled with NO usage and NO semantic hit — the streaming
+    /// path. Bill the estimate: it is the amount `check_budget` reserved and,
+    /// on `exact`, precisely what the agent settled on-chain.
+    EstimateFallback,
+}
+
+/// Select the spend-ledger arm for a delivered paid response.
+///
+/// Precedence: a failed post-delivery settle always wins (nothing was
+/// collected), then actual usage, then a usage-less semantic hit, and finally
+/// the estimate fallback — which guarantees every settled delivery records
+/// spend.
+pub(crate) fn select_spend_log_arm(
+    settle_after_deliver_failed: bool,
+    usage: Option<&Usage>,
+    semantic_hit: bool,
+) -> SpendLogArm<'_> {
+    if settle_after_deliver_failed {
+        SpendLogArm::SkipSettleFailed
+    } else if let Some(u) = usage {
+        SpendLogArm::ActualUsage(u)
+    } else if semantic_hit {
+        SpendLogArm::UsagelessSemanticHit
+    } else {
+        SpendLogArm::EstimateFallback
+    }
+}
+
 /// The full (undiscounted) all-in price to charge for a semantic-cache hit, in
 /// atomic USDC, or `None` if no positive price can be derived.
 ///
@@ -1650,6 +1701,78 @@ supports_vision = false
         assert!(PaymentScheme::from_accepted_str("Escrow").is_err());
         assert!(PaymentScheme::from_accepted_str("escrow ").is_err());
         assert!(PaymentScheme::from_accepted_str("escr0w").is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // select_spend_log_arm — exhaustive truth table. The fourth arm
+    // (EstimateFallback) is the streaming fix: a delivered, settled response
+    // with no usage and no semantic hit MUST still record spend.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn select_spend_log_arm_exhaustive_truth_table() {
+        let usage = Usage {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: 15,
+        };
+        // (settle_failed, usage, semantic_hit) → expected arm, all 8 combos.
+        // SkipSettleFailed wins unconditionally (payment never collected),
+        // then ActualUsage, then UsagelessSemanticHit, then EstimateFallback.
+        for (settle_failed, has_usage, semantic_hit) in [
+            (true, false, false),
+            (true, false, true),
+            (true, true, false),
+            (true, true, true),
+        ] {
+            let arm =
+                select_spend_log_arm(settle_failed, has_usage.then_some(&usage), semantic_hit);
+            assert!(
+                matches!(arm, SpendLogArm::SkipSettleFailed),
+                "settle-after-deliver failure must always skip spend logging \
+                 (usage={has_usage}, hit={semantic_hit}), got {arm:?}"
+            );
+        }
+        for semantic_hit in [false, true] {
+            let arm = select_spend_log_arm(false, Some(&usage), semantic_hit);
+            assert!(
+                matches!(arm, SpendLogArm::ActualUsage(u) if u.completion_tokens == 5),
+                "provider usage must win over a semantic hit (hit={semantic_hit}), got {arm:?}"
+            );
+        }
+        assert!(
+            matches!(
+                select_spend_log_arm(false, None, true),
+                SpendLogArm::UsagelessSemanticHit
+            ),
+            "usage-less semantic hit must bill the (scheme-gated) discounted estimate"
+        );
+        assert!(
+            matches!(
+                select_spend_log_arm(false, None, false),
+                SpendLogArm::EstimateFallback
+            ),
+            "a settled delivery with no usage and no hit (streaming) must bill \
+             the estimate — never fall through unlogged"
+        );
+    }
+
+    #[test]
+    fn estimate_fallback_bills_exactly_the_reservation() {
+        // In the EstimateFallback arm `cost_outcome` is None, so
+        // `scheme_realized_discount` is None for BOTH schemes and
+        // `spend_cost_atomic` is the identity: billed == reserved estimate ==
+        // (for exact) the amount settled on-chain. Pin that identity so the
+        // ledger can never drift from the money actually collected.
+        let estimate_atomic = 2625_u64;
+        for scheme in [PaymentScheme::Exact, PaymentScheme::Escrow] {
+            let realized = scheme_realized_discount(scheme, None);
+            assert_eq!(
+                spend_cost_atomic(realized, estimate_atomic),
+                estimate_atomic,
+                "estimate-fallback billing must equal the reservation on {scheme:?}"
+            );
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -34,7 +34,8 @@ use crate::AppState;
 use cost::{
     cap_usage_to_request_limits, completion_token_ceiling, compute_actual_atomic_cost,
     estimate_input_tokens, estimated_atomic_cost, is_free_estimate, scheme_realized_discount,
-    spend_cost_atomic, usdc_atomic_amount_checked, usdc_f64_to_atomic_safe, PaymentScheme,
+    select_spend_log_arm, spend_cost_atomic, usdc_atomic_amount_checked, usdc_f64_to_atomic_safe,
+    PaymentScheme, SpendLogArm,
 };
 use payment::{decode_payment_from_header, extract_payment_info, fire_escrow_claim};
 use provider::{ProviderCallContext, ProviderCallError, ProviderCallResult};
@@ -1264,132 +1265,205 @@ pub async fn chat_completions(
 
             // Log spend with actual usage (non-streaming) or estimated (streaming).
             //
-            // Two cases must both reconcile the `estimated_cost` reservation that
+            // Arm selection is the pure `select_spend_log_arm` (unit-tested
+            // exhaustively in cost.rs); the match below is exhaustive so a new
+            // arm is a compile error, never a silent fall-through. Three of the
+            // four arms must reconcile the `estimated_cost` reservation that
             // `check_budget` committed to the Redis counters (the H1 fix):
-            //   (a) usage present — price from the actual (capped) tokens.
-            //   (b) usage ABSENT but a semantic hit occurred (`cost_outcome` is
-            //       Some) — the cached response carried no `usage`. We MUST still
-            //       log, or the reservation is never settled down to the realised
-            //       price and the wallet's budget stays consumed at the full
-            //       reservation forever (merged_005 part 2 — ~70% over-consume).
+            //   (a) `ActualUsage` — price from the actual (capped) tokens.
+            //   (b) `UsagelessSemanticHit` — usage ABSENT but a semantic hit
+            //       occurred (`cost_outcome` is Some): the cached response
+            //       carried no `usage`. We MUST still log, or the reservation is
+            //       never settled down to the realised price and the wallet's
+            //       budget stays consumed at the full reservation forever
+            //       (merged_005 part 2 — ~70% over-consume).
+            //   (c) `EstimateFallback` — usage AND `cost_outcome` both absent:
+            //       the delivered+settled STREAMING path. Bill the estimate —
+            //       the amount reserved in `check_budget` and (for `exact`)
+            //       settled on-chain. Before this arm existed such requests
+            //       logged NOTHING: no spend_logs row, no tenant attribution,
+            //       and a never-reconciled reservation.
             //
-            // SKIP entirely when the post-delivery `exact` settle failed: the
-            // reservation was already reconciled (released) at the settle-failure
-            // branch above and the payment was never collected, so we must NOT also
-            // record spend here (which would over-count the wallet's budget for an
-            // uncollected charge) or release a second time.
-            if settle_after_deliver_failed {
-                // No-op: reservation already released, no spend to record.
-            } else if let Some(ref u) = usage {
-                match state
-                    .model_registry
-                    .estimate_cost(&req.model, u.prompt_tokens, u.completion_tokens)
-                    .and_then(|c| {
-                        c.total.parse::<f64>().map_err(|e| {
-                            solvela_router::models::ModelRegistryError::ParseError(e.to_string())
-                        })
-                    }) {
-                    Ok(cost) => {
-                        // On an ESCROW semantic-cache hit the agent is billed the
-                        // discounted price, so the spend ledger must record that —
-                        // not the full computed `cost`. On the exact scheme
-                        // `realized_discount` is None, so the FULL cost is logged
-                        // (the agent paid it on-chain with no refund). The counter
-                        // delta `(billed − reserved)` then settles the wallet's
-                        // budget to the right amount.
-                        //
-                        // Bill in atomic units end-to-end: `cost` is the f64
-                        // estimate from the registry, which we convert through
-                        // `usdc_f64_to_atomic_safe` (NaN/∞/negative/overflow
-                        // fail-closed → `None`). Both branches of
-                        // `spend_cost_atomic` then operate in `u64`, so the
-                        // ledger value is path-invariant. The legacy
-                        // `SpendLogEntry.cost_usdc: f64` shape gets the single
-                        // `/1_000_000.0` conversion right at the write site.
-                        let Some(cost_atomic) = usdc_f64_to_atomic_safe(cost) else {
+            // `SkipSettleFailed` (post-delivery `exact` settle failed) records
+            // nothing: the reservation was already reconciled (released) at the
+            // settle-failure branch above and the payment was never collected,
+            // so recording spend here would over-count the wallet's budget for
+            // an uncollected charge (or release a second time).
+            match select_spend_log_arm(
+                settle_after_deliver_failed,
+                usage.as_ref(),
+                cost_outcome.is_some(),
+            ) {
+                SpendLogArm::SkipSettleFailed => {
+                    // No-op: reservation already released, no spend to record.
+                }
+                SpendLogArm::ActualUsage(u) => {
+                    match state
+                        .model_registry
+                        .estimate_cost(&req.model, u.prompt_tokens, u.completion_tokens)
+                        .and_then(|c| {
+                            c.total.parse::<f64>().map_err(|e| {
+                                solvela_router::models::ModelRegistryError::ParseError(
+                                    e.to_string(),
+                                )
+                            })
+                        }) {
+                        Ok(cost) => {
+                            // On an ESCROW semantic-cache hit the agent is billed the
+                            // discounted price, so the spend ledger must record that —
+                            // not the full computed `cost`. On the exact scheme
+                            // `realized_discount` is None, so the FULL cost is logged
+                            // (the agent paid it on-chain with no refund). The counter
+                            // delta `(billed − reserved)` then settles the wallet's
+                            // budget to the right amount.
+                            //
+                            // Bill in atomic units end-to-end: `cost` is the f64
+                            // estimate from the registry, which we convert through
+                            // `usdc_f64_to_atomic_safe` (NaN/∞/negative/overflow
+                            // fail-closed → `None`). Both branches of
+                            // `spend_cost_atomic` then operate in `u64`, so the
+                            // ledger value is path-invariant. The legacy
+                            // `SpendLogEntry.cost_usdc: f64` shape gets the single
+                            // `/1_000_000.0` conversion right at the write site.
+                            let Some(cost_atomic) = usdc_f64_to_atomic_safe(cost) else {
+                                warn!(
+                                    model = %req.model,
+                                    wallet = %wallet_address,
+                                    raw_cost = cost,
+                                    "skipping spend log: computed cost is NaN/∞/negative/overflow — refusing to write a corrupt ledger entry"
+                                );
+                                return Ok(response);
+                            };
+                            let billed_atomic = spend_cost_atomic(realized_discount, cost_atomic);
+                            let billed_cost = billed_atomic as f64 / 1_000_000.0;
+                            // Pass the estimated_cost that was committed to Redis
+                            // counters in `check_budget` so log_spend can adjust
+                            // by the (billed − estimated) delta. Without this,
+                            // counters would be double-incremented.
+                            state.usage.log_spend(SpendLogEntry {
+                                wallet_address: wallet_address.clone(),
+                                model: req.model.clone(),
+                                provider: actual_provider
+                                    .unwrap_or_else(|| provider_name.to_string()),
+                                input_tokens: u.prompt_tokens,
+                                output_tokens: u.completion_tokens,
+                                cost_usdc: billed_cost,
+                                tx_signature: tx_signature.clone(),
+                                request_id: request_id.clone(),
+                                session_id: session_id.clone(),
+                                tenant: tenant.clone(),
+                                // Reconcile per-tenant counters only when
+                                // check_budget actually enforced a provisioned bucket
+                                // (decision == Enforce). Threaded from the reservation
+                                // so the Skip path never accumulates per-tenant spend.
+                                tenant_enforced: budget_reservation.tenant_enforced(),
+                                estimated_cost_usdc: Some(estimated_cost),
+                            });
+                        }
+                        Err(e) => {
                             warn!(
+                                error = %e,
                                 model = %req.model,
                                 wallet = %wallet_address,
-                                raw_cost = cost,
-                                "skipping spend log: computed cost is NaN/∞/negative/overflow — refusing to write a corrupt ledger entry"
+                                "failed to compute actual cost — skipping spend log to avoid $0 entry"
                             );
-                            return Ok(response);
-                        };
-                        let billed_atomic = spend_cost_atomic(realized_discount, cost_atomic);
-                        let billed_cost = billed_atomic as f64 / 1_000_000.0;
-                        // Pass the estimated_cost that was committed to Redis
-                        // counters in `check_budget` so log_spend can adjust
-                        // by the (billed − estimated) delta. Without this,
-                        // counters would be double-incremented.
-                        state.usage.log_spend(SpendLogEntry {
-                            wallet_address: wallet_address.clone(),
-                            model: req.model.clone(),
-                            provider: actual_provider.unwrap_or_else(|| provider_name.to_string()),
-                            input_tokens: u.prompt_tokens,
-                            output_tokens: u.completion_tokens,
-                            cost_usdc: billed_cost,
-                            tx_signature: tx_signature.clone(),
-                            request_id: request_id.clone(),
-                            session_id: session_id.clone(),
-                            tenant: tenant.clone(),
-                            // Reconcile per-tenant counters only when
-                            // check_budget actually enforced a provisioned bucket
-                            // (decision == Enforce). Threaded from the reservation
-                            // so the Skip path never accumulates per-tenant spend.
-                            tenant_enforced: budget_reservation.tenant_enforced(),
-                            estimated_cost_usdc: Some(estimated_cost),
-                        });
-                    }
-                    Err(e) => {
-                        warn!(
-                            error = %e,
-                            model = %req.model,
-                            wallet = %wallet_address,
-                            "failed to compute actual cost — skipping spend log to avoid $0 entry"
-                        );
+                        }
                     }
                 }
-            } else if cost_outcome.is_some() {
-                // Usage-less semantic hit: reconcile the reservation. On escrow,
-                // bill the discount; on exact, `realized_discount` is None so we
-                // bill the full reservation (`estimated_cost`) — a zero delta that
-                // correctly leaves the on-chain-settled full amount in the ledger.
-                // We have no token counts (the cached response omitted usage), so
-                // record the input estimate and zero output.
-                //
-                // Same atomic-domain billing as the usage-present arm. The pre-
-                // provider validator at line 561 already gated `estimated_cost`
-                // as finite + non-negative, but we still route through
-                // `usdc_f64_to_atomic_safe` so a corrupted re-derivation (or a
-                // future refactor that drops the early guard) cannot write a
-                // NaN/∞ entry to the spend ledger.
-                let Some(estimated_atomic) = usdc_f64_to_atomic_safe(estimated_cost) else {
-                    warn!(
-                        model = %req.model,
-                        wallet = %wallet_address,
-                        raw_estimated = estimated_cost,
-                        "skipping spend log: estimated_cost is NaN/∞/negative/overflow on usage-less semantic-hit fallback"
-                    );
-                    return Ok(response);
-                };
-                let billed_atomic = spend_cost_atomic(realized_discount, estimated_atomic);
-                let billed_cost = billed_atomic as f64 / 1_000_000.0;
-                state.usage.log_spend(SpendLogEntry {
-                    wallet_address: wallet_address.clone(),
-                    model: req.model.clone(),
-                    provider: actual_provider.unwrap_or_else(|| provider_name.to_string()),
-                    input_tokens: estimate_input_tokens(&req),
-                    output_tokens: 0,
-                    cost_usdc: billed_cost,
-                    tx_signature: tx_signature.clone(),
-                    request_id: request_id.clone(),
-                    session_id: session_id.clone(),
-                    tenant: tenant.clone(),
-                    // Same gating as the usage-present arm: reconcile per-tenant
-                    // counters only when a provisioned bucket was enforced.
-                    tenant_enforced: budget_reservation.tenant_enforced(),
-                    estimated_cost_usdc: Some(estimated_cost),
-                });
+                SpendLogArm::UsagelessSemanticHit => {
+                    // Usage-less semantic hit: reconcile the reservation. On escrow,
+                    // bill the discount; on exact, `realized_discount` is None so we
+                    // bill the full reservation (`estimated_cost`) — a zero delta that
+                    // correctly leaves the on-chain-settled full amount in the ledger.
+                    // We have no token counts (the cached response omitted usage), so
+                    // record the input estimate and zero output.
+                    //
+                    // Same atomic-domain billing as the usage-present arm. The pre-
+                    // provider validator at line 561 already gated `estimated_cost`
+                    // as finite + non-negative, but we still route through
+                    // `usdc_f64_to_atomic_safe` so a corrupted re-derivation (or a
+                    // future refactor that drops the early guard) cannot write a
+                    // NaN/∞ entry to the spend ledger.
+                    let Some(estimated_atomic) = usdc_f64_to_atomic_safe(estimated_cost) else {
+                        warn!(
+                            model = %req.model,
+                            wallet = %wallet_address,
+                            raw_estimated = estimated_cost,
+                            "skipping spend log: estimated_cost is NaN/∞/negative/overflow on usage-less semantic-hit fallback"
+                        );
+                        return Ok(response);
+                    };
+                    let billed_atomic = spend_cost_atomic(realized_discount, estimated_atomic);
+                    let billed_cost = billed_atomic as f64 / 1_000_000.0;
+                    state.usage.log_spend(SpendLogEntry {
+                        wallet_address: wallet_address.clone(),
+                        model: req.model.clone(),
+                        provider: actual_provider.unwrap_or_else(|| provider_name.to_string()),
+                        input_tokens: estimate_input_tokens(&req),
+                        output_tokens: 0,
+                        cost_usdc: billed_cost,
+                        tx_signature: tx_signature.clone(),
+                        request_id: request_id.clone(),
+                        session_id: session_id.clone(),
+                        tenant: tenant.clone(),
+                        // Same gating as the usage-present arm: reconcile per-tenant
+                        // counters only when a provisioned bucket was enforced.
+                        tenant_enforced: budget_reservation.tenant_enforced(),
+                        estimated_cost_usdc: Some(estimated_cost),
+                    });
+                }
+                SpendLogArm::EstimateFallback => {
+                    // Delivered + settled, but usage AND cost_outcome are both
+                    // absent — the streaming path (a streaming provider call
+                    // carries no usage data and missed the semantic cache).
+                    // Bill the ESTIMATE: it is the amount `check_budget`
+                    // reserved and, on the exact scheme, precisely what the
+                    // agent settled on-chain — so the ledger matches the money
+                    // collected. `realized_discount` is structurally None here
+                    // (no `cost_outcome`), so `spend_cost_atomic` is the
+                    // identity and billed == estimate; we still route through
+                    // it so all logging arms share one atomic-domain billing
+                    // path. `estimated_cost_usdc: Some(estimated_cost)` makes
+                    // `log_spend`'s `(billed − estimated)` reconciliation delta
+                    // zero — the reservation correctly stays at the estimate.
+                    //
+                    // Same fail-closed conversion as the other arms: the pre-
+                    // provider validator already gated `estimated_cost` as
+                    // finite + non-negative, but we still route through
+                    // `usdc_f64_to_atomic_safe` so a corrupted re-derivation
+                    // (or a future refactor that drops the early guard) cannot
+                    // write a NaN/∞ entry to the spend ledger.
+                    let Some(estimated_atomic) = usdc_f64_to_atomic_safe(estimated_cost) else {
+                        warn!(
+                            model = %req.model,
+                            wallet = %wallet_address,
+                            raw_estimated = estimated_cost,
+                            "skipping spend log: estimated_cost is NaN/∞/negative/overflow on streaming estimate fallback"
+                        );
+                        return Ok(response);
+                    };
+                    let billed_atomic = spend_cost_atomic(realized_discount, estimated_atomic);
+                    let billed_cost = billed_atomic as f64 / 1_000_000.0;
+                    state.usage.log_spend(SpendLogEntry {
+                        wallet_address: wallet_address.clone(),
+                        model: req.model.clone(),
+                        provider: actual_provider.unwrap_or_else(|| provider_name.to_string()),
+                        // No token data on this path: record the request-side
+                        // input estimate and zero output, consistent with the
+                        // usage-less semantic-hit arm.
+                        input_tokens: estimate_input_tokens(&req),
+                        output_tokens: 0,
+                        cost_usdc: billed_cost,
+                        tx_signature: tx_signature.clone(),
+                        request_id: request_id.clone(),
+                        session_id: session_id.clone(),
+                        tenant: tenant.clone(),
+                        // Same gating as the other arms: reconcile per-tenant
+                        // counters only when a provisioned bucket was enforced.
+                        tenant_enforced: budget_reservation.tenant_enforced(),
+                        estimated_cost_usdc: Some(estimated_cost),
+                    });
+                }
             }
 
             Ok(response)

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -1332,6 +1332,15 @@ pub async fn chat_completions(
                                     raw_cost = cost,
                                     "skipping spend log: computed cost is NaN/∞/negative/overflow — refusing to write a corrupt ledger entry"
                                 );
+                                counter!("solvela_spend_log_skipped_total", "reason" => "corrupt_actual_cost")
+                                    .increment(1);
+                                // Intentionally do NOT release the budget
+                                // reservation here: the payment WAS collected
+                                // (settled), so keeping the Redis reservation at
+                                // the estimate is the correct, conservative
+                                // accounting — releasing it would let the
+                                // wallet's budget under-count collected spend.
+                                // Only the DB ledger row is skipped.
                                 return Ok(response);
                             };
                             let billed_atomic = spend_cost_atomic(realized_discount, cost_atomic);
@@ -1391,6 +1400,14 @@ pub async fn chat_completions(
                             raw_estimated = estimated_cost,
                             "skipping spend log: estimated_cost is NaN/∞/negative/overflow on usage-less semantic-hit fallback"
                         );
+                        counter!("solvela_spend_log_skipped_total", "reason" => "corrupt_estimate_semantic_hit")
+                            .increment(1);
+                        // Intentionally do NOT release the budget reservation
+                        // here: the payment WAS collected (settled), so keeping
+                        // the Redis reservation at the estimate is the correct,
+                        // conservative accounting — releasing it would let the
+                        // wallet's budget under-count collected spend. Only the
+                        // DB ledger row is skipped.
                         return Ok(response);
                     };
                     let billed_atomic = spend_cost_atomic(realized_discount, estimated_atomic);
@@ -1440,6 +1457,14 @@ pub async fn chat_completions(
                             raw_estimated = estimated_cost,
                             "skipping spend log: estimated_cost is NaN/∞/negative/overflow on streaming estimate fallback"
                         );
+                        counter!("solvela_spend_log_skipped_total", "reason" => "corrupt_estimate_fallback")
+                            .increment(1);
+                        // Intentionally do NOT release the budget reservation
+                        // here: the payment WAS collected (settled), so keeping
+                        // the Redis reservation at the estimate is the correct,
+                        // conservative accounting — releasing it would let the
+                        // wallet's budget under-count collected spend. Only the
+                        // DB ledger row is skipped.
                         return Ok(response);
                     };
                     let billed_atomic = spend_cost_atomic(realized_discount, estimated_atomic);

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -3379,6 +3379,178 @@ async fn test_chat_stream_request_returns_ok() {
 }
 
 // ---------------------------------------------------------------------------
+// Paid spend logging — every delivered + settled paid request must record a
+// spend entry. The streaming path carries no provider usage and (on a cache
+// miss) no semantic-cost outcome, so it must log from the ESTIMATE — the same
+// amount `check_budget` reserved and (for `exact`) the agent settled on-chain.
+//
+// `UsageTracker::log_spend` emits a synchronous `info!("spend logged")` event
+// before the fire-and-forget DB/Redis writes, so a per-test capturing tracing
+// subscriber observes the production write through the REAL route — no seeded
+// fixtures (per feedback_test_through_real_paths).
+// ---------------------------------------------------------------------------
+
+/// A `MakeWriter` that captures formatted tracing output into a shared buffer
+/// so a test can assert on events emitted synchronously inside the handler.
+#[derive(Clone, Default)]
+struct CaptureWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Parse the captured JSON-formatted tracing output and return the `fields`
+/// object of every `"spend logged"` event (one per `log_spend` call).
+fn spend_logged_events(capture: &CaptureWriter) -> Vec<serde_json::Value> {
+    let bytes = capture.0.lock().unwrap().clone();
+    String::from_utf8(bytes)
+        .expect("captured tracing output is UTF-8")
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|v| v["fields"]["message"] == "spend logged")
+        .map(|v| v["fields"].clone())
+        .collect()
+}
+
+/// Send a paid request through the real route with a JSON tracing subscriber
+/// capturing handler-side events; returns (status, spend-logged field objects).
+async fn paid_request_capturing_spend_events(
+    body: &serde_json::Value,
+) -> (StatusCode, Vec<serde_json::Value>) {
+    use tracing::instrument::WithSubscriber;
+
+    let app = test_app_with_mock_provider();
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(body).unwrap()))
+                .unwrap(),
+        )
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+    (response.status(), spend_logged_events(&capture))
+}
+
+/// A settled paid STREAMING request (usage absent, no semantic-cache hit) must
+/// record exactly one spend entry billed at the ESTIMATE — the amount quoted in
+/// the 402 challenge, reserved by `check_budget`, and settled on-chain by the
+/// `exact` agent. Before the estimated-cost arm existed this path logged
+/// NOTHING (no spend_logs row, reservation never reconciled).
+#[tokio::test]
+async fn streaming_paid_request_logs_spend_from_estimate() {
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": true,
+    });
+
+    // The 402 amount is the observable proxy for the reservation/estimate
+    // through the real path (see the #500 reservation tests).
+    let reserved_atomic = quote_402_amount_atomic(&body.to_string()).await;
+
+    let (status, events) = paid_request_capturing_spend_events(&body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        events.len(),
+        1,
+        "a settled streaming paid request MUST write exactly one spend entry \
+         (got {}): the agent paid the estimate on-chain, so the ledger must \
+         record it",
+        events.len()
+    );
+    let logged_usdc = events[0]["cost_usdc"]
+        .as_f64()
+        .expect("spend logged event carries cost_usdc");
+    let logged_atomic = (logged_usdc * 1_000_000.0).round() as u64;
+    assert!(
+        logged_atomic.abs_diff(reserved_atomic) <= 1,
+        "streaming spend must be billed at the reserved estimate \
+         ({reserved_atomic} atomic), got {logged_atomic} atomic"
+    );
+    assert_eq!(
+        events[0]["output_tokens"].as_u64(),
+        Some(0),
+        "streaming has no token usage — output_tokens must be recorded as 0"
+    );
+    assert!(
+        events[0]["input_tokens"].as_u64().unwrap_or(0) >= 1,
+        "input tokens are estimated from the request (minimum 1)"
+    );
+}
+
+/// Regression guard for the arm rewiring: a settled paid NON-streaming request
+/// must keep logging spend from the provider's ACTUAL (capped) usage — the
+/// mock provider reports prompt=10 / completion=5.
+#[tokio::test]
+async fn non_streaming_paid_request_logs_spend_from_actual_usage() {
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+
+    let (status, events) = paid_request_capturing_spend_events(&body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        events.len(),
+        1,
+        "a settled non-streaming paid request must write exactly one spend entry"
+    );
+    assert_eq!(
+        events[0]["input_tokens"].as_u64(),
+        Some(10),
+        "non-streaming spend must record the provider-reported prompt tokens"
+    );
+    assert_eq!(
+        events[0]["output_tokens"].as_u64(),
+        Some(5),
+        "non-streaming spend must record the provider-reported completion tokens"
+    );
+    let logged_usdc = events[0]["cost_usdc"]
+        .as_f64()
+        .expect("spend logged event carries cost_usdc");
+    let expected_atomic = registry_quote_atomic("openai/gpt-4o", 10, 5);
+    let logged_atomic = (logged_usdc * 1_000_000.0).round() as u64;
+    assert!(
+        logged_atomic.abs_diff(expected_atomic) <= 1,
+        "non-streaming spend must be billed from actual usage \
+         ({expected_atomic} atomic), got {logged_atomic} atomic"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Rate limit headers present on responses
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Paid **streaming** requests that miss the semantic cache never write a `spend_logs` row. `execute_provider_call` returns `usage: None` for streams, and the post-response spend-log block had only three arms (settle-failed / actual usage / usage-less semantic hit) with **no fall-through arm** — a delivered, on-chain-settled streaming payment silently logged nothing. No row, no error (fire-and-forget masking), no per-tenant attribution, and the `check_budget` reservation was never reconciled by `log_spend`.

Confirmed live in prod 2026-06-11: a settled exact-scheme streaming request (payment verified → streamed → settled on-chain) produced no `spend_logs` row; Redis tenant reservation counters proved the `x-tenant` tag arrived and was enforced, so only the ledger write was missing. This is not a regression — the gap predates #491; the block's own comment promised an "estimated (streaming)" path that was never implemented.

## Fix

- New pure selector `select_spend_log_arm(settle_after_deliver_failed, usage, semantic_hit)` → `SpendLogArm` in `routes/chat/cost.rs`; the spend-log block in `routes/chat/mod.rs` is now an **exhaustive match** (a future variant is a compile error, never a silent fall-through). The three pre-existing arms are behavior-preserving (bodies unchanged, precedence identical).
- New `EstimateFallback` arm: logs from `estimated_cost` — the same value reserved in `check_budget`, and on the exact scheme precisely what the agent settled on-chain. Fail-closed through `usdc_f64_to_atomic_safe`; threads `tx_signature` / `tenant` / `tenant_enforced` / `estimated_cost_usdc: Some(estimated_cost)` (zero reconciliation delta) like the other arms. `input_tokens` from the request estimate, `output_tokens: 0` (no token data, consistent with the usage-less semantic arm).
- Review follow-up (second commit): the three `usdc_f64_to_atomic_safe` None-guards now increment `solvela_spend_log_skipped_total{reason=…}` so a settled request that writes no ledger row is visible in metrics, plus comments documenting that the budget reservation is **intentionally retained** there (payment was collected; releasing would under-count spend). No settlement semantics changed anywhere — this PR only records what was already collected.

## Tests

- `streaming_paid_request_logs_spend_from_estimate` (integration, real route via `oneshot` + mock provider + tracing-capture harness) — verified RED before the fix; proves the production `log_spend` call fires for a paid streaming request and bills the 402-quoted reservation (±1 atomic unit).
- `non_streaming_paid_request_logs_spend_from_actual_usage` — rewiring guard for the actual-usage arm.
- `select_spend_log_arm_exhaustive_truth_table` — all 8 input combinations / 4 arms incl. precedence.
- `estimate_fallback_bills_exactly_the_reservation` — billed == reserved on both exact and escrow.

`cargo fmt` / `clippy -D warnings` clean; gateway lib 748 passed, integration 209 passed.

## Review

Money-path two-round review done pre-PR: `rust-reviewer` (approve, control-flow equivalence of the three pre-existing arms verified) + `silent-failure-hunter` (one Major triaged: its suggested `release_reservation` in the None-guards was rejected as incorrect for settled payments — documented in-code instead; its observability finding became commit 2).