### PR TITLE
docs: add free-tier, A2A, and response-cache pages; verify every code example

### DIFF
--- a/dashboard/content/docs/api/authentication.mdx
+++ b/dashboard/content/docs/api/authentication.mdx
@@ -73,11 +73,9 @@ Enterprise accounts with API key auth unlock additional capabilities:
 | Feature | Description |
 |---------|-------------|
 | **Org hierarchy** | Manage multiple teams under a single organization |
-| **Team budgets** | Set hourly or daily spend caps per team |
-| **Session budgets** | Limit spending for individual sessions or users |
-| **Audit logs** | Full request and payment history per key |
+| **Team budgets** | Set hourly, daily, or monthly spend caps per team |
+| **Audit logs** | Full audit trail of org actions |
 | **Usage analytics** | Breakdown of spend by model, team, and time period |
-| **Per-model restrictions** | Restrict which models a team or key can access |
 
 ## Choosing a Method
 
@@ -85,7 +83,7 @@ Enterprise accounts with API key auth unlock additional capabilities:
 |--|------|---------|
 | Setup required | None | Enterprise account |
 | Auth mechanism | Payment signature | Bearer token |
-| Rate limiting | Per wallet address | Per API key |
+| Rate limiting | Per wallet address | Per source IP |
 | Billing | Pay per request | Managed via org budgets |
 | Best for | Individual use, developers | Teams, production deployments |
 

--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -263,9 +263,10 @@ data: [DONE]
         if err != nil {
             log.Fatal(err)
         }
-        // solvela-go ships UnimplementedSigner — implement the Signer
-        // interface yourself for paid requests. See /docs/sdks/go.
-        signer := myKeypairSigner{wallet: wallet}
+        // The built-in KeypairSigner signs escrow-scheme payments; the exact
+        // scheme is not yet implemented in Go (supply a custom Signer for it).
+        // Pass "" to default to mainnet-beta RPC. See /docs/sdks/go.
+        signer := solvela.NewKeypairSigner(wallet, "")
 
         client, err := solvela.NewClient(wallet, signer,
             solvela.WithGatewayURL("https://api.solvela.ai"),

--- a/dashboard/content/docs/api/errors.mdx
+++ b/dashboard/content/docs/api/errors.mdx
@@ -41,9 +41,9 @@ if (response.status === 402 && body.x402_version) {
 | `403` | Forbidden | Authenticated but lacking permission (e.g. member role calling admin-only org endpoints) |
 | `404` | Not Found | Unknown endpoint, or `model` ID not in the registry (`type: model_not_found`) |
 | `429` | Too Many Requests | Rate limit exceeded |
-| `500` | Internal Server Error | Gateway error (bug or misconfiguration), or all configured providers failed |
+| `500` | Internal Server Error | Gateway error (bug or misconfiguration), or payment settlement failed (`type: settlement_failed`) |
 | `502` | Bad Gateway | Upstream provider returned an error (`type: provider_error`) |
-| `503` | Service Unavailable | Required dependency unavailable (e.g. Prometheus recorder, database, or marketplace target marked unhealthy) |
+| `503` | Service Unavailable | No provider could serve a paid request (`type: upstream_unavailable` — payment not charged), or a required dependency is unavailable |
 
 ## Common errors and fixes
 
@@ -156,19 +156,24 @@ See [x402 Protocol](/docs/concepts/x402) for the full flow.
 
 ---
 
-### 500 — All providers failed
+### 503 — No provider available (paid request)
 
 ```json
-{ "error": { "message": "all providers failed for model 'gpt-4o'. Your payment was submitted but no response could be generated." } }
+{
+  "error": {
+    "type": "upstream_unavailable",
+    "message": "No provider could serve your request right now and your payment was NOT charged. Please retry shortly."
+  }
+}
 ```
 
-**Cause:** The gateway verified payment but could not get a response from the upstream provider.
+**Cause:** The gateway accepted your payment but no upstream provider could produce a response.
 
-**Fix:** Retry the request. If the issue persists, the provider may be experiencing an outage. Contact the gateway operator with the transaction signature.
+**You are not charged for an undelivered completion:**
+- **exact** scheme — the USDC transfer is deferred until after delivery, so nothing settled on-chain.
+- **escrow** scheme — the deposit settled pre-call, but the gateway never claims it for a failed request; the message is `"No provider could serve your request right now; no claim was made against your escrow deposit and it refunds at expiry. Please retry shortly."`
 
-<Warning>
-  If you receive a 500 after a confirmed payment, your USDC was spent but no response was returned. Contact support with your transaction signature.
-</Warning>
+**Fix:** Retry the request. If the issue persists, the provider may be experiencing an outage.
 
 ---
 

--- a/dashboard/content/docs/api/models.mdx
+++ b/dashboard/content/docs/api/models.mdx
@@ -82,8 +82,7 @@ For a full pricing table, see [Pricing](/docs/concepts/pricing).
 | `google/gemini-3.1-pro` | Google | $2.00 | $12.00 |
 | `google/gemini-2.5-flash` | Google | $0.30 | $2.50 |
 | `google/gemini-2.5-flash-lite` | Google | $0.10 | $0.40 |
-| `google/gemini-2.0-flash` | Google | $0.10 | $0.40 |
-| `google/gemini-2.0-flash-lite` | Google | $0.075 | $0.30 |
+| `google/gemini-3.1-flash-lite` | Google | $0.00 | $0.00 |
 | `xai/grok-4-fast-reasoning` | xAI | $0.20 | $0.50 |
 | `xai/grok-code-fast-1` | xAI | $0.20 | $1.50 |
 | `xai/grok-3` | xAI | $3.00 | $15.00 |

--- a/dashboard/content/docs/api/rate-limits.mdx
+++ b/dashboard/content/docs/api/rate-limits.mdx
@@ -1,45 +1,96 @@
 ---
 title: Rate Limits
-description: Rate limiting and quotas
+description: Rate limiting and quotas, including the anonymous free-tier limits
 ---
 
 Solvela applies rate limiting at multiple layers to protect gateway stability and ensure fair usage across all clients.
 
-## Middleware Stack
+## Middleware stack
 
 Requests pass through the following limiting layers in order:
 
-| Layer | Scope | Description |
-|-------|-------|-------------|
-| Per-client rate limiting | Payer wallet, falling back to client IP | Primary limit. The identity is the payer wallet derived from the signed transaction in the `PAYMENT-SIGNATURE` header; a request without a decodable payment falls back to its source IP. The fallback never trusts `X-Forwarded-For` (trivially spoofed) — set real client IPs at your proxy layer. |
-| Global concurrency limiting | Gateway-wide | Caps total in-flight requests across all clients to prevent overload. |
-| Request timeout | Per request | Hard timeout applied globally; long-running requests are terminated. |
+| Layer | Scope | Default | Description |
+|-------|-------|---------|-------------|
+| Per-client rate limiting | Payer wallet, falling back to client IP | 60 requests / 60 s (`SOLVELA_RATE_LIMIT_MAX`) | Primary limit. The identity is the payer wallet derived from the signed transaction in the `payment-signature` header; a request without a decodable payment falls back to its source IP. The fallback never trusts `X-Forwarded-For` (trivially spoofed) — set real client IPs at your proxy layer. |
+| Free-tier limits | Per IP + global aggregate | See [Free tier vs paid](#free-tier-vs-paid-limits) | Stricter limits enforced inside the chat handler on zero-cost requests only. |
+| Global concurrency limiting | Gateway-wide | 256 in-flight (`SOLVELA_MAX_CONCURRENT_REQUESTS`) | Caps total in-flight requests across all clients to prevent overload. |
+| Request timeout | Per request | 120 s (`SOLVELA_REQUEST_TIMEOUT_SECS`) | Hard timeout applied globally; expired requests return `408`. |
 
-## Rate Limit Headers
+Operational endpoints — `/health`, `/v1/models`, and `/metrics` — are exempt from rate limiting so health checks and load balancers keep working even when a client is over its limit.
 
-Every response includes headers indicating the current limit state for your client (wallet or IP):
+## Free tier vs paid limits
+
+A request is **free** if and only if its quoted cost is exactly `0` atomic USDC — i.e. the resolved model is zero-priced in the registry (currently `openai/gpt-oss-120b` and `google/gemini-3.1-flash-lite`, with `gemini-3.1-flash-lite` being the `free` routing profile's target). Free requests are served at $0 with no `payment-signature` header and never touch the payment path. A payment header sent with a free model is ignored — the quoted amount is `0`, so there is nothing to verify or claim.
+
+Because the free path is anonymous (no payer wallet), its rate-limit identity is the actual TCP peer IP — never a client-supplied header such as `X-Forwarded-For`. Two gates run, in order, before any provider call:
+
+| Limit | Bucket | Default | Window | Env override |
+|-------|--------|---------|--------|--------------|
+| Paid per-client | Payer wallet (IP fallback) | 60 requests | 60 s | `SOLVELA_RATE_LIMIT_MAX` |
+| Free per-IP | TCP peer IP | 5 requests | 60 s | `SOLVELA_FREE_TIER_RATE_LIMIT` |
+| Free aggregate (global) | All free clients combined | 12 requests | 60 s | `SOLVELA_FREE_TIER_GLOBAL_RPM` |
+
+### Per-IP free limit
+
+An in-memory fixed-window counter keyed on the peer IP, intentionally much stricter than the paid 60/min limit. When the peer address is unavailable, all unidentified clients share a single stricter "unknown" bucket: 10/min on the paid limiter, 2/min on the free limiter. The unknown-bucket limits are fixed and not env-overridable — `SOLVELA_FREE_TIER_RATE_LIMIT` tunes only the per-IP free limit.
+
+### Aggregate (global) free cap
+
+A single shared counter across **all** free clients per 1-minute window — distinct from the per-IP limiter, which cannot protect a shared ceiling (many distinct IPs each under their per-IP cap can still collectively exceed it). The free models are served on a shared upstream free-tier key, so the aggregate cap keeps total free throughput below the upstream provider's ceiling and the gateway returns its own clean `429` before the upstream's leaks through.
+
+The counter is backed by Redis when configured (one shared key across gateway instances). When Redis is absent or errors at runtime, it degrades to an in-memory per-instance counter — bounded, never unbounded.
+
+### Free-tier env var behavior
+
+- Setting `SOLVELA_FREE_TIER_RATE_LIMIT=0` or `SOLVELA_FREE_TIER_GLOBAL_RPM=0` does **not** disable the limit — it would disable all free-tier access, so the gateway logs a warning and uses the default instead.
+- Legacy `RCR_`-prefixed forms of all three rate-limit env vars are accepted as deprecated fallbacks.
+
+## Rate limit headers
+
+Responses on rate-limited paths include headers indicating the limit state for your bucket (wallet or IP):
 
 | Header | Description |
 |--------|-------------|
-| `X-RateLimit-Limit` | Maximum requests allowed in the current window |
-| `X-RateLimit-Remaining` | Requests remaining in the current window |
-| `X-RateLimit-Reset` | Unix timestamp when the current window resets |
+| `x-ratelimit-limit` | Maximum requests allowed in the current window |
+| `x-ratelimit-remaining` | Requests remaining in the current window (`0` on a `429`) |
+| `x-ratelimit-reset` | Window length in **seconds** — not a Unix timestamp. The limiter is fixed-window; the window starts at your first request in it. |
+| `retry-after` | `429` responses only — seconds to wait before retrying (same value as `x-ratelimit-reset`) |
 
-When a request is rejected due to rate limiting, the gateway returns `429 Too Many Requests` with a `rate_limited` error type. Use the `X-RateLimit-Reset` value to determine when to retry.
+When a request is rejected, the gateway returns `429 Too Many Requests` with an error of type `rate_limit_exceeded`:
+
+```json
+{
+  "error": {
+    "type": "rate_limit_exceeded",
+    "message": "Too many requests. Please slow down."
+  }
+}
+```
 
 ```bash
-# Example response headers
+# Successful paid request
 HTTP/2 200
-X-RateLimit-Limit: 60
-X-RateLimit-Remaining: 42
-X-RateLimit-Reset: 1712345678
+x-ratelimit-limit: 60
+x-ratelimit-remaining: 42
+x-ratelimit-reset: 60
 ```
+
+```bash
+# Rejected free-tier request (per-IP limit)
+HTTP/2 429
+x-ratelimit-limit: 5
+x-ratelimit-remaining: 0
+x-ratelimit-reset: 60
+retry-after: 60
+```
+
+On a `429`, the headers describe the limiter that rejected you: a free-tier rejection carries the free limit (e.g. `5`) and an aggregate-cap rejection carries the global cap (e.g. `12`) — the outer 60/min middleware never overwrites a `429`'s headers with its looser values.
 
 <Note>
 Rate limit windows and exact thresholds are subject to change. Always read the headers from live responses rather than hardcoding expected values.
 </Note>
 
-## Spending Controls (Enterprise)
+## Spending controls (enterprise)
 
 Separate from rate limiting, enterprise organizations can cap **spend** per team or per wallet. These limits are enforced at the gateway before a request is proxied to the provider, and are independent of the request-rate limits above.
 
@@ -63,14 +114,14 @@ When an estimated request cost would push a wallet over its limit, the gateway r
 
 See [Budgets](/docs/enterprise/budgets) for the full reference.
 
-## Handling Rate Limit Errors
+## Handling rate limit errors
 
-When you receive a `429`, read `X-RateLimit-Reset` and wait until that timestamp before retrying:
+When you receive a `429`, read `retry-after` (a duration in seconds) and wait that long before retrying:
 
 ```typescript
 function retryDelayMs(res: Response): number {
-  const resetAt = parseInt(res.headers.get("X-RateLimit-Reset") ?? "0", 10);
-  return Math.max(0, resetAt * 1000 - Date.now());
+  const retryAfterSecs = parseInt(res.headers.get("retry-after") ?? "60", 10);
+  return retryAfterSecs * 1000;
 }
 
 // On a 429 from any HTTP call to the gateway:
@@ -80,5 +131,5 @@ function retryDelayMs(res: Response): number {
 ```
 
 <Warning>
-Do not retry on `429` immediately in a tight loop. This will not succeed and will count against your limit once the window resets. Always wait for `X-RateLimit-Reset` before retrying.
+Do not retry on `429` immediately in a tight loop. The window is fixed, so retries before it elapses will not succeed and will count against your limit once it resets. `retry-after` and `x-ratelimit-reset` are durations in seconds, not timestamps — wait that many seconds before retrying.
 </Warning>

--- a/dashboard/content/docs/concepts/a2a.mdx
+++ b/dashboard/content/docs/concepts/a2a.mdx
@@ -1,0 +1,273 @@
+---
+title: A2A Protocol
+description: Agent-to-Agent JSON-RPC adapter with x402 payment metadata over Solana USDC-SPL
+---
+
+
+Solvela exposes an A2A (Agent-to-Agent) endpoint so autonomous agents can discover the gateway, get a price quote, and pay — all over JSON-RPC 2.0 instead of raw HTTP 402 handshakes. The A2A layer is a protocol adapter, not new payment logic: it translates `message/send` calls into the same x402 verification and chat pipeline used by `POST /v1/chat/completions`.
+
+Two routes:
+
+| Route | Purpose |
+|-------|---------|
+| `GET /.well-known/agent.json` | AgentCard discovery — advertises AP2 + x402 extensions |
+| `POST /a2a` | JSON-RPC 2.0 endpoint — `message/send` is the only method |
+
+A2A is **text-only today**. Messages carrying image `data` parts (`contentType` starting with `image/`) are rejected with an invalid-params error before any paid work happens.
+
+<Note>
+  The A2A task store lives in Redis. If Redis is not configured, new `message/send` requests fail with an internal error (`-32603`) rather than issuing a task ID a client could pay against but never redeem. Task records expire after 10 minutes.
+</Note>
+
+## AgentCard discovery
+
+Agents discover Solvela by fetching `GET /.well-known/agent.json`. The card advertises the AP2 extension (merchant role) and the x402 extension (Solana USDC-SPL settlement). A representative trimmed response:
+
+```json
+{
+  "name": "Solvela",
+  "description": "Solana-native AI agent payment gateway — pay for LLM API calls with USDC-SPL via x402",
+  "version": "0.1.0",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "extensions": [
+      {
+        "uri": "https://github.com/google-agentic-commerce/ap2/tree/v0.1",
+        "description": "AP2 merchant for AI agent LLM payments",
+        "required": true,
+        "params": { "roles": ["merchant"] }
+      },
+      {
+        "uri": "https://github.com/google-a2a/a2a-x402/v0.1",
+        "description": "x402 on-chain settlement via Solana USDC-SPL",
+        "required": true,
+        "params": {
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "schemes": ["exact", "escrow"]
+        }
+      }
+    ]
+  },
+  "skills": [
+    {
+      "id": "chat-completion",
+      "name": "Chat Completion",
+      "description": "Proxy AI chat completions to multiple LLM providers (OpenAI, Anthropic, Google, xAI, DeepSeek)",
+      "inputModes": ["text"],
+      "outputModes": ["text"]
+    }
+  ]
+}
+```
+
+Two details matter for payment construction:
+
+- `params.asset` is the **configured** USDC mint — the one the verifier actually enforces — never a compile-time constant. Build your payment against the mint the card advertises.
+- `params.schemes` contains `"exact"` always, and `"escrow"` only when the gateway has escrow configured.
+
+If the client sends an `x-a2a-extensions` header, the gateway echoes the x402 extension URI back in the same header on every `/a2a` response.
+
+## The message/send flow
+
+The payment flow is two `message/send` calls against the same task.
+
+<Steps>
+  <Step>
+    **First call — no `taskId` — get a payment quote**
+
+    The agent sends its prompt as a text part. An optional `metadata.model` hint accepts the same values as the REST route — routing profiles (`auto`, `eco`, `premium`), aliases (`sonnet`, `gpt5`), or direct model IDs. It defaults to `auto`.
+
+    ```json title="Request"
+    {
+      "jsonrpc": "2.0",
+      "method": "message/send",
+      "id": 1,
+      "params": {
+        "message": {
+          "role": "user",
+          "parts": [{ "kind": "text", "text": "What is x402?" }],
+          "metadata": { "model": "auto" }
+        }
+      }
+    }
+    ```
+
+    The gateway resolves the model, estimates cost (output capped at 1,000 tokens for the quote), stores a task record, and returns a Task in `input-required` state. The `x402.payment.required` metadata value is the same `PaymentRequired` object the REST route returns in a 402 body:
+
+    ```json title="Response"
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "id": "a2a_3f2c9a1b...",
+        "status": {
+          "state": "input-required",
+          "message": {
+            "role": "agent",
+            "parts": [
+              { "kind": "text", "text": "Payment required to process this request." }
+            ],
+            "metadata": {
+              "x402.payment.status": "payment-required",
+              "x402.payment.required": {
+                "x402_version": 2,
+                "resource": { "url": "/v1/chat/completions", "method": "POST" },
+                "accepts": [
+                  {
+                    "scheme": "exact",
+                    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                    "amount": "315",
+                    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "pay_to": "<gateway-wallet>",
+                    "max_timeout_seconds": 300
+                  }
+                ],
+                "cost_breakdown": {
+                  "provider_cost": "0.000300",
+                  "platform_fee": "0.000015",
+                  "total": "0.000315",
+                  "currency": "USDC",
+                  "fee_percent": 5
+                },
+                "error": "Payment required"
+              }
+            }
+          }
+        }
+      }
+    }
+    ```
+
+    When escrow is configured, `accepts` also contains a `"escrow"` entry with an `escrow_program_id` field, exactly as on the REST path.
+  </Step>
+  <Step>
+    **Agent signs a Solana transaction**
+
+    For the `exact` scheme, the agent builds and signs a USDC-SPL transfer of `amount` (atomic units) to `pay_to`. For `escrow`, it builds a deposit transaction — see [Escrow System](/docs/concepts/escrow).
+  </Step>
+  <Step>
+    **Second call — with `taskId` — submit the payment**
+
+    The agent resends `message/send` with the `taskId` from step 1 and two metadata keys: `x402.payment.status` set to `payment-submitted`, and `x402.payment.payload` carrying the same `PaymentPayload` JSON the REST path sends in the `payment-signature` header (here as plain JSON, not base64):
+
+    ```json title="Request"
+    {
+      "jsonrpc": "2.0",
+      "method": "message/send",
+      "id": 2,
+      "params": {
+        "taskId": "a2a_3f2c9a1b...",
+        "message": {
+          "role": "user",
+          "parts": [{ "kind": "text", "text": "Payment attached." }],
+          "metadata": {
+            "x402.payment.status": "payment-submitted",
+            "x402.payment.payload": {
+              "x402_version": 2,
+              "resource": { "url": "/v1/chat/completions", "method": "POST" },
+              "accepted": {
+                "scheme": "exact",
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "amount": "315",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "pay_to": "<gateway-wallet>",
+                "max_timeout_seconds": 300
+              },
+              "payload": {
+                "transaction": "<base64-encoded-signed-tx>"
+              }
+            }
+          }
+        }
+      }
+    }
+    ```
+
+    The gateway runs replay protection, validates the submitted `accepted` against the stored offer, verifies and settles the payment on-chain, runs the prompt guard, then proxies to the LLM provider with the same `max_tokens` cap that priced the quote. The response is a `completed` Task with the chat output as both the status message and an artifact, plus a settlement receipt:
+
+    ```json title="Response"
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "result": {
+        "id": "a2a_3f2c9a1b...",
+        "status": {
+          "state": "completed",
+          "message": {
+            "role": "agent",
+            "parts": [
+              { "kind": "text", "text": "x402 is an HTTP-native payment protocol..." }
+            ],
+            "metadata": {
+              "x402.payment.status": "payment-completed",
+              "x402.payment.receipts": { "tx_signature": "<solana-tx-signature>" }
+            }
+          }
+        },
+        "artifacts": [
+          {
+            "parts": [
+              { "kind": "text", "text": "x402 is an HTTP-native payment protocol..." }
+            ]
+          }
+        ]
+      }
+    }
+    ```
+  </Step>
+</Steps>
+
+## Payment metadata keys
+
+All x402 state rides in message `metadata` under namespaced keys:
+
+| Key | Direction | Value |
+|-----|-----------|-------|
+| `x402.payment.status` | both | One of `payment-required`, `payment-submitted`, `payment-completed`, `payment-failed` |
+| `x402.payment.required` | gateway → agent | The `PaymentRequired` object (same shape as the REST 402 body) |
+| `x402.payment.payload` | agent → gateway | The `PaymentPayload` object (same shape as the REST `payment-signature` header, unencoded) |
+| `x402.payment.receipts` | gateway → agent | `{ "tx_signature": "..." }` settlement receipt |
+
+## Task state machine
+
+Task states serialize in kebab-case: `input-required`, `working`, `completed`, `failed`. Valid transitions as implemented:
+
+| From | To |
+|------|----|
+| `input-required` | `working`, `completed`, `failed` |
+| `working` | `completed`, `failed` |
+| `completed` | — (terminal) |
+| `failed` | — (terminal) |
+
+The synchronous flow today goes `input-required` → `completed` directly; `working` is reserved for future async processing. Task records (state, original message, the quoted `PaymentRequired` snapshot, the model and `max_tokens` cap) live in Redis with a 10-minute TTL — paying after expiry yields a task-not-found error.
+
+## Error codes
+
+JSON-RPC errors are returned with HTTP 200 and an `error` object:
+
+| Code | Meaning |
+|------|---------|
+| `-32700` | Invalid JSON-RPC version (must be `"2.0"`) |
+| `-32601` | Method not found (only `message/send` is supported) |
+| `-32602` | Invalid params (missing text part, image parts, malformed payment metadata) |
+| `-32603` | Internal error (e.g. task store unavailable — no Redis) |
+| `-32000` | Task not found or expired |
+| `-32001` | Payment failed (replay detected, offer mismatch, verification or settlement failure) |
+| `-32002` | Provider error |
+| `-32003` | Model not found |
+
+## Same x402 verification as the REST path
+
+A2A adds no payment logic of its own. On the payment-submitted path the gateway reuses the REST pipeline piece by piece:
+
+- **Replay protection** — the transaction is checked against the same Redis replay set as REST payments. Without Redis, durable-nonce transactions are denied outright (their 24-hour replay window exceeds what the in-memory fallback can cover); regular transactions fall back to in-memory replay protection.
+- **Offer validation** — the submitted `accepted` must match an offer from the original quote on `(scheme, network, asset, pay_to)`, and the submitted amount (compared as integers) must be at least the quoted amount. This prevents a client from having the verifier check the on-chain transfer against a self-supplied lower amount.
+- **Settlement** — verification and settlement go through the same facilitator as the REST path. Deterministic on-chain rejections are reported as not-retryable (with the numeric program error code); transient submission or timeout failures are reported as retryable.
+- **Prompt guard** — the same injection/jailbreak/PII checks as the chat route run after payment is verified (never on the unpaid quote path, so anonymous callers cannot force the scans for free).
+- **Output cap** — the provider is called with the same `max_tokens` cap (1,000) that priced the quote, so actual output cannot exceed what the agent paid for.
+
+One A2A-specific restriction: wallets provisioned with per-tenant budgeting (`require_tenant`) are rejected on the A2A path with a payment-failed error before any settlement — those wallets must use `POST /v1/chat/completions`, where per-tenant budget enforcement runs.
+
+See [x402 Protocol](/docs/concepts/x402) for the underlying payment flow and [Escrow System](/docs/concepts/escrow) for the escrow scheme.

--- a/dashboard/content/docs/concepts/architecture.mdx
+++ b/dashboard/content/docs/concepts/architecture.mdx
@@ -63,11 +63,11 @@ Defines every available model: provider, context window, pricing, routing tier a
 </Accordion>
 
 <Accordion title="default.toml — gateway settings">
-Controls server bind address, timeout values, rate limit defaults, caching TTLs, and feature flags.
+Controls server bind address and port, Solana RPC URL and USDC mint, fee-payer balance monitor thresholds, and semantic-cache settings.
 </Accordion>
 
-<Accordion title="services.toml — external service config">
-Provider API base URLs, Facilitator endpoint, and Redis/PostgreSQL connection strings. Override via environment variables in production.
+<Accordion title="services.toml — x402 service marketplace registry">
+Registry of x402-compatible services available through the gateway. The marketplace phase is not yet wired in, so all entries ship commented out.
 </Accordion>
 
 ## Key Architectural Rules
@@ -94,7 +94,7 @@ Provider API base URLs, Facilitator endpoint, and Redis/PostgreSQL connection st
 </Steps>
 
 <Warning>
-PostgreSQL and Redis are optional but strongly recommended in production. Without Redis, replay protection and response caching are disabled. Without PostgreSQL, usage logs and spend tracking are lost.
+PostgreSQL and Redis are optional but strongly recommended in production. Without Redis, response caching is disabled and replay protection degrades to an in-memory LRU with TTL (single-instance only). Without PostgreSQL, usage logs and spend tracking are lost.
 </Warning>
 
 ## Provider Support
@@ -105,9 +105,9 @@ The `providers/` module inside `gateway` contains an adapter for each upstream L
 |----------|--------|
 | OpenAI | GPT-4o, o3, o4-mini, and more |
 | Anthropic | Claude Sonnet, Claude Opus, Claude Haiku |
-| Google | Gemini 2.0 Flash, Gemini 2.5 Pro |
-| xAI | Grok-3, Grok-3-mini |
-| DeepSeek | DeepSeek-V3, DeepSeek-R1 |
+| Google | Gemini 3.1 Pro, Gemini 2.5 Flash, Gemini 3.1 Flash-Lite |
+| xAI | Grok 4 Fast, Grok Code Fast, Grok 3, Grok 3 Mini |
+| DeepSeek | DeepSeek V3.2 Chat, V3.2 Reasoner, Coder V3 |
 
 <Tip>
 All providers accept the same OpenAI-compatible request format. Switching models or providers requires only changing the `model` field — no client code changes needed.

--- a/dashboard/content/docs/concepts/free-tier.mdx
+++ b/dashboard/content/docs/concepts/free-tier.mdx
@@ -1,0 +1,117 @@
+---
+title: Free Tier
+description: Zero-cost requests that skip the 402 challenge — no wallet, no signature, rate-limited per IP and globally
+---
+
+
+The free tier lets you call the gateway with no wallet, no USDC, and no payment signature. When the upfront cost estimate for a request is exactly zero, the gateway skips the entire 402 payment challenge and serves the request at $0. There is nothing to charge, so there is nothing to sign.
+
+The free model is `google/gemini-3.1-flash-lite`, registered with `0.0` input and output cost per million tokens.
+
+## How to use it
+
+Either route through the `free` profile or name the zero-cost model directly:
+
+```json
+{
+  "model": "free",
+  "messages": [{"role": "user", "content": "What is x402?"}]
+}
+```
+
+```json
+{
+  "model": "google/gemini-3.1-flash-lite",
+  "messages": [{"role": "user", "content": "What is x402?"}]
+}
+```
+
+No `payment-signature` header is needed. A successful response is standard OpenAI format, same as a paid request.
+
+```bash
+curl -s https://api.solvela.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "free",
+    "messages": [{"role": "user", "content": "What is x402?"}]
+  }'
+```
+
+The `free` profile (aliases: `oss`, `open`) maps every complexity tier — Simple, Medium, Complex, Reasoning — to `google/gemini-3.1-flash-lite`.
+
+## How free-ness is decided
+
+A request is free **iff** its computed cost estimate, in atomic USDC units, is exactly `0`. The gateway computes one upfront estimate per request and derives both decisions from it:
+
+1. Free-ness — atomic estimate `0` takes the zero-cost bypass.
+2. The amount advertised in a 402 `accepts[]` for a paid model.
+
+Because both come from the same estimate, a pricing change can never make a paid model silently bypass payment, or a free model wrongly 402. The check fails closed: any non-`"0"` or unparseable value is treated as not free, so a paid request can never take the free path.
+
+This means free-ness is a property of the **model's price**, not the profile name. `model: "free"` is just a routing profile that resolves to a zero-priced model; sending the model ID directly gets the same bypass.
+
+| | `free` routing profile | Zero-cost bypass |
+|-|------------------------|------------------|
+| What it is | Router feature: resolves `"free"` to a model | Payment feature: serves estimate-`0` requests at $0 |
+| Where it lives | Smart router (model resolution) | Chat handler (payment path) |
+| Trigger | `model` set to `free` / `oss` / `open` | Computed atomic cost estimate is exactly `0` |
+| Effect | Picks `google/gemini-3.1-flash-lite` for every tier | Skips 402, skips payment decode/verify/settlement |
+
+<Note>
+  A `payment-signature` header sent with a free request is ignored — the quoted amount is 0, so there is nothing to verify or claim. The request is served at $0 regardless.
+</Note>
+
+## Rate limits
+
+The free path is anonymous (no payer wallet), so abuse is bounded by two gates, both enforced **before** any provider call:
+
+| Gate | Default | Window | Override env var |
+|------|---------|--------|------------------|
+| Per-IP free limit | 5 requests | 60s | `SOLVELA_FREE_TIER_RATE_LIMIT` |
+| Shared "unknown" bucket (no `ConnectInfo`) | 2 requests | 60s | Not overridable |
+| Global aggregate cap (all clients combined) | 12 requests | 60s | `SOLVELA_FREE_TIER_GLOBAL_RPM` |
+
+For comparison, the paid per-client limit defaults to 60 requests per 60s — the free limit is deliberately stricter.
+
+**Per-IP limit.** Keyed on the actual TCP peer IP, never a client-supplied header like `X-Forwarded-For` (which is trivially spoofed). `SOLVELA_FREE_TIER_RATE_LIMIT` overrides only the per-IP value; the "unknown" bucket limit is fixed. Setting the override to `0` is rejected at startup (it would disable all free access) and the default is used instead.
+
+**Global aggregate cap.** The free model is served on Google's free Gemini API tier, whose hard limit is roughly 15 requests/min shared across the gateway's entire API key. Many distinct IPs each under their per-IP cap can still collectively exceed that, so a global counter caps combined free throughput at 12/min by default — leaving headroom so the gateway returns its own clean 429 before Google's leaks through. `SOLVELA_FREE_TIER_GLOBAL_RPM=0` is likewise rejected in favor of the default. (Legacy `RCR_`-prefixed forms of both env vars are accepted as fallbacks.)
+
+The cap counter lives in Redis when configured, so it is shared across gateway instances. Without Redis — or when Redis errors at runtime — it degrades to an in-memory per-instance counter. It never goes unbounded.
+
+Gate order on the free path: per-IP check → global cap → prompt guard → provider. A rate-limited free request never consumes upstream provider quota.
+
+## What a 429 looks like
+
+Both gates return the same response shape:
+
+```json
+{
+  "error": {
+    "type": "rate_limit_exceeded",
+    "message": "Too many requests. Please slow down."
+  }
+}
+```
+
+With headers reflecting whichever limit was hit:
+
+```http
+HTTP/1.1 429 Too Many Requests
+x-ratelimit-limit: 5
+x-ratelimit-remaining: 0
+x-ratelimit-reset: 60
+retry-after: 60
+```
+
+A global-cap 429 carries `x-ratelimit-limit: 12` instead. These headers are authoritative — the outer paid-tier rate-limit middleware preserves a free-tier 429's headers rather than overwriting them with its looser limits.
+
+## Limitations
+
+- **One model.** The free tier serves `google/gemini-3.1-flash-lite` only. The `free` profile does not pick different models by complexity tier the way `eco`/`auto`/`premium` do.
+- **Tight capacity.** 5 requests/min per IP and 12/min total across all users of the gateway, by default. The free tier is for trying the gateway, not running workloads.
+- **Anonymous, IP-keyed.** Clients behind a shared NAT share one per-IP bucket. There is no per-wallet allowance — paying with a wallet is the way to get the paid limits.
+- **Prompt guard still runs.** Free requests reach a real provider, so they pass the same injection/jailbreak/PII checks as paid requests.
+- **Usage is logged at $0.** Free requests appear in spend logs under a `free-tier` sentinel (no wallet address) with `cost_usdc: 0.0`, so they show up in usage and observability but never bill.
+
+See [Smart Router](/docs/concepts/smart-router) for how routing profiles work and [x402 Protocol](/docs/concepts/x402) for the paid payment flow.

--- a/dashboard/content/docs/concepts/meta.json
+++ b/dashboard/content/docs/concepts/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Concepts",
-  "pages": ["architecture", "x402", "smart-router", "escrow", "pricing", "request-flow", "payment-flow", "payment-pre-auth", "eip712-usdc-domain"]
+  "pages": ["architecture", "x402", "a2a", "smart-router", "free-tier", "response-cache", "escrow", "pricing", "request-flow", "payment-flow", "payment-pre-auth", "eip712-usdc-domain"]
 }

--- a/dashboard/content/docs/concepts/payment-flow.mdx
+++ b/dashboard/content/docs/concepts/payment-flow.mdx
@@ -87,7 +87,7 @@ If you are using the TypeScript, Python, Rust, or Go SDK, you never need to impl
   </Step>
 
   <Step title="Sign the Solana transaction">
-    Construct a USDC-SPL transfer for the exact `amount` to the `pay_to` address and sign it with your wallet's private key. The TypeScript SDK uses `@solana/web3.js`, the Python SDK uses `solders`, and the Rust CLI uses the `solana` crate. The Go SDK ships an `UnimplementedSigner` stub; implementers typically reach for `gagliardetto/solana-go` (or any Solana RPC client) to build and sign the transfer themselves — see [the Go SDK page](/docs/sdks/go#custom-signers).
+    Construct a USDC-SPL transfer for the exact `amount` to the `pay_to` address and sign it with your wallet's private key. The TypeScript SDK uses `@solana/web3.js`, the Python SDK uses `solders`, and the Rust CLI uses the `solana` crate. The Go SDK's built-in `KeypairSigner` (`solvela.NewKeypairSigner(wallet, rpcURL)`) signs `escrow` deposits over raw Solana JSON-RPC; the `exact` scheme is intentionally unimplemented in Go, so for direct transfers implementers reach for `gagliardetto/solana-go` (or any Solana RPC client) via a custom `Signer` — see [the Go SDK page](/docs/sdks/go#custom-signers).
 
     The signing step never broadcasts the transaction — it only produces a signed transaction bytes object. The gateway broadcasts it after verifying the signature is valid.
 
@@ -113,7 +113,7 @@ If you are using the TypeScript, Python, Rust, or Go SDK, you never need to impl
   </Step>
 
   <Step title="Receive the LLM response">
-    If the signature is valid and the nonce is fresh, the gateway broadcasts the transaction to Solana, waits for confirmation, then proxies the request to the upstream LLM and streams the response back to you in standard OpenAI format.
+    If the signature is valid and the nonce is fresh, the gateway verifies the transaction (validate + simulate), proxies the request to the upstream LLM, and streams the response back to you in standard OpenAI format. For the default `exact` scheme, the on-chain broadcast is deferred until after the response is delivered — you are not charged when the provider call fails. Escrow deposits are the exception: they must land on-chain before the request is served.
 
     ```json title="Successful response"
     {
@@ -143,7 +143,7 @@ The `cost_breakdown` object is present on every 402 response. All monetary value
 | `platform_fee` | string | 5% of `provider_cost`, retained by Solvela |
 | `total` | string | `provider_cost` + `platform_fee` |
 | `currency` | string | Always `"USDC"` today |
-| `fee_percent` | number | Platform fee percentage (currently `5.0`) |
+| `fee_percent` | number | Platform fee percentage (currently `5`, serialized as an integer) |
 
 ---
 
@@ -235,14 +235,15 @@ The official SDKs expose a **per-call** payment cap (the maximum amount they wil
   </Tab>
   <Tab value="Rust">
     ```rust
-    use solvela_client::{ClientConfig, SolvelaClient, Wallet};
+    use solvela_client::{ClientBuilder, SolvelaClient, Wallet};
 
     // solvela-client caps spend per call, not per session.
     // Track lifetime spend yourself if you need a session-wide budget.
     let wallet = Wallet::from_env("SOLANA_PRIVATE_KEY")?;
-    let config = ClientConfig::new()
+    let config = ClientBuilder::new()
         .gateway_url("https://api.solvela.ai")
-        .max_payment_amount(100_000); // per-call cap: 0.10 USDC atomic
+        .max_payment_amount(100_000) // per-call cap: 0.10 USDC atomic
+        .build_config();
     let client = SolvelaClient::new(wallet, config)?;
     ```
   </Tab>
@@ -251,7 +252,7 @@ The official SDKs expose a **per-call** payment cap (the maximum amount they wil
     // solvela-go caps spend per call, not per session.
     // Track lifetime spend yourself if you need a session-wide budget.
     wallet, _ := solvela.WalletFromEnv("SOLANA_PRIVATE_KEY")
-    signer := myKeypairSigner{wallet: wallet} // see /docs/sdks/go#custom-signers
+    signer := solvela.NewKeypairSigner(wallet, "https://api.mainnet-beta.solana.com")
 
     client, err := solvela.NewClient(wallet, signer,
         solvela.WithGatewayURL("https://api.solvela.ai"),

--- a/dashboard/content/docs/concepts/payment-pre-auth.mdx
+++ b/dashboard/content/docs/concepts/payment-pre-auth.mdx
@@ -134,7 +134,7 @@ So the same opt-in client header set works for EVM with no protocol change beyon
 
 Even with pre-auth disabled on Solana and constrained on EVM, the gateway carries a related layer that limits the blast radius of accidentally-replayed requests:
 
-The existing **response cache** (`ResponseCache` in [`crates/gateway/src/cache.rs`](https://github.com/solvela-ai/solvela/blob/main/crates/gateway/src/cache.rs)) keys on `SHA-256(model ‖ serialised_messages ‖ temperature)` and stores the upstream completion for the configured TTL (default 10 minutes). A client that issues the same prompt twice within the TTL window — pre-auth header or not — gets the cached response and the upstream LLM is only charged once.
+The existing **response cache** (`ResponseCache` in [`crates/gateway/src/cache/exact.rs`](https://github.com/solvela-ai/solvela/blob/main/crates/gateway/src/cache/exact.rs)) keys on `SHA-256(model ‖ serialised_messages ‖ tools ‖ tool_choice ‖ temperature)` and stores the upstream completion for the configured TTL (default 10 minutes). A client that issues the same prompt twice within the TTL window — pre-auth header or not — gets the cached response and the upstream LLM is only charged once.
 
 This is **not** a payment-replay guard. Payment-replay protection is handled separately: the gateway tracks transaction signatures and rejects duplicate `payment-signature` headers with `402 Invalid Payment`. The response cache is a cost-control / latency optimization, not a correctness safeguard against double-charging.
 

--- a/dashboard/content/docs/concepts/pricing.mdx
+++ b/dashboard/content/docs/concepts/pricing.mdx
@@ -63,8 +63,7 @@ All prices are USDC per million tokens (provider cost before the 5% fee).
 | Gemini 3.1 Pro | `google/gemini-3.1-pro` | $2.00 | $12.00 | 1M |
 | Gemini 2.5 Flash | `google/gemini-2.5-flash` | $0.30 | $2.50 | 1M |
 | Gemini 2.5 Flash Lite | `google/gemini-2.5-flash-lite` | $0.10 | $0.40 | 1M |
-| Gemini 2.0 Flash | `google/gemini-2.0-flash` | $0.10 | $0.40 | 1M |
-| Gemini 2.0 Flash Lite | `google/gemini-2.0-flash-lite` | $0.075 | $0.30 | 1M |
+| Gemini 3.1 Flash-Lite (Free) | `google/gemini-3.1-flash-lite` | $0.00 | $0.00 | 1M |
 
 ### xAI
 
@@ -104,7 +103,7 @@ curl https://api.solvela.ai/pricing
 The gateway estimates cost at request time using:
 
 1. **Input tokens**: estimated from the messages in the request (character count / 4, approximately)
-2. **Output tokens**: `max_tokens` if specified, otherwise defaults to 1000
+2. **Output tokens**: the completion-token ceiling — the tightest of `max_tokens` (if specified), the model's declared `max_output_tokens`, and a global 8,192-token cap. When `max_tokens` is omitted, the quote reserves for the full ceiling (up to 8,192 tokens), not a flat default
 3. **Cost**: `(input_tokens * input_rate + output_tokens * output_rate) / 1_000_000 * 1.05`
 
 The actual cost charged via escrow claim is based on the real token usage returned by the provider (when available).

--- a/dashboard/content/docs/concepts/response-cache.mdx
+++ b/dashboard/content/docs/concepts/response-cache.mdx
@@ -1,0 +1,96 @@
+---
+title: Response Cache
+description: Two-tier Redis response caching — deterministic exact match plus an optional embedding-similarity tier with discounted pricing
+---
+
+
+The gateway caches LLM completions in Redis in two tiers. Tier 1 is an exact-match cache keyed by a SHA-256 hash of the request — deterministic, zero false positives by construction. Tier 2 is an optional semantic cache that matches paraphrases by embedding similarity and bills a discounted price on a hit. Tier 2 is **off by default**.
+
+Streaming requests (`stream: true`) are never cached by either tier.
+
+## Exact-match tier
+
+The cache key is a SHA-256 hash over the request content:
+
+```
+key = "solvela:cache:" + SHA256(model ‖ messages_json ‖ tools_json ‖ tool_choice_json ‖ temperature)
+```
+
+Because the key is a hash of the normalized request, a hit can only come from a content-equivalent request — one that normalizes to the same bytes. There are no false positives by construction: two genuinely different prompts always produce different keys.
+
+| In the cache key | Not in the cache key |
+|------------------|----------------------|
+| `model` | `max_tokens` |
+| `messages` (content + order) | `top_p` |
+| `tools` | `stream` (gated separately — streams bypass the cache) |
+| `tool_choice` | Payer wallet address |
+| `temperature` | |
+
+Details that matter:
+
+- **Message order is significant.** Messages are part of the conversation, so they are not sorted before hashing — the same content in a different order is a different key.
+- **Tool spec is part of the key.** `tools` and `tool_choice` materially change the response shape (`tool_calls` vs prose), so requests that differ only in their tool spec never collide.
+- **The key is wire-shape independent.** The same text prompt sent as a bare JSON string and as a text-parts array hashes to the same key, so a curl client and an array-shaped agent share hits for text-identical prompts.
+- **Images are keyed by content.** For multimodal messages, each image URL is substituted with a short stable representation before hashing: `http(s)` URLs verbatim, `data:` URIs as a hash of the declared media type plus the base64 payload. Distinct images produce distinct keys; the same image is stable; a multi-megabyte payload is never hashed into the key verbatim.
+
+### Wallet-agnostic by design
+
+Cache keys contain no payer identity. If wallet A and wallet B send identical prompts, wallet B receives the response cached for wallet A. **Both wallets pay the gateway's 402 fee** — payment verification runs before the cache check — but the upstream LLM is only charged once. This is an intentional trade-off: prompt deduplication lowers upstream costs and improves margin, at the cost of cross-wallet response sharing. If per-wallet isolation were ever required, the payer address would have to be added to the cache key.
+
+### TTL and Redis dependency
+
+- Default TTL is **600 seconds (10 minutes)**.
+- Cache writes are fire-and-forget (`tokio::spawn`) — they never block the request path.
+- Responses without a `usage` block are refused on write and evicted on read, because settlement reconciliation requires usage data.
+
+Redis is optional. When Redis is unreachable, cache reads simply miss and every request goes upstream — requests still succeed. (Transaction replay protection, which shares the same Redis client, degrades to an in-memory LRU bounded to 10,000 entries, with a warning logged.)
+
+## Semantic tier (optional)
+
+Where the exact tier matches identical requests, the semantic tier matches by **prompt-embedding similarity**: a paraphrase of a previously answered prompt can hit. Lookups run as a single KNN vector query over a RediSearch HNSW cosine index.
+
+Requirements beyond the exact tier:
+
+- Redis with the **RediSearch module** (redis-stack).
+- The local `bge-small-en-v1.5` embedding model, auto-downloaded by `fastembed` on first run (~133 MB).
+
+A candidate is returned only if cosine similarity meets the configured threshold. Hits are hard-gated to the **same model** and the **same `temperature`/`top_p`** — an answer sampled under one regime is never served for another. Like the exact tier, stored entries hold no payer identity. Prompts longer than 2,000 characters are neither cached nor served from this tier (the embedder truncates at 512 tokens, which could collide distinct long prompts); they fall through to a normal upstream call.
+
+### Discounted pricing on semantic hits
+
+A semantic hit bills `hit_price_percent` of the full all-in price (provider cost + 5% platform fee). The default is `30` — pay 30%, a 70% discount. A hit costs the gateway no upstream call, so the discounted amount is gateway revenue minus the sub-cent embedding cost.
+
+<Note>
+  The discount is realised on the **escrow** payment scheme only: the gateway claims the discounted fraction from the deposit and refunds the remainder. The direct-transfer `exact` scheme settles the full amount up front, so no discount applies there.
+</Note>
+
+### Configuration
+
+All fields live under `[cache.semantic]`:
+
+```toml title="config/default.toml"
+[cache.semantic]
+enabled = false
+threshold = 0.85
+hit_price_percent = 30
+ttl_secs = 600
+# model_cache_dir = "/var/lib/solvela/fastembed"
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Enable the semantic tier. Off by default — enabling it is the only behavior change. |
+| `threshold` | `0.85` | Minimum cosine similarity for a hit, in `(0.0, 1.0]`. PoC data put paraphrases ≥ 0.89 and unrelated prompts ≤ 0.59. |
+| `hit_price_percent` | `30` | Percent of the full price billed on a hit, in `1..=100`. |
+| `ttl_secs` | `600` | TTL in seconds for stored semantic entries. Must be ≥ 1. |
+| `model_cache_dir` | unset | Explicit on-disk directory for the embedding model. Unset → `fastembed`'s default `./.fastembed_cache`. |
+
+<Warning>
+  When the tier is enabled, invalid values are **fatal at startup**, not silently degraded: `threshold` outside `(0.0, 1.0]`, `hit_price_percent` outside `1..=100`, or `ttl_secs = 0` all refuse to boot. A misconfigured running cache is an operator error, distinct from Redis being unavailable (which degrades gracefully).
+</Warning>
+
+## See also
+
+- [Escrow System](/docs/concepts/escrow) — how the semantic discount is claimed and refunded on-chain
+- [x402 Protocol](/docs/concepts/x402) — the payment flow that runs before any cache check
+- [Pricing](/docs/concepts/pricing) — model pricing and the 5% platform fee

--- a/dashboard/content/docs/concepts/smart-router.mdx
+++ b/dashboard/content/docs/concepts/smart-router.mdx
@@ -84,7 +84,7 @@ Each (Profile, Tier) pair maps to a specific model:
 | Complex | `deepseek/deepseek-chat` | `google/gemini-3.1-pro` | `anthropic/claude-opus-4-6` | `google/gemini-3.1-flash-lite` |
 | Reasoning | `deepseek/deepseek-reasoner` | `xai/grok-4-fast-reasoning` | `openai/o3` | `google/gemini-3.1-flash-lite` |
 
-> **`free` profile vs. the free tier:** the `free` profile is a routing choice — it sends every tier to the zero-cost model. Separately, any request whose estimated cost is zero (which is what routing to a zero-cost model produces) skips the 402 payment challenge entirely: no wallet or signature needed. Free-tier traffic is subject to per-IP and aggregate rate limits.
+> **`free` profile vs. the free tier:** the `free` profile is a routing choice — it sends every tier to the zero-cost model. Separately, any request whose estimated cost is zero (which is what routing to a zero-cost model produces) skips the 402 payment challenge entirely: no wallet or signature needed. Free-tier traffic is subject to per-IP and aggregate rate limits. See [Free tier](/docs/concepts/free-tier) for details.
 
 ## Example: same prompt, different profiles
 
@@ -108,7 +108,7 @@ Tier: Reasoning (reasoning markers: "prove", "step by step", "analyze", "compare
 ```
 
 <Note>
-  The router classifies based on user message content only. System messages and assistant turns do not affect the score.
+  The router's keyword dimensions score user message content only, but the conversation-depth dimension counts every message — system and assistant turns included — so a long history can nudge a request across a tier boundary.
 </Note>
 
 ## Bypassing the router

--- a/dashboard/content/docs/enterprise/analytics.mdx
+++ b/dashboard/content/docs/enterprise/analytics.mdx
@@ -13,7 +13,7 @@ All `total_cost_usdc` values are in USDC (e.g. `4.75` = $4.75 USDC).
 
 ## Team stats
 
-Returns spend and requests for a single team, broken down by model and by wallet.
+Returns spend and requests for a single team, broken down by model, by provider, and by wallet.
 
 Requires `member` role or higher.
 
@@ -44,6 +44,18 @@ Authorization: Bearer <admin-token | solvela_k_...>
     },
     {
       "model": "gpt-4o-mini",
+      "request_count": 2721,
+      "total_cost_usdc": 48.30
+    }
+  ],
+  "by_provider": [
+    {
+      "provider": "anthropic",
+      "request_count": 2100,
+      "total_cost_usdc": 94.50
+    },
+    {
+      "provider": "openai",
       "request_count": 2721,
       "total_cost_usdc": 48.30
     }

--- a/dashboard/content/docs/enterprise/teams.mdx
+++ b/dashboard/content/docs/enterprise/teams.mdx
@@ -30,7 +30,8 @@ Content-Type: application/json
   "id": "019c3d4e-...",
   "org_id": "018f1a2b-...",
   "name": "research-agents",
-  "created_at": "2025-09-01T00:00:00Z"
+  "created_at": "2025-09-01T00:00:00Z",
+  "updated_at": "2025-09-01T00:00:00Z"
 }
 ```
 
@@ -45,7 +46,7 @@ Authorization: Bearer <admin-token | solvela_k_...>
 
 ## Add a member
 
-Requires `admin` or `owner` role. Non-owners cannot assign the `owner` role.
+Requires `admin` or `owner` role. Non-owners cannot assign the `owner` or `admin` role.
 
 ```http title="POST /v1/orgs/:id/members"
 POST /v1/orgs/018f1a2b-.../members

--- a/dashboard/content/docs/operations/deployment.mdx
+++ b/dashboard/content/docs/operations/deployment.mdx
@@ -18,7 +18,7 @@ Services:
 | Service | Image | Port | Purpose |
 |---------|-------|------|---------|
 | `postgres` | `postgres:16-alpine` | `127.0.0.1:5432` | Spend logs, wallet budgets |
-| `redis` | `redis:7-alpine` | `127.0.0.1:6379` | Response cache, replay protection |
+| `redis` | `redis/redis-stack-server:7.4.0-v3` | `127.0.0.1:6379` | Response cache, replay protection (redis-stack bundles the RediSearch module the semantic cache needs) |
 
 <Warning>
 Default credentials (`solvela` / `solvela_dev_password`) are for local development only. Never use in production.
@@ -26,7 +26,7 @@ Default credentials (`solvela` / `solvela_dev_password`) are for local developme
 
 Ports are bound to `127.0.0.1` only -- not accessible from the network.
 
-Redis is configured with 256MB LRU eviction and no RDB persistence (the cache is ephemeral).
+Redis is configured with 256MB LRU eviction. Default RDB snapshotting is left on — harmless for an ephemeral local-dev cache.
 
 Migrations in `migrations/` are mounted into the PostgreSQL container and run automatically on first start.
 
@@ -36,8 +36,10 @@ The `Dockerfile` uses a 2-stage build. Dependency caching is achieved by copying
 
 ```dockerfile
 # Stage 1: Build
-FROM rust:1.88-slim-bookworm AS builder
-RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+FROM rust:1.96-slim-trixie AS builder
+# g++ is required so the linker can resolve -lstdc++ — the fastembed
+# dep pulls in the ONNX Runtime C++ bindings (via `ort` / `ort-sys`).
+RUN apt-get update && apt-get install -y pkg-config libssl-dev g++ && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 # Copy workspace manifests first for dependency caching
@@ -67,8 +69,10 @@ RUN touch crates/protocol/src/lib.rs crates/x402/src/lib.rs crates/router/src/li
 RUN cargo build --release --bin solvela-gateway
 
 # Stage 2: Runtime
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM debian:trixie-slim
+# libstdc++6 is the runtime counterpart to the builder's g++ — fastembed's
+# ONNX Runtime layer dynamically links against libstdc++.so.6.
+RUN apt-get update && apt-get install -y ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*
 
 # Create non-root runtime user (no home, no login shell)
 RUN useradd --uid 1001 --no-create-home --shell /usr/sbin/nologin solvela
@@ -85,7 +89,7 @@ Key points:
 
 - Dependency caching is layer-based: workspace `Cargo.toml`s + dummy sources compile first; the real source is copied in a later layer so unchanged dependencies don't rebuild.
 - Migration SQL files in `migrations/` are read at compile time by `sqlx::migrate!`, so they must be present in the build context.
-- Runtime image is `debian:bookworm-slim` with only `ca-certificates` installed.
+- Runtime image is `debian:trixie-slim` with only `ca-certificates` and `libstdc++6` installed.
 - Exposes port 8402.
 - Runs as non-root user `solvela` (UID 1001). Files copied from the build stage use `--chown=solvela:solvela` so the binary and config are owned by the runtime user.
 
@@ -137,7 +141,7 @@ primary_region = "ord"
     protocol = "http"
     timeout = "5s"
 
-[vm]
+[[vm]]
   size = "shared-cpu-1x"
   memory = "512mb"
 ```

--- a/dashboard/content/docs/operations/monitoring.mdx
+++ b/dashboard/content/docs/operations/monitoring.mdx
@@ -47,7 +47,7 @@ scrape_configs:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `solvela_payments_total` | Counter | `status` | Payment outcomes. Status values: `verified` (valid payment), `dev_bypass` (payment bypass enabled in dev), `none` (402 returned, no payment header), `failed` (verification failed). |
+| `solvela_payments_total` | Counter | `status` | Payment outcomes. Status values: `verified` (valid payment), `settled` (payment settled), `settle_after_deliver_failed` (settlement failed after delivery), `dev_bypass` (payment bypass enabled in dev), `none` (402 returned, no payment header), `failed` (verification failed), `free` (zero-cost bypass), `free_rate_limited` / `free_global_rate_limited` (free-tier 429s), `escrow_unclaimed_provider_failure` (escrow deposit left unclaimed because the provider call failed). |
 | `solvela_payment_amount_usdc` | Histogram | -- | Distribution of payment amounts in USDC. |
 | `solvela_replay_rejections_total` | Counter | -- | Number of rejected replay attacks. |
 | `solvela_paid_stub_rejections_total` | Counter | -- | Paid requests that reached the fallback-stub path because every provider failed. The gateway returns an error instead of a stub so a paying caller never receives a fabricated response. |
@@ -63,7 +63,7 @@ scrape_configs:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `solvela_cache_total` | Counter | `result` | Cache outcomes. Result values: `hit` (served from cache), `miss` (not cached), `skip` (caching disabled or streaming). |
+| `solvela_cache_total` | Counter | `result` | Cache outcomes. Result values: `hit` (served from the exact-match cache), `semantic_hit` (served from the semantic tier), `miss` (not cached), `skip` (caching disabled or streaming). |
 
 ### Escrow Metrics
 

--- a/dashboard/content/docs/operations/troubleshooting.mdx
+++ b/dashboard/content/docs/operations/troubleshooting.mdx
@@ -9,7 +9,7 @@ description: Common issues, debug headers, and diagnostics
 |---------|-------|-----|
 | Paid chat requests return 500 with `error.type = "internal_error"` and `"all providers failed"` | No upstream provider API key configured for the resolved model's provider | Set at least one matching provider key in `.env` (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `DEEPSEEK_API_KEY`) and restart the gateway |
 | 402 response but SDK does not auto-pay | Wallet key env var not set, or read under the wrong name (the CLI reads `SOLANA_WALLET_KEY`; the TypeScript/Python SDK examples read `SOLANA_PRIVATE_KEY` — the env var name is whatever you pass to `Wallet.fromEnv()` / `Wallet.from_env()`) | Set the env var your code reads and verify the value is a base58-encoded Solana keypair |
-| 402 returned with `accepts[0].amount: "0"` | Using a free model (`gpt-oss-120b`) | Free models do not require payment; remove the `PAYMENT-SIGNATURE` header |
+| Free-model request served at $0 even with a `PAYMENT-SIGNATURE` header | Using a free model (`google/gemini-3.1-flash-lite`) — zero-cost requests skip the 402 challenge entirely and any payment header is ignored | Expected behavior; no payment is needed for free models |
 | Redis connection refused | Redis not running | Run `docker compose up -d redis` |
 | 402 `"transaction has already been used; each payment signature may only be submitted once"` | Same transaction signature submitted twice | Generate a new transaction for each request |
 | 400 `"payment amount insufficient: paid N but cost is M atomic USDC"` | Signed amount less than the quoted price | Fetch a fresh 402, use `accepts[0].amount` exactly (atomic units: 1 USDC = 1,000,000) |
@@ -23,7 +23,7 @@ description: Common issues, debug headers, and diagnostics
 | Wallet stats returns 503 | PostgreSQL not configured | Set `DATABASE_URL` in `.env` |
 | CORS errors in browser | Origin not in allowlist | Add your domain to `SOLVELA_CORS_ORIGINS` (or `RCR_CORS_ORIGINS` for backward compat) |
 | Slow responses (>10s) | Provider latency or network issues | Check `solvela_provider_request_duration_seconds` metric; try a different provider |
-| "circuit breaker open" in escrow health | >50% claim failures in 5-minute window | Wait 1 minute for auto-reset; check fee payer balance and RPC connectivity |
+| "claim circuit breaker OPENED" in gateway logs | >50% claim failures in 5-minute window (minimum 4 samples) | Wait 1 minute for auto-reset; check fee payer balance and RPC connectivity |
 
 ## Debug Headers
 
@@ -78,14 +78,14 @@ curl -s http://localhost:8402/v1/escrow/health \
 
 Key fields to check:
 
-- `claims_failed > 0`: some claims are failing; check fee payer balance
-- `circuit_breaker_open: true`: claiming is paused; check RPC connectivity
-- `queue_depth > 50`: claim processing is falling behind
-- `fee_payers_healthy < fee_payers_total`: some fee payer keys are in cooldown
+- `status`: `"ok"`, `"degraded"` (claim processor not running or no fee payer wallets), or `"down"` (escrow disabled)
+- `claims.failed > 0`: some claims are failing; check fee payer balance
+- `claims.pending_in_queue > 50`: claim processing is falling behind
+- `fee_payer_wallets == 0`: no fee payer keys loaded — claims cannot be submitted
 
 ## CLI Diagnostics
 
-The `solvela doctor` command runs a comprehensive check:
+The `solvela doctor` command runs a quick diagnostic:
 
 ```bash
 cargo run -p solvela-cli -- doctor
@@ -93,14 +93,12 @@ cargo run -p solvela-cli -- doctor
 
 Checks performed:
 
-1. **Wallet loaded** -- verifies `SOLANA_WALLET_KEY` is valid
-2. **Gateway reachable** -- connects to the gateway's `/health` endpoint
-3. **Models available** -- fetches model list from `/v1/models`
-4. **RPC connected** -- verifies Solana RPC connectivity
-5. **Balance check** -- queries USDC-SPL balance
-6. **Payment flow** -- sends a test request and verifies the 402/200 cycle
+1. **Gateway reachable** -- connects to the gateway's `/health` endpoint (`OK` / `ERROR` / `FAIL`)
+2. **Wallet file** -- checks that `~/.solvela/wallet.json` exists (`FOUND` / `NOT FOUND`); it does not validate the key
+3. **Models available** -- fetches the model list from `/v1/models` (`OK (N models)` / `UNAVAILABLE`)
+4. **`SOLANA_WALLET_KEY`** -- reports whether the env var is set (`SET` / `NOT SET`)
 
-Each check reports PASS, FAIL, WARN, or SKIP.
+It does not test Solana RPC connectivity, USDC balance, or the 402/200 payment cycle — use `solvela wallet status` and a real request for those.
 
 ## Log Levels
 
@@ -148,7 +146,7 @@ psql postgres://solvela:solvela_dev_password@localhost:5432/solvela \
 
 # Check spend logs
 psql postgres://solvela:solvela_dev_password@localhost:5432/solvela \
-  -c "SELECT COUNT(*) FROM spend_log"
+  -c "SELECT COUNT(*) FROM spend_logs"
 ```
 
 ## Redis Troubleshooting

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -56,34 +56,48 @@ First, send a request without any payment header. The gateway will respond with 
 <Tabs items={['TypeScript', 'Python', 'Go', 'cURL']}>
   <Tab value="TypeScript">
     ```typescript
-    import { SolvelaClient, ChatRequest, ChatMessage } from '@solvela/sdk';
+    import { SolvelaClient, ChatRequest, ChatMessage, PaymentRequiredError } from '@solvela/sdk';
 
     const client = new SolvelaClient({
       config: { gatewayUrl: 'https://api.solvela.ai' },
     });
 
-    // The SDK automatically handles the 402 flow —
-    // you only need a private key (via env or a Signer) to sign.
-    const response = await client.chat(
-      new ChatRequest('auto', [new ChatMessage('user', 'What is x402?')]),
-    );
-    console.log(response.choices[0].message.content);
+    // No signer wired in — paid requests throw PaymentRequiredError,
+    // so we can see the price quote. The next step wires in a signer
+    // so the SDK handles the 402 flow automatically.
+    try {
+      await client.chat(
+        new ChatRequest('auto', [new ChatMessage('user', 'What is x402?')]),
+      );
+    } catch (e) {
+      if (e instanceof PaymentRequiredError) {
+        const cost = e.paymentRequired.costBreakdown;
+        console.log(`price quote: ${cost.total} ${cost.currency}`);
+      } else {
+        throw e;
+      }
+    }
     ```
   </Tab>
   <Tab value="Python">
     ```python
     import asyncio
-    from solvela import SolvelaClient
+    from solvela import SolvelaClient, PaymentRequiredError
     from solvela.types import ChatRequest, ChatMessage, Role
 
     async def main():
         client = SolvelaClient()  # defaults to https://api.solvela.ai
-        # The SDK handles the 402 flow when a Signer is configured.
-        response = await client.chat(ChatRequest(
-            model='auto',
-            messages=[ChatMessage(role=Role.USER, content='What is x402?')],
-        ))
-        print(response.choices[0].message.content)
+        # No signer wired in — paid requests raise PaymentRequiredError,
+        # so we can see the price quote. The next step wires in a signer
+        # so the SDK handles the 402 flow automatically.
+        try:
+            await client.chat(ChatRequest(
+                model='auto',
+                messages=[ChatMessage(role=Role.USER, content='What is x402?')],
+            ))
+        except PaymentRequiredError as exc:
+            cost = exc.payment_required.cost_breakdown
+            print(f'price quote: {cost.total} {cost.currency}')
 
     asyncio.run(main())
     ```
@@ -213,11 +227,15 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
 <Tabs items={['TypeScript', 'Python', 'Go', 'solvela CLI']}>
   <Tab value="TypeScript">
     ```typescript
-    import { SolvelaClient, ChatRequest, ChatMessage } from '@solvela/sdk';
+    import { SolvelaClient, ChatRequest, ChatMessage, Wallet, KeypairSigner } from '@solvela/sdk';
 
-    // The SDK reads SOLANA_PRIVATE_KEY from env by default, or you can
-    // pass an explicit `wallet` + `signer` in the constructor options.
+    // Construct the wallet + signer explicitly — the SDK does not read
+    // SOLANA_PRIVATE_KEY on its own.
+    const wallet = Wallet.fromEnv('SOLANA_PRIVATE_KEY');
+    const signer = new KeypairSigner(wallet);
     const client = new SolvelaClient({
+      wallet,
+      signer,
       config: { gatewayUrl: 'https://api.solvela.ai' },
     });
 
@@ -258,9 +276,10 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
         log.Fatal(err)
     }
 
-    // solvela-go ships an UnimplementedSigner stub; implement the Signer
-    // interface yourself for production paid requests. See /docs/sdks/go.
-    signer := myKeypairSigner{wallet: wallet}
+    // The built-in KeypairSigner signs escrow-scheme payments; the exact
+    // scheme is not yet implemented in Go (supply a custom Signer for it).
+    // Pass "" to default to mainnet-beta RPC. See /docs/sdks/go.
+    signer := solvela.NewKeypairSigner(wallet, "")
 
     client, err := solvela.NewClient(wallet, signer,
         solvela.WithGatewayURL("https://api.solvela.ai"),
@@ -319,7 +338,7 @@ A successful response is standard OpenAI format. Gateway-specific metadata (requ
 ## What's next
 
 <Note>
-  The SDKs handle all of this for you. If you're using TypeScript or Python, you only need to pass a private key — the rest is automatic. The Go SDK ships an `UnimplementedSigner` stub; see [the Go SDK page](/docs/sdks/go#custom-signers) for plugging in your own `Signer`.
+  The SDKs handle all of this for you. If you're using TypeScript or Python, you only need to pass a private key — the rest is automatic. The Go SDK's built-in `KeypairSigner` signs escrow-scheme payments only (`exact` is intentionally unimplemented); see [the Go SDK page](/docs/sdks/go) for supplying your own `Signer`.
 </Note>
 
 - [x402 Protocol](/docs/concepts/x402) — understand the full payment flow

--- a/dashboard/content/docs/sdks/ai-sdk.mdx
+++ b/dashboard/content/docs/sdks/ai-sdk.mdx
@@ -184,7 +184,7 @@ const result = streamText({
 
 for await (const chunk of result.fullStream) {
   if (chunk.type === 'text-delta') {
-    process.stdout.write(chunk.delta);
+    process.stdout.write(chunk.text);
   }
 }
 ```

--- a/dashboard/content/docs/sdks/go.mdx
+++ b/dashboard/content/docs/sdks/go.mdx
@@ -16,10 +16,10 @@ description: Go client for Solvela with functional-option configuration and tran
 go get github.com/solvela-ai/solvela/sdks/go
 ```
 
-The SDK depends only on the standard library plus `github.com/mr-tron/base58`. No Solana SDK is pulled in by default — that decision is left to the `Signer` implementation you plug in.
+The SDK depends only on the standard library plus `github.com/mr-tron/base58` and `filippo.io/edwards25519`. No full Solana SDK is pulled in — the built-in `KeypairSigner` builds transactions over raw Solana JSON-RPC.
 
 <Note>
-  **`UnimplementedSigner` is a stub.** The signer shipped in `solvela-go` returns an error from `SignPayment` — it exists so the package compiles, not so it signs. To make paid requests, implement the `Signer` interface yourself (see [Custom signers](#custom-signers)) or call the gateway through the Python or TypeScript SDK, which ship working keypair signers.
+  **`KeypairSigner` signs `escrow` only.** The default signer (`solvela.NewKeypairSigner(wallet, rpcURL)`) builds real on-chain escrow deposits, and scheme selection automatically prefers `escrow` for it (via the optional `SchemeCapable` interface). The `exact` (direct USDC-SPL transfer) scheme is intentionally unimplemented in Go — `SignPayment` returns a clear error rather than silently substituting another scheme. For exact-scheme payments, use the Rust SDK or supply a custom `Signer` (see [Custom signers](#custom-signers)).
 </Note>
 
 ## Quick start
@@ -79,6 +79,7 @@ client, err := solvela.NewClient(wallet, signer,
 	solvela.WithTimeout(60*time.Second),                  // default: 180s
 	solvela.WithMaxPaymentAmount(10_000_000),             // per-call cap: 10 USDC atomic
 	solvela.WithExpectedRecipient("recipient-wallet-pub"),// if set, gateway must pay-to this
+	solvela.WithExpectedEscrowProgram(solvela.MainnetEscrowProgramID), // escrow program pin (this is the default)
 	solvela.WithCache(true),                              // opt-in response caching
 	solvela.WithSessions(true),                           // opt-in three-strike escalation
 	solvela.WithSessionTTL(30*time.Minute),
@@ -95,6 +96,8 @@ client, err := solvela.NewClient(wallet, signer,
 | `WithTimeout(d)` | Override the 180s default HTTP timeout. |
 | `WithMaxPaymentAmount(atomic)` | Cap each signed payment. Default: 10 USDC (`10_000_000` atomic units). |
 | `WithExpectedRecipient(addr)` | Refuse 402s whose `pay_to` doesn't match. |
+| `WithExpectedEscrowProgram(id)` | Pin the escrow program ID the client will sign deposits against. Default: `MainnetEscrowProgramID`. |
+| `DisableEscrowProgramPin()` | Clear the escrow-program pin, allowing any advertised program ID. Prefer `WithExpectedEscrowProgram` for non-default deployments. |
 | `WithCache(bool)` / `WithSessions(bool)` | Toggle in-memory caches. Default: both off. |
 | `WithSessionTTL(d)` | Lifetime of session entries when sessions are on. |
 | `WithQualityCheck(bool)` / `WithMaxQualityRetries(n)` | Retry on empty/repetitive/truncated responses. |
@@ -106,6 +109,7 @@ client, err := solvela.NewClient(wallet, signer,
 - Non-loopback `gateway_url` must use `https://`. Plaintext `http://` to a remote host returns `*ClientError` from `NewClient`.
 - Unknown payment schemes from the gateway raise `*ClientError` at JSON decode time rather than silently mis-branching downstream.
 - `MaxPaymentAmount` defaults to 10 USDC (atomic) — a misbehaving gateway cannot drain the wallet on a single call.
+- `ExpectedEscrowProgram` is pinned to `MainnetEscrowProgramID` by default, so an escrow deposit is never signed against an unexpected program — a mismatching 402 returns `*EscrowProgramMismatchError` before signing. Repoint with `WithExpectedEscrowProgram` or clear with `DisableEscrowProgramPin`.
 - The HTTP client refuses redirects to keep the `Payment-Signature` header from leaking to a third party.
 
 ## The chat flow
@@ -158,8 +162,8 @@ client, err := solvela.NewClient(wallet, signer,
     	log.Fatal(err)
     }
 
-    // Implement your own Signer — see the Custom signers section below.
-    signer := myKeypairSigner{wallet: wallet}
+    // The built-in KeypairSigner signs escrow-scheme payments.
+    signer := solvela.NewKeypairSigner(wallet, "https://api.mainnet-beta.solana.com")
 
     client, err := solvela.NewClient(wallet, signer,
     	solvela.WithGatewayURL("https://api.solvela.ai"),
@@ -214,7 +218,7 @@ for chunk := range ch {
 fmt.Println()
 ```
 
-`ChatStream` runs the same preflight payment handshake as `Chat` — a `Signer` is required for paid streaming, otherwise the call returns `*PaymentRequiredError` before opening the stream. A post-signing 402 on the streaming POST is converted to `*PaymentRejectedError`.
+`ChatStream` runs the same preflight payment handshake as `Chat` — a `Signer` is required for paid streaming, otherwise the call returns `*PaymentRequiredError` before opening the stream. A post-signing 402 on the streaming POST surfaces as `*PaymentRequiredError` (unlike the non-streaming path, it is not converted to `*PaymentRejectedError`).
 
 ## Models and pricing
 
@@ -281,6 +285,7 @@ if err != nil {
 | `*PaymentRejectedError` | Gateway returns 402 *again* after a signed retry. Carries `Reason`. |
 | `*AmountExceedsMaxError` | Gateway's quoted amount exceeds the configured `MaxPaymentAmount`. Carries `Amount` and `MaxAmount`. |
 | `*RecipientMismatchError` | Gateway's `pay_to` doesn't match the configured `ExpectedRecipient`. |
+| `*EscrowProgramMismatchError` | The 402's escrow program ID doesn't match the configured `ExpectedEscrowProgram` pin. Returned before any escrow deposit is signed. Carries `Expected` and `Actual`. |
 | `*InsufficientBalanceError` | Wallet balance is too low for the quoted amount. Carries `Have` / `Need`. |
 | `*GatewayError` | Non-200/402 HTTP response. Carries `Status` and `Message`. |
 | `*SignerError` | The configured `Signer` failed to build or sign the payment transaction. |
@@ -337,7 +342,7 @@ wg.Wait()
 
 ## Custom signers
 
-`solvela-go` ships only the `UnimplementedSigner` stub. To send paid requests, implement the `Signer` interface yourself:
+The built-in `KeypairSigner` signs `escrow`-scheme payments only. To sign `exact`-scheme payments — or to plug in HSM-backed signing or a custodial backend — implement the `Signer` interface yourself:
 
 ```go
 type Signer interface {
@@ -383,7 +388,7 @@ Wire amounts (`PaymentAccept.Amount`) are decimal strings in atomic USDC units (
 
 ## Smoke harness
 
-A 100-line smoke test in [`sdks/go/scripts/smoke/main.go`](https://github.com/solvela-ai/solvela/blob/main/sdks/go/scripts/smoke/main.go) exercises the wire contract against a live gateway: it lists models, asserts at least one reports streaming + paid input pricing, and issues an unsigned chat to verify the 402 round-trip parses cleanly. Run it before tagging a release:
+A smoke test in [`sdks/go/scripts/smoke/main.go`](https://github.com/solvela-ai/solvela/blob/main/sdks/go/scripts/smoke/main.go) exercises the wire contract against a live gateway: it lists models, asserts at least one reports streaming + paid input pricing, and issues an unsigned chat to verify the 402 round-trip parses cleanly. Run it before tagging a release:
 
 ```bash
 SOLVELA_GATEWAY_URL=https://staging.solvela.ai go run ./scripts/smoke

--- a/dashboard/content/docs/sdks/index.mdx
+++ b/dashboard/content/docs/sdks/index.mdx
@@ -16,7 +16,7 @@ Official SDKs are available for four languages plus an MCP server. All SDKs hand
 |----------|---------|---------|-------------------|-------|
 | TypeScript | `@solvela/sdk` | `npm install @solvela/sdk@^0.2.4` | Yes | Yes |
 | Python | `solvela-sdk` | `pip install solvela-sdk` | Yes | Yes (async-only) |
-| Go | `github.com/solvela-ai/solvela/sdks/go` | `go get github.com/solvela-ai/solvela/sdks/go` | Yes (BYO Signer) | Yes (context-based) |
+| Go | `github.com/solvela-ai/solvela/sdks/go` | `go get github.com/solvela-ai/solvela/sdks/go` | Yes (built-in `KeypairSigner`, escrow scheme; `exact` needs a custom Signer) | Yes (context-based) |
 | Rust CLI | `solvela-cli` | `cargo install solvela-cli` | Yes | — |
 | MCP Server | (in-monorepo, not on npm) | see [MCP page](/docs/sdks/mcp) | Yes | — |
 
@@ -30,12 +30,12 @@ All four language SDKs live in the [`solvela-ai/solvela`](https://github.com/sol
 - MCP server — [`sdks/mcp/`](https://github.com/solvela-ai/solvela/tree/main/sdks/mcp)
 - Vercel AI SDK provider, OpenClaw provider, npm CLI shim, signer-core primitives — [`sdks/ai-sdk-provider/`](https://github.com/solvela-ai/solvela/tree/main/sdks/ai-sdk-provider), [`sdks/openclaw-provider/`](https://github.com/solvela-ai/solvela/tree/main/sdks/openclaw-provider), [`sdks/cli-npm/`](https://github.com/solvela-ai/solvela/tree/main/sdks/cli-npm), [`sdks/signer-core/`](https://github.com/solvela-ai/solvela/tree/main/sdks/signer-core)
 
-The Rust client SDK was consolidated into the monorepo on 2026-05-16 ([#316](https://github.com/solvela-ai/solvela/pull/316)) at [`sdks/rust/`](https://github.com/solvela-ai/solvela/tree/main/sdks/rust); the standalone `solvela-ai/solvela-client` repo is archived. The four legacy Rust crates (`solvela-client`, `solvela-client-cli`, `solvela-client-cli-args`, `solvela-client-proxy`) remain published on crates.io at `0.2.1` — `cargo install solvela-client-cli` still works. The monorepo's flagship CLI is `solvela-cli` (`cargo install solvela-cli`); a monorepo-native publish workflow for the four legacy crates is the remaining runbook step.
+The Rust client SDK was consolidated into the monorepo on 2026-05-16 ([#316](https://github.com/solvela-ai/solvela/pull/316)) at [`sdks/rust/`](https://github.com/solvela-ai/solvela/tree/main/sdks/rust); the standalone `solvela-ai/solvela-client` repo is archived. The four legacy Rust crates (`solvela-client`, `solvela-client-cli`, `solvela-client-cli-args`, `solvela-client-proxy`) remain published on crates.io (currently `0.2.5`) — `cargo install solvela-client-cli` still works, and they now publish from the monorepo via a tag-triggered workflow. The monorepo's flagship CLI is `solvela-cli` (`cargo install solvela-cli`).
 
 <CardGroup>
   <Card title="TypeScript" description="@solvela/sdk@^0.2.4 — async client with automatic x402 signing and built-in Solana wallet support" href="/docs/sdks/typescript" />
   <Card title="Python" description="pip install solvela-sdk — async-first client with built-in Solana signing" href="/docs/sdks/python" />
-  <Card title="Go" description="go get github.com/solvela-ai/solvela/sdks/go — context-aware, goroutine-safe; ships an UnimplementedSigner stub (bring your own)" href="/docs/sdks/go" />
+  <Card title="Go" description="go get github.com/solvela-ai/solvela/sdks/go — context-aware, goroutine-safe; built-in KeypairSigner signs the escrow scheme (exact needs a custom Signer)" href="/docs/sdks/go" />
   <Card title="Rust CLI" description="cargo install solvela-cli — interactive chat, model listing, health checks" href="/docs/sdks/rust" />
   <Card title="MCP Server" description="In-monorepo MCP server — expose Solvela to MCP-compatible AI agents" href="/docs/sdks/mcp" />
 </CardGroup>

--- a/dashboard/content/docs/sdks/mcp.mdx
+++ b/dashboard/content/docs/sdks/mcp.mdx
@@ -39,8 +39,9 @@ The server reads these environment variables on startup:
 | `SOLVELA_SESSION_BUDGET` | No | Per-session USDC cap (e.g. `2.00`) |
 | `SOLVELA_TIMEOUT_MS` | No | HTTP timeout for gateway calls |
 | `SOLVELA_SIGNING_MODE` | No | `auto` / `escrow` / `direct` / `off` (default `auto`) |
-| `SOLVELA_ESCROW_PROGRAM_ID` | If `escrow` mode | Escrow program ID on Solana mainnet |
-| `SOLVELA_RECIPIENT_WALLET` | If `escrow` mode | Gateway recipient pubkey |
+| `SOLVELA_ESCROW_MODE` | No | Set to `enabled` to expose the `deposit_escrow` tool |
+| `SOLVELA_ESCROW_PROGRAM_ID` | If `SOLVELA_ESCROW_MODE=enabled` | Escrow program ID on Solana mainnet |
+| `SOLVELA_RECIPIENT_WALLET` | If `SOLVELA_ESCROW_MODE=enabled` | Gateway recipient pubkey |
 
 ```bash
 export SOLVELA_API_URL=https://api.solvela.ai
@@ -87,7 +88,7 @@ The MCP server exposes the following tools to connected agents:
 | `wallet_status` | Check the configured Solana wallet's status and gateway connectivity |
 | `list_models` | List available models with pricing |
 | `spending` | Show USDC spending statistics for the current session |
-| `deposit_escrow` | Deposit USDC into a trustless escrow PDA for a future call |
+| `deposit_escrow` | Deposit USDC into a trustless escrow PDA for a future call (only listed when `SOLVELA_ESCROW_MODE=enabled`) |
 
 ## Example usage in Claude Desktop
 

--- a/dashboard/content/docs/sdks/python.mdx
+++ b/dashboard/content/docs/sdks/python.mdx
@@ -46,6 +46,7 @@ Without a `Signer`, paid endpoints raise `PaymentRequiredError` on the first cal
   <Tab value="Dataclass">
     ```python
     from solvela import ClientConfig
+    from solvela.constants import MAINNET_ESCROW_PROGRAM_ID
     from solvela.types import AtomicUsdc
 
     config = ClientConfig(
@@ -55,6 +56,7 @@ Without a `Signer`, paid endpoints raise `PaymentRequiredError` on the first cal
         timeout=180.0,
         max_payment_amount=AtomicUsdc(10_000_000),  # cap per call (10 USDC = 10_000_000 atomic)
         expected_recipient=None,                # if set, gateway must pay-to this address
+        expected_escrow_program_id=MAINNET_ESCROW_PROGRAM_ID,  # default-on escrow program pin
         enable_cache=False,                     # opt-in response caching
         enable_sessions=False,                  # opt-in three-strike session escalation
         session_ttl=1800.0,
@@ -79,12 +81,17 @@ Without a `Signer`, paid endpoints raise `PaymentRequiredError` on the first cal
         .build()
     )
     ```
+
+    The builder also exposes `.expected_escrow_program_id(value)` to repoint the
+    escrow-program pin (e.g. at a devnet deployment) and
+    `.disable_escrow_program_pin()` to clear it entirely.
   </Tab>
 </Tabs>
 
 ### Security defaults
 
 - Non-loopback `gateway_url` or `rpc_url` must use `https://`. Plain `http://` to a remote host raises `ClientError` at construction.
+- `expected_escrow_program_id` is pinned to `MAINNET_ESCROW_PROGRAM_ID` by default, so an escrow deposit is never signed against an unexpected program — a mismatching 402 raises `EscrowProgramMismatchError` before signing.
 - Unknown payment schemes from the gateway raise `ClientError` rather than silently mis-branching.
 - Malformed amount strings in the 402 body raise `ClientError`, not bare `ValueError`.
 
@@ -199,6 +206,7 @@ from solvela import (
     PaymentRejectedError,
     AmountExceedsMaxError,
     RecipientMismatchError,
+    EscrowProgramMismatchError,
     InsufficientBalanceError,
     GatewayError,
     SignerError,
@@ -227,6 +235,7 @@ except SolvelaTimeoutError as exc:
 | `PaymentRejectedError` | Gateway returns 402 *again* after a signed retry. Carries `reason` and (optional) `payment_required`. |
 | `AmountExceedsMaxError` | Gateway's quoted amount exceeds the local `max_payment_amount` cap. Carries `amount` and `max_amount` as `AtomicUsdc`. |
 | `RecipientMismatchError` | Gateway's `pay_to` doesn't match the configured `expected_recipient`. |
+| `EscrowProgramMismatchError` | The 402's escrow program ID doesn't match the configured `expected_escrow_program_id` pin. Raised before any escrow deposit is signed. Carries `expected` and `actual`. |
 | `InsufficientBalanceError` | Wallet balance is too low for the quoted amount. Carries `have` / `need` as `AtomicUsdc`. |
 | `GatewayError` | Non-200/402 HTTP response. Carries `status` and `message`. |
 | `SignerError` | The configured `Signer` failed to build or sign the payment transaction. |
@@ -303,5 +312,5 @@ class MyCustomSigner(Signer):
 `ClientConfig.timeout` (default 180s) caps every HTTP call. Cancel an in-flight `chat()` by cancelling the surrounding asyncio task — `httpx` propagates cancellation through cleanly.
 
 <Note>
-  Source: [`sdks/python/`](https://github.com/solvela-ai/solvela/tree/main/sdks/python) in the monorepo. The canonical chat-flow entry point is [`src/solvela/client.py`](https://github.com/solvela-ai/solvela/blob/main/sdks/python/src/solvela/client.py); a 60-line end-to-end smoke test lives at [`scripts/smoke.py`](https://github.com/solvela-ai/solvela/blob/main/sdks/python/scripts/smoke.py). See also [x402 Protocol](/docs/concepts/x402) for the underlying payment flow.
+  Source: [`sdks/python/`](https://github.com/solvela-ai/solvela/tree/main/sdks/python) in the monorepo. The canonical chat-flow entry point is [`src/solvela/client.py`](https://github.com/solvela-ai/solvela/blob/main/sdks/python/src/solvela/client.py); an end-to-end smoke test lives at [`scripts/smoke.py`](https://github.com/solvela-ai/solvela/blob/main/sdks/python/scripts/smoke.py). See also [x402 Protocol](/docs/concepts/x402) for the underlying payment flow.
 </Note>

--- a/dashboard/content/docs/sdks/rust.mdx
+++ b/dashboard/content/docs/sdks/rust.mdx
@@ -24,7 +24,6 @@ The CLI reads these environment variables:
 ```bash
 export SOLVELA_API_URL=https://api.solvela.ai              # optional; default https://api.solvela.ai
 export SOLANA_RPC_URL=https://api.mainnet-beta.solana.com  # required for any paid command (signs USDC-SPL tx)
-export RUST_LOG=info                                       # optional logging
 ```
 
 `SOLANA_RPC_URL` is required whenever the CLI has to sign a payment
@@ -111,22 +110,26 @@ solvela doctor
 
 ```bash
 $ solvela health
-{
-  "status": "ok",
-  "solana_rpc": "connected",
-  "providers": ["openai", "anthropic", "google", "xai", "deepseek"]
-}
+Checking gateway at https://api.solvela.ai...
+Status: ok
 
 $ solvela models
-ID                                    Provider    Input $/M   Output $/M
-openai/gpt-4o                         openai      2.50        10.00
-anthropic/claude-opus-4-6             anthropic   5.00        25.00
-google/gemini-2.5-flash               google      0.30        2.50
+MODEL                          PROVIDER     INPUT $/1M      OUTPUT $/1M
+------------------------------------------------------------------------
+openai/gpt-4o                  openai       $2.50           $10.00
+anthropic/claude-opus-4-6      anthropic    $5.00           $25.00
+google/gemini-2.5-flash        google       $0.30           $2.50
 ...
 
+25 models available. 5% platform fee included.
+
 $ solvela chat --model eco "Hello, what can you do?"
+Cost breakdown:
+  Provider cost : 0.000040 USDC
+  Platform fee  : 0.000002 USDC (5%)
+  Total         : 0.000042 USDC
+Proceed? [y/N] y
 Hello! I'm an AI assistant. I can help you with...
-Cost: $0.000042 USDC
 ```
 
 <Note>

--- a/dashboard/src/app/sitemap.ts
+++ b/dashboard/src/app/sitemap.ts
@@ -11,8 +11,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${DOCS}/docs`, lastModified: now, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${DOCS}/docs/quickstart`, lastModified: now, priority: 0.8 },
     { url: `${DOCS}/docs/concepts/x402`, lastModified: now, priority: 0.7 },
+    { url: `${DOCS}/docs/concepts/a2a`, lastModified: now, priority: 0.7 },
     { url: `${DOCS}/docs/concepts/escrow`, lastModified: now, priority: 0.7 },
     { url: `${DOCS}/docs/concepts/smart-router`, lastModified: now, priority: 0.7 },
+    { url: `${DOCS}/docs/concepts/free-tier`, lastModified: now, priority: 0.7 },
+    { url: `${DOCS}/docs/concepts/response-cache`, lastModified: now, priority: 0.7 },
     { url: `${DOCS}/docs/api`, lastModified: now, priority: 0.7 },
     { url: `${DOCS}/docs/sdks`, lastModified: now, priority: 0.6 },
   ]


### PR DESCRIPTION
## Summary

PR 2 of the website/docs revamp: documents three shipped-but-undocumented features and runs a full accuracy sweep over every code example in the docs.

### New pages (each factual claim carries a file:line ledger from the authoring pass)
- **`concepts/free-tier.mdx`** — zero-cost 402 bypass (`is_free_estimate`), per-IP limit (default 5/60s) + global aggregate cap (default 12 RPM, sized under Google's free-tier ceiling), `SOLVELA_FREE_TIER_*` env vars, 429 shape, free *profile* vs free *tier* distinction
- **`concepts/a2a.mdx`** — AgentCard discovery, `message/send` JSON-RPC flow with request/response pairs, task states, `x402.payment.*` metadata keys, error codes — all field names copied from `crates/gateway/src/a2a/`
- **`concepts/response-cache.mdx`** — exact tier (content-equivalent SHA-256 key incl. tools/tool_choice, wallet-agnostic, zero false positives by construction) + opt-in semantic tier with real `[cache.semantic]` defaults

### Example/accuracy sweep (4 agents over disjoint file sets; highlights)
- Rust SDK example used a **nonexistent `ClientConfig::new()` builder** — would not compile
- pricing: dropped two discontinued gemini-2.0 models (same family as the #485 bug), added the free model, corrected the output-token estimate to the 8192-capped completion ceiling
- payment-flow: exact-scheme broadcast is **deferred post-delivery** (#486); Go signer is `NewKeypairSigner`, not a stub
- deployment: Dockerfile (rust 1.96-trixie, g++/libstdc++6 for fastembed), `redis-stack-server` image, `[[vm]]` syntax
- monitoring: complete `solvela_payments_total` / `solvela_cache_total` label enumerations
- troubleshooting: real `solvela doctor` behavior (4 checks, actual output strings)
- Python/Go SDK pages: escrow-program-pin config + `EscrowProgramMismatchError`; Go streaming 402 error type corrected to `*PaymentRequiredError`

### Truth gate
Authored claims + sweep results were adversarially re-verified by independent agents re-deriving evidence from source: **16 refutations found, 16 applied** (e.g. "without Redis replay protection is disabled" was false — it degrades to an in-memory LRU).

One SDK behavior bug surfaced by the sweep (not a docs issue): the Go SDK returns `*PaymentRequiredError` for post-signing streaming 402s where Python converts to `PaymentRejectedError` — docs now describe the actual behavior; SDK-side unification is a candidate follow-up.

## Verification
- `npm test` 100/100 · `next build` green, all docs paths generated (incl. the 3 new pages)
- New pages registered in `concepts/meta.json` + `sitemap.ts`
- Rebased onto main post-#542/#543; smart-router conflict resolved keeping the merged truth fixes