### PR TITLE
fix(sdk-ts): throw PaymentRejectedError on post-signing 402, both paths

### DIFF
--- a/dashboard/content/docs/sdks/index.mdx
+++ b/dashboard/content/docs/sdks/index.mdx
@@ -7,14 +7,14 @@ description: Client libraries for Solvela — TypeScript, Python, Go, Rust CLI, 
 Official SDKs are available for four languages plus an MCP server. All SDKs handle the x402 payment handshake automatically — pass a private key and the SDK signs transactions for you.
 
 <Note>
-`@solvela/sdk@0.2.4` (published 2026-06-06) adds opt-in escrow-program-id pinning (atop the native escrow-deposit signing from 0.2.3) and is wire-aligned with the live gateway. Pin to `^0.2.4` — earlier `0.2.x` releases predate the v2 payment envelope and will not complete a real payment against `api.solvela.ai`.
+`@solvela/sdk@0.3.0` converts post-signing 402s to `PaymentRejectedError` on both paths, atop 0.2.4's opt-in escrow-program-id pinning and the native escrow-deposit signing from 0.2.3, and is wire-aligned with the live gateway. Pin to `^0.3.0` — `0.2.x` releases before 0.2.2 predate the v2 payment envelope and will not complete a real payment against `api.solvela.ai`.
 </Note>
 
 ## Comparison
 
 | Language | Package | Install | x402 Auto-payment | Async |
 |----------|---------|---------|-------------------|-------|
-| TypeScript | `@solvela/sdk` | `npm install @solvela/sdk@^0.2.4` | Yes | Yes |
+| TypeScript | `@solvela/sdk` | `npm install @solvela/sdk@^0.3.0` | Yes | Yes |
 | Python | `solvela-sdk` | `pip install solvela-sdk` | Yes | Yes (async-only) |
 | Go | `github.com/solvela-ai/solvela/sdks/go` | `go get github.com/solvela-ai/solvela/sdks/go` | Yes (built-in `KeypairSigner`, escrow scheme; `exact` needs a custom Signer) | Yes (context-based) |
 | Rust CLI | `solvela-cli` | `cargo install solvela-cli` | Yes | — |
@@ -30,10 +30,10 @@ All four language SDKs live in the [`solvela-ai/solvela`](https://github.com/sol
 - MCP server — [`sdks/mcp/`](https://github.com/solvela-ai/solvela/tree/main/sdks/mcp)
 - Vercel AI SDK provider, OpenClaw provider, npm CLI shim, signer-core primitives — [`sdks/ai-sdk-provider/`](https://github.com/solvela-ai/solvela/tree/main/sdks/ai-sdk-provider), [`sdks/openclaw-provider/`](https://github.com/solvela-ai/solvela/tree/main/sdks/openclaw-provider), [`sdks/cli-npm/`](https://github.com/solvela-ai/solvela/tree/main/sdks/cli-npm), [`sdks/signer-core/`](https://github.com/solvela-ai/solvela/tree/main/sdks/signer-core)
 
-The Rust client SDK was consolidated into the monorepo on 2026-05-16 ([#316](https://github.com/solvela-ai/solvela/pull/316)) at [`sdks/rust/`](https://github.com/solvela-ai/solvela/tree/main/sdks/rust); the standalone `solvela-ai/solvela-client` repo is archived. The four legacy Rust crates (`solvela-client`, `solvela-client-cli`, `solvela-client-cli-args`, `solvela-client-proxy`) remain published on crates.io (currently `0.2.5`) — `cargo install solvela-client-cli` still works, and they now publish from the monorepo via a tag-triggered workflow. The monorepo's flagship CLI is `solvela-cli` (`cargo install solvela-cli`).
+The Rust client SDK was consolidated into the monorepo on 2026-05-16 ([#316](https://github.com/solvela-ai/solvela/pull/316)) at [`sdks/rust/`](https://github.com/solvela-ai/solvela/tree/main/sdks/rust); the standalone `solvela-ai/solvela-client` repo is archived. The four legacy Rust crates (`solvela-client`, `solvela-client-cli`, `solvela-client-cli-args`, `solvela-client-proxy`) remain published on crates.io (currently `0.3.0`) — `cargo install solvela-client-cli` still works, and they now publish from the monorepo via a tag-triggered workflow. The monorepo's flagship CLI is `solvela-cli` (`cargo install solvela-cli`).
 
 <CardGroup>
-  <Card title="TypeScript" description="@solvela/sdk@^0.2.4 — async client with automatic x402 signing and built-in Solana wallet support" href="/docs/sdks/typescript" />
+  <Card title="TypeScript" description="@solvela/sdk@^0.3.0 — async client with automatic x402 signing and built-in Solana wallet support" href="/docs/sdks/typescript" />
   <Card title="Python" description="pip install solvela-sdk — async-first client with built-in Solana signing" href="/docs/sdks/python" />
   <Card title="Go" description="go get github.com/solvela-ai/solvela/sdks/go — context-aware, goroutine-safe; built-in KeypairSigner signs the escrow scheme (exact needs a custom Signer)" href="/docs/sdks/go" />
   <Card title="Rust CLI" description="cargo install solvela-cli — interactive chat, model listing, health checks" href="/docs/sdks/rust" />

--- a/dashboard/content/docs/sdks/typescript.mdx
+++ b/dashboard/content/docs/sdks/typescript.mdx
@@ -9,9 +9,10 @@ The Solvela TypeScript SDK lives in the monorepo at
 ## Status
 
 <Note>
-`@solvela/sdk@0.2.4` (published 2026-06-06) adds opt-in escrow-program-id
+`@solvela/sdk@0.3.0` converts post-signing 402s to `PaymentRejectedError` on
+both paths; `0.2.4` (published 2026-06-06) added opt-in escrow-program-id
 pinning (atop the native escrow-deposit signing from 0.2.3) and is wire-aligned
-with the production gateway at `api.solvela.ai`. Pin to `^0.2.4` — earlier
+with the production gateway at `api.solvela.ai`. Pin to `^0.3.0` — earlier
 `0.2.x` releases emit a `PaymentPayload` envelope shape the gateway no longer accepts.
 </Note>
 
@@ -29,7 +30,7 @@ package exposes the x402 parser + payment-signer primitives that
 ## Documentation
 
 - **Source:** [`sdks/typescript/`](https://github.com/solvela-ai/solvela/tree/main/sdks/typescript) in the monorepo
-- **npm package:** [@solvela/sdk](https://www.npmjs.com/package/@solvela/sdk) (current: `0.2.4`)
+- **npm package:** [@solvela/sdk](https://www.npmjs.com/package/@solvela/sdk) (current: `0.3.0`)
 
 ## History
 

--- a/dashboard/content/docs/sdks/typescript.mdx
+++ b/dashboard/content/docs/sdks/typescript.mdx
@@ -15,6 +15,12 @@ with the production gateway at `api.solvela.ai`. Pin to `^0.2.4` — earlier
 `0.2.x` releases emit a `PaymentPayload` envelope shape the gateway no longer accepts.
 </Note>
 
+As of `0.3.0`, a post-signing 402 on the retry — after a `Payment-Signature`
+was attached — is converted to `PaymentRejectedError` on both the non-streaming
+and streaming paths, exactly like the Go and Python SDKs — `instanceof
+PaymentRejectedError` distinguishes "signed and rejected" from a pre-signing
+`PaymentRequiredError` challenge on both paths.
+
 For low-level use inside or outside the monorepo, the
 [`@solvela/signer-core`](https://github.com/solvela-ai/solvela/tree/main/sdks/signer-core)
 package exposes the x402 parser + payment-signer primitives that

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solvela/sdk",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solvela/sdk",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/spl-token": "^0.4",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solvela/sdk",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "TypeScript SDK for Solvela — Solana-native AI agent payment gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -17,6 +17,7 @@ import {
 } from './types.js';
 import {
   ClientError,
+  PaymentRejectedError,
   PaymentRequiredError,
   RecipientMismatchError,
   EscrowProgramMismatchError,
@@ -191,7 +192,23 @@ export class SolvelaClient {
     } catch (e) {
       if (e instanceof PaymentRequiredError && this.signer) {
         const signature = await this.signPaymentForRequest(effectiveRequest, e.paymentRequired);
-        yield* this.transport.sendChatStream(effectiveRequest, signature);
+        try {
+          yield* this.transport.sendChatStream(effectiveRequest, signature);
+        } catch (retryErr) {
+          // A 402 on the retry — with the Payment-Signature attached — is a
+          // *post-signing* rejection, not a fresh challenge. Convert to
+          // PaymentRejectedError exactly as handlePaymentRequired does on the
+          // non-streaming path (and as the canonical Python chat_stream and
+          // Go ChatStream do). The outer pre-signing 402 still surfaces as
+          // PaymentRequiredError via the else-branch below.
+          if (retryErr instanceof PaymentRequiredError) {
+            throw new PaymentRejectedError(
+              'Payment rejected: second 402 after signing (streaming)',
+              retryErr.paymentRequired,
+            );
+          }
+          throw retryErr;
+        }
       } else {
         throw e;
       }
@@ -303,7 +320,12 @@ export class SolvelaClient {
     const signature = await this.signPaymentForRequest(request, pr);
     const result = await this.transport.sendChat(request, signature, extraHeaders);
     if (result instanceof PaymentRequired) {
-      throw new PaymentRequiredError(result);
+      // A 402 after a Payment-Signature was attached is a *post-signing*
+      // rejection, not a fresh challenge — surface it as the typed
+      // PaymentRejectedError carrying the second 402 body (mirrors the
+      // canonical Python client and the Go SDK), so callers can distinguish
+      // "needs signing" from "signed and rejected".
+      throw new PaymentRejectedError('Payment rejected: second 402 after signing', result);
     }
     return result;
   }

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -48,8 +48,20 @@ export class PaymentRequiredError extends ClientError {
   }
 }
 
+/**
+ * Raised when the gateway returns a 402 AFTER a signed payment was attached —
+ * a post-signing rejection, distinct from the initial PaymentRequiredError
+ * challenge. `paymentRequired` carries the second 402 body (cost breakdown,
+ * accepted schemes, gateway error message) so callers can inspect WHY the
+ * payment was rejected — replay nonce, expired signature, balance issue —
+ * instead of a bare reason string. Optional for backward compatibility with
+ * callers constructing this error from a message only.
+ */
 export class PaymentRejectedError extends ClientError {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    public readonly paymentRequired?: PaymentRequired,
+  ) {
     super(message);
     this.name = 'PaymentRejectedError';
   }

--- a/sdks/typescript/tests/integration/client.test.ts
+++ b/sdks/typescript/tests/integration/client.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { SolvelaClient } from '../../src/client.js';
 import { ChatRequest, ChatMessage, PaymentPayload, SolanaPayload } from '../../src/types.js';
-import { InsufficientBalanceError, PaymentRequiredError } from '../../src/errors.js';
+import {
+  GatewayError,
+  InsufficientBalanceError,
+  PaymentRejectedError,
+  PaymentRequiredError,
+} from '../../src/errors.js';
 import { BalanceMonitor } from '../../src/balance.js';
 import type { Signer } from '../../src/signer.js';
 import type { PaymentAccept, Resource } from '../../src/types.js';
@@ -88,7 +93,51 @@ describe('SolvelaClient integration (mocked fetch)', () => {
 
     const client = new SolvelaClient();
     const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hello')]);
-    await expect(client.chat(request)).rejects.toThrow(PaymentRequiredError);
+    const err = await client.chat(request).then(
+      () => {
+        throw new Error('expected rejection');
+      },
+      (e: unknown) => e,
+    );
+    // Initial 402 challenge (no signature attached yet) must stay a
+    // PaymentRequiredError — never the post-signing PaymentRejectedError.
+    expect(err).toBeInstanceOf(PaymentRequiredError);
+    expect(err).not.toBeInstanceOf(PaymentRejectedError);
+  });
+
+  it('chat throws PaymentRejectedError on second 402 after signing', async () => {
+    // Gateway returns 402 on every call: the first is the challenge, the
+    // second — after a Payment-Signature was attached — is a post-signing
+    // rejection and must surface as PaymentRejectedError carrying the second
+    // 402 body (mirrors the canonical Python client and Go PR #548).
+    const fetchFn = vi.fn().mockResolvedValue({
+      status: 402,
+      json: async () => prBody,
+      body: null,
+      statusText: 'Payment Required',
+    });
+    globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+    const signer: Signer = {
+      async signPayment(_a, _r, resource, accepted: PaymentAccept) {
+        return new PaymentPayload(2, resource, accepted, new SolanaPayload('tx=='));
+      },
+    };
+    const client = new SolvelaClient({ signer });
+    const err = await client
+      .chat(new ChatRequest('gpt-4', [new ChatMessage('user', 'Hello')]))
+      .then(
+        () => {
+          throw new Error('expected rejection');
+        },
+        (e: unknown) => e,
+      );
+    expect(err).toBeInstanceOf(PaymentRejectedError);
+    expect(err).not.toBeInstanceOf(PaymentRequiredError);
+    const rejected = err as PaymentRejectedError;
+    expect(rejected.paymentRequired).toBeDefined();
+    expect(rejected.paymentRequired?.accepts[0].amount).toBe('1000000');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
   it('chat with quality retry retries on degraded response', async () => {
@@ -364,10 +413,92 @@ describe('SolvelaClient chatStream payment retry (mocked fetch)', () => {
     const client = new SolvelaClient();
     const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hello')]);
 
-    await expect(async () => {
+    const err = await (async () => {
       for await (const _chunk of client.chatStream(request)) {
         // consume
       }
-    }).rejects.toThrow(PaymentRequiredError);
+    })().then(
+      () => {
+        throw new Error('expected rejection');
+      },
+      (e: unknown) => e,
+    );
+    // Initial 402 challenge (no signature attached yet) must stay a
+    // PaymentRequiredError — never the post-signing PaymentRejectedError.
+    expect(err).toBeInstanceOf(PaymentRequiredError);
+    expect(err).not.toBeInstanceOf(PaymentRejectedError);
+  });
+
+  it('chatStream throws PaymentRejectedError on second 402 after signing', async () => {
+    // 402 on every call: first is the challenge, second — with the
+    // Payment-Signature attached on the streaming retry — is a post-signing
+    // rejection and must convert to PaymentRejectedError (mirrors the
+    // canonical Python chat_stream and Go ChatStream, PR #548).
+    const fetchFn = vi.fn().mockResolvedValue({
+      status: 402,
+      json: async () => prBody,
+      body: null,
+      statusText: 'Payment Required',
+    });
+    globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+    const client = new SolvelaClient({ signer: makeMockSigner() });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hello')]);
+
+    const err = await (async () => {
+      for await (const _chunk of client.chatStream(request)) {
+        // consume
+      }
+    })().then(
+      () => {
+        throw new Error('expected rejection');
+      },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(PaymentRejectedError);
+    expect(err).not.toBeInstanceOf(PaymentRequiredError);
+    const rejected = err as PaymentRejectedError;
+    expect(rejected.paymentRequired).toBeDefined();
+    expect(rejected.paymentRequired?.accepts[0].amount).toBe('1000000');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('chatStream propagates a non-402 error from the signed retry unconverted', async () => {
+    // 402 challenge, then 500 on the signed retry: the conversion must stay
+    // scoped to PaymentRequiredError — anything else from the signed retry
+    // propagates verbatim (never wrapped into PaymentRejectedError).
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: 402,
+        json: async () => prBody,
+        body: null,
+        statusText: 'Payment Required',
+      })
+      .mockResolvedValueOnce({
+        status: 500,
+        json: async () => ({}),
+        body: null,
+        statusText: 'Internal Server Error',
+      });
+    globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+    const client = new SolvelaClient({ signer: makeMockSigner() });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hello')]);
+
+    const err = await (async () => {
+      for await (const _chunk of client.chatStream(request)) {
+        // consume
+      }
+    })().then(
+      () => {
+        throw new Error('expected rejection');
+      },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(GatewayError);
+    expect(err).not.toBeInstanceOf(PaymentRejectedError);
+    expect(err).not.toBeInstanceOf(PaymentRequiredError);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 });

--- a/sdks/typescript/tests/unit/errors.test.ts
+++ b/sdks/typescript/tests/unit/errors.test.ts
@@ -79,6 +79,22 @@ describe('PaymentRejectedError', () => {
     const err = new PaymentRejectedError('rejected');
     expect(err).toBeInstanceOf(ClientError);
     expect(err.name).toBe('PaymentRejectedError');
+    expect(err.paymentRequired).toBeUndefined();
+  });
+
+  it('optionally carries the second 402 body', () => {
+    const pr = new PaymentRequired(
+      2,
+      new Resource('/v1/chat/completions', 'POST'),
+      [],
+      new CostBreakdown('0', '0', '0', 'USDC', 5),
+      'replay nonce already used',
+    );
+    const err = new PaymentRejectedError('second 402 after signing', pr);
+    expect(err).toBeInstanceOf(ClientError);
+    expect(err.name).toBe('PaymentRejectedError');
+    expect(err.paymentRequired).toBe(pr);
+    expect(err.paymentRequired?.error).toBe('replay nonce already used');
   });
 });
 


### PR DESCRIPTION
## Summary

TypeScript half of the cross-SDK post-signing 402 unification (Go: #548). `PaymentRejectedError` existed but was never thrown — both paths re-threw `PaymentRequiredError` after signing, so callers couldn't distinguish "signed and rejected" from the initial challenge.

- Non-streaming (`handlePaymentRequired` second 402) and streaming (signed retry in `chatStream`) now throw `PaymentRejectedError`, matching Python (canonical) and Go (#548)
- Additive optional constructor param carries the second 402 body (1-arg form pinned for back-compat); transport stays dumb
- Pre-signing challenges unchanged (`PaymentRequiredError`, pinned with negative assertions); non-402 errors from the signed retry propagate unconverted (pinned, added per reviewer finding)
- `package.json` → **0.3.0** (error-type behavior change on 0.x); `typescript.mdx` updated with version-gated wording

## Process (money-path discipline)
- Money-path engineer agent, signer-audit + x402 skills, tests-first (3 watched red)
- Independent adversarial review: **APPROVE** — verified the streaming wrap is provably scoped to the signed retry (transport's only `PaymentRequiredError` throw is pre-stream), back-compat intact, conversion pinned both directions; its one MEDIUM finding (missing non-402 propagation test) is addressed in this PR
- `tsc --noEmit` clean · vitest **213/213** · build clean (CI command set)

npm release of 0.3.0 follows after merge via the tag-triggered publish workflow.