### PR TITLE
fix(sdk-go): convert post-signing streaming 402 to PaymentRejectedError

### DIFF
--- a/dashboard/content/docs/sdks/go.mdx
+++ b/dashboard/content/docs/sdks/go.mdx
@@ -218,7 +218,7 @@ for chunk := range ch {
 fmt.Println()
 ```
 
-`ChatStream` runs the same preflight payment handshake as `Chat` — a `Signer` is required for paid streaming, otherwise the call returns `*PaymentRequiredError` before opening the stream. A post-signing 402 on the streaming POST surfaces as `*PaymentRequiredError` (unlike the non-streaming path, it is not converted to `*PaymentRejectedError`).
+`ChatStream` runs the same preflight payment handshake as `Chat` — a `Signer` is required for paid streaming, otherwise the call returns `*PaymentRequiredError` before opening the stream. A post-signing 402 on the streaming POST is converted to `*PaymentRejectedError`, exactly like the non-streaming path — `errors.As(err, &rejErr)` distinguishes "signed and rejected" from a pre-signing `*PaymentRequiredError` challenge on both paths.
 
 ## Models and pricing
 

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -222,7 +223,10 @@ func (c *SolvelaClient) Chat(ctx context.Context, request *ChatRequest) (*ChatRe
 // the payment, and the streaming request is then re-sent with the
 // Payment-Signature header attached. If no [Signer] is configured and a 402 is
 // returned, this method surfaces a [PaymentRequiredError] rather than silently
-// streaming an unauthenticated request.
+// streaming an unauthenticated request. If the gateway returns a second 402
+// AFTER a signed payment was attached to the streaming request, that is a
+// post-signing rejection and surfaces as a [PaymentRejectedError] — the same
+// distinction the non-streaming [SolvelaClient.Chat] path makes.
 func (c *SolvelaClient) ChatStream(ctx context.Context, request *ChatRequest) (<-chan ChatChunkOrError, error) {
 	model := request.Model
 
@@ -280,6 +284,17 @@ func (c *SolvelaClient) ChatStream(ctx context.Context, request *ChatRequest) (<
 	ch, err := c.transport.SendChatStream(streamCtx, effectiveReq, sig, nil)
 	if err != nil {
 		cancel()
+		// A 402 on the streaming POST after a Payment-Signature was attached
+		// is a *post-signing* rejection, not a fresh challenge. Convert it to
+		// PaymentRejectedError exactly as sendWithPayment does for the
+		// non-streaming path (and as the canonical Python client does in
+		// chat_stream), so callers can distinguish "needs signing" from
+		// "signed and rejected". The sig guard keeps a pre-signing 402
+		// surfacing as PaymentRequiredError.
+		var prErr *PaymentRequiredError
+		if sig != "" && errors.As(err, &prErr) {
+			return nil, &PaymentRejectedError{Reason: "payment rejected after signing (streaming)"}
+		}
 		return nil, err
 	}
 

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -1291,6 +1291,108 @@ func TestChatPaymentRejectedAfterSign(t *testing.T) {
 	}
 }
 
+// TestChatStreamPaymentRejectedAfterSign drives the streaming path against a
+// gateway that returns 402 on both the non-streaming probe AND the post-sign
+// streaming POST. Once the SDK has signed and attached a Payment-Signature,
+// a second 402 is a *post-signing* rejection and must surface as
+// *PaymentRejectedError — the same conversion sendWithPayment performs on the
+// non-streaming path — not the bare *PaymentRequiredError the transport
+// returns for any 402. Mirrors the canonical Python semantics
+// (client.py chat_stream: second 402 after signing → PaymentRejectedError).
+func TestChatStreamPaymentRejectedAfterSign(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always 402 — the probe gets the price challenge, and the signed
+		// streaming follow-up is rejected with a second 402.
+		pr := PaymentRequired{
+			X402Version:   X402Version,
+			CostBreakdown: CostBreakdown{Total: "100"},
+			Resource:      Resource{URL: serverURL + "/v1/chat/completions", Method: "POST"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, fakeStreamSigner{},
+		WithGatewayURL(server.URL),
+		WithMaxPaymentAmount(1000),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.ChatStream(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected PaymentRejectedError, got nil")
+	}
+	var rejErr *PaymentRejectedError
+	if !errors.As(err, &rejErr) {
+		t.Fatalf("expected *PaymentRejectedError, got %T: %v", err, err)
+	}
+	if rejErr.Reason == "" {
+		t.Error("PaymentRejectedError.Reason should be non-empty")
+	}
+	// The post-signing rejection must NOT also match the pre-signing
+	// challenge type — callers branch on the distinction.
+	var reqErr *PaymentRequiredError
+	if errors.As(err, &reqErr) {
+		t.Errorf("post-signing 402 must not surface as *PaymentRequiredError: %v", err)
+	}
+}
+
+// TestChatStream402WithoutSignerStaysPaymentRequired pins the pre-signing
+// challenge path: with no signer configured, a streaming-call 402 means
+// "needs payment" and must still surface as *PaymentRequiredError. The
+// rejected-after-signing conversion only applies once a Payment-Signature
+// was actually attached — do not break the challenge path.
+func TestChatStream402WithoutSignerStaysPaymentRequired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := PaymentRequired{
+			X402Version:   X402Version,
+			CostBreakdown: CostBreakdown{Total: "1000", Currency: "USDC"},
+			Accepts: []PaymentAccept{
+				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "1000", PayTo: "recipient123"},
+			},
+		}
+		w.WriteHeader(402)
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	wallet, _, _ := CreateWallet()
+	client, err := NewClient(wallet, nil, WithGatewayURL(server.URL)) // no signer
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.ChatStream(context.Background(), &ChatRequest{
+		Model:    "gpt-4",
+		Messages: []ChatMessage{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected PaymentRequiredError, got nil")
+	}
+	var reqErr *PaymentRequiredError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("expected *PaymentRequiredError, got %T: %v", err, err)
+	}
+	var rejErr *PaymentRejectedError
+	if errors.As(err, &rejErr) {
+		t.Errorf("pre-signing 402 must not surface as *PaymentRejectedError: %v", err)
+	}
+}
+
 // TestClientEscrowProgramMismatch verifies the escrow-program pin rejects a 402
 // whose advertised escrow program differs from the configured pin, before any
 // deposit is signed. Mirrors TestClientRecipientMismatch for the escrow path.


### PR DESCRIPTION
## Summary

Closes the Go half of the streaming error divergence found during the docs revamp's adversarial verify pass.

**Before:** a 402 returned after `ChatStream` attached a signed payment surfaced as `*PaymentRequiredError` (raw transport error), so `errors.As(err, &rejErr)` for "signed and rejected" never matched on the streaming path — unlike Go's own non-streaming path and the Python SDK, which both convert to `PaymentRejectedError`.

**After:** `ChatStream` applies the identical conversion, guarded on a non-empty payment signature. The pre-signing 402 challenge still surfaces as `*PaymentRequiredError` (pinned by test). No signing/amount/scheme/retry behavior changes; non-402 errors propagate verbatim.

## Process (money-path discipline)
- Implemented by the money-path engineer agent with `solvela-sdk-signer-audit` + `solvela-x402` skills loaded, tests-first (the rejected-path test was watched fail red before the fix)
- Independent adversarial review (Go reviewer): **APPROVE** — verified the `sig != ""` discriminator has no false-positive path, no Unwrap-chain surprises, no other caller type-asserts on the old behavior (smoke script uses `Chat` only)
- `go build` / `go vet` / `gofmt` clean; `go test ./...` **199 pass / 0 fail**
- Docs `sdks/go.mdx` updated to the unified behavior

## Known remaining divergences (follow-ups, out of scope)
- **TypeScript**: `PaymentRejectedError` exists but is never thrown — both paths re-throw `PaymentRequiredError` (`client.ts:304-307`, `transport.ts:127-129`)
- **Rust**: non-streaming converts (`client.rs:755`) but streaming surfaces `ClientError::Gateway { status: 402 }` (`client.rs:408-416`)
- Field parity: Python's `PaymentRejectedError` carries the second 402 body; Go's carries only `Reason` (pre-existing on both Go paths)

`sdks/go/v0.3.0` will be tagged after merge (error-type change on 0.x → minor bump).