### PR TITLE
feat(dashboard): A2A, router/cache, and architecture diagrams + embeds

### DIFF
--- a/dashboard/content/docs/concepts/a2a.mdx
+++ b/dashboard/content/docs/concepts/a2a.mdx
@@ -6,6 +6,8 @@ description: Agent-to-Agent JSON-RPC adapter with x402 payment metadata over Sol
 
 Solvela exposes an A2A (Agent-to-Agent) endpoint so autonomous agents can discover the gateway, get a price quote, and pay — all over JSON-RPC 2.0 instead of raw HTTP 402 handshakes. The A2A layer is a protocol adapter, not new payment logic: it translates `message/send` calls into the same x402 verification and chat pipeline used by `POST /v1/chat/completions`.
 
+<A2ADiagram />
+
 Two routes:
 
 | Route | Purpose |

--- a/dashboard/content/docs/concepts/architecture.mdx
+++ b/dashboard/content/docs/concepts/architecture.mdx
@@ -3,6 +3,8 @@ title: Architecture
 description: How Solvela is structured
 ---
 
+<ArchitectureDiagram />
+
 Solvela is a Rust workspace composed of five focused crates, an on-chain Anchor escrow program, a set of multi-language SDKs, and a Next.js dashboard. Every inbound HTTP request is handled by a single binary — the gateway — which delegates to the other crates for routing logic, payment verification, and shared wire types.
 
 ## Workspace Crates

--- a/dashboard/content/docs/concepts/response-cache.mdx
+++ b/dashboard/content/docs/concepts/response-cache.mdx
@@ -8,6 +8,8 @@ The gateway caches LLM completions in Redis in two tiers. Tier 1 is an exact-mat
 
 Streaming requests (`stream: true`) are never cached by either tier.
 
+<RouterCacheDiagram />
+
 ## Exact-match tier
 
 The cache key is a SHA-256 hash over the request content:

--- a/dashboard/content/docs/concepts/smart-router.mdx
+++ b/dashboard/content/docs/concepts/smart-router.mdx
@@ -6,7 +6,9 @@ description: Automatic model selection based on request complexity across 15 dim
 
 The smart router classifies each request's complexity and routes it to the most appropriate model based on a routing profile you specify. This saves cost on simple requests while ensuring complex ones get capable models.
 
-The router is pure rule-based logic with no external calls. Classification takes under 1 microsecond.
+The router is pure rule-based logic — deterministic, with zero external calls.
+
+<RouterCacheDiagram />
 
 ## How to use it
 

--- a/dashboard/src/app/components/docs/mdx/index.tsx
+++ b/dashboard/src/app/components/docs/mdx/index.tsx
@@ -20,6 +20,11 @@ import { LinkMap } from './link-map'
 import { TierCards } from './tier-cards'
 import { UpgradeCta } from './upgrade-cta'
 
+// Shared diagram components (also used on the landing page)
+import { A2ADiagram } from '@/components/landing/a2a-diagram'
+import { RouterCacheDiagram } from '@/components/landing/router-cache-diagram'
+import { ArchitectureDiagram } from '@/components/landing/architecture-diagram'
+
 // Re-export for direct imports
 export { Card, CardGroup } from './card'
 export { Info, Tip, Warning, Note, Check } from './callout'
@@ -36,6 +41,9 @@ export { FlowSteps } from './flow-steps'
 export { LinkMap } from './link-map'
 export { TierCards } from './tier-cards'
 export { UpgradeCta } from './upgrade-cta'
+export { A2ADiagram } from '@/components/landing/a2a-diagram'
+export { RouterCacheDiagram } from '@/components/landing/router-cache-diagram'
+export { ArchitectureDiagram } from '@/components/landing/architecture-diagram'
 
 export function getMDXComponents(): MDXComponents {
   return {
@@ -70,6 +78,10 @@ export function getMDXComponents(): MDXComponents {
     RequestExample,
     ResponseExample,
     CodeGroup,
+    // Shared diagrams
+    A2ADiagram,
+    RouterCacheDiagram,
+    ArchitectureDiagram,
 
     // HTML element overrides
     h1: ({ children, id }) => (

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import { LandingTopStrip } from '@/components/landing/landing-chrome'
 import { SmoothScroll } from '@/components/motion/smooth-scroll'
 import { HeroPanel } from '@/components/landing/hero-panel'
+import { A2ASection } from '@/components/landing/a2a-section'
+import { ArchitectureSection } from '@/components/landing/architecture-section'
 import { LifecycleScene } from '@/components/landing/lifecycle-scene'
 import { WhySolvela } from '@/components/landing/why-solvela'
 import { ProviderRow } from '@/components/landing/provider-row'
@@ -49,10 +51,12 @@ export default async function LandingPage() {
       <SmoothScroll>
         <LandingTopStrip />
         <HeroPanel />
+        <A2ASection />
         <LifecycleScene />
         <WhySolvela />
         <ProviderRow />
         <EnterprisePanel />
+        <ArchitectureSection />
         <SdkCtaPanel preHighlighted={preHighlighted} />
         <LandingFooter />
       </SmoothScroll>

--- a/dashboard/src/components/landing/a2a-diagram.tsx
+++ b/dashboard/src/components/landing/a2a-diagram.tsx
@@ -1,0 +1,630 @@
+'use client'
+
+// Animated A2A discovery + payment flow diagram.
+//
+// Two actors face each other: a requesting AI agent (left) and the Solvela
+// gateway (right). Five beats trace the canonical A2A x402 handshake, every
+// label sourced verbatim from crates/gateway/src/a2a/{agent_card,types,handler}.rs:
+//
+//   0  GET /.well-known/agent.json  → AgentCard (capabilities + x402·ap2 ext)
+//   1  message/send (text prompt)   → Task: input-required + x402.payment.required
+//   2  agent signs USDC payment     (brief Solana chain-tick moment)
+//   3  message/send (taskId + x402.payment.payload)
+//   4  Task: completed + artifacts + x402.payment.receipts (tx_signature)
+//
+// House style mirrors escrow-diagram-animated.tsx: gradient cube surfaces,
+// SMIL <animateMotion> packets that ride named <path>s, beat-gated transient
+// groups remounted via a loopKey. Packets carry their label so a request/
+// response method rides the wire rather than overprinting a cube face — the
+// escrow diagram's sublabel-collision bug is avoided by keeping ALL captions
+// outside the cube footprints.
+//
+// API:
+//   <A2ADiagram />               self-runs on a timed loop, paused off-screen
+//   <A2ADiagram beat={n} />      parent-driven (future scroll scenes)
+// Reduced motion: renders the final `completed` frame, statically.
+
+import { useEffect, useRef, useState } from 'react'
+
+import { diagramPalette as C } from '@/lib/diagram-colors'
+
+export type A2ABeat = 0 | 1 | 2 | 3 | 4
+
+const LAST_BEAT: A2ABeat = 4
+
+// Dwell per beat (ms). The signing beat (2) is the shortest — an abstract
+// chain tick, not a transfer. The resolved frame (4) holds longest so the
+// receipt is readable.
+const BEAT_MS: Record<A2ABeat, number> = {
+  0: 1500,
+  1: 1600,
+  2: 1100,
+  3: 1600,
+  4: 2400,
+}
+
+const LOOPS_BEFORE_HOLD = 3
+
+interface Props {
+  /** When provided, the parent drives the beat. When omitted, self-runs. */
+  beat?: number
+}
+
+export function A2ADiagram({ beat: beatProp }: Props) {
+  const selfDriven = beatProp === undefined
+
+  const [beat, setBeat] = useState<A2ABeat>(0)
+  const [loopKey, setLoopKey] = useState(0)
+  const [loopCount, setLoopCount] = useState(0)
+  const [isHolding, setIsHolding] = useState(false)
+  const [inView, setInView] = useState(false)
+  const [reduced, setReduced] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  // Reduced-motion preference: snap to the resolved frame and never advance.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const apply = () => {
+      if (mq.matches) {
+        setReduced(true)
+        setBeat(LAST_BEAT)
+        setIsHolding(true)
+      } else {
+        setReduced(false)
+      }
+    }
+    apply()
+    mq.addEventListener('change', apply)
+    return () => mq.removeEventListener('change', apply)
+  }, [])
+
+  // Pause when scrolled out of view — resume from the current beat, no reset.
+  useEffect(() => {
+    if (!selfDriven) return
+    const node = wrapperRef.current
+    if (!node) return
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) setInView(e.isIntersecting)
+      },
+      { rootMargin: '200px 0px' },
+    )
+    io.observe(node)
+    return () => io.disconnect()
+  }, [selfDriven])
+
+  // Self-run beat machine — one timeout per beat. Each new beat bumps loopKey
+  // so the SMIL packets remount and replay from scratch.
+  useEffect(() => {
+    if (!selfDriven || reduced || !inView || isHolding) return
+    const id = setTimeout(() => {
+      if (beat === LAST_BEAT) {
+        const next = loopCount + 1
+        if (next >= LOOPS_BEFORE_HOLD) {
+          setIsHolding(true)
+        } else {
+          setLoopCount(next)
+          setBeat(0)
+          setLoopKey((k) => k + 1)
+        }
+      } else {
+        setBeat((b) => (b + 1) as A2ABeat)
+        setLoopKey((k) => k + 1)
+      }
+    }, BEAT_MS[beat])
+    return () => clearTimeout(id)
+  }, [selfDriven, reduced, inView, isHolding, beat, loopCount])
+
+  // Resolve the beat actually rendered. Parent-driven mode clamps the prop;
+  // reduced motion always shows the resolved frame.
+  const activeBeat: A2ABeat = reduced
+    ? LAST_BEAT
+    : selfDriven
+      ? beat
+      : (Math.max(0, Math.min(LAST_BEAT, Math.floor(beatProp ?? 0))) as A2ABeat)
+
+  // loopKey only matters in self-run mode; parent-driven mode uses the beat
+  // itself as the remount key so each parent step replays its packets.
+  const effLoopKey = selfDriven ? loopKey : activeBeat
+
+  return (
+    <div ref={wrapperRef} className="h-full w-full">
+      <A2ADiagramSvg beat={activeBeat} loopKey={effLoopKey} />
+    </div>
+  )
+}
+
+/* ── The SVG ─────────────────────────────────────────────────────────── */
+
+interface SvgProps {
+  beat: A2ABeat
+  loopKey: number
+}
+
+// viewBox is generous in height so captions sit in clear bands above and below
+// the two actors — nothing overprints a cube face at any width down to 320px.
+function A2ADiagramSvg({ beat, loopKey }: SvgProps) {
+  // The AgentCard tags read as "lit" once discovery has happened. They light
+  // from the moment of the response in beat 0 and stay lit thereafter.
+  const cardReturned = true
+  const taskState: 'input-required' | 'completed' | null =
+    beat >= 4 ? 'completed' : beat >= 1 ? 'input-required' : null
+
+  return (
+    <svg
+      viewBox="0 0 640 380"
+      role="img"
+      aria-label={A11Y_LABEL}
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <defs>
+        <linearGradient id="a2a-agent" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={C.nodeFrontMid} />
+          <stop offset="1" stopColor={C.nodeFrontDark} />
+        </linearGradient>
+        <linearGradient id="a2a-gateway" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={C.nodeTopSurface} />
+          <stop offset="1" stopColor={C.nodeRightDark} />
+        </linearGradient>
+
+        {/* Named wire paths. Requests run agent→gateway (left→right) along the
+            upper lane; responses run gateway→agent along the lower lane. All
+            coordinates live in the 640×380 viewBox. */}
+        <path id="a2a-req" d="M 168 150 C 250 132, 388 132, 470 150" fill="none" />
+        <path id="a2a-res" d="M 470 214 C 388 232, 250 232, 168 214" fill="none" />
+        {/* The signing tick is local to the agent — a short downward stub. */}
+        <path id="a2a-sign" d="M 96 196 C 96 214, 96 226, 96 240" fill="none" />
+      </defs>
+
+      {/* Faint wire skeleton so the two lanes read even between packets. */}
+      <g aria-hidden="true" fill="none" strokeDasharray="2 6" opacity="0.16">
+        <use href="#a2a-req" stroke={C.neutralText} strokeWidth="1" />
+        <use href="#a2a-res" stroke={C.neutralText} strokeWidth="1" />
+      </g>
+
+      {/* Lane direction hints — tiny static glyphs, decorative. */}
+      <g aria-hidden="true" opacity="0.5">
+        <text
+          x="320"
+          y="118"
+          textAnchor="middle"
+          fontFamily="'JetBrains Mono', monospace"
+          fontSize="9"
+          letterSpacing="2"
+          fill={C.neutralText}
+        >
+          REQUEST →
+        </text>
+        <text
+          x="320"
+          y="258"
+          textAnchor="middle"
+          fontFamily="'JetBrains Mono', monospace"
+          fontSize="9"
+          letterSpacing="2"
+          fill={C.neutralText}
+        >
+          ← RESPONSE
+        </text>
+      </g>
+
+      {/* Actors */}
+      <g aria-hidden="true">
+        <Cube
+          x={40}
+          y={150}
+          label="agent"
+          fill="url(#a2a-agent)"
+          dot={C.neutralText}
+          highlight={beat === 0 || beat === 2 || beat === 3}
+          pulse={beat === 2}
+        />
+        <Cube
+          x={452}
+          y={150}
+          label="solvela"
+          fill="url(#a2a-gateway)"
+          dot={C.accentGold}
+          highlight={beat === 1 || beat === 4}
+        />
+      </g>
+
+      {/* Gateway status block — AgentCard tags, then the live Task state.
+          Sits BELOW the gateway cube, clear of its face (cube bottom ≈ y226). */}
+      <g transform="translate(506, 300)" aria-hidden="true">
+        <text
+          x="0"
+          y="0"
+          textAnchor="middle"
+          fontFamily="'JetBrains Mono', monospace"
+          fontSize="9"
+          letterSpacing="1.5"
+          fill={C.neutralText}
+          opacity={cardReturned ? 0.85 : 0.3}
+        >
+          agent-card
+        </text>
+        {/* extension tags: x402 · ap2 */}
+        <g transform="translate(0, 16)">
+          <ExtTag x={-34} label="x402" lit={cardReturned} />
+          <ExtTag x={18} label="ap2" lit={cardReturned} />
+        </g>
+      </g>
+
+      {/* Task-state pill — the authoritative A2A lifecycle state, anchored under
+          the gateway block so it never collides with the cube or the tags. */}
+      <g transform="translate(506, 350)" aria-hidden="true">
+        <TaskPill state={taskState} />
+      </g>
+
+      {/* Agent-side caption — what the agent holds after settlement. */}
+      <g transform="translate(96, 300)" aria-hidden="true">
+        <text
+          x="0"
+          y="0"
+          textAnchor="middle"
+          fontFamily="'JetBrains Mono', monospace"
+          fontSize="9"
+          letterSpacing="1.5"
+          fill={C.neutralText}
+          opacity="0.55"
+        >
+          {beat >= 4 ? 'ARTIFACTS' : beat === 2 ? 'SIGNING' : 'WALLET'}
+        </text>
+        <text
+          x="0"
+          y="18"
+          textAnchor="middle"
+          fontFamily="'Source Serif 4', Georgia, serif"
+          fontSize="14"
+          fontWeight="500"
+          fill={beat >= 4 ? C.accentGold : C.neutralText}
+        >
+          {beat >= 4 ? 'received' : beat === 2 ? 'usdc-spl' : 'usdc'}
+        </text>
+      </g>
+
+      {/* ── Beat-gated transient packets ──────────────────────────────── */}
+
+      {/* Beat 0: discovery — GET request rides up, AgentCard rides back. */}
+      {beat === 0 && (
+        <g key={`b0-${loopKey}`} aria-hidden="true">
+          <WirePacket
+            pathId="#a2a-req"
+            label="GET /.well-known/agent.json"
+            color={C.neutralText}
+            dur="1.0s"
+          />
+          <WirePacket
+            pathId="#a2a-res"
+            label="AgentCard"
+            color={C.accentGold}
+            dur="0.95s"
+            begin="0.5s"
+          />
+        </g>
+      )}
+
+      {/* Beat 1: message/send (text prompt) up; input-required Task back. */}
+      {beat === 1 && (
+        <g key={`b1-${loopKey}`} aria-hidden="true">
+          <WirePacket
+            pathId="#a2a-req"
+            label="message/send"
+            color={C.neutralText}
+            dur="1.0s"
+          />
+          <WirePacket
+            pathId="#a2a-res"
+            label="x402.payment.required"
+            color={C.accentSalmon}
+            dur="0.95s"
+            begin="0.55s"
+          />
+        </g>
+      )}
+
+      {/* Beat 2: agent signs — a brief Solana chain tick, abstract. */}
+      {beat === 2 && (
+        <g key={`b2-${loopKey}`} aria-hidden="true">
+          {/* one-shot ring pulse around the agent */}
+          <circle
+            cx={96}
+            cy={188}
+            r="18"
+            fill="none"
+            stroke={C.accentGold}
+            strokeWidth="1.5"
+          >
+            <animate attributeName="r" from="18" to="60" dur="0.95s" fill="freeze" />
+            <animate
+              attributeName="opacity"
+              from="0.7"
+              to="0"
+              dur="0.95s"
+              fill="freeze"
+            />
+          </circle>
+          {/* chain tick travels down the local sign stub */}
+          <ChainTick pathId="#a2a-sign" dur="0.85s" />
+          <text
+            x="96"
+            y="256"
+            textAnchor="middle"
+            fontFamily="'JetBrains Mono', monospace"
+            fontSize="10"
+            letterSpacing="0.5"
+            fill={C.accentGold}
+          >
+            sign · solana
+            <animate
+              attributeName="opacity"
+              from="0"
+              to="1"
+              dur="0.4s"
+              fill="freeze"
+            />
+          </text>
+        </g>
+      )}
+
+      {/* Beat 3: message/send (taskId + x402.payment.payload) up. */}
+      {beat === 3 && (
+        <g key={`b3-${loopKey}`} aria-hidden="true">
+          <WirePacket
+            pathId="#a2a-req"
+            label="message/send · taskId"
+            color={C.neutralText}
+            dur="1.0s"
+          />
+          <WirePacket
+            pathId="#a2a-req"
+            label="x402.payment.payload"
+            color={C.accentGold}
+            dur="1.0s"
+            begin="0.18s"
+            offsetY={16}
+          />
+        </g>
+      )}
+
+      {/* Beat 4: completed Task back — artifacts + receipt (tx signature). */}
+      {beat === 4 && (
+        <g key={`b4-${loopKey}`} aria-hidden="true">
+          <WirePacket
+            pathId="#a2a-res"
+            label="completed · artifacts"
+            color={C.neutralText}
+            dur="1.0s"
+          />
+          <WirePacket
+            pathId="#a2a-res"
+            label="x402.payment.receipts"
+            color={C.accentGold}
+            dur="1.0s"
+            begin="0.18s"
+            offsetY={16}
+          />
+        </g>
+      )}
+    </svg>
+  )
+}
+
+const A11Y_LABEL =
+  'Agent-to-agent discovery and payment flow. A requesting agent fetches the ' +
+  'Solvela AgentCard at GET /.well-known/agent.json, with x402 and ap2 ' +
+  'extensions. It calls message/send, receiving a Task in the input-required ' +
+  'state with x402.payment.required metadata. The agent signs a USDC payment ' +
+  'on Solana, then calls message/send again with the taskId and ' +
+  'x402.payment.payload. Solvela returns a completed Task with artifacts and ' +
+  'x402.payment.receipts containing the transaction signature.'
+
+/* ── Packet components ───────────────────────────────────────────────── */
+
+interface WirePacketProps {
+  pathId: string
+  label: string
+  color: string
+  dur: string
+  begin?: string
+  /** Vertical offset for the label so two concurrent packets don't overlap. */
+  offsetY?: number
+}
+
+// A dot that rides a wire path, trailing its method label. The label rides the
+// same path (so it tracks the dot) and is offset above the wire — never landing
+// on a cube face. Begin can be staggered for request/response pairs.
+function WirePacket({
+  pathId,
+  label,
+  color,
+  dur,
+  begin = '0s',
+  offsetY = 0,
+}: WirePacketProps) {
+  return (
+    <g>
+      <circle r="5" fill={color}>
+        <animateMotion dur={dur} begin={begin} fill="freeze">
+          <mpath href={pathId} />
+        </animateMotion>
+      </circle>
+      <text
+        y={-11 - offsetY}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="11"
+        fontWeight="500"
+        fill={color}
+      >
+        {label}
+        <animateMotion dur={dur} begin={begin} fill="freeze">
+          <mpath href={pathId} />
+        </animateMotion>
+      </text>
+    </g>
+  )
+}
+
+// The Solana chain-tick: a small square (block) that ticks down the sign stub.
+function ChainTick({ pathId, dur }: { pathId: string; dur: string }) {
+  return (
+    <rect x="-4" y="-4" width="8" height="8" rx="1.5" fill={C.accentGold}>
+      <animateMotion dur={dur} begin="0s" fill="freeze" rotate="auto">
+        <mpath href={pathId} />
+      </animateMotion>
+    </rect>
+  )
+}
+
+/* ── Static label helpers ────────────────────────────────────────────── */
+
+// A small extension-capability tag (x402 / ap2) drawn under the AgentCard label.
+function ExtTag({ x, label, lit }: { x: number; label: string; lit: boolean }) {
+  const w = label.length * 7 + 14
+  return (
+    <g transform={`translate(${x}, 0)`}>
+      <rect
+        x="0"
+        y="-9"
+        width={w}
+        height="16"
+        rx="3"
+        fill="none"
+        stroke={lit ? C.accentGold : C.nodeStroke}
+        strokeWidth="1"
+        opacity={lit ? 0.9 : 0.4}
+      />
+      <text
+        x={w / 2}
+        y="2"
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="9"
+        letterSpacing="0.5"
+        fill={lit ? C.accentGold : C.neutralText}
+        opacity={lit ? 1 : 0.5}
+      >
+        {label}
+      </text>
+    </g>
+  )
+}
+
+// The A2A Task lifecycle pill. `null` = no task yet (pre-discovery hold).
+function TaskPill({ state }: { state: 'input-required' | 'completed' | null }) {
+  if (state === null) {
+    return (
+      <text
+        x="0"
+        y="2"
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="9"
+        letterSpacing="1.5"
+        fill={C.neutralText}
+        opacity="0.3"
+      >
+        no task
+      </text>
+    )
+  }
+  const done = state === 'completed'
+  const color = done ? C.accentGold : C.accentSalmon
+  const w = state.length * 7 + 26
+  return (
+    <g>
+      <rect
+        x={-w / 2}
+        y="-11"
+        width={w}
+        height="20"
+        rx="4"
+        fill="none"
+        stroke={color}
+        strokeWidth="1.2"
+        opacity="0.9"
+      />
+      <circle cx={-w / 2 + 11} cy="-1" r="2.5" fill={color} />
+      <text
+        x={6}
+        y="3"
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="10"
+        letterSpacing="0.5"
+        fill={color}
+      >
+        {state}
+      </text>
+    </g>
+  )
+}
+
+/* ── Isometric cube actor (mirrors escrow-diagram-animated) ──────────── */
+
+interface CubeProps {
+  x: number
+  y: number
+  label: string
+  fill: string
+  dot: string
+  highlight?: boolean
+  pulse?: boolean
+}
+
+function Cube({ x, y, label, fill, dot, highlight, pulse }: CubeProps) {
+  const w = 96
+  const d = 46
+  const h = 56
+
+  const stroke = highlight ? C.accentGold : C.nodeStroke
+  const strokeWidth = highlight ? 1.4 : 1
+
+  const ax = x
+  const ay = y + h
+
+  const tfl = [ax, ay - h]
+  const tfr = [ax + w, ay - h]
+  const tbr = [ax + w + d * 0.6, ay - h - d * 0.5]
+  const tbl = [ax + d * 0.6, ay - h - d * 0.5]
+  const rbr = [ax + w + d * 0.6, ay - d * 0.5]
+
+  return (
+    <g style={pulse ? { filter: `drop-shadow(0 0 6px ${C.accentGold})` } : undefined}>
+      <polygon
+        points={`${ax},${ay} ${ax + w},${ay} ${tfr[0]},${tfr[1]} ${tfl[0]},${tfl[1]}`}
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+      <polygon
+        points={`${ax + w},${ay} ${rbr[0]},${rbr[1]} ${tbr[0]},${tbr[1]} ${tfr[0]},${tfr[1]}`}
+        fill={C.nodeRightDark}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        opacity="0.88"
+      />
+      <polygon
+        points={`${tfl[0]},${tfl[1]} ${tfr[0]},${tfr[1]} ${tbr[0]},${tbr[1]} ${tbl[0]},${tbl[1]}`}
+        fill={C.nodeTopSurface}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+      <circle cx={ax + 13} cy={ay - h + 13} r="3" fill={dot} />
+      <text
+        x={ax + 13}
+        y={ay - 20}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="14"
+        fill={C.headingText}
+        letterSpacing="1"
+      >
+        {label}
+      </text>
+    </g>
+  )
+}

--- a/dashboard/src/components/landing/a2a-section.tsx
+++ b/dashboard/src/components/landing/a2a-section.tsx
@@ -1,0 +1,53 @@
+import { Reveal } from '@/components/motion/primitives'
+import { A2ADiagram } from './a2a-diagram'
+import { DOCS_URL } from './config'
+
+/**
+ * Agent-to-agent section — the discovery story. An agent finds Solvela's
+ * AgentCard, gets a payment-required task, signs, and receives artifacts,
+ * with no human onboarding anywhere in the loop. Copy stays inside the
+ * truth-verified claim set; the diagram labels come from the a2a module.
+ */
+export function A2ASection() {
+  return (
+    <section aria-labelledby="a2a-heading" className="border-t border-border/60">
+      <div className="mx-auto max-w-[1320px] px-6 py-16 lg:py-24">
+        <div className="grid items-center gap-12 lg:grid-cols-[minmax(0,0.46fr)_minmax(0,0.54fr)]">
+          <div>
+            <Reveal>
+              <span className="eyebrow">agent-to-agent</span>
+              <h2
+                id="a2a-heading"
+                className="display-wonk mt-3 max-w-[14ch] text-[var(--heading-color)]"
+                style={{ fontSize: 'clamp(2rem, 4.6vw, 4rem)' }}
+              >
+                No signup form. An AgentCard.
+              </h2>
+            </Reveal>
+            <Reveal index={1}>
+              <p className="mt-6 max-w-[52ch] text-[15px] leading-[1.65] text-muted-foreground">
+                Solvela speaks the A2A protocol. An agent fetches{' '}
+                <code className="font-mono text-[13px] text-[var(--accent-gold)]">
+                  /.well-known/agent.json
+                </code>
+                , sends a <code className="font-mono text-[13px]">message/send</code>,
+                gets back a task that says exactly what it costs, signs a USDC
+                payment, and collects its artifacts — discovery to settlement
+                over one JSON-RPC surface, no human in the loop.
+              </p>
+              <a
+                href={`${DOCS_URL}/docs/concepts/a2a`}
+                className="mt-7 inline-flex items-center gap-2 font-mono text-[12px] uppercase tracking-[0.18em] text-[var(--accent-salmon)] hover:text-[var(--accent-salmon-hover)]"
+              >
+                a2a docs →
+              </a>
+            </Reveal>
+          </div>
+          <Reveal index={2}>
+            <A2ADiagram />
+          </Reveal>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/components/landing/architecture-diagram.tsx
+++ b/dashboard/src/components/landing/architecture-diagram.tsx
@@ -1,0 +1,991 @@
+'use client'
+
+// System architecture diagram for the Solvela landing page.
+//
+// Unlike <EscrowDiagramAnimated> (a narrated, beat-driven sequence), this is a
+// REFERENCE diagram: mostly static, true to the codebase topology. The only
+// motion is a subtle ambient "packet drift" along the main request path
+// (client → gateway → provider), which is:
+//   • paused while the diagram is out of view (IntersectionObserver), and
+//   • absent entirely under prefers-reduced-motion.
+//
+// Everything else is plain SVG and renders server-side. The 'use client'
+// directive is only here because the ambient drift needs the hooks below; the
+// static structure does not depend on the client at all.
+//
+// Topology + labels are grounded in:
+//   crates/{gateway,x402,router,protocol,cli} + programs/escrow + CLAUDE.md.
+// No invented services — every label maps to a real crate, module, store,
+// provider, or on-chain account.
+
+import { useEffect, useRef, useState } from 'react'
+
+import { diagramPalette as C } from '@/lib/diagram-colors'
+
+/* ── Public API ──────────────────────────────────────────────────────
+ * <ArchitectureDiagram compact?={boolean} />
+ *   compact — stack the planes vertically (clients → gateway → providers,
+ *   settlement below) for narrow viewports. Defaults to false (wide layout).
+ *   The wide SVG is itself fully responsive down to 320px via viewBox scaling;
+ *   `compact` is offered for callers that prefer a taller, single-column read.
+ * ─────────────────────────────────────────────────────────────────── */
+
+interface ArchitectureDiagramProps {
+  compact?: boolean
+}
+
+const ARIA_LABEL =
+  'Solvela system architecture. Clients (TypeScript, Python, Go, Rust, and MCP SDKs, plus A2A agents via agent-card) call the Solvela gateway, an Axum server containing x402 payment verification, a 15-dimension router, an exact response cache, and a prompt guard. The gateway uses optional Redis (cache, replay, rate limit) and optional PostgreSQL (spend, orgs, audit) side stores, and proxies to five providers: OpenAI, Anthropic, Google, xAI, and DeepSeek. Payments settle on Solana mainnet: the exact scheme is a deferred USDC-SPL transfer, while the escrow scheme deposits to an on-chain escrow program PDA and claims plus refunds in one transaction; a fee-payer pool sponsors transactions.'
+
+export function ArchitectureDiagram({ compact = false }: ArchitectureDiagramProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [drift, setDrift] = useState(false)
+
+  // Ambient drift runs only when in view AND reduced-motion is not requested.
+  useEffect(() => {
+    const node = wrapperRef.current
+    if (!node) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) setDrift(e.isIntersecting)
+      },
+      { rootMargin: '120px 0px' }
+    )
+    io.observe(node)
+    return () => io.disconnect()
+  }, [])
+
+  return (
+    <div ref={wrapperRef} className="h-full w-full">
+      {compact ? (
+        <CompactSvg drift={drift} />
+      ) : (
+        <WideSvg drift={drift} />
+      )}
+    </div>
+  )
+}
+
+/* ── Wide (default) layout ───────────────────────────────────────────
+ * 960×620 viewBox. Three vertical planes (clients · gateway · providers)
+ * with a settlement plane spanning the bottom.
+ * ─────────────────────────────────────────────────────────────────── */
+
+function WideSvg({ drift }: { drift: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 960 620"
+      role="img"
+      aria-label={ARIA_LABEL}
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <Defs />
+
+      {/* ── Edges (drawn under nodes) ─────────────────────────────── */}
+      <g fill="none">
+        {/* request bus: clients → gateway */}
+        <path
+          id="arch-req"
+          d="M 232 196 C 290 196, 318 224, 360 224"
+          stroke={C.neutralText}
+          strokeWidth="1.5"
+          opacity="0.5"
+        />
+        {/* response/proxy bus: gateway → providers */}
+        <path
+          id="arch-proxy"
+          d="M 600 224 C 648 224, 676 196, 728 196"
+          stroke={C.neutralText}
+          strokeWidth="1.5"
+          opacity="0.5"
+        />
+        {/* gateway → redis (right side store) */}
+        <line x1="480" y1="312" x2="480" y2="352" stroke={C.nodeStroke} strokeWidth="1" strokeDasharray="4 4" opacity="0.6" />
+        {/* redis → postgres are siblings; gateway → postgres */}
+        <line x1="690" y1="312" x2="690" y2="352" stroke={C.nodeStroke} strokeWidth="1" strokeDasharray="4 4" opacity="0.6" />
+
+        {/* settlement: exact (deferred transfer) — gold */}
+        <path
+          id="arch-exact"
+          d="M 410 318 C 380 420, 360 470, 320 506"
+          stroke={C.accentGold}
+          strokeWidth="1.5"
+          strokeDasharray="2 5"
+          opacity="0.7"
+        />
+        {/* settlement: escrow deposit/claim+refund — salmon */}
+        <path
+          id="arch-escrow"
+          d="M 520 318 C 560 420, 600 470, 660 506"
+          stroke={C.accentSalmon}
+          strokeWidth="1.5"
+          strokeDasharray="2 5"
+          opacity="0.7"
+        />
+        <ArrowHead x={357} y={224} dir="right" color={C.neutralText} />
+        <ArrowHead x={731} y={196} dir="right" color={C.neutralText} />
+      </g>
+
+      {/* edge captions */}
+      <EdgeLabel x={296} y={188} text="POST /v1/chat/completions" />
+      <EdgeLabel x={664} y={188} text="OpenAI ⇄ native" />
+
+      {/* ── Plane labels ──────────────────────────────────────────── */}
+      <PlaneLabel x={120} y={62} text="clients" />
+      <PlaneLabel x={480} y={62} text="solvela gateway · axum" />
+      <PlaneLabel x={840} y={62} text="providers" />
+
+      {/* ── Left plane: clients ───────────────────────────────────── */}
+      <ClientStack x={40} y={96} />
+      {/* A2A agents */}
+      <NodeBox
+        x={40}
+        y={256}
+        w={192}
+        h={56}
+        title="A2A agents"
+        sub=".well-known/agent.json"
+        dot={C.accentGold}
+      />
+
+      {/* ── Center plane: gateway ─────────────────────────────────── */}
+      <GatewayBox x={360} y={96} drift={drift} />
+
+      {/* side stores */}
+      <StoreBox
+        x={384}
+        y={352}
+        title="redis"
+        lines={['cache', 'replay', 'rate']}
+        note="optional · degrades"
+      />
+      <StoreBox
+        x={594}
+        y={352}
+        title="postgres"
+        lines={['spend', 'orgs', 'audit']}
+        note="optional · degrades"
+      />
+
+      {/* ── Right plane: providers ────────────────────────────────── */}
+      <ProviderStack x={728} y={96} />
+
+      {/* ── Settlement plane ──────────────────────────────────────── */}
+      <SettlementPlane x={40} y={486} w={880} h={104} />
+
+      {/* drift packets on the main request path (in view + motion only) */}
+      {drift && (
+        <g aria-hidden="true">
+          <DriftPacket pathId="#arch-req" color={C.neutralText} dur="3.2s" begin="0s" />
+          <DriftPacket pathId="#arch-req" color={C.neutralText} dur="3.2s" begin="1.6s" />
+          <DriftPacket pathId="#arch-proxy" color={C.neutralText} dur="3.2s" begin="0.8s" />
+          <DriftPacket pathId="#arch-proxy" color={C.neutralText} dur="3.2s" begin="2.4s" />
+        </g>
+      )}
+    </svg>
+  )
+}
+
+/* ── Compact layout ──────────────────────────────────────────────────
+ * 380×900 viewBox. Single column: clients → gateway (+ stores) →
+ * providers, settlement plane at the bottom. Same labels, stacked.
+ * ─────────────────────────────────────────────────────────────────── */
+
+function CompactSvg({ drift }: { drift: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 380 980"
+      role="img"
+      aria-label={ARIA_LABEL}
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <Defs />
+
+      {/* vertical request spine */}
+      <g fill="none">
+        <path
+          id="arch-c-req"
+          d="M 190 214 L 190 250"
+          stroke={C.neutralText}
+          strokeWidth="1.5"
+          opacity="0.5"
+        />
+        <path
+          id="arch-c-proxy"
+          d="M 190 560 L 190 596"
+          stroke={C.neutralText}
+          strokeWidth="1.5"
+          opacity="0.5"
+        />
+        <ArrowHead x={190} y={249} dir="down" color={C.neutralText} />
+        <ArrowHead x={190} y={595} dir="down" color={C.neutralText} />
+
+        {/* settlement links */}
+        <path
+          d="M 150 568 C 130 660, 120 720, 120 760"
+          stroke={C.accentGold}
+          strokeWidth="1.5"
+          strokeDasharray="2 5"
+          opacity="0.7"
+        />
+        <path
+          d="M 230 568 C 250 660, 260 720, 260 760"
+          stroke={C.accentSalmon}
+          strokeWidth="1.5"
+          strokeDasharray="2 5"
+          opacity="0.7"
+        />
+      </g>
+
+      <PlaneLabel x={190} y={36} text="clients" />
+      <SdkChips x={30} y={56} w={320} />
+      <NodeBox
+        x={30}
+        y={148}
+        w={320}
+        h={56}
+        title="A2A agents"
+        sub=".well-known/agent.json"
+        dot={C.accentGold}
+        center
+      />
+
+      <PlaneLabel x={190} y={282} text="solvela gateway · axum" />
+      <GatewayBox x={30} y={300} drift={drift} compact />
+
+      <StoreBox x={40} y={476} title="redis" lines={['cache · replay · rate']} note="optional" wideLine />
+      <StoreBox x={206} y={476} title="postgres" lines={['spend · orgs · audit']} note="optional" wideLine />
+
+      <PlaneLabel x={190} y={628} text="providers" />
+      <ProviderChips x={30} y={648} w={320} />
+
+      <SettlementPlane x={30} y={744} w={320} h={206} compact />
+
+      {drift && (
+        <g aria-hidden="true">
+          <DriftPacket pathId="#arch-c-req" color={C.neutralText} dur="2.6s" begin="0s" />
+          <DriftPacket pathId="#arch-c-proxy" color={C.neutralText} dur="2.6s" begin="1.3s" />
+        </g>
+      )}
+    </svg>
+  )
+}
+
+/* ── Defs ────────────────────────────────────────────────────────── */
+
+function Defs() {
+  return (
+    <defs>
+      <linearGradient id="arch-node" x1="0" x2="0" y1="0" y2="1">
+        <stop offset="0" stopColor={C.nodeFrontMid} />
+        <stop offset="1" stopColor={C.nodeFrontDark} />
+      </linearGradient>
+      <linearGradient id="arch-gateway" x1="0" x2="0" y1="0" y2="1">
+        <stop offset="0" stopColor={C.nodeTopSurface} />
+        <stop offset="1" stopColor={C.nodeRightDark} />
+      </linearGradient>
+      <linearGradient id="arch-plane" x1="0" x2="0" y1="0" y2="1">
+        <stop offset="0" stopColor={C.nodeFrontDark} />
+        <stop offset="1" stopColor={C.nodeBlackish} />
+      </linearGradient>
+    </defs>
+  )
+}
+
+/* ── Plane / structural pieces ───────────────────────────────────── */
+
+function PlaneLabel({ x, y, text }: { x: number; y: number; text: string }) {
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor="middle"
+      fontFamily="'JetBrains Mono', monospace"
+      fontSize="11"
+      fill={C.neutralText}
+      opacity="0.6"
+      letterSpacing="2"
+    >
+      {text.toUpperCase()}
+    </text>
+  )
+}
+
+function EdgeLabel({ x, y, text }: { x: number; y: number; text: string }) {
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor="middle"
+      fontFamily="'JetBrains Mono', monospace"
+      fontSize="9"
+      fill={C.neutralText}
+      opacity="0.55"
+      letterSpacing="0.5"
+    >
+      {text}
+    </text>
+  )
+}
+
+interface NodeBoxProps {
+  x: number
+  y: number
+  w: number
+  h: number
+  title: string
+  sub?: string
+  dot?: string
+  center?: boolean
+}
+
+function NodeBox({ x, y, w, h, title, sub, dot, center }: NodeBoxProps) {
+  const tx = center ? x + w / 2 : x + 16
+  const anchor = center ? 'middle' : 'start'
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx="6"
+        fill="url(#arch-node)"
+        stroke={C.nodeStroke}
+        strokeWidth="1"
+      />
+      {dot && !center && <circle cx={x + 14} cy={y + 16} r="3" fill={dot} />}
+      <text
+        x={center ? tx : x + (dot ? 28 : 16)}
+        y={y + (sub ? 24 : h / 2 + 4)}
+        textAnchor={anchor}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="13"
+        fill={C.headingText}
+        letterSpacing="0.5"
+      >
+        {title}
+      </text>
+      {sub && (
+        <text
+          x={center ? tx : x + (dot ? 28 : 16)}
+          y={y + 42}
+          textAnchor={anchor}
+          fontFamily="'JetBrains Mono', monospace"
+          fontSize="9.5"
+          fill={C.neutralText}
+          opacity="0.6"
+        >
+          {sub}
+        </text>
+      )}
+    </g>
+  )
+}
+
+/* ── Clients ─────────────────────────────────────────────────────── */
+
+const SDKS = ['ts', 'python', 'go', 'rust', 'mcp'] as const
+
+function ClientStack({ x, y }: { x: number; y: number }) {
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={192}
+        height={142}
+        rx="6"
+        fill="url(#arch-node)"
+        stroke={C.nodeStroke}
+        strokeWidth="1"
+      />
+      <text
+        x={x + 16}
+        y={y + 26}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="13"
+        fill={C.headingText}
+        letterSpacing="0.5"
+      >
+        SDKs
+      </text>
+      <text
+        x={x + 16}
+        y={y + 42}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="9"
+        fill={C.neutralText}
+        opacity="0.55"
+      >
+        x402 + signed tx, no api keys
+      </text>
+      <g>
+        {SDKS.map((s, i) => (
+          <Chip key={s} x={x + 16 + (i % 3) * 56} y={y + 58 + Math.floor(i / 3) * 36} label={s} />
+        ))}
+      </g>
+    </g>
+  )
+}
+
+function SdkChips({ x, y, w }: { x: number; y: number; w: number }) {
+  return (
+    <g>
+      <rect x={x} y={y} width={w} height={76} rx="6" fill="url(#arch-node)" stroke={C.nodeStroke} strokeWidth="1" />
+      <text
+        x={x + w / 2}
+        y={y + 24}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="13"
+        fill={C.headingText}
+      >
+        SDKs
+      </text>
+      <g>
+        {SDKS.map((s, i) => (
+          <Chip key={s} x={x + 14 + i * 61} y={y + 40} label={s} />
+        ))}
+      </g>
+    </g>
+  )
+}
+
+function Chip({ x, y, label }: { x: number; y: number; label: string }) {
+  const w = Math.max(34, label.length * 8 + 14)
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={22}
+        rx="4"
+        fill={C.nodeBlackish}
+        stroke={C.nodeStroke}
+        strokeWidth="0.75"
+      />
+      <text
+        x={x + w / 2}
+        y={y + 15}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="11"
+        fill={C.neutralText}
+      >
+        {label}
+      </text>
+    </g>
+  )
+}
+
+/* ── Gateway ─────────────────────────────────────────────────────── */
+
+const GATEWAY_MODULES: { title: string; sub: string }[] = [
+  { title: 'x402 verify', sub: 'payment middleware' },
+  { title: '15-dim router', sub: 'eco · auto · premium' },
+  { title: 'exact cache', sub: 'wallet-agnostic' },
+  { title: 'prompt guard', sub: 'injection · pii' },
+]
+
+function GatewayBox({
+  x,
+  y,
+  drift,
+  compact,
+}: {
+  x: number
+  y: number
+  drift: boolean
+  compact?: boolean
+}) {
+  const w = compact ? 320 : 240
+  const h = compact ? 158 : 216
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx="8"
+        fill="url(#arch-gateway)"
+        stroke={drift ? C.accentSalmon : C.nodeStroke}
+        strokeWidth={drift ? 1.3 : 1}
+      />
+      {/* inner modules */}
+      {compact ? (
+        <g>
+          {GATEWAY_MODULES.map((m, i) => (
+            <ModuleCell
+              key={m.title}
+              x={x + 14 + (i % 2) * 150}
+              y={y + 30 + Math.floor(i / 2) * 58}
+              w={138}
+              {...m}
+            />
+          ))}
+        </g>
+      ) : (
+        <g>
+          {GATEWAY_MODULES.map((m, i) => (
+            <ModuleCell key={m.title} x={x + 16} y={y + 24 + i * 46} w={w - 32} {...m} />
+          ))}
+        </g>
+      )}
+    </g>
+  )
+}
+
+function ModuleCell({
+  x,
+  y,
+  w,
+  title,
+  sub,
+}: {
+  x: number
+  y: number
+  w: number
+  title: string
+  sub: string
+}) {
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={40}
+        rx="5"
+        fill={C.nodeBlackish}
+        stroke={C.nodeStroke}
+        strokeWidth="0.75"
+      />
+      <circle cx={x + 12} cy={y + 14} r="2.5" fill={C.accentGold} opacity="0.85" />
+      <text
+        x={x + 24}
+        y={y + 17}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="11.5"
+        fill={C.headingText}
+      >
+        {title}
+      </text>
+      <text
+        x={x + 24}
+        y={y + 31}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="8.5"
+        fill={C.neutralText}
+        opacity="0.55"
+      >
+        {sub}
+      </text>
+    </g>
+  )
+}
+
+/* ── Side stores ─────────────────────────────────────────────────── */
+
+function StoreBox({
+  x,
+  y,
+  title,
+  lines,
+  note,
+  wideLine,
+}: {
+  x: number
+  y: number
+  title: string
+  lines: string[]
+  note: string
+  wideLine?: boolean
+}) {
+  const w = wideLine ? 150 : 162
+  const h = 96
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx="6"
+        fill="url(#arch-node)"
+        stroke={C.nodeStroke}
+        strokeWidth="1"
+        strokeDasharray="6 4"
+      />
+      <text
+        x={x + 14}
+        y={y + 24}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="13"
+        fill={C.headingText}
+        letterSpacing="0.5"
+      >
+        {title}
+      </text>
+      {lines.map((l, i) => (
+        <text
+          key={l}
+          x={x + 14}
+          y={y + 44 + i * 15}
+          fontFamily="'JetBrains Mono', monospace"
+          fontSize="10"
+          fill={C.neutralText}
+          opacity="0.75"
+        >
+          {l}
+        </text>
+      ))}
+      <text
+        x={x + 14}
+        y={y + h - 12}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="8.5"
+        fill={C.accentGold}
+        opacity="0.75"
+        letterSpacing="0.5"
+      >
+        {note}
+      </text>
+    </g>
+  )
+}
+
+/* ── Providers ───────────────────────────────────────────────────── */
+
+const PROVIDER_NODES = [
+  { id: 'openai', name: 'openai', dot: '#10a37f' },
+  { id: 'anthropic', name: 'anthropic', dot: '#d97757' },
+  { id: 'google', name: 'google', dot: '#4285f4' },
+  { id: 'xai', name: 'xai', dot: C.neutralText },
+  { id: 'deepseek', name: 'deepseek', dot: '#536dfe' },
+] as const
+
+function ProviderStack({ x, y }: { x: number; y: number }) {
+  return (
+    <g>
+      {PROVIDER_NODES.map((p, i) => (
+        <g key={p.id}>
+          <rect
+            x={x}
+            y={y + i * 48}
+            width={192}
+            height={40}
+            rx="5"
+            fill="url(#arch-node)"
+            stroke={C.nodeStroke}
+            strokeWidth="1"
+          />
+          <circle cx={x + 16} cy={y + i * 48 + 20} r="3.5" fill={p.dot} />
+          <text
+            x={x + 30}
+            y={y + i * 48 + 25}
+            fontFamily="'JetBrains Mono', monospace"
+            fontSize="13"
+            fill={C.headingText}
+            letterSpacing="0.5"
+          >
+            {p.name}
+          </text>
+        </g>
+      ))}
+    </g>
+  )
+}
+
+function ProviderChips({ x, y, w }: { x: number; y: number; w: number }) {
+  return (
+    <g>
+      <rect x={x} y={y} width={w} height={76} rx="6" fill="url(#arch-node)" stroke={C.nodeStroke} strokeWidth="1" />
+      <g>
+        {PROVIDER_NODES.slice(0, 3).map((p, i) => (
+          <ProviderPill key={p.id} x={x + 14 + i * 100} y={y + 14} p={p} />
+        ))}
+        {PROVIDER_NODES.slice(3).map((p, i) => (
+          <ProviderPill key={p.id} x={x + 14 + i * 100} y={y + 44} p={p} />
+        ))}
+      </g>
+    </g>
+  )
+}
+
+function ProviderPill({
+  x,
+  y,
+  p,
+}: {
+  x: number
+  y: number
+  p: { name: string; dot: string }
+}) {
+  return (
+    <g>
+      <circle cx={x + 8} cy={y + 11} r="3.5" fill={p.dot} />
+      <text
+        x={x + 18}
+        y={y + 15}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="11"
+        fill={C.neutralText}
+      >
+        {p.name}
+      </text>
+    </g>
+  )
+}
+
+/* ── Settlement plane ────────────────────────────────────────────── */
+
+function SettlementPlane({
+  x,
+  y,
+  w,
+  h,
+  compact,
+}: {
+  x: number
+  y: number
+  w: number
+  h: number
+  compact?: boolean
+}) {
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx="8"
+        fill="url(#arch-plane)"
+        stroke={C.nodeStroke}
+        strokeWidth="1"
+      />
+      <text
+        x={x + 18}
+        y={y + 24}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="11"
+        fill={C.neutralText}
+        opacity="0.6"
+        letterSpacing="2"
+      >
+        SOLANA MAINNET · USDC-SPL
+      </text>
+
+      {compact ? (
+        <g>
+          <FlowChip
+            x={x + 16}
+            y={y + 40}
+            w={w - 32}
+            color={C.accentGold}
+            title="exact"
+            sub="deferred transfer"
+          />
+          <FlowChip
+            x={x + 16}
+            y={y + 90}
+            w={w - 32}
+            color={C.accentSalmon}
+            title="escrow"
+            sub="deposit → claim + refund"
+          />
+          <NodeMini
+            x={x + 16}
+            y={y + 140}
+            w={(w - 44) / 2}
+            title="escrow program"
+            sub="PDA"
+            dashed
+          />
+          <NodeMini
+            x={x + 16 + (w - 44) / 2 + 12}
+            y={y + 140}
+            w={(w - 44) / 2}
+            title="fee-payer pool"
+            sub="sponsors tx"
+          />
+        </g>
+      ) : (
+        <g>
+          {/* exact (gold) */}
+          <FlowChip
+            x={x + 24}
+            y={y + 42}
+            w={280}
+            color={C.accentGold}
+            title="exact"
+            sub="deferred USDC-SPL transfer"
+          />
+          {/* escrow (salmon) */}
+          <FlowChip
+            x={x + 320}
+            y={y + 42}
+            w={300}
+            color={C.accentSalmon}
+            title="escrow"
+            sub="deposit → claim + refund (1 tx)"
+          />
+          {/* on-chain accounts on the right */}
+          <NodeMini x={x + 644} y={y + 36} w={210} title="escrow program" sub="PDA · anchor" dashed />
+          <NodeMini x={x + 644} y={y + 70} w={210} title="fee-payer pool" sub="sponsors tx" />
+        </g>
+      )}
+    </g>
+  )
+}
+
+function FlowChip({
+  x,
+  y,
+  w,
+  color,
+  title,
+  sub,
+}: {
+  x: number
+  y: number
+  w: number
+  color: string
+  title: string
+  sub: string
+}) {
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={40}
+        rx="5"
+        fill={C.nodeBlackish}
+        stroke={color}
+        strokeWidth="1"
+        opacity="0.95"
+      />
+      <circle cx={x + 14} cy={y + 20} r="4" fill={color} />
+      <text
+        x={x + 28}
+        y={y + 17}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="12"
+        fill={C.headingText}
+        letterSpacing="0.5"
+      >
+        {title}
+      </text>
+      <text
+        x={x + 28}
+        y={y + 31}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="9"
+        fill={C.neutralText}
+        opacity="0.7"
+      >
+        {sub}
+      </text>
+    </g>
+  )
+}
+
+function NodeMini({
+  x,
+  y,
+  w,
+  title,
+  sub,
+  dashed,
+}: {
+  x: number
+  y: number
+  w: number
+  title: string
+  sub: string
+  dashed?: boolean
+}) {
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={28}
+        rx="4"
+        fill={C.nodeFrontDark}
+        stroke={dashed ? C.accentGold : C.nodeStroke}
+        strokeWidth="1"
+        strokeDasharray={dashed ? '5 4' : undefined}
+      />
+      <text
+        x={x + 12}
+        y={y + 13}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="10.5"
+        fill={C.headingText}
+      >
+        {title}
+      </text>
+      <text
+        x={x + 12}
+        y={y + 24}
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="8.5"
+        fill={C.neutralText}
+        opacity="0.6"
+      >
+        {sub}
+      </text>
+    </g>
+  )
+}
+
+/* ── Small SVG helpers ───────────────────────────────────────────── */
+
+function ArrowHead({
+  x,
+  y,
+  dir,
+  color,
+}: {
+  x: number
+  y: number
+  dir: 'right' | 'down'
+  color: string
+}) {
+  const pts =
+    dir === 'right'
+      ? `${x},${y - 4} ${x + 6},${y} ${x},${y + 4}`
+      : `${x - 4},${y - 6} ${x + 4},${y - 6} ${x},${y}`
+  return <polygon points={pts} fill={color} opacity="0.7" />
+}
+
+function DriftPacket({
+  pathId,
+  color,
+  dur,
+  begin,
+}: {
+  pathId: string
+  color: string
+  dur: string
+  begin: string
+}) {
+  return (
+    <circle r="2.5" fill={color} opacity="0.85">
+      <animateMotion dur={dur} begin={begin} repeatCount="indefinite" rotate="auto">
+        <mpath href={pathId} />
+      </animateMotion>
+    </circle>
+  )
+}

--- a/dashboard/src/components/landing/architecture-section.tsx
+++ b/dashboard/src/components/landing/architecture-section.tsx
@@ -1,0 +1,50 @@
+import { Reveal } from '@/components/motion/primitives'
+import { ArchitectureDiagram } from './architecture-diagram'
+import { DOCS_URL } from './config'
+
+/**
+ * "Under the hood" — the static reference topology: SDKs and A2A agents in,
+ * gateway internals (x402 verify, router, cache, guard), five providers out,
+ * Solana settlement plane underneath. Both stores labeled optional because
+ * the gateway genuinely degrades gracefully without them.
+ */
+export function ArchitectureSection() {
+  return (
+    <section aria-labelledby="arch-heading" className="border-t border-border/60">
+      <div className="mx-auto max-w-[1320px] px-6 py-16 lg:py-24">
+        <Reveal>
+          <span className="eyebrow">under the hood</span>
+          <h2
+            id="arch-heading"
+            className="display-wonk mt-3 max-w-[18ch] text-[var(--heading-color)]"
+            style={{ fontSize: 'clamp(2rem, 4.6vw, 4rem)' }}
+          >
+            One gateway. Two ways to settle.
+          </h2>
+        </Reveal>
+        <Reveal index={1} className="mt-10">
+          <div className="hidden md:block">
+            <ArchitectureDiagram />
+          </div>
+          <div className="md:hidden">
+            <ArchitectureDiagram compact />
+          </div>
+        </Reveal>
+        <Reveal index={2}>
+          <p className="mt-6 max-w-[68ch] text-[14px] leading-[1.6] text-muted-foreground">
+            Exact payments verify up front and settle after delivery; escrow
+            deposits land on-chain first, then claim and refund settle in one
+            transaction. Redis and Postgres are optional — the gateway degrades
+            gracefully without either.{' '}
+            <a
+              href={`${DOCS_URL}/docs/concepts/architecture`}
+              className="font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--accent-salmon)] hover:text-[var(--accent-salmon-hover)]"
+            >
+              architecture docs →
+            </a>
+          </p>
+        </Reveal>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/components/landing/router-cache-diagram.tsx
+++ b/dashboard/src/components/landing/router-cache-diagram.tsx
@@ -1,0 +1,687 @@
+'use client'
+
+// Animated router / cache flow diagram for the Solvela landing surface.
+//
+// Two passes loop forever:
+//   PASS A (cache hit):  request → exact-cache check → HIT → response returns.
+//   PASS B (route):      request → exact-cache check → MISS → 15-dimension
+//                        scorer → tier classification → profile column picks
+//                        a model → provider.
+//
+// Driving model (mirrors the house pattern in escrow-diagram-animated.tsx /
+// escrow-sequence.tsx, but self-contained because this component owns its own
+// clock):
+//   - `beat` PROVIDED  → fully controlled; render exactly that beat, no timers.
+//   - `beat` UNDEFINED → self-running setTimeout chain, paused via
+//                        IntersectionObserver when scrolled out of view, and
+//                        rendered as a single COMPLETE static frame when the
+//                        user prefers reduced motion.
+//
+// Ground truth:
+//   crates/router/src/scorer.rs   — 15 weighted dimensions (names + weights)
+//   crates/router/src/profiles.rs — tiers (simple/medium/complex/reasoning),
+//                                    profiles (eco/auto/premium/free)
+//   crates/gateway/src/cache/exact.rs — exact-match short-circuit before the
+//                                    provider call; SHA-256 key ⇒ zero false
+//                                    positives.
+
+import { useEffect, useRef, useState } from 'react'
+
+import { diagramPalette as C } from '@/lib/diagram-colors'
+
+/**
+ * Beats. The loop runs 0 → 9 then wraps. The two passes share the request and
+ * cache-check frames so the diagram reads as one pipeline answering twice.
+ *
+ *   0  idle (request waiting)
+ *   1  request → cache check                    (PASS A begins)
+ *   2  cache HIT — response returns immediately
+ *   3  hold on the returned response
+ *   4  request → cache check                    (PASS B begins)
+ *   5  cache MISS — continue down the pipeline
+ *   6  15-dimension scorer evaluates
+ *   7  tier classified
+ *   8  profile column picks the model
+ *   9  provider answers
+ */
+export type RouterBeat = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
+
+const LAST_BEAT = 9 as const
+
+// Milliseconds per beat when self-driving. Tuned so the eye can read each
+// stage; the two cache frames are quicker, the scorer/profile frames linger.
+const BEAT_MS: Record<RouterBeat, number> = {
+  0: 700,
+  1: 1100,
+  2: 1100,
+  3: 1500,
+  4: 1100,
+  5: 900,
+  6: 1500,
+  7: 1100,
+  8: 1400,
+  9: 1700,
+}
+
+interface Props {
+  /** When provided the diagram is fully controlled (no internal timers). */
+  beat?: number
+}
+
+export function RouterCacheDiagram({ beat: controlled }: Props) {
+  const isControlled = controlled !== undefined
+
+  const [autoBeat, setAutoBeat] = useState<RouterBeat>(0)
+  const [loopKey, setLoopKey] = useState(0)
+  const [inView, setInView] = useState(false)
+  const [reduced, setReduced] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  // Reduced-motion: pick up once, render the complete static frame (beat 9 view
+  // augmented by `reduced` so BOTH passes' end-states are shown at once).
+  useEffect(() => {
+    if (isControlled) return
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    if (mq.matches) setReduced(true)
+  }, [isControlled])
+
+  // Pause when out of view — resume from the current beat (don't reset).
+  useEffect(() => {
+    if (isControlled || reduced) return
+    const node = wrapperRef.current
+    if (!node) return
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) setInView(e.isIntersecting)
+      },
+      { rootMargin: '200px 0px' }
+    )
+    io.observe(node)
+    return () => io.disconnect()
+  }, [isControlled, reduced])
+
+  // Self-running clock: one timeout per beat, cleaned up on every state change.
+  useEffect(() => {
+    if (isControlled || reduced || !inView) return
+    const id = setTimeout(() => {
+      setAutoBeat((b) => {
+        const next = (b >= LAST_BEAT ? 0 : b + 1) as RouterBeat
+        return next
+      })
+      // Bump the loop key whenever we wrap so SMIL packets remount and replay.
+      if (autoBeat >= LAST_BEAT) setLoopKey((k) => k + 1)
+    }, BEAT_MS[autoBeat])
+    return () => clearTimeout(id)
+  }, [autoBeat, inView, isControlled, reduced])
+
+  const beat: RouterBeat = isControlled
+    ? (clampBeat(controlled) as RouterBeat)
+    : autoBeat
+
+  return (
+    <div ref={wrapperRef} className="h-full w-full">
+      <DiagramSvg beat={beat} loopKey={isControlled ? 0 : loopKey} staticAll={reduced} />
+    </div>
+  )
+}
+
+function clampBeat(n: number): number {
+  if (Number.isNaN(n)) return 0
+  if (n < 0) return 0
+  if (n > LAST_BEAT) return LAST_BEAT
+  return Math.floor(n)
+}
+
+/* ── Geometry ────────────────────────────────────────────────────────────
+   A single horizontal pipeline that stays legible at 320px because the SVG
+   scales to the container width while preserving aspect ratio. Coordinates
+   live in a 720×420 viewBox. The cache node branches UP to the response chip
+   (hit) and DOWN-RIGHT into the scorer (miss). */
+
+const VB_W = 720
+const VB_H = 420
+
+// X anchors for the pipeline columns.
+const X_REQ = 70
+const X_CACHE = 214
+const X_SCORER = 372
+const X_TIER = 522
+const X_PROFILE = 522
+const X_PROVIDER = 650
+
+// Y anchors.
+const Y_MAIN = 232 // the main left-to-right spine
+const Y_HIT = 92 // the response chip sits above the spine
+
+/* ── The 15 scorer dimensions (verbatim from scorer.rs WEIGHTS comments) ──
+   We surface real names + their real weights as a compact tick grid. No
+   latency is shown — the scorer is deterministic with zero external calls. */
+
+interface Dim {
+  label: string
+  weight: number
+}
+
+const DIMENSIONS: Dim[] = [
+  { label: 'token count', weight: 0.08 },
+  { label: 'code presence', weight: 0.15 },
+  { label: 'reasoning markers', weight: 0.18 },
+  { label: 'technical terms', weight: 0.1 },
+  { label: 'creative markers', weight: 0.05 },
+  { label: 'simple indicators', weight: 0.02 },
+  { label: 'multi-step', weight: 0.12 },
+  { label: 'question complexity', weight: 0.05 },
+  { label: 'agentic markers', weight: 0.04 },
+  { label: 'math / logic', weight: 0.06 },
+  { label: 'language complexity', weight: 0.04 },
+  { label: 'conversation depth', weight: 0.03 },
+  { label: 'tool usage', weight: 0.04 },
+  { label: 'output format', weight: 0.02 },
+  { label: 'domain specificity', weight: 0.02 },
+]
+
+const TIERS = ['simple', 'medium', 'complex', 'reasoning'] as const
+const PROFILES = ['eco', 'auto', 'premium', 'free'] as const
+
+// In the route pass we land on the "complex" tier and the "auto" profile,
+// which together resolve to google/gemini-3.1-pro (profiles.rs).
+const PICKED_TIER = 'complex'
+const PICKED_PROFILE = 'auto'
+const PICKED_MODEL = 'gemini-3.1-pro'
+
+interface SvgProps {
+  beat: RouterBeat
+  loopKey: number
+  /** Reduced-motion: render every stage of both passes simultaneously. */
+  staticAll: boolean
+}
+
+function DiagramSvg({ beat, loopKey, staticAll }: SvgProps) {
+  // Phase flag. In static mode everything is "reached" so the full pipeline
+  // and both end-states render at once with no motion.
+  const passB = staticAll || beat >= 4
+
+  const cacheActive = staticAll || beat === 1 || beat === 4
+  const hitShown = staticAll || beat >= 2
+  const missShown = staticAll || beat >= 5
+  const scorerActive = staticAll || beat === 6
+  const scorerReached = staticAll || beat >= 6
+  const tierReached = staticAll || beat >= 7
+  const profileReached = staticAll || beat >= 8
+  const providerReached = staticAll || beat >= 9
+
+  const ariaLabel =
+    'Solvela request pipeline. A request first hits the exact-match cache. ' +
+    'On a cache hit the stored response returns immediately with zero false ' +
+    'positives. On a miss the request flows into a deterministic ' +
+    '15-dimension scorer with zero external calls, which classifies it into a ' +
+    'complexity tier; the chosen routing profile then picks a model and the ' +
+    'provider answers.'
+
+  return (
+    <svg
+      viewBox={`0 0 ${VB_W} ${VB_H}`}
+      role="img"
+      aria-label={ariaLabel}
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <defs>
+        <linearGradient id="rc-node" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={C.nodeFrontMid} />
+          <stop offset="1" stopColor={C.nodeFrontDark} />
+        </linearGradient>
+        <linearGradient id="rc-cache" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={C.nodeTopSurface} />
+          <stop offset="1" stopColor={C.nodeFrontDark} />
+        </linearGradient>
+
+        {/* Connector paths (packets ride these). */}
+        <path id="rc-path-req-cache" d={`M ${X_REQ + 40} ${Y_MAIN} L ${X_CACHE - 46} ${Y_MAIN}`} fill="none" />
+        <path id="rc-path-hit" d={`M ${X_CACHE} ${Y_MAIN - 44} C ${X_CACHE} ${Y_HIT + 60}, ${X_CACHE} ${Y_HIT + 40}, ${X_CACHE + 8} ${Y_HIT + 24}`} fill="none" />
+        <path id="rc-path-miss" d={`M ${X_CACHE + 46} ${Y_MAIN} L ${X_SCORER - 58} ${Y_MAIN}`} fill="none" />
+        <path id="rc-path-scorer-tier" d={`M ${X_SCORER + 58} ${Y_MAIN} L ${X_TIER - 44} ${Y_MAIN}`} fill="none" />
+        <path id="rc-path-profile-provider" d={`M ${X_PROFILE + 44} ${Y_MAIN + 40} C ${X_PROVIDER - 30} ${Y_MAIN + 40}, ${X_PROVIDER - 20} ${Y_MAIN}, ${X_PROVIDER} ${Y_MAIN}`} fill="none" />
+      </defs>
+
+      {/* ── Static guide rails (faint) ─────────────────────────────────── */}
+      <g fill="none" strokeWidth="1.5">
+        <use href="#rc-path-req-cache" stroke={C.nodeStroke} opacity={cacheActive || hitShown || missShown ? 0.5 : 0.2} />
+        <use
+          href="#rc-path-hit"
+          stroke={C.accentGold}
+          strokeDasharray="4 4"
+          opacity={hitShown ? 0.55 : 0.18}
+        />
+        <use
+          href="#rc-path-miss"
+          stroke={C.nodeStroke}
+          strokeDasharray="4 4"
+          opacity={missShown ? 0.55 : 0.18}
+        />
+        <use href="#rc-path-scorer-tier" stroke={C.nodeStroke} opacity={tierReached ? 0.5 : 0.18} />
+        <use href="#rc-path-profile-provider" stroke={C.accentSalmon} opacity={providerReached ? 0.5 : 0.18} />
+      </g>
+
+      {/* ── Request node ───────────────────────────────────────────────── */}
+      <StageBox
+        cx={X_REQ}
+        cy={Y_MAIN}
+        w={80}
+        h={52}
+        fill="url(#rc-node)"
+        label="request"
+        sub="POST /v1"
+        dot={C.neutralText}
+        active={beat === 0 || beat === 1 || beat === 4}
+      />
+
+      {/* ── Exact-cache node ───────────────────────────────────────────── */}
+      <StageBox
+        cx={X_CACHE}
+        cy={Y_MAIN}
+        w={92}
+        h={60}
+        fill="url(#rc-cache)"
+        label="exact cache"
+        sub="SHA-256 key"
+        dot={C.accentGold}
+        active={cacheActive}
+        highlight={cacheActive}
+      />
+
+      {/* ── Cache-hit response chip (above the spine) ──────────────────── */}
+      <ResponseChip cx={X_CACHE + 78} cy={Y_HIT} shown={hitShown} dim={passB && !staticAll && beat >= 4} />
+
+      {/* ── 15-dimension scorer (weight grid) ──────────────────────────── */}
+      <ScorerGrid
+        cx={X_SCORER}
+        cy={Y_MAIN}
+        active={scorerActive}
+        reached={scorerReached}
+      />
+
+      {/* ── Tier classification column ─────────────────────────────────── */}
+      <PickColumn
+        x={X_TIER}
+        topY={Y_MAIN - 96}
+        title="tier"
+        items={TIERS as unknown as string[]}
+        picked={PICKED_TIER}
+        reached={tierReached}
+        tone={C.neutralText}
+      />
+
+      {/* ── Profile column (picks the model) ───────────────────────────── */}
+      <PickColumn
+        x={X_PROFILE}
+        topY={Y_MAIN + 28}
+        title="profile"
+        items={PROFILES as unknown as string[]}
+        picked={PICKED_PROFILE}
+        reached={profileReached}
+        tone={C.accentGold}
+      />
+
+      {/* Picked-model caption between profile and provider. */}
+      {(profileReached || providerReached) && (
+        <text
+          x={X_PROFILE + 56}
+          y={Y_MAIN - 4}
+          fontFamily="'JetBrains Mono', monospace"
+          fontSize="10"
+          fill={C.accentGold}
+          opacity={providerReached ? 1 : 0.7}
+        >
+          {PICKED_MODEL}
+        </text>
+      )}
+
+      {/* ── Provider node ──────────────────────────────────────────────── */}
+      <StageBox
+        cx={X_PROVIDER}
+        cy={Y_MAIN}
+        w={86}
+        h={56}
+        fill="url(#rc-node)"
+        label="provider"
+        sub="LLM call"
+        dot={C.accentSalmon}
+        active={providerReached}
+        highlight={beat === 9}
+      />
+
+      {/* ── Animated packets (transient; remount each loop via loopKey) ── */}
+      {!staticAll && beat === 1 && (
+        <g key={`reqA-${loopKey}`}>
+          <Packet pathId="#rc-path-req-cache" color={C.neutralText} dur="0.9s" />
+        </g>
+      )}
+      {!staticAll && beat === 2 && (
+        <g key={`hit-${loopKey}`}>
+          <Packet pathId="#rc-path-hit" color={C.accentGold} dur="0.85s" />
+        </g>
+      )}
+      {!staticAll && beat === 4 && (
+        <g key={`reqB-${loopKey}`}>
+          <Packet pathId="#rc-path-req-cache" color={C.neutralText} dur="0.9s" />
+        </g>
+      )}
+      {!staticAll && beat === 5 && (
+        <g key={`miss-${loopKey}`}>
+          <Packet pathId="#rc-path-miss" color={C.neutralText} dur="0.9s" />
+        </g>
+      )}
+      {!staticAll && beat === 7 && (
+        <g key={`tier-${loopKey}`}>
+          <Packet pathId="#rc-path-scorer-tier" color={C.neutralText} dur="0.85s" />
+        </g>
+      )}
+      {!staticAll && beat === 9 && (
+        <g key={`prov-${loopKey}`}>
+          <Packet pathId="#rc-path-profile-provider" color={C.accentSalmon} dur="0.85s" />
+        </g>
+      )}
+
+      {/* ── Bottom legend ──────────────────────────────────────────────── */}
+      <g transform={`translate(${VB_W / 2}, ${VB_H - 20})`} textAnchor="middle">
+        <text
+          x="0"
+          y="0"
+          fontFamily="'JetBrains Mono', monospace"
+          fontSize="10"
+          letterSpacing="1.5"
+          fill={C.neutralText}
+          opacity="0.6"
+        >
+          {staticAll
+            ? 'cache hit · zero false positives    │    miss → deterministic scorer · zero external calls'
+            : passB
+              ? 'miss → deterministic scorer · zero external calls'
+              : 'cache hit · zero false positives'}
+        </text>
+      </g>
+    </svg>
+  )
+}
+
+/* ── Sub-components ────────────────────────────────────────────────────── */
+
+interface StageBoxProps {
+  cx: number
+  cy: number
+  w: number
+  h: number
+  fill: string
+  label: string
+  sub: string
+  dot: string
+  active?: boolean
+  highlight?: boolean
+}
+
+function StageBox({ cx, cy, w, h, fill, label, sub, dot, active, highlight }: StageBoxProps) {
+  const x = cx - w / 2
+  const y = cy - h / 2
+  const stroke = active ? C.accentGold : C.nodeStroke
+  return (
+    <g style={highlight ? { filter: `drop-shadow(0 0 5px ${C.accentGold})` } : undefined}>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={6}
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={active ? 1.4 : 1}
+      />
+      <circle cx={x + 11} cy={y + 12} r="2.5" fill={dot} />
+      <text
+        x={cx}
+        y={cy - 2}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="12"
+        fill={C.headingText}
+        letterSpacing="0.5"
+      >
+        {label}
+      </text>
+      <text
+        x={cx}
+        y={cy + 14}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="9"
+        fill={C.neutralText}
+        opacity="0.6"
+        letterSpacing="0.5"
+      >
+        {sub}
+      </text>
+    </g>
+  )
+}
+
+interface ResponseChipProps {
+  cx: number
+  cy: number
+  shown: boolean
+  /** Fade the hit chip while pass B runs so it doesn't compete for attention. */
+  dim: boolean
+}
+
+function ResponseChip({ cx, cy, shown, dim }: ResponseChipProps) {
+  const opacity = shown ? (dim ? 0.32 : 1) : 0.12
+  const w = 132
+  const h = 44
+  const x = cx - w / 2
+  const y = cy - h / 2
+  return (
+    <g opacity={opacity} style={{ transition: 'opacity 300ms ease' }}>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={6}
+        fill={C.nodeBlackish}
+        stroke={C.accentGold}
+        strokeWidth={shown && !dim ? 1.4 : 1}
+      />
+      <text
+        x={cx}
+        y={cy - 3}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="11"
+        fill={C.accentGold}
+        letterSpacing="0.5"
+      >
+        cached response
+      </text>
+      <text
+        x={cx}
+        y={cy + 12}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="8"
+        fill={C.neutralText}
+        opacity="0.7"
+        letterSpacing="1"
+      >
+        returns immediately
+      </text>
+    </g>
+  )
+}
+
+interface ScorerGridProps {
+  cx: number
+  cy: number
+  active: boolean
+  reached: boolean
+}
+
+function ScorerGrid({ cx, cy, active, reached }: ScorerGridProps) {
+  // 5 columns × 3 rows of weight ticks. Each tick's height encodes its real
+  // weight from scorer.rs. The grid sits inside a labelled panel.
+  const cols = 5
+  const rows = 3
+  const cellW = 19
+  const cellH = 26
+  const gridW = cols * cellW
+  const gridH = rows * cellH
+  const panelPadX = 14
+  const panelPadTop = 30
+  const panelPadBottom = 16
+  const panelW = gridW + panelPadX * 2
+  const panelH = gridH + panelPadTop + panelPadBottom
+  const panelX = cx - panelW / 2
+  const panelY = cy - panelH / 2
+
+  const gridX = panelX + panelPadX
+  const gridY = panelY + panelPadTop
+
+  const maxW = Math.max(...DIMENSIONS.map((d) => d.weight))
+  const barMax = cellH - 6
+
+  return (
+    <g style={active ? { filter: `drop-shadow(0 0 6px ${C.accentGold})` } : undefined}>
+      <rect
+        x={panelX}
+        y={panelY}
+        width={panelW}
+        height={panelH}
+        rx={7}
+        fill={C.nodeFrontDark}
+        stroke={active ? C.accentGold : C.nodeStroke}
+        strokeWidth={active ? 1.4 : 1}
+      />
+      <text
+        x={cx}
+        y={panelY + 18}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="11"
+        fill={C.headingText}
+        letterSpacing="0.5"
+      >
+        15-dim scorer
+      </text>
+
+      {DIMENSIONS.map((d, i) => {
+        const col = i % cols
+        const row = Math.floor(i / cols)
+        const bx = gridX + col * cellW + cellW / 2
+        const baseY = gridY + row * cellH + cellH - 4
+        const barH = 4 + (d.weight / maxW) * barMax
+        return (
+          <g key={d.label}>
+            <title>{`${d.label} · weight ${d.weight}`}</title>
+            <rect
+              x={bx - 5}
+              y={baseY - barH}
+              width={10}
+              height={barH}
+              rx={1.5}
+              fill={reached ? C.accentGold : C.neutralText}
+              opacity={reached ? 0.85 : 0.4}
+            />
+          </g>
+        )
+      })}
+
+      <text
+        x={cx}
+        y={panelY + panelH - 5}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="8"
+        fill={C.neutralText}
+        opacity="0.6"
+        letterSpacing="1"
+      >
+        deterministic
+      </text>
+    </g>
+  )
+}
+
+interface PickColumnProps {
+  x: number
+  topY: number
+  title: string
+  items: string[]
+  picked: string
+  reached: boolean
+  tone: string
+}
+
+function PickColumn({ x, topY, title, items, picked, reached, tone }: PickColumnProps) {
+  const rowH = 17
+  const w = 86
+  return (
+    <g opacity={reached ? 1 : 0.4} style={{ transition: 'opacity 300ms ease' }}>
+      <text
+        x={x}
+        y={topY - 6}
+        textAnchor="middle"
+        fontFamily="'JetBrains Mono', monospace"
+        fontSize="9"
+        fill={C.neutralText}
+        opacity="0.6"
+        letterSpacing="1.5"
+      >
+        {title.toUpperCase()}
+      </text>
+      {items.map((item, i) => {
+        const y = topY + i * rowH
+        const isPicked = reached && item === picked
+        return (
+          <g key={item}>
+            <rect
+              x={x - w / 2}
+              y={y}
+              width={w}
+              height={rowH - 3}
+              rx={3}
+              fill={isPicked ? C.nodeBlackish : 'none'}
+              stroke={isPicked ? tone : C.nodeStroke}
+              strokeWidth={isPicked ? 1.3 : 0.75}
+              opacity={isPicked ? 1 : 0.55}
+            />
+            <text
+              x={x}
+              y={y + rowH - 7}
+              textAnchor="middle"
+              fontFamily="'JetBrains Mono', monospace"
+              fontSize="10"
+              fill={isPicked ? tone : C.neutralText}
+              opacity={isPicked ? 1 : 0.55}
+            >
+              {item}
+            </text>
+          </g>
+        )
+      })}
+    </g>
+  )
+}
+
+interface PacketProps {
+  pathId: string
+  color: string
+  dur: string
+}
+
+function Packet({ pathId, color, dur }: PacketProps) {
+  return (
+    <circle r="5" fill={color}>
+      <animateMotion dur={dur} begin="0s" fill="freeze" rotate="auto">
+        <mpath href={pathId} />
+      </animateMotion>
+    </circle>
+  )
+}


### PR DESCRIPTION
## Summary

PR 4 of the website/docs revamp: the three remaining graphics, all in the v2 visual language (warm-dark `diagram-colors` palette, SMIL packet animation, IntersectionObserver pause, reduced-motion static fallbacks, `role="img"` + descriptive aria-labels).

- **`a2a-diagram`** — the centerpiece: AgentCard discovery → `message/send` → `input-required` task with `x402.payment.required` → signed payment → `completed` + `x402.payment.receipts`. Every protocol label (metadata keys, task states, method names) copied from `crates/gateway/src/a2a/`, not from spec memory.
- **`router-cache-diagram`** — exact-cache hit short-circuit ("zero false positives") and miss → 15-dimension scorer (all 15 dimension names verbatim from `scorer.rs`) → tier → profile → model. No latency numbers anywhere.
- **`architecture-diagram`** — true topology: SDK (ts/python/go/rust/mcp) + A2A clients → gateway internals (x402 verify, router, exact cache, prompt guard) → 5 providers, with the Solana settlement plane showing exact (deferred transfer) vs escrow (deposit → claim+refund) as distinct flows; redis/postgres labeled optional·degrades. `compact` prop for narrow viewports.

**Embeds:** two new landing sections (agent-to-agent after the hero; "under the hood" after enterprise) and four docs pages (`a2a`, `smart-router`, `response-cache`, `architecture`) via `getMDXComponents`.

**Bonus truth fix:** removed the unbenchmarked "Classification takes under 1 microsecond" claim from smart-router.mdx (now "deterministic, with zero external calls").

## Verification
- `npm test` 100/100 · `next build` green (53/53 pages incl. all embed pages)
- Screenshot-verified on desktop: landing A2A section, architecture section, docs embeds render correctly; reduced-motion renders complete static frames (built on the same gated primitives as #543)
- Label truth-check: each builder agent returned its verbatim label list with file:line evidence; decorative-only labels (REQUEST→/WALLET/etc.) are framing, not claims