### PR TITLE
ci(sdk-ts-publish): poll npm visibility before tarball SHA verification

### DIFF
--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -83,7 +83,24 @@ jobs:
           LOCAL_SHA=$(shasum -a 256 "$LOCAL_TARBALL" | awk '{print $1}')
           echo "Local tarball SHA256: $LOCAL_SHA"
 
-          TARBALL_URL=$(npm view "${PKG_NAME}@${PKG_VERSION}" dist.tarball)
+          # npm's read path can lag the publish by seconds-to-minutes: the
+          # 0.3.0 release hit a 404 from `npm view` ~1s after a correct,
+          # provenance-signed publish and this step went red on the race.
+          # Poll for visibility within a ~5-minute budget before fetching,
+          # mirroring sdk-rust-publish.yml's crates.io visibility loop.
+          TARBALL_URL=""
+          for i in $(seq 1 30); do
+            TARBALL_URL=$(npm view "${PKG_NAME}@${PKG_VERSION}" dist.tarball 2>/dev/null || true)
+            if [ -n "$TARBALL_URL" ]; then
+              break
+            fi
+            echo "Attempt $i/30: ${PKG_NAME}@${PKG_VERSION} not visible on the registry yet; sleeping 10s"
+            sleep 10
+          done
+          if [ -z "$TARBALL_URL" ]; then
+            echo "ERROR: ${PKG_NAME}@${PKG_VERSION} not visible on the registry after ~5 minutes"
+            exit 1
+          fi
           echo "Registry tarball URL: $TARBALL_URL"
           curl -fsSL "$TARBALL_URL" -o registry.tgz
           REGISTRY_SHA=$(shasum -a 256 registry.tgz | awk '{print $1}')


### PR DESCRIPTION
## Summary

Fixes the flaky final step of the TypeScript publish workflow. On the 0.3.0 release (run 27390126991), the "Verify published tarball SHA" step ran `npm view ... dist.tarball` ~1 second after publish, hit npm's read-path propagation lag (404), and `set -e` killed the step — red run despite a correct, Sigstore-provenance-signed publish whose shasum was later verified bit-identical.

**Fix:** wrap only the `npm view` lookup in a `30 × 10s` visibility poll (~5-minute budget), mirroring `sdk-rust-publish.yml`'s crates.io visibility loop (which went green on the same day's release). The SHA comparison is unchanged — the integrity gate isn't weakened, and a genuinely missing version still fails after the budget.

## Verification
- Loop body extracted **verbatim** from the workflow file and exercised locally against a stubbed `npm`: transient-404 case (2 failures → success) passes with retries logged; never-visible case exhausts 30 attempts and exits 1
- Workflow YAML parses clean
- Note: this workflow only triggers on `sdks/typescript/v*` tags, so the real-world confirmation lands with the next TS release