### PR TITLE
polish(dashboard): interface-feel pass — transition scope, text-wrap, smoothing, hit areas

### DIFF
--- a/dashboard/src/app/components/docs/mdx/pre.tsx
+++ b/dashboard/src/app/components/docs/mdx/pre.tsx
@@ -42,7 +42,9 @@ export function Pre({ children, className, 'data-language': language, ...props }
         <button
           onClick={handleCopy}
           className={cn(
-            'absolute top-2 right-2 flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium transition-all',
+            // after:-inset-2 grows the hit area toward the 44px target without
+            // changing the visible chip; transition props listed explicitly.
+            'absolute top-2 right-2 flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium transition-[color,background-color,border-color,opacity] after:absolute after:-inset-2 after:content-[""]',
             'text-muted-foreground hover:text-foreground',
             'bg-background/80 hover:bg-background border border-border/50',
             'opacity-60 hover:opacity-100',

--- a/dashboard/src/app/components/docs/search-dialog.tsx
+++ b/dashboard/src/app/components/docs/search-dialog.tsx
@@ -36,7 +36,7 @@ export function SearchTrigger() {
           'flex items-center gap-3 px-4 py-2.5 rounded-lg w-full max-w-md',
           'bg-muted/50 border border-border/50',
           'text-sm text-muted-foreground hover:text-foreground hover:bg-muted hover:border-border',
-          'transition-all'
+          'transition-[color,background-color,border-color]'
         )}
       >
         <SearchIcon className="w-4 h-4 shrink-0" />

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1079,3 +1079,41 @@ pre::before {
   color: var(--heading-color);
   font-variant-numeric: tabular-nums lining-nums;
 }
+
+/* ==========================================================
+   Interface polish pass (make-interfaces-feel-better)
+   ========================================================== */
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Short display headlines: avoid one-word orphan lines. */
+.display-wonk,
+.display-calm,
+.prose :is(h1, h2, h3) {
+  text-wrap: balance;
+}
+
+/* Body-adjacent short text reads better with pretty wrapping;
+   long prose, code, and tables are deliberately excluded. */
+.prose :is(p, li, figcaption) {
+  text-wrap: pretty;
+}
+
+/* Neutral inset outline keeps doc images from bleeding into the
+   surface. Neutral alpha only — never brand-tinted. */
+:root,
+.dark {
+  --img-outline: rgba(255, 255, 255, 0.08);
+}
+@media (prefers-color-scheme: light) {
+  :root:not(.dark) {
+    --img-outline: rgba(0, 0, 0, 0.08);
+  }
+}
+.prose img {
+  outline: 1px solid var(--img-outline);
+  outline-offset: -1px;
+}

--- a/dashboard/src/components/landing/hero-panel.tsx
+++ b/dashboard/src/components/landing/hero-panel.tsx
@@ -93,7 +93,7 @@ export function HeroPanel() {
             >
               <a
                 href={QUICKSTART_URL}
-                className="group inline-flex items-center gap-2 rounded-md bg-foreground px-5 py-3 font-mono text-[12px] uppercase tracking-[0.16em] text-[var(--primary-foreground)] transition-all duration-150 hover:-translate-y-[1px] hover:bg-[var(--heading-color)] active:translate-y-0"
+                className="group inline-flex items-center gap-2 rounded-md bg-foreground px-5 py-3 font-mono text-[12px] uppercase tracking-[0.16em] text-[var(--primary-foreground)] transition-[transform,background-color] duration-150 hover:-translate-y-[1px] hover:bg-[var(--heading-color)] active:translate-y-0"
               >
                 start building
                 <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />

--- a/dashboard/src/components/landing/sdk-cta-panel.tsx
+++ b/dashboard/src/components/landing/sdk-cta-panel.tsx
@@ -222,7 +222,7 @@ export function SdkCtaPanel({ preHighlighted }: SdkCtaPanelProps) {
               </div>
               <a
                 href={QUICKSTART_URL}
-                className="inline-flex items-center gap-2 self-start rounded-md bg-[var(--accent-salmon)] px-5 py-3 font-mono text-[12px] uppercase tracking-[0.16em] text-[var(--color-bg-inset)] shadow-[0_0_0_0_transparent] transition-all duration-200 hover:-translate-y-[1px] hover:bg-[var(--accent-salmon-hover)] hover:shadow-[0_8px_24px_-10px_var(--tint-salmon-drop)] active:translate-y-0 sm:self-auto"
+                className="inline-flex items-center gap-2 self-start rounded-md bg-[var(--accent-salmon)] px-5 py-3 font-mono text-[12px] uppercase tracking-[0.16em] text-[var(--color-bg-inset)] shadow-[0_0_0_0_transparent] transition-[transform,background-color,box-shadow] duration-200 hover:-translate-y-[1px] hover:bg-[var(--accent-salmon-hover)] hover:shadow-[0_8px_24px_-10px_var(--tint-salmon-drop)] active:translate-y-0 sm:self-auto"
               >
                 open quickstart
                 <ArrowRight className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Design-engineering polish pass over the v2 surface (make-interfaces-feel-better checklist). No layout, palette, or content changes.

| Principle | Before | After |
| --- | --- | --- |
| Transition scope | `transition-all` on hero CTA, quickstart CTA, docs copy chip, docs search trigger | Explicit property lists (`transition-[transform,background-color,…]`) at all four sites |
| Font smoothing | none | `html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }` |
| Text wrapping | no `text-wrap` anywhere | `balance` on `.display-wonk`/`.display-calm` + prose h1–h3; `pretty` on prose p/li/figcaption; code + tables excluded |
| Hit areas | docs code-copy chip ≈26px tall | `after:-inset-2` pseudo-element grows the hit area toward 44px, visible chip unchanged |
| Image outlines | doc images bleed into the surface | `.prose img` 1px neutral inset outline (`--img-outline`: white-alpha dark / black-alpha light, never brand-tinted) |

Checked and already compliant (no change): `tabular-nums` on metric classes + data tables; `will-change` limited to `transform` on the readout track; landing `CopyButton` already 44px; enter/exit motion split and reduced-motion-gated from #543.

## Verification
- `npm test` 100/100 · `next build` green