### PR TITLE
feat(sdk-go): carry the second 402 body on PaymentRejectedError

### DIFF
--- a/dashboard/content/docs/sdks/go.mdx
+++ b/dashboard/content/docs/sdks/go.mdx
@@ -198,7 +198,7 @@ With a signer wired up, the SDK automatically:
 4. Calls `signer.SignPayment(ctx, amount, payTo, resource, accepted)` to build and sign the SPL transfer.
 5. Retries with the `Payment-Signature` header.
 
-If the gateway returns 402 *again* after the signed retry, the SDK returns `*PaymentRejectedError` carrying the rejection reason so the caller can inspect why.
+If the gateway returns 402 *again* after the signed retry, the SDK returns `*PaymentRejectedError` carrying the rejection reason. As of v0.4.0 it also carries the second 402's parsed body in the `PaymentRequired` field (cost breakdown, accepted schemes, gateway error message) — on both the non-streaming and streaming paths — so callers can inspect *why* the payment was rejected without re-parsing the response. The field is `nil` when the error is constructed from a reason alone, matching Python's `payment_required` and TypeScript's `paymentRequired`.
 
 ## Streaming
 
@@ -218,7 +218,7 @@ for chunk := range ch {
 fmt.Println()
 ```
 
-`ChatStream` runs the same preflight payment handshake as `Chat` — a `Signer` is required for paid streaming, otherwise the call returns `*PaymentRequiredError` before opening the stream. A post-signing 402 on the streaming POST is converted to `*PaymentRejectedError`, exactly like the non-streaming path — `errors.As(err, &rejErr)` distinguishes "signed and rejected" from a pre-signing `*PaymentRequiredError` challenge on both paths.
+`ChatStream` runs the same preflight payment handshake as `Chat` — a `Signer` is required for paid streaming, otherwise the call returns `*PaymentRequiredError` before opening the stream. A post-signing 402 on the streaming POST is converted to `*PaymentRejectedError`, exactly like the non-streaming path — `errors.As(err, &rejErr)` distinguishes "signed and rejected" from a pre-signing `*PaymentRequiredError` challenge on both paths. The conversion carries the rejection's parsed 402 body across into `rejErr.PaymentRequired` (v0.4.0+).
 
 ## Models and pricing
 
@@ -282,7 +282,7 @@ if err != nil {
 | Error | Returned when |
 |---|---|
 | `*PaymentRequiredError` | Gateway returns 402 and no `Signer` is configured (or no compatible scheme was found). Carries `PaymentRequired`. |
-| `*PaymentRejectedError` | Gateway returns 402 *again* after a signed retry. Carries `Reason`. |
+| `*PaymentRejectedError` | Gateway returns 402 *again* after a signed retry. Carries `Reason`, plus (v0.4.0+) the second 402's parsed body in `PaymentRequired` — populated on both the non-streaming and streaming paths, `nil` if constructed from a reason alone. |
 | `*AmountExceedsMaxError` | Gateway's quoted amount exceeds the configured `MaxPaymentAmount`. Carries `Amount` and `MaxAmount`. |
 | `*RecipientMismatchError` | Gateway's `pay_to` doesn't match the configured `ExpectedRecipient`. |
 | `*EscrowProgramMismatchError` | The 402's escrow program ID doesn't match the configured `ExpectedEscrowProgram` pin. Returned before any escrow deposit is signed. Carries `Expected` and `Actual`. |

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -293,7 +293,15 @@ func (c *SolvelaClient) ChatStream(ctx context.Context, request *ChatRequest) (<
 		// surfacing as PaymentRequiredError.
 		var prErr *PaymentRequiredError
 		if sig != "" && errors.As(err, &prErr) {
-			return nil, &PaymentRejectedError{Reason: "payment rejected after signing (streaming)"}
+			// Carry the second 402's parsed body (already decoded by the
+			// transport into the PaymentRequiredError) across the conversion,
+			// matching the non-streaming path. Copy the value out so the
+			// rejected error does not keep the whole source error alive.
+			pr := prErr.PaymentRequired
+			return nil, &PaymentRejectedError{
+				Reason:          "payment rejected after signing (streaming)",
+				PaymentRequired: &pr,
+			}
 		}
 		return nil, err
 	}
@@ -389,7 +397,12 @@ func (c *SolvelaClient) sendWithPayment(ctx context.Context, request *ChatReques
 		return nil, err
 	}
 	if result.PaymentRequired != nil {
-		return nil, &PaymentRejectedError{Reason: "payment rejected after signing"}
+		// Carry the second 402's parsed body so callers can inspect the
+		// rejection's cost breakdown / accepts / gateway error message.
+		return nil, &PaymentRejectedError{
+			Reason:          "payment rejected after signing",
+			PaymentRequired: result.PaymentRequired,
+		}
 	}
 	return result.Response, nil
 }

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -1251,7 +1251,10 @@ func TestChatPaymentRejectedAfterSign(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Always return 402 — the gateway "rejects" both the probe and the
 		// signed retry. The double-402 guard in sendWithPayment must catch
-		// the second 402 and return PaymentRejectedError.
+		// the second 402 and return PaymentRejectedError. The post-signing
+		// rejection (Payment-Signature attached) carries a distinguishing
+		// body so the test can prove the SECOND 402's parsed body — not the
+		// initial challenge — flows into PaymentRejectedError.PaymentRequired.
 		pr := PaymentRequired{
 			X402Version:   X402Version,
 			CostBreakdown: CostBreakdown{Total: "100"},
@@ -1259,6 +1262,11 @@ func TestChatPaymentRejectedAfterSign(t *testing.T) {
 			Accepts: []PaymentAccept{
 				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
 			},
+		}
+		if r.Header.Get("Payment-Signature") != "" {
+			pr.Error = "replay nonce already used"
+			pr.CostBreakdown.Total = "105"
+			pr.Accepts[0].Amount = "105"
 		}
 		w.WriteHeader(402)
 		json.NewEncoder(w).Encode(pr)
@@ -1289,6 +1297,19 @@ func TestChatPaymentRejectedAfterSign(t *testing.T) {
 	if pre.Reason == "" {
 		t.Error("PaymentRejectedError.Reason should be non-empty")
 	}
+	// The second 402's parsed body must be carried on the error so callers
+	// can inspect the rejection's cost breakdown / accepts without
+	// re-parsing the response.
+	if pre.PaymentRequired == nil {
+		t.Fatal("PaymentRejectedError.PaymentRequired should carry the second 402 body")
+	}
+	if pre.PaymentRequired.Error != "replay nonce already used" {
+		t.Errorf("PaymentRequired.Error: got %q, want %q (second 402 body, not the initial challenge)",
+			pre.PaymentRequired.Error, "replay nonce already used")
+	}
+	if got := pre.PaymentRequired.Accepts[0].Amount; got != "105" {
+		t.Errorf("PaymentRequired.Accepts[0].Amount: got %q, want %q", got, "105")
+	}
 }
 
 // TestChatStreamPaymentRejectedAfterSign drives the streaming path against a
@@ -1303,7 +1324,10 @@ func TestChatStreamPaymentRejectedAfterSign(t *testing.T) {
 	var serverURL string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Always 402 — the probe gets the price challenge, and the signed
-		// streaming follow-up is rejected with a second 402.
+		// streaming follow-up is rejected with a second 402 carrying a
+		// distinguishing body, so the test can prove the SECOND 402's parsed
+		// body flows into PaymentRejectedError.PaymentRequired on the
+		// streaming path too.
 		pr := PaymentRequired{
 			X402Version:   X402Version,
 			CostBreakdown: CostBreakdown{Total: "100"},
@@ -1311,6 +1335,11 @@ func TestChatStreamPaymentRejectedAfterSign(t *testing.T) {
 			Accepts: []PaymentAccept{
 				{Scheme: "exact", Network: SolanaNetwork, Asset: USDCMint, Amount: "100", PayTo: "recipient"},
 			},
+		}
+		if r.Header.Get("Payment-Signature") != "" {
+			pr.Error = "payment signature expired"
+			pr.CostBreakdown.Total = "210"
+			pr.Accepts[0].Amount = "210"
 		}
 		w.WriteHeader(402)
 		json.NewEncoder(w).Encode(pr)
@@ -1341,6 +1370,19 @@ func TestChatStreamPaymentRejectedAfterSign(t *testing.T) {
 	}
 	if rejErr.Reason == "" {
 		t.Error("PaymentRejectedError.Reason should be non-empty")
+	}
+	// The second 402's parsed body must be carried across the
+	// PaymentRequiredError -> PaymentRejectedError conversion so streaming
+	// callers see the same rejection detail as non-streaming callers.
+	if rejErr.PaymentRequired == nil {
+		t.Fatal("PaymentRejectedError.PaymentRequired should carry the second 402 body")
+	}
+	if rejErr.PaymentRequired.Error != "payment signature expired" {
+		t.Errorf("PaymentRequired.Error: got %q, want %q (second 402 body, not the initial challenge)",
+			rejErr.PaymentRequired.Error, "payment signature expired")
+	}
+	if got := rejErr.PaymentRequired.Accepts[0].Amount; got != "210" {
+		t.Errorf("PaymentRequired.Accepts[0].Amount: got %q, want %q", got, "210")
 	}
 	// The post-signing rejection must NOT also match the pre-signing
 	// challenge type — callers branch on the distinction.

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -52,8 +52,20 @@ func (e *PaymentRequiredError) Error() string {
 }
 
 // PaymentRejectedError indicates the payment was not accepted.
+//
+// PaymentRequired, when non-nil, carries the parsed second 402 body the
+// gateway returned AFTER a signed payment was attached — cost breakdown,
+// accepted schemes, and the gateway's error message — so callers can inspect
+// WHY the payment was rejected (replay nonce, expired signature, balance
+// issue) without re-parsing the response. Both the non-streaming
+// ([SolvelaClient.Chat]) and streaming ([SolvelaClient.ChatStream]) paths
+// populate it. It is nil for callers constructing the error from a Reason
+// alone (backward compatible). Mirrors Python's
+// PaymentRejectedError.payment_required and TypeScript's
+// PaymentRejectedError.paymentRequired.
 type PaymentRejectedError struct {
-	Reason string
+	Reason          string
+	PaymentRequired *PaymentRequired
 }
 
 func (e *PaymentRejectedError) Error() string {

--- a/sdks/go/errors_test.go
+++ b/sdks/go/errors_test.go
@@ -52,9 +52,43 @@ func TestPaymentRequiredError(t *testing.T) {
 }
 
 func TestPaymentRejectedError(t *testing.T) {
+	// Back-compat pin: Reason-only construction (the historical shape) must
+	// keep working, with PaymentRequired defaulting to nil and Error()
+	// unchanged for existing consumers.
 	err := &PaymentRejectedError{Reason: "invalid signature"}
 	if err.Error() != "payment rejected: invalid signature" {
 		t.Errorf("got %q", err.Error())
+	}
+	if err.PaymentRequired != nil {
+		t.Error("Reason-only construction should leave PaymentRequired nil")
+	}
+}
+
+func TestPaymentRejectedErrorWithPaymentRequired(t *testing.T) {
+	pr := &PaymentRequired{
+		Error:         "replay nonce already used",
+		CostBreakdown: CostBreakdown{Total: "1050"},
+		Accepts: []PaymentAccept{
+			{Scheme: SchemeExact, Network: SolanaNetwork, Asset: USDCMint, Amount: "1050", PayTo: "recipient"},
+		},
+	}
+	err := &PaymentRejectedError{Reason: "payment rejected after signing", PaymentRequired: pr}
+
+	// Error() string is unchanged by the new field — existing consumers that
+	// match on the message must not break.
+	if err.Error() != "payment rejected: payment rejected after signing" {
+		t.Errorf("got %q", err.Error())
+	}
+	// Round-trip: the same pointer should be retrievable so callers can
+	// inspect the rejection's cost breakdown / accepts without re-parsing.
+	if err.PaymentRequired != pr {
+		t.Error("PaymentRequired field should round-trip the supplied pointer")
+	}
+	if err.PaymentRequired.Error != "replay nonce already used" {
+		t.Errorf("PaymentRequired.Error: got %q", err.PaymentRequired.Error)
+	}
+	if err.PaymentRequired.Accepts[0].Amount != "1050" {
+		t.Errorf("PaymentRequired.Accepts[0].Amount: got %q", err.PaymentRequired.Accepts[0].Amount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the last cross-SDK parity nit from the post-signing-402 unification (#548/#549/#550): Go's `PaymentRejectedError` now carries the parsed second-402 body in an additive `PaymentRequired *PaymentRequired` field, matching Python's `payment_required` and TS 0.3.0's `paymentRequired`. `Reason` stays; `Error()` unchanged; field is nil on reason-only construction (pinned).

Populated at both conversion sites from data already in hand — no re-fetch/re-parse:
- non-streaming `sendWithPayment`: the second `SendChatResult.PaymentRequired`
- streaming `ChatStream`: the wrapped body of the source `*PaymentRequiredError`

## Process (money-path discipline)
- Money-path engineer, signer-audit + x402 skills, tests-first (both provenance tests watched red, asserting the **second** 402's distinguishing body — not the initial challenge — flows through, keyed on `Payment-Signature` header presence)
- Independent adversarial review: **APPROVE, no findings** — back-compat verified (all in-repo literals keyed, smoke script unaffected), provenance proven at both sites (no aliasing with the challenge body), nil-safety traced, and confirmed the carried body is inert: it feeds no signing/amount path
- `go build`/`vet`/`gofmt` clean · `go test ./...` green

`sdks/go/v0.4.0` follows after merge (new exported field = feature on 0.x).