### PR TITLE
feat(dashboard): dynamic OG images, JSON-LD, v2 restyle for metrics/sponsor

### DIFF
--- a/dashboard/src/app/docs/[[...slug]]/page.tsx
+++ b/dashboard/src/app/docs/[[...slug]]/page.tsx
@@ -102,13 +102,28 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   if (!page) return {}
 
-  const tree = source.pageTree
-  const section = findSectionName(tree, page.url)
   const title = page.data.title
   const description = page.data.description
+
+  // Point OG/Twitter at the dynamic docs image route (see src/app/docs/og).
+  // slug is the page path under /docs; empty for the docs root.
+  const slugPath = (slug ?? []).join('/')
+  const ogImage = `/docs/og${slugPath ? `?slug=${encodeURIComponent(slugPath)}` : ''}`
 
   return {
     title,
     description,
+    openGraph: {
+      title,
+      description,
+      images: [{ url: ogImage, width: 1200, height: 630 }],
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
   }
 }

--- a/dashboard/src/app/docs/og/route.tsx
+++ b/dashboard/src/app/docs/og/route.tsx
@@ -1,0 +1,31 @@
+/**
+ * Dynamic OG image for documentation pages.
+ *
+ * Why a route handler instead of the `opengraph-image` file convention:
+ * Next.js forbids metadata image files under an optional catch-all segment
+ * (`/docs/[[...slug]]/opengraph-image` → "Optional catch-all must be the last
+ * part of the URL"). So the docs page's generateMetadata points
+ * openGraph.images at this handler with a `?slug=` query, and we resolve the
+ * page title from the same fumadocs source the page uses.
+ *
+ * No external network fetch at request time; see src/lib/og.tsx.
+ */
+import type { NextRequest } from 'next/server'
+import { source } from '@/lib/source'
+import { renderOgImage } from '@/lib/og'
+
+export const runtime = 'nodejs'
+
+export function GET(req: NextRequest) {
+  const raw = req.nextUrl.searchParams.get('slug') ?? ''
+  // slug is the page url path under /docs, slash-joined (e.g. "concepts/x402").
+  const slug = raw ? raw.split('/').filter(Boolean) : undefined
+  const page = source.getPage(slug)
+  const title = page?.data.title ?? 'Documentation'
+
+  return renderOgImage({
+    eyebrow: 'solvela docs',
+    kicker: 'documentation',
+    title,
+  })
+}

--- a/dashboard/src/app/metrics/opengraph-image.tsx
+++ b/dashboard/src/app/metrics/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { renderOgImage, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const runtime = 'nodejs'
+export const alt = 'Solvela — public metrics'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+
+export default function Image() {
+  return renderOgImage({
+    eyebrow: "what's actually shipped",
+    title: 'Public metrics',
+  })
+}

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -109,7 +109,7 @@ export default async function MetricsPage() {
           <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-tertiary">
             solvela / public metrics
           </p>
-          <h1 className="font-display text-4xl md:text-5xl font-semibold leading-tight">
+          <h1 className="display-wonk text-4xl md:text-5xl leading-tight text-[var(--heading-color)]">
             What&rsquo;s actually shipped.
           </h1>
           <p className="max-w-[60ch] text-[15px] leading-[1.6] text-muted-foreground">

--- a/dashboard/src/app/opengraph-image.tsx
+++ b/dashboard/src/app/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { renderOgImage, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const runtime = 'nodejs'
+export const alt = 'Solvela — trustless escrow for agent payments'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+
+export default function Image() {
+  return renderOgImage({
+    eyebrow: 'solana-native x402 gateway',
+    title: 'Trustless escrow for agent payments',
+  })
+}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -18,22 +18,56 @@ export const metadata: Metadata = {
   description:
     'Solana-native x402 gateway for AI agents. Pay only for what your agent receives — escrow-settled in USDC-SPL. No accounts, no API keys, just wallets.',
   openGraph: {
+    // No `images` key here on purpose: the file-convention
+    // src/app/opengraph-image.tsx supplies the dynamic OG image and only
+    // takes precedence when metadata doesn't hardcode one.
     title: 'Solvela — trustless escrow for agent payments',
     description:
       'Solana-native x402 gateway for AI agents. Pay only for what your agent receives — escrow-settled in USDC-SPL.',
     url: 'https://solvela.ai',
     siteName: 'Solvela',
-    images: [{ url: 'https://solvela.ai/logo.png', width: 1200, height: 630 }],
     type: 'website',
   },
   twitter: {
+    // Same rationale: omit `images` so the dynamic opengraph-image is used.
     card: 'summary_large_image',
     title: 'Solvela — trustless escrow for agent payments',
     description:
       'Solana-native x402 gateway for AI agents. Pay only for what your agent receives.',
-    images: ['https://solvela.ai/logo.png'],
   },
   alternates: { canonical: 'https://solvela.ai' },
+}
+
+// Structured data — Organization + SoftwareApplication. Emitted as a single
+// @graph so crawlers read both entities from one script. No ratings, reviews,
+// prices, or other fields we can't substantiate.
+const JSON_LD = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': 'https://solvela.ai/#organization',
+      name: 'Solvela',
+      url: 'https://solvela.ai',
+      sameAs: ['https://github.com/solvela-ai/solvela'],
+      contactPoint: {
+        '@type': 'ContactPoint',
+        email: 'partnerships@solvela.ai',
+        contactType: 'partnerships',
+      },
+    },
+    {
+      '@type': 'SoftwareApplication',
+      '@id': 'https://solvela.ai/#software',
+      name: 'Solvela',
+      url: 'https://solvela.ai',
+      applicationCategory: 'DeveloperApplication',
+      operatingSystem: 'any',
+      description:
+        'Solana-native x402 gateway for AI agents. Pay only for what your agent receives — escrow-settled in USDC-SPL.',
+      publisher: { '@id': 'https://solvela.ai/#organization' },
+    },
+  ],
 }
 
 export default async function LandingPage() {
@@ -48,6 +82,11 @@ export default async function LandingPage() {
     // forcing it here prevents OS-light users from falling through to the
     // (untested for landing) light-mode token set.
     <main className="dark min-h-screen bg-[var(--background)] text-foreground">
+      <script
+        type="application/ld+json"
+        // Serialized server-side; content is static and contains no user input.
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }}
+      />
       <SmoothScroll>
         <LandingTopStrip />
         <HeroPanel />

--- a/dashboard/src/app/sponsor/opengraph-image.tsx
+++ b/dashboard/src/app/sponsor/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { renderOgImage, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const runtime = 'nodejs'
+export const alt = 'Sponsor Solvela — keep the gateway lit'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+
+export default function Image() {
+  return renderOgImage({
+    eyebrow: 'sponsor solvela',
+    title: 'Keep the gateway lit',
+  })
+}

--- a/dashboard/src/app/sponsor/page.tsx
+++ b/dashboard/src/app/sponsor/page.tsx
@@ -128,7 +128,7 @@ export default function SponsorPage() {
           <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-tertiary">
             solvela / sponsor
           </p>
-          <h1 className="font-display text-4xl md:text-5xl font-semibold leading-tight">
+          <h1 className="display-wonk text-4xl md:text-5xl leading-tight text-[var(--heading-color)]">
             Keep the gateway lit.
           </h1>
           <p className="max-w-[60ch] text-[15px] leading-[1.6] text-muted-foreground">

--- a/dashboard/src/lib/og.tsx
+++ b/dashboard/src/lib/og.tsx
@@ -1,0 +1,157 @@
+/**
+ * Shared renderer for dynamic Open Graph images (1200×630).
+ *
+ * Deliberately uses no external network fetches at request time and no
+ * web-font file load: next/font packages fetch from Google at *build* time
+ * and ship no .woff2 we can read with fs at runtime, and pulling a font over
+ * the network inside the image route would make OG generation flaky. The
+ * brand reads through layout, scale, and the salmon/gold palette instead of
+ * font fidelity — reliability beats a serif here.
+ *
+ * Palette mirrors src/app/globals.css:
+ *   bg #262624 · heading #FAF9F5 · body #DEDCD1 · salmon #FE8181 · gold #C8A240
+ */
+import { ImageResponse } from 'next/og'
+
+export const OG_SIZE = { width: 1200, height: 630 }
+export const OG_CONTENT_TYPE = 'image/png'
+
+const BG = '#262624'
+const HEADING = '#FAF9F5'
+const SALMON = '#FE8181'
+const GOLD = '#C8A240'
+const FAINT = '#807d72'
+
+interface OgArgs {
+  /** Mono eyebrow, rendered lowercase in salmon. */
+  eyebrow: string
+  /** Large editorial title. */
+  title: string
+  /** Optional kicker shown above the wordmark footer (e.g. a doc section). */
+  kicker?: string
+}
+
+/**
+ * Build the 1200×630 ImageResponse. Returned by each route's GET handler.
+ */
+export function renderOgImage({ eyebrow, title, kicker }: OgArgs): ImageResponse {
+  // Scale the title down for long strings so doc titles don't overflow.
+  const titleSize = title.length > 46 ? 64 : title.length > 30 ? 76 : 92
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          backgroundColor: BG,
+          // 56px grid, faded — echoes the landing hero backdrop.
+          backgroundImage:
+            'linear-gradient(90deg, rgba(222,220,209,0.05) 1px, transparent 1px), linear-gradient(rgba(222,220,209,0.05) 1px, transparent 1px)',
+          backgroundSize: '56px 56px',
+          padding: '72px 80px',
+          position: 'relative',
+        }}
+      >
+        {/* salmon-tipped top rule */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 6,
+            display: 'flex',
+            backgroundColor: SALMON,
+          }}
+        />
+
+        {/* eyebrow */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            fontSize: 26,
+            letterSpacing: 6,
+            textTransform: 'uppercase',
+            color: SALMON,
+            fontFamily: 'monospace',
+          }}
+        >
+          {eyebrow}
+        </div>
+
+        {/* title block */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18, maxWidth: 1000 }}>
+          {kicker ? (
+            <div
+              style={{
+                display: 'flex',
+                fontSize: 28,
+                letterSpacing: 3,
+                textTransform: 'uppercase',
+                color: GOLD,
+                fontFamily: 'monospace',
+              }}
+            >
+              {kicker}
+            </div>
+          ) : null}
+          <div
+            style={{
+              display: 'flex',
+              fontSize: titleSize,
+              lineHeight: 1.02,
+              fontWeight: 700,
+              letterSpacing: -2,
+              color: HEADING,
+            }}
+          >
+            {title}
+          </div>
+        </div>
+
+        {/* footer wordmark: red dot + solvela + domain */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            borderTop: `1px solid ${GOLD}40`,
+            paddingTop: 28,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+            <div
+              style={{
+                width: 18,
+                height: 18,
+                borderRadius: 9,
+                backgroundColor: SALMON,
+                display: 'flex',
+              }}
+            />
+            <div style={{ display: 'flex', fontSize: 40, fontWeight: 600, color: HEADING }}>
+              solvela
+            </div>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 24,
+              letterSpacing: 2,
+              color: FAINT,
+              fontFamily: 'monospace',
+            }}
+          >
+            solana-native · usdc settled
+          </div>
+        </div>
+      </div>
+    ),
+    { ...OG_SIZE },
+  )
+}


### PR DESCRIPTION
## Summary

PR 5 (final) of the website/docs revamp: social previews, structured data, and bringing the metrics/sponsor pages into the v2 voice.

- **Dynamic OG images** (`next/og` ImageResponse, 1200×630, brand palette, no runtime network fetches): landing / metrics / sponsor via the file convention; docs via a `/docs/og?slug=` route handler wired through `generateMetadata` with per-page titles from the fumadocs source (the file convention is rejected under an optional catch-all route — verified distinct renders per slug). Hardcoded `logo.png` og/twitter entries removed so the dynamic images win.
- **JSON-LD** on the landing page: Organization + SoftwareApplication `@graph` (name/url/sameAs/contact only — no invented ratings or review fields).
- **Metrics + sponsor**: h1s moved to the v2 Fraunces display voice; zero data/table changes.
- **Dead-link sweep**: all 25 internal `/docs/...` targets + 3 anchor fragments verified against the content tree — none broken.

## Verification
- `npm test` 100/100 · `next build` green
- All five OG endpoints curl-verified `200 image/png` on a production build (`next start`), with per-page docs titles confirmed by differing render sizes