### PR TITLE
feat(gateway): per-service vendor_wallet payment recipient with vendor-absorbed fee recording (P1)

### DIFF
--- a/config/services.toml
+++ b/config/services.toml
@@ -37,3 +37,21 @@
 # category = "search"
 # x402_enabled = true
 # internal = false
+#
+# ── Vendor-settled services (settlement-platform P1) ────────────────
+#
+# `vendor_wallet` (optional, external services only) makes the agent pay the
+# listed `price_per_request_usdc` directly to the vendor's wallet — no 5%
+# fee-on-top. Solvela's 5% is recorded in spend_logs as an off-chain
+# receivable against the vendor (vendor absorbs; see the
+# "Vendor-Settlement Fee Mechanics" RFC, 2026-06-12). The value must be a
+# valid base58 Solana pubkey; the gateway fails closed at load time otherwise.
+#
+# [services.vendor-data-api]
+# name = "Vendor Data API"
+# endpoint = "https://api.vendor.example.com/v1/data"    # PLACEHOLDER — do not enable
+# category = "data"
+# x402_enabled = true
+# internal = false
+# price_per_request_usdc = 0.02
+# vendor_wallet = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"  # PLACEHOLDER

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -156,10 +156,23 @@ async fn main() -> anyhow::Result<()> {
     // Load service registry from config file
     let services_toml = std::fs::read_to_string("config/services.toml")
         .unwrap_or_else(|_| include_str!("../../../config/services.toml").to_string());
-    let service_registry_inner = ServiceRegistry::from_toml(&services_toml).unwrap_or_else(|e| {
-        warn!(error = %e, "failed to parse services.toml, using empty registry");
-        ServiceRegistry::empty()
-    });
+    // Attach the gateway's global recipient so registration (load-time AND
+    // the runtime admin route) rejects a vendor_wallet equal to it — the
+    // degenerate case would silently undercharge agents 5% and have the
+    // gateway invoice itself for the receivable. A conflicting entry fails
+    // the load like any other invalid entry (empty registry, loud warn).
+    let service_registry_inner = ServiceRegistry::from_toml(&services_toml)
+        .and_then(|registry| registry.with_gateway_recipient(&app_config.solana.recipient_wallet))
+        .unwrap_or_else(|e| {
+            warn!(error = %e, "failed to load services.toml, using empty registry");
+            ServiceRegistry::empty()
+                .with_gateway_recipient(&app_config.solana.recipient_wallet)
+                .unwrap_or_else(|_| {
+                    // Unreachable: an empty registry has no vendor wallets to
+                    // conflict. Kept non-panicking per the no-unwrap rule.
+                    ServiceRegistry::empty()
+                })
+        });
     info!(
         services = service_registry_inner.all().len(),
         "loaded service registry"

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -515,6 +515,7 @@ pub async fn chat_completions(
                     tenant: tenant.clone(),
                     tenant_enforced: false,
                     estimated_cost_usdc: None,
+                    vendor: None,
                 });
                 Ok(result.response)
             }
@@ -1367,6 +1368,7 @@ pub async fn chat_completions(
                                 // so the Skip path never accumulates per-tenant spend.
                                 tenant_enforced: budget_reservation.tenant_enforced(),
                                 estimated_cost_usdc: Some(estimated_cost),
+                                vendor: None,
                             });
                         }
                         Err(e) => {
@@ -1427,6 +1429,7 @@ pub async fn chat_completions(
                         // counters only when a provisioned bucket was enforced.
                         tenant_enforced: budget_reservation.tenant_enforced(),
                         estimated_cost_usdc: Some(estimated_cost),
+                        vendor: None,
                     });
                 }
                 SpendLogArm::EstimateFallback => {
@@ -1487,6 +1490,7 @@ pub async fn chat_completions(
                         // counters only when a provisioned bucket was enforced.
                         tenant_enforced: budget_reservation.tenant_enforced(),
                         estimated_cost_usdc: Some(estimated_cost),
+                        vendor: None,
                     });
                 }
             }

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -109,6 +109,66 @@ fn compute_service_cost(price_usdc: f64) -> Result<ServiceCost, String> {
     })
 }
 
+/// Where a paid service request settles, with the amounts attached to each leg.
+///
+/// "Vendor-Settlement Fee Mechanics" RFC (2026-06-12, mechanism C / record +
+/// invoice, VENDOR ABSORBS the fee). Modeling the two paths as an enum (rather
+/// than a tuple of loosely-coupled values) makes it a compile error to mix the
+/// gateway's fee-on-top amounts with the vendor's fee-absorbed ones.
+#[derive(Debug, Clone)]
+enum PaymentTarget {
+    /// Today's default: the agent pays `price × 1.05` to the gateway's global
+    /// recipient wallet; the 5% is collected on-chain in the same transfer.
+    Gateway { total_atomic: u64, fee_atomic: u64 },
+    /// Settlement-platform P1: the agent pays EXACTLY the listed price to the
+    /// service's `vendor_wallet`; Solvela's 5% is never charged to the agent —
+    /// it is recorded as an off-chain receivable against the vendor
+    /// (`VendorSettlement`, spend_logs).
+    Vendor {
+        price_atomic: u64,
+        settlement: VendorSettlement,
+    },
+}
+
+impl PaymentTarget {
+    /// Atomic USDC amount the AGENT must pay (quoted in the 402 and enforced
+    /// against the payment header's `amount`).
+    fn expected_atomic(&self) -> u64 {
+        match self {
+            Self::Gateway { total_atomic, .. } => *total_atomic,
+            Self::Vendor { price_atomic, .. } => *price_atomic,
+        }
+    }
+
+    /// Fee charged to the AGENT, in atomic USDC — zero on the vendor path
+    /// (the vendor absorbs it; rule #5: the cost_breakdown stays truthful to
+    /// what the agent pays).
+    fn agent_fee_atomic(&self) -> u64 {
+        match self {
+            Self::Gateway { fee_atomic, .. } => *fee_atomic,
+            Self::Vendor { .. } => 0,
+        }
+    }
+
+    /// Agent-facing fee rate for the 402 `cost_breakdown`. Keeping `5` next
+    /// to a `0.000000` fee would contradict the amounts on the vendor path.
+    fn agent_fee_percent(&self) -> u8 {
+        match self {
+            Self::Gateway { .. } => PLATFORM_FEE_PERCENT,
+            Self::Vendor { .. } => 0,
+        }
+    }
+
+    /// The vendor-settlement record to attach to the spend log; `None` on the
+    /// gateway path. Consumes the target — call once, when building the entry.
+    fn into_vendor_settlement(self) -> Option<VendorSettlement> {
+        match self {
+            Self::Gateway { .. } => None,
+            Self::Vendor { settlement, .. } => Some(settlement),
+        }
+    }
+}
+
 /// POST /v1/services/{service_id}/proxy — proxy a paid request to an external service.
 ///
 /// Flow:
@@ -194,44 +254,50 @@ pub async fn proxy_service(
     // Services without a vendor wallet keep today's behavior unchanged:
     // `price × 1.05` paid to the gateway's global recipient.
     //
-    // `agent_fee_atomic` is what the AGENT is charged as a fee — zero on the
-    // vendor path — and is what the 402 `cost_breakdown` must show (rule #5:
-    // the breakdown stays truthful to what the agent pays).
-    let (pay_to_wallet, expected_atomic, agent_fee_atomic, vendor_settlement) =
-        match service.vendor_wallet.as_deref() {
-            Some(vendor_wallet) => {
-                // Fail closed before quoting or charging: the receivable
-                // ledger columns are BIGINT, so a priced amount that cannot
-                // be represented as i64 must reject the request, not get
-                // recorded wrapped or skipped.
-                let settled_atomic = i64::try_from(provider_atomic).map_err(|_| {
-                    GatewayError::Internal(format!(
-                        "service '{service_id}' price exceeds the recordable range"
-                    ))
-                })?;
-                let fee_receivable_atomic = i64::try_from(fee_atomic).map_err(|_| {
-                    GatewayError::Internal(format!(
-                        "service '{service_id}' fee exceeds the recordable range"
-                    ))
-                })?;
-                (
-                    vendor_wallet.to_string(),
-                    provider_atomic,
-                    0u64,
-                    Some(VendorSettlement {
-                        vendor_wallet: vendor_wallet.to_string(),
-                        settled_atomic,
-                        fee_receivable_atomic,
-                    }),
-                )
+    // See `PaymentTarget`: the vendor path quotes the agent ZERO fee (the
+    // vendor absorbs it) and the 402 `cost_breakdown` must show exactly what
+    // the agent pays (rule #5).
+    let (pay_to_wallet, payment_target) = match service.vendor_wallet.as_deref() {
+        Some(vendor_wallet) => {
+            // AUTHORITATIVE pre-quote guard (fail closed before quoting or
+            // charging): the receivable ledger columns are BIGINT, so a
+            // priced amount that cannot be represented as i64 must reject
+            // the request up front — never quote a 402 the ledger cannot
+            // record. The single u64 → i64 conversion at the sqlx bind site
+            // (`usage.rs::log_spend`) is a belt-and-braces re-check that
+            // logs a reconcilable loss event instead of panicking; this
+            // guard is what makes that arm unreachable.
+            if i64::try_from(provider_atomic).is_err() {
+                return Err(GatewayError::Internal(format!(
+                    "service '{service_id}' price exceeds the recordable range"
+                )));
             }
-            None => (
-                state.config.solana.recipient_wallet.clone(),
+            if i64::try_from(fee_atomic).is_err() {
+                return Err(GatewayError::Internal(format!(
+                    "service '{service_id}' fee exceeds the recordable range"
+                )));
+            }
+            (
+                vendor_wallet.to_string(),
+                PaymentTarget::Vendor {
+                    price_atomic: provider_atomic,
+                    settlement: VendorSettlement {
+                        vendor_wallet: vendor_wallet.to_string(),
+                        settled_atomic: provider_atomic,
+                        fee_receivable_atomic: fee_atomic,
+                    },
+                },
+            )
+        }
+        None => (
+            state.config.solana.recipient_wallet.clone(),
+            PaymentTarget::Gateway {
                 total_atomic,
                 fee_atomic,
-                None,
-            ),
-        };
+            },
+        ),
+    };
+    let expected_atomic = payment_target.expected_atomic();
 
     // Step 3: Check for payment header.
     // Non-ASCII bytes in header value must produce 400, not a silent 402.
@@ -252,11 +318,11 @@ pub async fn proxy_service(
         info!(service_id = %service_id, "no payment signature, returning 402");
 
         // Format cost breakdown from integer-derived values for display.
-        // On the vendor path `agent_fee_atomic` is 0 and the total equals the
+        // On the vendor path the agent fee is 0 and the total equals the
         // provider price — the breakdown reflects what the AGENT pays, not
         // the off-chain receivable the vendor owes.
         let provider_usdc = provider_atomic as f64 / 1_000_000.0;
-        let fee_usdc = agent_fee_atomic as f64 / 1_000_000.0;
+        let fee_usdc = payment_target.agent_fee_atomic() as f64 / 1_000_000.0;
         let total_usdc = expected_atomic as f64 / 1_000_000.0;
 
         let payment_required = PaymentRequired {
@@ -284,13 +350,9 @@ pub async fn proxy_service(
                 total: format!("{total_usdc:.6}"),
                 currency: "USDC".to_string(),
                 // Agent-facing fee rate: 0 on the vendor path (the vendor
-                // absorbs the 5%, invoiced off-chain), 5 otherwise. Keeping
-                // `5` next to a `0.000000` fee would contradict the amounts.
-                fee_percent: if vendor_settlement.is_some() {
-                    0
-                } else {
-                    PLATFORM_FEE_PERCENT
-                },
+                // absorbs the 5%, invoiced off-chain), 5 otherwise — see
+                // `PaymentTarget::agent_fee_percent`.
+                fee_percent: payment_target.agent_fee_percent(),
             },
             error: "Payment required".to_string(),
         };
@@ -521,14 +583,14 @@ pub async fn proxy_service(
     // (`RecipientOverrideUnsupported`) for any verifier that does not support
     // recipient override (e.g. the escrow scheme, whose vendor split is P4).
     // Non-vendor services keep today's `verify_and_settle` path unchanged.
-    let settlement_outcome = match &vendor_settlement {
-        Some(_) => {
+    let settlement_outcome = match &payment_target {
+        PaymentTarget::Vendor { .. } => {
             state
                 .facilitator
                 .verify_and_settle_to(&payload, &pay_to_wallet)
                 .await
         }
-        None => state.facilitator.verify_and_settle(&payload).await,
+        PaymentTarget::Gateway { .. } => state.facilitator.verify_and_settle(&payload).await,
     };
     match settlement_outcome {
         Ok(settlement) if !settlement.success => {
@@ -609,7 +671,7 @@ pub async fn proxy_service(
         // reservation is committed and log_spend increments by the full
         // cost. None preserves the legacy behavior here.
         estimated_cost_usdc: None,
-        vendor: vendor_settlement,
+        vendor: payment_target.into_vendor_settlement(),
     };
     let deferred_spend_entry = if spend_entry.vendor.is_some() {
         state.usage.log_spend(spend_entry);
@@ -1541,6 +1603,15 @@ mod tests {
     /// `vendor_wallet` is the caller's choice, and a configured global
     /// recipient of `TEST_GLOBAL_RECIPIENT`.
     fn make_state_with_vendor_service(vendor_wallet: Option<&str>) -> Arc<AppState> {
+        make_state_with_vendor_service_priced(vendor_wallet, 0.01)
+    }
+
+    /// Like [`make_state_with_vendor_service`] but with a caller-supplied
+    /// `price_per_request_usdc`, for boundary pricing (fee floor, i64 range).
+    fn make_state_with_vendor_service_priced(
+        vendor_wallet: Option<&str>,
+        price_usdc: f64,
+    ) -> Arc<AppState> {
         make_state_with_entry(
             ServiceEntry {
                 id: "test-svc".to_string(),
@@ -1554,7 +1625,7 @@ mod tests {
                 chains: vec!["solana".to_string()],
                 source: "api".to_string(),
                 healthy: None,
-                price_per_request_usdc: Some(0.01),
+                price_per_request_usdc: Some(price_usdc),
                 vendor_wallet: vendor_wallet.map(String::from),
             },
             TEST_GLOBAL_RECIPIENT,
@@ -1661,6 +1732,77 @@ mod tests {
         assert!(
             matches!(err, GatewayError::InvalidPayment(ref m) if m.contains("verification failed")),
             "expected to reach (and fail at) verification, got {err:?}"
+        );
+    }
+
+    /// Fee floor (round-2 item 9, unit half): a $0.000019 service prices to
+    /// 19 atomic; `19 × 105 / 100 = 19` (integer floor), so the receivable is
+    /// legitimately ZERO. Pins that sub-$0.00002 services round the 5% down
+    /// to nothing rather than up to 1 atomic.
+    #[test]
+    fn test_compute_service_cost_fee_floor_sub_cent_price_has_zero_fee() {
+        let cost = compute_service_cost(0.000019).unwrap();
+        assert_eq!(cost.provider_atomic, 19);
+        assert_eq!(cost.fee_atomic, 0, "floor(19 × 5 / 100) must be 0");
+        assert_eq!(cost.total_atomic, 19);
+    }
+
+    /// Fee floor through the handler: the vendor 402 for a $0.000019 service
+    /// advertises amount "19", platform_fee "0.000000", and fee_percent 0 —
+    /// the agent-facing quote stays truthful at the rounding floor.
+    #[tokio::test]
+    async fn proxy_vendor_402_fee_floor_advertises_zero_fee() {
+        let state = make_state_with_vendor_service_priced(Some(TEST_VENDOR_WALLET), 0.000019);
+        let err = call_expect_err(state, "test-svc", HeaderMap::new()).await;
+        match err {
+            GatewayError::PaymentChallenge(pr) => {
+                assert_eq!(pr.accepts[0].pay_to, TEST_VENDOR_WALLET);
+                assert_eq!(pr.accepts[0].amount, "19");
+                assert_eq!(pr.cost_breakdown.provider_cost, "0.000019");
+                assert_eq!(pr.cost_breakdown.platform_fee, "0.000000");
+                assert_eq!(pr.cost_breakdown.total, "0.000019");
+                assert_eq!(pr.cost_breakdown.fee_percent, 0);
+            }
+            other => panic!("expected PaymentChallenge, got {other:?}"),
+        }
+    }
+
+    /// Round-2 item 7: a vendor service priced so `provider_atomic` exceeds
+    /// `i64::MAX` (registration only requires price > 0, and
+    /// `validate_price_usdc` allows up to ~u64::MAX/1e6) must fail CLOSED
+    /// with an Internal error BEFORE any 402 is quoted — never quote an
+    /// amount the BIGINT receivable ledger cannot record.
+    #[tokio::test]
+    async fn proxy_vendor_service_unrecordable_price_fails_closed_before_402() {
+        // 1.0e13 USDC → 1.0e19 atomic: within the u64 pricing cap
+        // (~1.8446e13 USDC) but beyond i64::MAX (~9.22e18 atomic).
+        let state = make_state_with_vendor_service_priced(Some(TEST_VENDOR_WALLET), 1.0e13);
+        let err = call_expect_err(state, "test-svc", HeaderMap::new()).await;
+        match err {
+            GatewayError::Internal(msg) => {
+                assert!(
+                    msg.contains("recordable range"),
+                    "error must name the recordable-range guard, got: {msg}"
+                );
+            }
+            GatewayError::PaymentChallenge(pr) => panic!(
+                "must fail closed BEFORE quoting a 402, but quoted amount {}",
+                pr.accepts[0].amount
+            ),
+            other => panic!("expected Internal from the pre-quote guard, got {other:?}"),
+        }
+    }
+
+    /// Same price on a NON-vendor service stays on the legacy gateway path
+    /// (no receivable ledger involved) — pins that the new guard is scoped
+    /// to the vendor path and does not change plain-service behavior.
+    #[tokio::test]
+    async fn proxy_plain_service_huge_price_still_quotes_402() {
+        let state = make_state_with_vendor_service_priced(None, 1.0e13);
+        let err = call_expect_err(state, "test-svc", HeaderMap::new()).await;
+        assert!(
+            matches!(err, GatewayError::PaymentChallenge(_)),
+            "non-vendor path must keep today's behavior, got {err:?}"
         );
     }
 

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -24,7 +24,7 @@ use crate::error::GatewayError;
 use crate::middleware::x402::decode_payment_header;
 use crate::payment_util::extract_payer_wallet;
 use crate::security;
-use crate::usage::SpendLogEntry;
+use crate::usage::{SpendLogEntry, VendorSettlement};
 use crate::AppState;
 
 /// Upstream request timeout for external service proxying.
@@ -174,13 +174,64 @@ pub async fn proxy_service(
     let ServiceCost {
         provider_atomic,
         fee_atomic,
-        total_atomic: expected_atomic,
+        total_atomic,
     } = compute_service_cost(price_usdc).map_err(|e| {
         warn!(service_id = %service_id, error = %e, "invalid service pricing");
         GatewayError::Internal(format!(
             "service '{service_id}' has invalid price_per_request_usdc"
         ))
     })?;
+
+    // Per-service settlement recipient (settlement-platform P1).
+    //
+    // "Vendor-Settlement Fee Mechanics" RFC (2026-06-12, mechanism C / record
+    // + invoice, VENDOR ABSORBS the fee): for a service with a
+    // `vendor_wallet`, the agent pays EXACTLY the listed price
+    // (`provider_atomic`, no 5% on top) in a single transfer addressed to the
+    // vendor wallet, and Solvela's 5% (`fee_atomic`, the canonical
+    // `floor(price × 105 / 100) − price` from `compute_service_cost`) is
+    // recorded as an off-chain receivable against the vendor in spend_logs.
+    // Services without a vendor wallet keep today's behavior unchanged:
+    // `price × 1.05` paid to the gateway's global recipient.
+    //
+    // `agent_fee_atomic` is what the AGENT is charged as a fee — zero on the
+    // vendor path — and is what the 402 `cost_breakdown` must show (rule #5:
+    // the breakdown stays truthful to what the agent pays).
+    let (pay_to_wallet, expected_atomic, agent_fee_atomic, vendor_settlement) =
+        match service.vendor_wallet.as_deref() {
+            Some(vendor_wallet) => {
+                // Fail closed before quoting or charging: the receivable
+                // ledger columns are BIGINT, so a priced amount that cannot
+                // be represented as i64 must reject the request, not get
+                // recorded wrapped or skipped.
+                let settled_atomic = i64::try_from(provider_atomic).map_err(|_| {
+                    GatewayError::Internal(format!(
+                        "service '{service_id}' price exceeds the recordable range"
+                    ))
+                })?;
+                let fee_receivable_atomic = i64::try_from(fee_atomic).map_err(|_| {
+                    GatewayError::Internal(format!(
+                        "service '{service_id}' fee exceeds the recordable range"
+                    ))
+                })?;
+                (
+                    vendor_wallet.to_string(),
+                    provider_atomic,
+                    0u64,
+                    Some(VendorSettlement {
+                        vendor_wallet: vendor_wallet.to_string(),
+                        settled_atomic,
+                        fee_receivable_atomic,
+                    }),
+                )
+            }
+            None => (
+                state.config.solana.recipient_wallet.clone(),
+                total_atomic,
+                fee_atomic,
+                None,
+            ),
+        };
 
     // Step 3: Check for payment header.
     // Non-ASCII bytes in header value must produce 400, not a silent 402.
@@ -200,9 +251,12 @@ pub async fn proxy_service(
         counter!("solvela_payments_total", "status" => "none").increment(1);
         info!(service_id = %service_id, "no payment signature, returning 402");
 
-        // Format cost breakdown from integer-derived values for display
+        // Format cost breakdown from integer-derived values for display.
+        // On the vendor path `agent_fee_atomic` is 0 and the total equals the
+        // provider price — the breakdown reflects what the AGENT pays, not
+        // the off-chain receivable the vendor owes.
         let provider_usdc = provider_atomic as f64 / 1_000_000.0;
-        let fee_usdc = fee_atomic as f64 / 1_000_000.0;
+        let fee_usdc = agent_fee_atomic as f64 / 1_000_000.0;
         let total_usdc = expected_atomic as f64 / 1_000_000.0;
 
         let payment_required = PaymentRequired {
@@ -218,7 +272,9 @@ pub async fn proxy_service(
                 // Quote the CONFIGURED mint (what the verifier enforces),
                 // never the compile-time constant.
                 asset: state.config.solana.usdc_mint.clone(),
-                pay_to: state.config.solana.recipient_wallet.clone(),
+                // Per-service recipient: the vendor wallet when configured,
+                // the gateway's global recipient otherwise.
+                pay_to: pay_to_wallet.clone(),
                 max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
                 escrow_program_id: None,
             }],
@@ -227,7 +283,14 @@ pub async fn proxy_service(
                 platform_fee: format!("{fee_usdc:.6}"),
                 total: format!("{total_usdc:.6}"),
                 currency: "USDC".to_string(),
-                fee_percent: PLATFORM_FEE_PERCENT,
+                // Agent-facing fee rate: 0 on the vendor path (the vendor
+                // absorbs the 5%, invoiced off-chain), 5 otherwise. Keeping
+                // `5` next to a `0.000000` fee would contradict the amounts.
+                fee_percent: if vendor_settlement.is_some() {
+                    0
+                } else {
+                    PLATFORM_FEE_PERCENT
+                },
             },
             error: "Payment required".to_string(),
         };
@@ -305,11 +368,17 @@ pub async fn proxy_service(
         )));
     }
 
-    // Validate pay_to matches the gateway's recipient wallet
-    if payload.accepted.pay_to != state.config.solana.recipient_wallet {
+    // Validate pay_to matches this service's expected recipient — the vendor
+    // wallet when configured, the gateway's global recipient otherwise. Hard
+    // equality both ways: a vendor service paid to the global wallet is
+    // rejected, and vice versa.
+    if payload.accepted.pay_to != pay_to_wallet {
+        // GHSA-cgqx-mg48-949v posture: `pay_to` is client-controlled — cap to
+        // the max base58 pubkey length before echoing (mirrors the asset
+        // truncation above).
+        let pay_to_prefix: String = payload.accepted.pay_to.chars().take(44).collect();
         return Err(GatewayError::BadRequest(format!(
-            "payment pay_to must be '{}', got '{}'",
-            state.config.solana.recipient_wallet, payload.accepted.pay_to
+            "payment pay_to must be '{pay_to_wallet}', got '{pay_to_prefix}'"
         )));
     }
 
@@ -445,7 +514,23 @@ pub async fn proxy_service(
     // `success` flag is `false` (e.g. RPC confirmation timed out). We mirror that
     // here so an unconfirmed transaction cannot be forwarded to the upstream
     // service as a paid request.
-    match state.facilitator.verify_and_settle(&payload).await {
+    //
+    // Vendor-wallet services verify against the PER-SERVICE recipient via
+    // `verify_and_settle_to` — the verifier re-derives the expected ATA from
+    // the vendor wallet and enforces hard equality, and fails closed
+    // (`RecipientOverrideUnsupported`) for any verifier that does not support
+    // recipient override (e.g. the escrow scheme, whose vendor split is P4).
+    // Non-vendor services keep today's `verify_and_settle` path unchanged.
+    let settlement_outcome = match &vendor_settlement {
+        Some(_) => {
+            state
+                .facilitator
+                .verify_and_settle_to(&payload, &pay_to_wallet)
+                .await
+        }
+        None => state.facilitator.verify_and_settle(&payload).await,
+    };
+    match settlement_outcome {
         Ok(settlement) if !settlement.success => {
             counter!("solvela_payments_total", "status" => "failed").increment(1);
             warn!(
@@ -491,6 +576,47 @@ pub async fn proxy_service(
         .get("x-request-id")
         .and_then(|v| v.to_str().ok())
         .map(String::from);
+
+    // Build the spend entry once (fire-and-forget: log_spend spawns its own
+    // writes, never awaited on the hot path).
+    //
+    // WHEN it is logged differs by path:
+    // - Vendor services log NOW, at settlement time: the 5% receivable is owed
+    //   on SETTLED volume (the vendor was just paid on-chain), so deferring
+    //   the record past the upstream call would silently drop receivables for
+    //   settled requests whose upstream then times out or is unreachable.
+    // - Non-vendor services keep the legacy post-upstream write below,
+    //   byte-for-byte today's behavior.
+    let spend_entry = SpendLogEntry {
+        wallet_address,
+        model: service_id.clone(),
+        provider: "external-service".to_string(),
+        input_tokens: 0,
+        output_tokens: 0,
+        cost_usdc: expected_atomic as f64 / 1_000_000.0,
+        tx_signature,
+        request_id: request_id.clone(),
+        session_id: None,
+        // PR1 keeps the service-marketplace proxy minimal: it does not read the
+        // x-tenant header. Per-tenant attribution for the proxy path can be
+        // added later; None leaves these rows untagged for now.
+        tenant: None,
+        // No tenant tag is read on the proxy path, so no per-tenant bucket is
+        // enforced — never reconcile per-tenant counters here.
+        tenant_enforced: false,
+        // Service-marketplace proxy doesn't go through `check_budget`
+        // (it has flat per-request pricing, not per-wallet budgets), so no
+        // reservation is committed and log_spend increments by the full
+        // cost. None preserves the legacy behavior here.
+        estimated_cost_usdc: None,
+        vendor: vendor_settlement,
+    };
+    let deferred_spend_entry = if spend_entry.vendor.is_some() {
+        state.usage.log_spend(spend_entry);
+        None
+    } else {
+        Some(spend_entry)
+    };
 
     // Step 5: SSRF check — resolve DNS once, validate all addresses are public,
     // then pin the validated IP into a per-request reqwest client. This eliminates
@@ -599,31 +725,12 @@ pub async fn proxy_service(
 
     let upstream_status = upstream_response.status();
 
-    // Step 7: Fire-and-forget spend log (log_spend internally uses tokio::spawn)
-    let total_cost_usdc = expected_atomic as f64 / 1_000_000.0;
-    state.usage.log_spend(SpendLogEntry {
-        wallet_address,
-        model: service_id.clone(),
-        provider: "external-service".to_string(),
-        input_tokens: 0,
-        output_tokens: 0,
-        cost_usdc: total_cost_usdc,
-        tx_signature,
-        request_id: request_id.clone(),
-        session_id: None,
-        // PR1 keeps the service-marketplace proxy minimal: it does not read the
-        // x-tenant header. Per-tenant attribution for the proxy path can be
-        // added later; None leaves these rows untagged for now.
-        tenant: None,
-        // No tenant tag is read on the proxy path, so no per-tenant bucket is
-        // enforced — never reconcile per-tenant counters here.
-        tenant_enforced: false,
-        // Service-marketplace proxy doesn't go through `check_budget`
-        // (it has flat per-request pricing, not per-wallet budgets), so no
-        // reservation is committed and log_spend increments by the full
-        // cost. None preserves the legacy behavior here.
-        estimated_cost_usdc: None,
-    });
+    // Step 7: Fire-and-forget spend log (log_spend internally uses
+    // tokio::spawn). Non-vendor services only — vendor services already
+    // logged at settlement time above (one row per request either way).
+    if let Some(entry) = deferred_spend_entry {
+        state.usage.log_spend(entry);
+    }
 
     // Handle upstream response based on status
     if upstream_status.is_server_error() {
@@ -944,6 +1051,7 @@ mod tests {
             source: "api".to_string(),
             healthy: None,
             price_per_request_usdc: Some(0.01),
+            vendor_wallet: None,
         })
         .expect("valid test service entry"); // safe: known-good test data
 
@@ -1046,6 +1154,38 @@ mod tests {
         x402_enabled: bool,
         healthy: Option<bool>,
     ) -> Arc<AppState> {
+        // Endpoint shape must match the validator's rule: internal services
+        // use a relative path; external services use an absolute https URL.
+        let endpoint = if internal {
+            "/v1/test".to_string()
+        } else {
+            "https://test.example.com/api".to_string()
+        };
+        make_state_with_entry(
+            ServiceEntry {
+                id: "test-svc".to_string(),
+                name: "Test Service".to_string(),
+                category: "test".to_string(),
+                endpoint,
+                x402_enabled,
+                internal,
+                description: None,
+                pricing_label: "per-request".to_string(),
+                chains: vec!["solana".to_string()],
+                source: "api".to_string(),
+                healthy,
+                price_per_request_usdc: price,
+                vendor_wallet: None,
+            },
+            // AppConfig::default() leaves recipient_wallet empty — the legacy
+            // tests above build payloads with `pay_to: String::new()`.
+            "",
+        )
+    }
+
+    /// Construct an AppState from a fully-specified service entry and a
+    /// configured global recipient wallet.
+    fn make_state_with_entry(entry: ServiceEntry, recipient_wallet: &str) -> Arc<AppState> {
         use crate::config::AppConfig;
         use crate::providers::health::{CircuitBreakerConfig, ProviderHealthTracker};
         use crate::providers::ProviderRegistry;
@@ -1055,31 +1195,13 @@ mod tests {
         use solvela_x402::facilitator::Facilitator;
 
         let mut reg = ServiceRegistry::empty();
-        // Endpoint shape must match the validator's rule: internal services
-        // use a relative path; external services use an absolute https URL.
-        let endpoint = if internal {
-            "/v1/test".to_string()
-        } else {
-            "https://test.example.com/api".to_string()
-        };
-        reg.register(ServiceEntry {
-            id: "test-svc".to_string(),
-            name: "Test Service".to_string(),
-            category: "test".to_string(),
-            endpoint,
-            x402_enabled,
-            internal,
-            description: None,
-            pricing_label: "per-request".to_string(),
-            chains: vec!["solana".to_string()],
-            source: "api".to_string(),
-            healthy,
-            price_per_request_usdc: price,
-        })
-        .expect("valid test service entry");
+        reg.register(entry).expect("valid test service entry");
+
+        let mut config = AppConfig::default();
+        config.solana.recipient_wallet = recipient_wallet.to_string();
 
         Arc::new(AppState {
-            config: AppConfig::default(),
+            config,
             model_registry: ModelRegistry::from_toml(
                 "[models.placeholder]\nprovider=\"t\"\nmodel_id=\"t\"\ndisplay_name=\"T\"\n\
                  input_cost_per_million=1.0\noutput_cost_per_million=1.0\ncontext_window=4096\n\
@@ -1405,6 +1527,141 @@ mod tests {
             }
             other => panic!("expected InvalidPayment from empty facilitator, got {other:?}"),
         }
+    }
+
+    // ── Per-service vendor_wallet recipient (settlement-platform P1) ──────
+
+    /// Vendor wallet used by the vendor-recipient tests (valid base58 pubkey).
+    const TEST_VENDOR_WALLET: &str = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    /// Global recipient configured on the gateway in vendor tests (valid
+    /// base58 pubkey, distinct from the vendor wallet).
+    const TEST_GLOBAL_RECIPIENT: &str = "So11111111111111111111111111111111111111112";
+
+    /// State with one external service ("test-svc", $0.01) whose
+    /// `vendor_wallet` is the caller's choice, and a configured global
+    /// recipient of `TEST_GLOBAL_RECIPIENT`.
+    fn make_state_with_vendor_service(vendor_wallet: Option<&str>) -> Arc<AppState> {
+        make_state_with_entry(
+            ServiceEntry {
+                id: "test-svc".to_string(),
+                name: "Test Service".to_string(),
+                category: "test".to_string(),
+                endpoint: "https://test.example.com/api".to_string(),
+                x402_enabled: true,
+                internal: false,
+                description: None,
+                pricing_label: "per-request".to_string(),
+                chains: vec!["solana".to_string()],
+                source: "api".to_string(),
+                healthy: None,
+                price_per_request_usdc: Some(0.01),
+                vendor_wallet: vendor_wallet.map(String::from),
+            },
+            TEST_GLOBAL_RECIPIENT,
+        )
+    }
+
+    /// (c) 402 challenge: a vendor_wallet service must advertise the vendor
+    /// wallet as `pay_to` and the LISTED PRICE as the amount (vendor absorbs
+    /// the fee — the agent is never charged the 5% on this path), with a
+    /// cost_breakdown that stays truthful to what the agent pays (rule #5):
+    /// platform_fee = 0, total = provider price.
+    #[tokio::test]
+    async fn proxy_402_advertises_vendor_wallet_as_pay_to() {
+        let state = make_state_with_vendor_service(Some(TEST_VENDOR_WALLET));
+        let err = call_expect_err(state, "test-svc", HeaderMap::new()).await;
+        match err {
+            GatewayError::PaymentChallenge(pr) => {
+                assert_eq!(pr.accepts[0].pay_to, TEST_VENDOR_WALLET);
+                // $0.01 listed price = 10_000 atomic — NOT 10_500 (no 5% on top).
+                assert_eq!(pr.accepts[0].amount, "10000");
+                assert_eq!(pr.cost_breakdown.provider_cost, "0.010000");
+                assert_eq!(pr.cost_breakdown.platform_fee, "0.000000");
+                assert_eq!(pr.cost_breakdown.total, "0.010000");
+                assert_eq!(pr.cost_breakdown.fee_percent, 0);
+            }
+            other => panic!("expected PaymentChallenge, got {other:?}"),
+        }
+    }
+
+    /// (c) fallback: without a vendor_wallet the 402 advertises the global
+    /// recipient and `price × 1.05` — byte-for-byte today's behavior.
+    #[tokio::test]
+    async fn proxy_402_advertises_global_recipient_without_vendor_wallet() {
+        let state = make_state_with_vendor_service(None);
+        let err = call_expect_err(state, "test-svc", HeaderMap::new()).await;
+        match err {
+            GatewayError::PaymentChallenge(pr) => {
+                assert_eq!(pr.accepts[0].pay_to, TEST_GLOBAL_RECIPIENT);
+                assert_eq!(pr.accepts[0].amount, "10500");
+                assert_eq!(pr.cost_breakdown.provider_cost, "0.010000");
+                assert_eq!(pr.cost_breakdown.platform_fee, "0.000500");
+                assert_eq!(pr.cost_breakdown.total, "0.010500");
+                assert_eq!(pr.cost_breakdown.fee_percent, PLATFORM_FEE_PERCENT);
+            }
+            other => panic!("expected PaymentChallenge, got {other:?}"),
+        }
+    }
+
+    /// (d) wrong amount on the vendor path: anything below the listed price
+    /// is insufficient (the vendor threshold is `price`, not `price × 1.05`).
+    #[tokio::test]
+    async fn proxy_vendor_service_rejects_amount_below_price() {
+        let state = make_state_with_vendor_service(Some(TEST_VENDOR_WALLET));
+        let mut p = valid_payload("test-svc");
+        p.accepted.pay_to = TEST_VENDOR_WALLET.to_string();
+        p.accepted.amount = "9999".to_string(); // expected is 10_000
+        let err = call_expect_err(state, "test-svc", make_headers_with_payment(&p)).await;
+        assert!(
+            matches!(err, GatewayError::BadRequest(ref m)
+                if m.contains("insufficient") && m.contains("10000")),
+            "expected insufficient-amount rejection at the listed price, got {err:?}"
+        );
+    }
+
+    /// (d) a payment addressed to the GLOBAL recipient must be rejected for a
+    /// vendor_wallet service — hard equality against the per-service recipient.
+    #[tokio::test]
+    async fn proxy_vendor_service_rejects_pay_to_global_recipient() {
+        let state = make_state_with_vendor_service(Some(TEST_VENDOR_WALLET));
+        let mut p = valid_payload("test-svc");
+        p.accepted.pay_to = TEST_GLOBAL_RECIPIENT.to_string();
+        let err = call_expect_err(state, "test-svc", make_headers_with_payment(&p)).await;
+        assert!(
+            matches!(err, GatewayError::BadRequest(ref m)
+                if m.contains("pay_to") && m.contains(TEST_VENDOR_WALLET)),
+            "expected pay_to mismatch naming the vendor wallet, got {err:?}"
+        );
+    }
+
+    /// (d) vice versa: a payment addressed to the VENDOR wallet must be
+    /// rejected for a service without a vendor_wallet.
+    #[tokio::test]
+    async fn proxy_global_service_rejects_pay_to_vendor_wallet() {
+        let state = make_state_with_vendor_service(None);
+        let mut p = valid_payload("test-svc");
+        p.accepted.pay_to = TEST_VENDOR_WALLET.to_string();
+        let err = call_expect_err(state, "test-svc", make_headers_with_payment(&p)).await;
+        assert!(
+            matches!(err, GatewayError::BadRequest(ref m)
+                if m.contains("pay_to") && m.contains(TEST_GLOBAL_RECIPIENT)),
+            "expected pay_to mismatch naming the global recipient, got {err:?}"
+        );
+    }
+
+    /// A payment addressed to the vendor wallet must clear the recipient
+    /// equality gate and reach verification (which fails here only because
+    /// the test facilitator has no verifiers).
+    #[tokio::test]
+    async fn proxy_vendor_service_pay_to_vendor_reaches_verification() {
+        let state = make_state_with_vendor_service(Some(TEST_VENDOR_WALLET));
+        let mut p = valid_payload("test-svc");
+        p.accepted.pay_to = TEST_VENDOR_WALLET.to_string();
+        let err = call_expect_err(state, "test-svc", make_headers_with_payment(&p)).await;
+        assert!(
+            matches!(err, GatewayError::InvalidPayment(ref m) if m.contains("verification failed")),
+            "expected to reach (and fail at) verification, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/gateway/src/routes/services.rs
+++ b/crates/gateway/src/routes/services.rs
@@ -100,6 +100,11 @@ pub struct RegisterServiceRequest {
     #[serde(default)]
     pub pricing_label: Option<String>,
     pub price_per_request_usdc: Option<f64>,
+    /// Per-service payment recipient (vendor-absorbs fee semantics — see
+    /// `ServiceEntry::vendor_wallet` and the "Vendor-Settlement Fee Mechanics"
+    /// RFC, 2026-06-12). Validated as a Solana pubkey by the registry.
+    #[serde(default)]
+    pub vendor_wallet: Option<String>,
 }
 
 /// POST /v1/services/register — register a new external service at runtime.
@@ -176,6 +181,18 @@ pub async fn register_service(
                 .into_response();
         }
     }
+    // Base58 32-byte pubkeys are at most 44 characters; cap before the
+    // registry's full pubkey validation so an oversized value is rejected
+    // cheaply (mirrors the other field-length guards above).
+    if let Some(ref vendor_wallet) = body.vendor_wallet {
+        if vendor_wallet.len() > 44 {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "vendor_wallet must be at most 44 characters" })),
+            )
+                .into_response();
+        }
+    }
 
     // Validate endpoint is not a private/internal network address (SSRF prevention)
     match security::is_private_endpoint(&body.endpoint).await {
@@ -217,6 +234,7 @@ pub async fn register_service(
         source: "api".to_string(),
         healthy: None,
         price_per_request_usdc: body.price_per_request_usdc,
+        vendor_wallet: body.vendor_wallet,
     };
 
     // Acquire write lock and register

--- a/crates/gateway/src/routes/services.rs
+++ b/crates/gateway/src/routes/services.rs
@@ -61,6 +61,9 @@ pub async fn list_services(
             // useful reconnaissance for availability attacks. Operators
             // can query health via a dedicated admin-protected endpoint
             // (TODO: add `GET /v1/admin/services/health`).
+            // `svc.vendor_wallet` is deliberately omitted too: settlement
+            // recipients are a vendor/operator concern, not public-listing
+            // data — the payer learns the pay_to from the 402 challenge.
             json!({
                 "id": svc.id,
                 "name": svc.name,

--- a/crates/gateway/src/services.rs
+++ b/crates/gateway/src/services.rs
@@ -5,6 +5,7 @@
 //! Supports runtime registration via `register()` for the admin API.
 
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -46,6 +47,12 @@ pub enum RegistrationError {
 
     #[error("price_per_request_usdc must be greater than 0")]
     InvalidPrice,
+
+    #[error("vendor_wallet must be a valid base58-encoded 32-byte Solana pubkey")]
+    InvalidVendorWallet,
+
+    #[error("vendor_wallet is only supported on external services")]
+    VendorWalletOnInternalService,
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +73,8 @@ struct RawServiceEntry {
     pub pricing_label: Option<String>,
     #[serde(default)]
     pub price_per_request_usdc: Option<f64>,
+    #[serde(default)]
+    pub vendor_wallet: Option<String>,
 }
 
 /// Outer TOML wrapper: `[services.<id>]` tables.
@@ -108,6 +117,22 @@ pub struct ServiceEntry {
     /// Flat per-request price in USDC (used by external services).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price_per_request_usdc: Option<f64>,
+    /// Per-service payment recipient (base58 Solana wallet pubkey).
+    ///
+    /// Settlement-platform P1, per the "Vendor-Settlement Fee Mechanics" RFC
+    /// (2026-06-12, mechanism C / record + invoice, **vendor absorbs** the fee):
+    /// when set, the agent pays EXACTLY `price_per_request_usdc` (no 5%
+    /// fee-on-top) in a single transfer addressed to this wallet, and
+    /// Solvela's 5% platform fee is RECORDED as an off-chain receivable
+    /// against the vendor (spend_logs), never charged to the agent. When
+    /// `None`, today's behavior applies unchanged: `price × 1.05` paid to the
+    /// gateway's global recipient wallet.
+    ///
+    /// Validated as a base58 32-byte Solana pubkey at load/registration time
+    /// (fail closed) and only permitted on external services — the internal
+    /// chat pipeline does not honor it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor_wallet: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -159,6 +184,7 @@ impl ServiceRegistry {
                 source: "config".to_string(),
                 healthy: None,
                 price_per_request_usdc: raw.price_per_request_usdc,
+                vendor_wallet: raw.vendor_wallet,
             };
             validate_entry(&entry).map_err(|source| ServiceRegistryError::InvalidEntry {
                 id: id.clone(),
@@ -260,6 +286,21 @@ fn validate_entry(entry: &ServiceEntry) -> Result<(), RegistrationError> {
         match entry.price_per_request_usdc {
             Some(price) if price > 0.0 => {}
             _ => return Err(RegistrationError::InvalidPrice),
+        }
+    }
+
+    // vendor_wallet — fail closed on anything that is not a base58 32-byte
+    // Solana pubkey: an invalid recipient must reject the entry at load /
+    // registration time, never surface later as an unpayable 402 quote or a
+    // misdirected transfer. Internal services reject it outright: the chat
+    // pipeline does not honor vendor settlement, so accepting it there would
+    // let config claim a vendor gets paid while the gateway pays itself.
+    if let Some(ref vendor_wallet) = entry.vendor_wallet {
+        if entry.internal {
+            return Err(RegistrationError::VendorWalletOnInternalService);
+        }
+        if solvela_x402::solana_types::Pubkey::from_str(vendor_wallet).is_err() {
+            return Err(RegistrationError::InvalidVendorWallet);
         }
     }
 
@@ -427,6 +468,7 @@ internal = true
             source: "api".to_string(),
             healthy: None,
             price_per_request_usdc: Some(0.01),
+            vendor_wallet: None,
         };
         assert!(registry.register(entry).is_ok());
         assert_eq!(registry.all().len(), 1);
@@ -449,6 +491,7 @@ internal = true
             source: "api".to_string(),
             healthy: None,
             price_per_request_usdc: Some(0.01),
+            vendor_wallet: None,
         };
         registry.register(entry.clone()).unwrap();
         let result = registry.register(entry);
@@ -474,6 +517,7 @@ internal = true
             source: "api".to_string(),
             healthy: None,
             price_per_request_usdc: Some(0.01),
+            vendor_wallet: None,
         };
         assert_eq!(
             registry.register(entry),
@@ -497,6 +541,7 @@ internal = true
             source: "api".to_string(),
             healthy: None,
             price_per_request_usdc: Some(0.01),
+            vendor_wallet: None,
         };
         assert_eq!(registry.register(entry), Err(RegistrationError::InvalidId));
     }
@@ -517,6 +562,7 @@ internal = true
             source: "api".to_string(),
             healthy: None,
             price_per_request_usdc: None,
+            vendor_wallet: None,
         };
         assert_eq!(
             registry.register(entry),
@@ -591,6 +637,173 @@ price_per_request_usdc = 0.001
             }
             other => panic!("expected InvalidEntry, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // vendor_wallet (settlement-platform P1: per-service payment recipient)
+    // -----------------------------------------------------------------------
+
+    /// A valid base58 Solana pubkey (the exact-scheme golden vector's pay_to).
+    const VALID_VENDOR_WALLET: &str = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+    #[test]
+    fn from_toml_parses_vendor_wallet() {
+        let toml = format!(
+            r#"
+[services.vendor-svc]
+name = "Vendor Service"
+endpoint = "https://vendor.example.com/api"
+category = "data"
+x402_enabled = true
+internal = false
+pricing_label = "$0.01/request"
+price_per_request_usdc = 0.01
+vendor_wallet = "{VALID_VENDOR_WALLET}"
+"#
+        );
+        let registry = ServiceRegistry::from_toml(&toml).expect("valid vendor_wallet must load");
+        assert_eq!(
+            registry.get("vendor-svc").unwrap().vendor_wallet.as_deref(),
+            Some(VALID_VENDOR_WALLET)
+        );
+    }
+
+    #[test]
+    fn vendor_wallet_defaults_to_none_when_absent() {
+        let registry = ServiceRegistry::from_toml(SAMPLE_TOML).unwrap();
+        for svc in registry.all() {
+            assert_eq!(
+                svc.vendor_wallet, None,
+                "service '{}' must default to no vendor wallet",
+                svc.id
+            );
+        }
+    }
+
+    /// Fail closed at load time: a vendor_wallet that is not a valid Solana
+    /// pubkey must reject the whole registry, not surface later as an
+    /// unpayable 402 or a misdirected transfer.
+    #[test]
+    fn from_toml_rejects_invalid_vendor_wallet() {
+        let bad = r#"
+[services.bad-vendor]
+name = "Bad Vendor"
+endpoint = "https://vendor.example.com/api"
+category = "data"
+x402_enabled = true
+internal = false
+pricing_label = "$0.01/request"
+price_per_request_usdc = 0.01
+vendor_wallet = "not-a-valid-pubkey"
+"#;
+        let err = ServiceRegistry::from_toml(bad).expect_err("must reject invalid vendor_wallet");
+        match err {
+            ServiceRegistryError::InvalidEntry { id, source } => {
+                assert_eq!(id, "bad-vendor");
+                assert_eq!(source, RegistrationError::InvalidVendorWallet);
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    /// Valid base58 but not 32 bytes — must also reject.
+    #[test]
+    fn from_toml_rejects_short_base58_vendor_wallet() {
+        let bad = r#"
+[services.short-vendor]
+name = "Short Vendor"
+endpoint = "https://vendor.example.com/api"
+category = "data"
+x402_enabled = true
+internal = false
+pricing_label = "$0.01/request"
+price_per_request_usdc = 0.01
+vendor_wallet = "abc"
+"#;
+        let err = ServiceRegistry::from_toml(bad).expect_err("must reject short vendor_wallet");
+        match err {
+            ServiceRegistryError::InvalidEntry { source, .. } => {
+                assert_eq!(source, RegistrationError::InvalidVendorWallet);
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    /// vendor_wallet on an internal service would be silently ignored by the
+    /// chat pipeline (this P1 only wires the proxy path) — reject it outright
+    /// so config cannot claim a vendor gets paid when the gateway pays itself.
+    #[test]
+    fn from_toml_rejects_vendor_wallet_on_internal_service() {
+        let bad = format!(
+            r#"
+[services.internal-vendor]
+name = "Internal With Vendor"
+endpoint = "/v1/chat/completions"
+category = "intelligence"
+x402_enabled = true
+internal = true
+vendor_wallet = "{VALID_VENDOR_WALLET}"
+"#
+        );
+        let err = ServiceRegistry::from_toml(&bad)
+            .expect_err("must reject vendor_wallet on internal service");
+        match err {
+            ServiceRegistryError::InvalidEntry { source, .. } => {
+                assert_eq!(source, RegistrationError::VendorWalletOnInternalService);
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    fn external_entry_with_vendor_wallet(vendor_wallet: Option<String>) -> ServiceEntry {
+        ServiceEntry {
+            id: "vendor-svc".to_string(),
+            name: "Vendor Service".to_string(),
+            category: "data".to_string(),
+            endpoint: "https://vendor.example.com/api".to_string(),
+            x402_enabled: true,
+            internal: false,
+            description: None,
+            pricing_label: "$0.01/request".to_string(),
+            chains: vec!["solana".to_string()],
+            source: "api".to_string(),
+            healthy: None,
+            price_per_request_usdc: Some(0.01),
+            vendor_wallet,
+        }
+    }
+
+    #[test]
+    fn register_accepts_valid_vendor_wallet() {
+        let mut registry = ServiceRegistry::empty();
+        let entry = external_entry_with_vendor_wallet(Some(VALID_VENDOR_WALLET.to_string()));
+        assert!(registry.register(entry).is_ok());
+        assert_eq!(
+            registry.get("vendor-svc").unwrap().vendor_wallet.as_deref(),
+            Some(VALID_VENDOR_WALLET)
+        );
+    }
+
+    #[test]
+    fn register_rejects_invalid_vendor_wallet() {
+        let mut registry = ServiceRegistry::empty();
+        let entry = external_entry_with_vendor_wallet(Some("0OIl-not-base58".to_string()));
+        assert_eq!(
+            registry.register(entry),
+            Err(RegistrationError::InvalidVendorWallet)
+        );
+    }
+
+    #[test]
+    fn register_rejects_vendor_wallet_on_internal_service() {
+        let mut registry = ServiceRegistry::empty();
+        let mut entry = external_entry_with_vendor_wallet(Some(VALID_VENDOR_WALLET.to_string()));
+        entry.internal = true;
+        entry.endpoint = "/v1/test".to_string();
+        assert_eq!(
+            registry.register(entry),
+            Err(RegistrationError::VendorWalletOnInternalService)
+        );
     }
 
     #[test]

--- a/crates/gateway/src/services.rs
+++ b/crates/gateway/src/services.rs
@@ -53,6 +53,14 @@ pub enum RegistrationError {
 
     #[error("vendor_wallet is only supported on external services")]
     VendorWalletOnInternalService,
+
+    #[error(
+        "vendor_wallet must differ from the gateway's global recipient wallet: \
+         a vendor service is quoted WITHOUT the 5% agent-side fee (vendor \
+         absorbs), so pointing it at the gateway's own wallet would undercharge \
+         the agent and have the gateway invoice itself for the receivable"
+    )]
+    VendorWalletIsGatewayRecipient,
 }
 
 // ---------------------------------------------------------------------------
@@ -147,6 +155,16 @@ pub struct ServiceEntry {
 #[derive(Debug, Clone)]
 pub struct ServiceRegistry {
     services: Vec<ServiceEntry>,
+    /// The gateway's global recipient wallet, when known (set via
+    /// [`ServiceRegistry::with_gateway_recipient`] at startup; `None` in
+    /// registries built without one, e.g. bare test fixtures).
+    ///
+    /// When present, `register()` (and the startup re-validation) rejects any
+    /// `vendor_wallet` equal to it: a "vendor" pointing at the gateway's own
+    /// wallet would be quoted vendor-absorbs (agent pays NO 5% on top) while
+    /// the receivable is invoiced to... the gateway itself — a silent 5%
+    /// undercharge. See [`RegistrationError::VendorWalletIsGatewayRecipient`].
+    gateway_recipient: Option<String>,
 }
 
 impl ServiceRegistry {
@@ -154,7 +172,36 @@ impl ServiceRegistry {
     pub fn empty() -> Self {
         Self {
             services: Vec::new(),
+            gateway_recipient: None,
         }
+    }
+
+    /// Attach the gateway's global recipient wallet and re-validate every
+    /// already-loaded entry against it.
+    ///
+    /// Call once at startup, after config is final (see `main.rs`). Returns
+    /// `Err(ServiceRegistryError::InvalidEntry)` naming the offending service
+    /// if any loaded `vendor_wallet` equals the recipient — fail-closed at
+    /// load, never at quote time. An empty `recipient_wallet` (unconfigured
+    /// dev mode) disables the check: no valid base58 `vendor_wallet` can ever
+    /// equal the empty string anyway.
+    pub fn with_gateway_recipient(
+        mut self,
+        recipient_wallet: &str,
+    ) -> Result<Self, ServiceRegistryError> {
+        if recipient_wallet.is_empty() {
+            return Ok(self);
+        }
+        for entry in &self.services {
+            if entry.vendor_wallet.as_deref() == Some(recipient_wallet) {
+                return Err(ServiceRegistryError::InvalidEntry {
+                    id: entry.id.clone(),
+                    source: RegistrationError::VendorWalletIsGatewayRecipient,
+                });
+            }
+        }
+        self.gateway_recipient = Some(recipient_wallet.to_string());
+        Ok(self)
     }
 
     /// Parse a TOML string (content of `services.toml`) into a registry.
@@ -196,7 +243,10 @@ impl ServiceRegistry {
         // Stable alphabetical order so response is deterministic.
         services.sort_by(|a, b| a.id.cmp(&b.id));
 
-        Ok(Self { services })
+        Ok(Self {
+            services,
+            gateway_recipient: None,
+        })
     }
 
     /// Return all registered services.
@@ -225,6 +275,20 @@ impl ServiceRegistry {
     /// `Err(RegistrationError)` if validation fails or the ID is taken.
     pub fn register(&mut self, entry: ServiceEntry) -> Result<(), RegistrationError> {
         validate_entry(&entry)?;
+
+        // Degenerate-recipient guard: a vendor_wallet equal to the gateway's
+        // own recipient wallet silently undercharges the agent 5% (vendor
+        // quotes drop the agent-side fee) and books a receivable the gateway
+        // would invoice to itself. Only enforceable when the registry knows
+        // the recipient — see `with_gateway_recipient`.
+        if let (Some(recipient), Some(vendor_wallet)) = (
+            self.gateway_recipient.as_deref(),
+            entry.vendor_wallet.as_deref(),
+        ) {
+            if vendor_wallet == recipient {
+                return Err(RegistrationError::VendorWalletIsGatewayRecipient);
+            }
+        }
 
         // Check uniqueness against the current registry.
         if self.services.iter().any(|s| s.id == entry.id) {
@@ -804,6 +868,89 @@ vendor_wallet = "{VALID_VENDOR_WALLET}"
             registry.register(entry),
             Err(RegistrationError::VendorWalletOnInternalService)
         );
+    }
+
+    // ── vendor_wallet == gateway recipient (degenerate-recipient guard) ─────
+
+    /// Stand-in for the gateway's configured global recipient wallet. Must be
+    /// a VALID base58 pubkey (distinct from `VALID_VENDOR_WALLET`) so the
+    /// equality guard — not the pubkey-format check — is what rejects.
+    const GATEWAY_RECIPIENT: &str = "So11111111111111111111111111111111111111112";
+
+    /// `register()` on a recipient-aware registry must reject a vendor_wallet
+    /// equal to the gateway's own recipient: the degenerate case silently
+    /// undercharges the agent 5% and has the gateway invoice itself.
+    #[test]
+    fn register_rejects_vendor_wallet_equal_to_gateway_recipient() {
+        let mut registry = ServiceRegistry::empty()
+            .with_gateway_recipient(GATEWAY_RECIPIENT)
+            .expect("empty registry cannot conflict");
+        let entry = external_entry_with_vendor_wallet(Some(GATEWAY_RECIPIENT.to_string()));
+        assert_eq!(
+            registry.register(entry),
+            Err(RegistrationError::VendorWalletIsGatewayRecipient)
+        );
+        assert!(
+            registry.get("vendor-svc").is_none(),
+            "rejected entry must not be registered"
+        );
+    }
+
+    /// A distinct vendor_wallet still registers fine on a recipient-aware
+    /// registry — the guard only fires on equality.
+    #[test]
+    fn register_accepts_distinct_vendor_wallet_with_gateway_recipient_set() {
+        let mut registry = ServiceRegistry::empty()
+            .with_gateway_recipient(GATEWAY_RECIPIENT)
+            .expect("empty registry cannot conflict");
+        let entry = external_entry_with_vendor_wallet(Some(VALID_VENDOR_WALLET.to_string()));
+        assert!(registry.register(entry).is_ok());
+    }
+
+    /// `with_gateway_recipient` re-validates TOML-loaded entries: a
+    /// services.toml whose vendor_wallet equals the configured recipient must
+    /// fail the startup attach, naming the offending service.
+    #[test]
+    fn with_gateway_recipient_rejects_toml_loaded_conflicting_vendor_wallet() {
+        let toml = format!(
+            r#"
+[services.self-paying-svc]
+name = "Self Paying"
+endpoint = "https://vendor.example.com/api"
+category = "data"
+x402_enabled = true
+internal = false
+pricing_label = "$0.01/request"
+price_per_request_usdc = 0.01
+vendor_wallet = "{VALID_VENDOR_WALLET}"
+"#
+        );
+        let registry = ServiceRegistry::from_toml(&toml).expect("valid TOML must load");
+        // Attaching the SAME wallet as the gateway recipient must reject.
+        let err = registry
+            .clone()
+            .with_gateway_recipient(VALID_VENDOR_WALLET)
+            .expect_err("conflicting vendor_wallet must fail the recipient attach");
+        match err {
+            ServiceRegistryError::InvalidEntry { id, source } => {
+                assert_eq!(id, "self-paying-svc");
+                assert_eq!(source, RegistrationError::VendorWalletIsGatewayRecipient);
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+        // A different recipient attaches fine.
+        assert!(registry.with_gateway_recipient(GATEWAY_RECIPIENT).is_ok());
+    }
+
+    /// An EMPTY recipient (unconfigured dev mode) disables the guard rather
+    /// than rejecting every vendor service — no base58 pubkey equals "".
+    #[test]
+    fn with_gateway_recipient_empty_recipient_disables_guard() {
+        let mut registry = ServiceRegistry::empty()
+            .with_gateway_recipient("")
+            .expect("empty recipient must be accepted");
+        let entry = external_entry_with_vendor_wallet(Some(VALID_VENDOR_WALLET.to_string()));
+        assert!(registry.register(entry).is_ok());
     }
 
     #[test]

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -287,6 +287,35 @@ pub struct SpendLogEntry {
     /// counters were not pre-committed (legacy / proxy / test paths) and
     /// `log_spend` increments by `cost_usdc` directly.
     pub estimated_cost_usdc: Option<f64>,
+    /// Vendor-settlement record for marketplace services with a per-service
+    /// `vendor_wallet` (settlement-platform P1). `None` on every other path.
+    pub vendor: Option<VendorSettlement>,
+}
+
+/// Fee-receivable record for a vendor-settled marketplace request.
+///
+/// Settlement-platform P1, "Vendor-Settlement Fee Mechanics" RFC (2026-06-12,
+/// mechanism C / record + invoice, vendor absorbs): the agent's single
+/// transfer settles `settled_atomic` directly to `vendor_wallet`; Solvela's 5%
+/// platform fee is never charged on-chain on this path — it is recorded here
+/// (atomic units, integer math) and invoiced to the vendor off-chain.
+///
+/// All three fields travel together: a receivable without its vendor wallet
+/// (or vice versa) would be uninvoiceable, so the spend entry carries this as
+/// a single `Option`.
+#[derive(Debug, Clone)]
+pub struct VendorSettlement {
+    /// Vendor wallet (base58 pubkey) the payment settled to on-chain.
+    pub vendor_wallet: String,
+    /// Amount settled to the vendor, in atomic USDC (6 decimals). `i64` to
+    /// match the Postgres `BIGINT` column; the proxy fails closed before
+    /// charging if the priced amount cannot be represented.
+    pub settled_atomic: i64,
+    /// Solvela's 5% fee receivable in atomic USDC, computed as
+    /// `floor(settled × 105 / 100) − settled` (the canonical platform-fee
+    /// formula; equivalent to `floor(settled × 5 / 100)`, i.e. the receivable
+    /// rounds DOWN — see `compute_service_cost` in `routes/proxy.rs`).
+    pub fee_receivable_atomic: i64,
 }
 
 /// Error types for usage tracking.
@@ -389,6 +418,14 @@ impl UsageTracker {
             tx_signature = entry.tx_signature.as_deref().unwrap_or("none"),
             request_id = entry.request_id.as_deref().unwrap_or("none"),
             session_prefix = %session_prefix,
+            vendor_wallet = entry
+                .vendor
+                .as_ref()
+                .map(|v| v.vendor_wallet.as_str())
+                .unwrap_or("none"),
+            vendor_settled_atomic = entry.vendor.as_ref().map_or(0, |v| v.settled_atomic),
+            vendor_fee_receivable_atomic =
+                entry.vendor.as_ref().map_or(0, |v| v.fee_receivable_atomic),
             "spend logged"
         );
 
@@ -398,8 +435,8 @@ impl UsageTracker {
             let db_entry = entry.clone();
             tokio::spawn(async move {
                 let result = sqlx::query(
-                    r#"INSERT INTO spend_logs (id, wallet_address, model, provider, input_tokens, output_tokens, cost_usdc, tx_signature, request_id, session_id, tenant, created_at)
-                       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)"#,
+                    r#"INSERT INTO spend_logs (id, wallet_address, model, provider, input_tokens, output_tokens, cost_usdc, tx_signature, request_id, session_id, tenant, vendor_wallet, vendor_settled_atomic, vendor_fee_receivable_atomic, created_at)
+                       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)"#,
                 )
                 .bind(id)
                 .bind(&db_entry.wallet_address)
@@ -412,6 +449,9 @@ impl UsageTracker {
                 .bind(&db_entry.request_id)
                 .bind(&db_entry.session_id)
                 .bind(&db_entry.tenant)
+                .bind(db_entry.vendor.as_ref().map(|v| v.vendor_wallet.clone()))
+                .bind(db_entry.vendor.as_ref().map(|v| v.settled_atomic))
+                .bind(db_entry.vendor.as_ref().map(|v| v.fee_receivable_atomic))
                 .bind(created_at)
                 .execute(&pool)
                 .await;
@@ -1937,6 +1977,7 @@ mod tests {
             tenant: None,
             tenant_enforced: false,
             estimated_cost_usdc: None,
+            vendor: None,
         });
     }
 

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -457,7 +457,27 @@ impl UsageTracker {
                 .await;
 
                 if let Err(e) = result {
-                    warn!(error = %e, "failed to write spend log to database");
+                    // A vendor row carries Solvela's 5% fee receivable
+                    // (settlement-platform P1): the agent already settled to
+                    // the vendor on-chain, so a lost row is revenue that can
+                    // no longer be invoiced. Emit every field needed to
+                    // reconcile the receivable by hand, and count the failure
+                    // so it can be alerted on. (On this path `model` carries
+                    // the marketplace service id — see `routes/proxy.rs`.)
+                    if let Some(vendor) = &db_entry.vendor {
+                        metrics::counter!("solvela_vendor_receivable_write_failures_total")
+                            .increment(1);
+                        error!(
+                            error = %e,
+                            vendor_wallet = %vendor.vendor_wallet,
+                            settled_atomic = vendor.settled_atomic,
+                            fee_receivable_atomic = vendor.fee_receivable_atomic,
+                            service_id = %db_entry.model,
+                            "failed to write vendor spend log to database — fee receivable may be lost"
+                        );
+                    } else {
+                        warn!(error = %e, "failed to write spend log to database");
+                    }
                 }
             });
         }

--- a/crates/gateway/src/usage.rs
+++ b/crates/gateway/src/usage.rs
@@ -307,15 +307,18 @@ pub struct SpendLogEntry {
 pub struct VendorSettlement {
     /// Vendor wallet (base58 pubkey) the payment settled to on-chain.
     pub vendor_wallet: String,
-    /// Amount settled to the vendor, in atomic USDC (6 decimals). `i64` to
-    /// match the Postgres `BIGINT` column; the proxy fails closed before
-    /// charging if the priced amount cannot be represented.
-    pub settled_atomic: i64,
+    /// Amount settled to the vendor, in atomic USDC (6 decimals). `u64` —
+    /// semantically non-negative, like every other atomic amount on the money
+    /// path. The Postgres columns are `BIGINT`; the proxy fails closed BEFORE
+    /// quoting if the priced amount cannot be represented as `i64` (see the
+    /// pre-quote guard in `routes/proxy.rs`), and `log_spend` performs the
+    /// single `i64::try_from` at the bind site.
+    pub settled_atomic: u64,
     /// Solvela's 5% fee receivable in atomic USDC, computed as
     /// `floor(settled × 105 / 100) − settled` (the canonical platform-fee
     /// formula; equivalent to `floor(settled × 5 / 100)`, i.e. the receivable
     /// rounds DOWN — see `compute_service_cost` in `routes/proxy.rs`).
-    pub fee_receivable_atomic: i64,
+    pub fee_receivable_atomic: u64,
 }
 
 /// Error types for usage tracking.
@@ -434,6 +437,35 @@ impl UsageTracker {
             let pool = pool.clone();
             let db_entry = entry.clone();
             tokio::spawn(async move {
+                // The ONE u64 → BIGINT conversion on the vendor-receivable
+                // path. The proxy's pre-quote guard (`routes/proxy.rs`)
+                // already rejected any request whose amounts exceed i64, so
+                // the Err arm is unreachable in practice — but a money write
+                // is never skipped silently: on Err we emit the same
+                // reconcilable vendor-loss event (counter + full fields) the
+                // INSERT-failure path uses, instead of panicking.
+                let vendor_bind: Option<(&str, i64, i64)> = match &db_entry.vendor {
+                    None => None,
+                    Some(v) => match (
+                        i64::try_from(v.settled_atomic),
+                        i64::try_from(v.fee_receivable_atomic),
+                    ) {
+                        (Ok(settled), Ok(fee)) => Some((v.vendor_wallet.as_str(), settled, fee)),
+                        _ => {
+                            metrics::counter!("solvela_vendor_receivable_write_failures_total")
+                                .increment(1);
+                            error!(
+                                vendor_wallet = %v.vendor_wallet,
+                                settled_atomic = v.settled_atomic,
+                                fee_receivable_atomic = v.fee_receivable_atomic,
+                                service_id = %db_entry.model,
+                                "vendor settlement amounts exceed the BIGINT range — \
+                                 spend row not written, fee receivable may be lost"
+                            );
+                            return;
+                        }
+                    },
+                };
                 let result = sqlx::query(
                     r#"INSERT INTO spend_logs (id, wallet_address, model, provider, input_tokens, output_tokens, cost_usdc, tx_signature, request_id, session_id, tenant, vendor_wallet, vendor_settled_atomic, vendor_fee_receivable_atomic, created_at)
                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)"#,
@@ -449,9 +481,9 @@ impl UsageTracker {
                 .bind(&db_entry.request_id)
                 .bind(&db_entry.session_id)
                 .bind(&db_entry.tenant)
-                .bind(db_entry.vendor.as_ref().map(|v| v.vendor_wallet.clone()))
-                .bind(db_entry.vendor.as_ref().map(|v| v.settled_atomic))
-                .bind(db_entry.vendor.as_ref().map(|v| v.fee_receivable_atomic))
+                .bind(vendor_bind.map(|(wallet, _, _)| wallet.to_string()))
+                .bind(vendor_bind.map(|(_, settled, _)| settled))
+                .bind(vendor_bind.map(|(_, _, fee)| fee))
                 .bind(created_at)
                 .execute(&pool)
                 .await;

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -442,7 +442,12 @@ fn test_app() -> axum::Router {
 /// recording failures on the `ProviderHealthTracker`).
 fn test_app_with_state() -> (axum::Router, Arc<AppState>) {
     let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
-    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    // Mirror production wiring (`main.rs`): the registry knows the gateway's
+    // global recipient so registration can reject a conflicting vendor_wallet.
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML)
+        .unwrap()
+        .with_gateway_recipient(TEST_RECIPIENT_WALLET)
+        .unwrap();
 
     // Use the always-pass mock verifier so tests exercise the full request path
     let facilitator =
@@ -1966,6 +1971,36 @@ fn valid_escrow_payment_header_for_payer(resource_url: &str, agent_pubkey: &str)
             deposit_tx: base64::engine::general_purpose::STANDARD.encode(b"mock_deposit_tx_bytes"),
             service_id: base64::engine::general_purpose::STANDARD.encode([0u8; 32]),
             agent_pubkey: agent_pubkey.to_string(),
+        }),
+    };
+    let json = serde_json::to_vec(&payload).unwrap();
+    base64::engine::general_purpose::STANDARD.encode(&json)
+}
+
+/// Like [`valid_escrow_payment_header`] but with a caller-supplied `pay_to`,
+/// so vendor-recipient tests can address the escrow payment to the service's
+/// `vendor_wallet` and prove the scheme fails closed downstream of the
+/// recipient-equality gate.
+fn valid_escrow_payment_header_with_pay_to(resource_url: &str, pay_to: &str) -> String {
+    let payload = PaymentPayload {
+        x402_version: 2,
+        resource: Resource {
+            url: resource_url.to_string(),
+            method: "POST".to_string(),
+        },
+        accepted: PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: SOLANA_NETWORK.to_string(),
+            amount: TEST_PAYMENT_AMOUNT.to_string(),
+            asset: USDC_MINT.to_string(),
+            pay_to: pay_to.to_string(),
+            max_timeout_seconds: 300,
+            escrow_program_id: Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string()),
+        },
+        payload: PayloadData::Escrow(EscrowPayload {
+            deposit_tx: base64::engine::general_purpose::STANDARD.encode(b"mock_deposit_tx_bytes"),
+            service_id: base64::engine::general_purpose::STANDARD.encode([0u8; 32]),
+            agent_pubkey: "11111111111111111111111111111111".to_string(),
         }),
     };
     let json = serde_json::to_vec(&payload).unwrap();
@@ -7939,12 +7974,22 @@ impl PaymentVerifier for VendorRecipientRecordingVerifier {
 /// Register a vendor-wallet service ($0.02/request) through the REAL
 /// admin-token route and return the 201 response body.
 async fn register_vendor_service(app: &axum::Router, id: &str) -> serde_json::Value {
+    register_vendor_service_priced(app, id, 0.02).await
+}
+
+/// Like [`register_vendor_service`] but with a caller-supplied price, for
+/// boundary pricing (e.g. the sub-$0.00002 fee floor).
+async fn register_vendor_service_priced(
+    app: &axum::Router,
+    id: &str,
+    price_usdc: f64,
+) -> serde_json::Value {
     let body = serde_json::json!({
         "id": id,
         "name": "Vendor Data API",
         "endpoint": "https://vendor-api.example.com/v1/data",
         "category": "data",
-        "price_per_request_usdc": 0.02,
+        "price_per_request_usdc": price_usdc,
         "vendor_wallet": TEST_VENDOR_WALLET_B58,
     });
     let response = app
@@ -8229,6 +8274,199 @@ async fn test_vendor_paid_request_records_fee_receivable_spend_log() {
     assert!(
         (logged_usdc - 0.02).abs() < 1e-9,
         "agent spend must equal the listed price, got {logged_usdc}"
+    );
+}
+
+/// Round-2 item 6: an ESCROW-scheme payment to a vendor_wallet service must
+/// fail CLOSED through the real route. The escrow verifier wired here would
+/// PASS plain `verify_payment` — so the rejection can only come from the
+/// vendor path routing through `verify_and_settle_to`, whose default
+/// recipient-override hook fails closed (`RecipientOverrideUnsupported`;
+/// the escrow verifier's vendor split is P4 and unimplemented). A refactor
+/// that routed escrow+vendor through plain `verify_and_settle` would settle
+/// this payment against the WRONG recipient model and fail this test.
+#[tokio::test]
+async fn test_proxy_vendor_service_escrow_payment_fails_closed() {
+    use tracing::instrument::WithSubscriber;
+
+    let app = test_app_with_provider_registry_and_escrow_verifier(
+        ProviderRegistry::from_env(reqwest::Client::new()),
+        Arc::new(AlwaysPassEscrowVerifier),
+    );
+    register_vendor_service(&app, "vendor-data-api").await;
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/vendor-data-api/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    // Escrow scheme, correctly addressed to the vendor wallet
+                    // — it passes every pre-verification gate and must be
+                    // stopped by the fail-closed verifier dispatch itself.
+                    valid_escrow_payment_header_with_pay_to(
+                        "/v1/services/vendor-data-api/proxy",
+                        TEST_VENDOR_WALLET_B58,
+                    ),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+    // `GatewayError::InvalidPayment` maps to 402 with the sanitized
+    // verification-failure message (GHSA-cgqx-mg48-949v).
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "escrow payment to a vendor service must be rejected, not settled"
+    );
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "invalid_payment");
+    let message = json["error"]["message"].as_str().unwrap();
+    assert!(
+        message.contains("Payment verification failed"),
+        "rejection must be the fail-closed verification error, got: {message}"
+    );
+
+    // Fail-closed means NO settlement: no spend entry and no vendor
+    // receivable may have been recorded for the rejected payment.
+    let events = spend_logged_events(&capture);
+    assert!(
+        events.is_empty(),
+        "a rejected escrow payment must not record spend/receivables, got {events:?}"
+    );
+}
+
+/// Round-2 item 9 (integration half): a vendor service priced at $0.000019
+/// (19 atomic → 5% fee floors to 0) settles with a VendorSettlement whose
+/// `fee_receivable_atomic` is ZERO — sub-$0.00002 services legitimately
+/// record no receivable, rather than being rejected or rounded up.
+#[tokio::test]
+async fn test_vendor_fee_floor_service_records_zero_receivable() {
+    use tracing::instrument::WithSubscriber;
+
+    let recorded_recipient = Arc::new(std::sync::Mutex::new(None));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        ProviderRegistry::from_env(reqwest::Client::new()),
+        Arc::new(VendorRecipientRecordingVerifier {
+            recorded_recipient: Arc::clone(&recorded_recipient),
+        }),
+    );
+    register_vendor_service_priced(&app, "tiny-vendor-api", 0.000019).await;
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/tiny-vendor-api/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header_with(
+                        "/v1/services/tiny-vendor-api/proxy",
+                        USDC_MINT,
+                        TEST_VENDOR_WALLET_B58,
+                    ),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "payment must have been accepted"
+    );
+
+    let events = spend_logged_events(&capture);
+    assert_eq!(events.len(), 1, "exactly one spend entry, got {events:?}");
+    assert_eq!(events[0]["vendor_wallet"], TEST_VENDOR_WALLET_B58);
+    // $0.000019 = 19 atomic settled; floor(19 × 105/100) − 19 = 0 receivable.
+    assert_eq!(events[0]["vendor_settled_atomic"].as_i64(), Some(19));
+    assert_eq!(
+        events[0]["vendor_fee_receivable_atomic"].as_i64(),
+        Some(0),
+        "fee floor: the 5% on 19 atomic must round DOWN to a zero receivable"
+    );
+}
+
+/// Round-2 item 3 (rejection route, through the real admin route): a
+/// vendor_wallet equal to the gateway's own recipient wallet must be
+/// rejected at registration — the degenerate case would quote the agent NO
+/// fee (vendor absorbs) while booking a receivable the gateway invoices to
+/// itself, silently undercharging 5%.
+#[tokio::test]
+async fn test_register_service_rejects_vendor_wallet_equal_to_gateway_recipient() {
+    let (app, state) = test_app_with_state();
+
+    // The stock test fixture recipient (`TEST_RECIPIENT_WALLET`) is a 46-char
+    // non-pubkey string that the route's 44-char cap would reject before the
+    // registry guard. Swap in a registry whose known gateway recipient is a
+    // VALID pubkey so this test exercises the equality guard itself.
+    {
+        let mut registry = state.service_registry.write().await;
+        *registry = ServiceRegistry::empty()
+            .with_gateway_recipient(TEST_VENDOR_WALLET_B58)
+            .expect("empty registry cannot conflict");
+    }
+
+    let body = serde_json::json!({
+        "id": "self-paying-api",
+        "name": "Self Paying API",
+        "endpoint": "https://vendor-api.example.com/v1/data",
+        "category": "data",
+        "price_per_request_usdc": 0.02,
+        "vendor_wallet": TEST_VENDOR_WALLET_B58,
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/register")
+                .header("content-type", "application/json")
+                .header("Authorization", format!("Bearer {TEST_ADMIN_TOKEN}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+    let error = json["error"].as_str().unwrap();
+    assert!(
+        error.contains("global recipient wallet"),
+        "error must name the recipient-equality guard, got: {error}"
+    );
+
+    let registry = state.service_registry.read().await;
+    assert!(
+        registry.get("self-paying-api").is_none(),
+        "the conflicting entry must not be registered"
     );
 }
 

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -7836,6 +7836,7 @@ async fn test_services_list_includes_registered_services() {
                 source: "api".to_string(),
                 healthy: None,
                 price_per_request_usdc: Some(0.05),
+                vendor_wallet: None,
             })
             .unwrap();
     }
@@ -7864,6 +7865,371 @@ async fn test_services_list_includes_registered_services() {
     assert_eq!(runtime_svc["name"], "Runtime Service");
     assert_eq!(runtime_svc["source"], "api");
     assert_eq!(runtime_svc["category"], "compute");
+}
+
+// ---------------------------------------------------------------------------
+// Per-service vendor_wallet (settlement-platform P1)
+//
+// "Vendor-Settlement Fee Mechanics" RFC (2026-06-12): mechanism C
+// (record + invoice) with vendor-absorbs semantics — the agent pays exactly
+// the listed price to the vendor wallet; Solvela's 5% is recorded in
+// spend_logs as an off-chain receivable, never charged to the agent.
+// ---------------------------------------------------------------------------
+
+/// Valid base58 32-byte Solana pubkey used as the vendor wallet in tests.
+const TEST_VENDOR_WALLET_B58: &str = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+/// An `exact` verifier that supports the per-request recipient override
+/// (`verify_payment_to`) and records the recipient it was asked to verify
+/// against, so a test can prove the vendor wallet — not the gateway's static
+/// recipient — reached verification through the real route.
+struct VendorRecipientRecordingVerifier {
+    recorded_recipient: Arc<std::sync::Mutex<Option<String>>>,
+}
+
+#[async_trait::async_trait]
+impl PaymentVerifier for VendorRecipientRecordingVerifier {
+    fn network(&self) -> &str {
+        SOLANA_NETWORK
+    }
+
+    fn scheme(&self) -> &str {
+        "exact"
+    }
+
+    async fn verify_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<VerificationResult, X402Error> {
+        Ok(VerificationResult {
+            valid: true,
+            reason: None,
+            verified_amount: Some(20_000),
+        })
+    }
+
+    async fn verify_payment_to(
+        &self,
+        _payload: &PaymentPayload,
+        expected_recipient: &str,
+    ) -> Result<VerificationResult, X402Error> {
+        *self.recorded_recipient.lock().unwrap() = Some(expected_recipient.to_string());
+        Ok(VerificationResult {
+            valid: true,
+            reason: None,
+            verified_amount: Some(20_000),
+        })
+    }
+
+    async fn settle_payment(
+        &self,
+        _payload: &PaymentPayload,
+    ) -> Result<SettlementResult, X402Error> {
+        Ok(SettlementResult {
+            success: true,
+            tx_signature: Some("VendorSettleSig".to_string()),
+            network: SOLANA_NETWORK.to_string(),
+            error: None,
+            verified_amount: None,
+            failure_kind: None,
+        })
+    }
+}
+
+/// Register a vendor-wallet service ($0.02/request) through the REAL
+/// admin-token route and return the 201 response body.
+async fn register_vendor_service(app: &axum::Router, id: &str) -> serde_json::Value {
+    let body = serde_json::json!({
+        "id": id,
+        "name": "Vendor Data API",
+        "endpoint": "https://vendor-api.example.com/v1/data",
+        "category": "data",
+        "price_per_request_usdc": 0.02,
+        "vendor_wallet": TEST_VENDOR_WALLET_B58,
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/register")
+                .header("content-type", "application/json")
+                .header("Authorization", format!("Bearer {TEST_ADMIN_TOKEN}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "vendor service registration must succeed"
+    );
+    let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&resp_body).unwrap()
+}
+
+/// (b) runtime registration with a vendor_wallet succeeds and the wallet is
+/// echoed on the created entry.
+#[tokio::test]
+async fn test_register_service_with_vendor_wallet_creates_entry() {
+    let (app, state) = test_app_with_state();
+
+    let json = register_vendor_service(&app, "vendor-data-api").await;
+    assert_eq!(json["id"], "vendor-data-api");
+    assert_eq!(json["vendor_wallet"], TEST_VENDOR_WALLET_B58);
+
+    let registry = state.service_registry.read().await;
+    assert_eq!(
+        registry
+            .get("vendor-data-api")
+            .unwrap()
+            .vendor_wallet
+            .as_deref(),
+        Some(TEST_VENDOR_WALLET_B58)
+    );
+}
+
+/// (b) runtime registration with an INVALID vendor_wallet is rejected (400)
+/// and nothing is registered — fail closed.
+#[tokio::test]
+async fn test_register_service_rejects_invalid_vendor_wallet() {
+    let (app, state) = test_app_with_state();
+
+    let body = serde_json::json!({
+        "id": "bad-vendor-api",
+        "name": "Bad Vendor API",
+        "endpoint": "https://vendor-api.example.com/v1/data",
+        "category": "data",
+        "price_per_request_usdc": 0.02,
+        "vendor_wallet": "not-a-valid-pubkey",
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/register")
+                .header("content-type", "application/json")
+                .header("Authorization", format!("Bearer {TEST_ADMIN_TOKEN}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+    assert!(
+        json["error"].as_str().unwrap().contains("vendor_wallet"),
+        "error must name vendor_wallet, got: {}",
+        json["error"]
+    );
+
+    let registry = state.service_registry.read().await;
+    assert!(
+        registry.get("bad-vendor-api").is_none(),
+        "an invalid vendor_wallet must not register anything"
+    );
+}
+
+/// (c) the 402 challenge for a vendor service advertises pay_to = vendor
+/// wallet and amount = listed price (20_000 atomic, NOT ×1.05), with a
+/// cost_breakdown truthful to what the agent pays: platform_fee 0.
+#[tokio::test]
+async fn test_proxy_402_for_vendor_service_advertises_vendor_wallet_and_price() {
+    let (app, _state) = test_app_with_state();
+    register_vendor_service(&app, "vendor-data-api").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/vendor-data-api/proxy")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let payment_info: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let accepts = payment_info["accepts"].as_array().unwrap();
+    assert_eq!(accepts[0]["pay_to"], TEST_VENDOR_WALLET_B58);
+    assert_eq!(accepts[0]["amount"], "20000");
+
+    let cost = &payment_info["cost_breakdown"];
+    assert_eq!(cost["provider_cost"], "0.020000");
+    assert_eq!(cost["platform_fee"], "0.000000");
+    assert_eq!(cost["total"], "0.020000");
+    assert_eq!(cost["fee_percent"], 0);
+}
+
+/// (d) a payment addressed to the gateway's GLOBAL recipient must be rejected
+/// for a vendor service — hard equality against the per-service recipient.
+#[tokio::test]
+async fn test_proxy_vendor_service_rejects_payment_to_global_recipient() {
+    let (app, _state) = test_app_with_state();
+    register_vendor_service(&app, "vendor-data-api").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/vendor-data-api/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    // pay_to = global recipient — wrong for a vendor service.
+                    valid_payment_header("/v1/services/vendor-data-api/proxy"),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let message = json["error"]["message"].as_str().unwrap();
+    assert!(
+        message.contains("pay_to") && message.contains(TEST_VENDOR_WALLET_B58),
+        "rejection must name the expected vendor wallet, got: {message}"
+    );
+}
+
+/// (d) vice versa: a payment addressed to a vendor wallet must be rejected
+/// for a PLAIN service whose recipient is the global wallet (regression
+/// guard for today's behavior).
+#[tokio::test]
+async fn test_proxy_plain_service_rejects_payment_to_vendor_wallet() {
+    let app = test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/web-search/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header_with(
+                        "/v1/services/web-search/proxy",
+                        USDC_MINT,
+                        TEST_VENDOR_WALLET_B58,
+                    ),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let message = json["error"]["message"].as_str().unwrap();
+    assert!(
+        message.contains("pay_to") && message.contains(TEST_RECIPIENT_WALLET),
+        "rejection must name the global recipient, got: {message}"
+    );
+}
+
+/// (e) a settled paid request to a vendor service must write the
+/// fee-receivable spend entry — observed through the REAL route via the
+/// synchronous `info!("spend logged")` event (the same capture mechanism the
+/// #541 streaming tests use; a missing production write fails this test).
+///
+/// Also proves the per-service recipient threads into verification: the
+/// verifier's `verify_payment_to` must be called with the VENDOR wallet.
+///
+/// The receivable is recorded at SETTLEMENT time (the vendor was just paid
+/// on-chain), so the entry must exist even though the upstream fetch then
+/// fails on the unresolvable test endpoint.
+#[tokio::test]
+async fn test_vendor_paid_request_records_fee_receivable_spend_log() {
+    use tracing::instrument::WithSubscriber;
+
+    let recorded_recipient = Arc::new(std::sync::Mutex::new(None));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        ProviderRegistry::from_env(reqwest::Client::new()),
+        Arc::new(VendorRecipientRecordingVerifier {
+            recorded_recipient: Arc::clone(&recorded_recipient),
+        }),
+    );
+    register_vendor_service(&app, "vendor-data-api").await;
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/vendor-data-api/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header_with(
+                        "/v1/services/vendor-data-api/proxy",
+                        USDC_MINT,
+                        TEST_VENDOR_WALLET_B58,
+                    ),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+    // Payment was accepted and settled — whatever the upstream outcome, this
+    // must not be a payment rejection.
+    assert_ne!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "payment must have been accepted"
+    );
+
+    // Verification ran against the per-service vendor wallet.
+    assert_eq!(
+        recorded_recipient.lock().unwrap().as_deref(),
+        Some(TEST_VENDOR_WALLET_B58),
+        "verify_payment_to must receive the vendor wallet as expected recipient"
+    );
+
+    // Exactly one spend entry, carrying the vendor receivable record.
+    let events = spend_logged_events(&capture);
+    assert_eq!(
+        events.len(),
+        1,
+        "a settled vendor-service request MUST write exactly one spend entry \
+         (got {}): the vendor was paid on-chain, so the 5% receivable must be \
+         recorded",
+        events.len()
+    );
+    assert_eq!(events[0]["vendor_wallet"], TEST_VENDOR_WALLET_B58);
+    // $0.02 listed price = 20_000 atomic settled to the vendor; receivable =
+    // floor(20_000 × 105 / 100) − 20_000 = 1_000 atomic.
+    assert_eq!(events[0]["vendor_settled_atomic"].as_i64(), Some(20_000));
+    assert_eq!(
+        events[0]["vendor_fee_receivable_atomic"].as_i64(),
+        Some(1_000)
+    );
+    // The agent-paid cost is the listed price — no 5% on top.
+    let logged_usdc = events[0]["cost_usdc"].as_f64().unwrap();
+    assert!(
+        (logged_usdc - 0.02).abs() < 1e-9,
+        "agent spend must equal the listed price, got {logged_usdc}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/gateway/tests/usage_integration.rs
+++ b/crates/gateway/tests/usage_integration.rs
@@ -5,12 +5,14 @@
 //! are left for a follow-up — they require a fresh Redis instance per test
 //! and a different fixture story.
 
+use std::sync::Arc;
+
 use sqlx::PgPool;
 use uuid::Uuid;
 
 use gateway::usage::{
     get_stats_by_day, get_stats_by_model, get_wallet_stats, BudgetConfig, SpendLogEntry,
-    UsageError, UsageTracker,
+    UsageError, UsageTracker, VendorSettlement,
 };
 
 const WALLET_A: &str = "DZNuWFpYwzEAcyaMQzqgbxA4d1f4Yq8EU2YbLPLYxNTw";
@@ -421,4 +423,162 @@ async fn get_stats_filters_outside_window(pool: PgPool) {
         "30-day-old row must be filtered out by the 7-day window"
     );
     assert!((stats.total_cost - 0.001).abs() < 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Vendor fee-receivable write-failure observability (review round 1,
+// silent-failure-hunter Critical on the P1 vendor_wallet PR).
+//
+// A vendor spend row that fails to INSERT is revenue silently lost: the agent
+// already settled to the vendor on-chain, and Solvela's 5% receivable exists
+// ONLY in that row. The failure branch must emit an event carrying every field
+// needed to reconcile the receivable by hand; non-vendor rows keep the
+// existing single warn.
+// ---------------------------------------------------------------------------
+
+/// A `MakeWriter` capturing formatted tracing output into a shared buffer
+/// (same mechanism as the #541 streaming spend-log tests in integration.rs).
+#[derive(Clone, Default)]
+struct CaptureWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Poll the capture buffer (the events are emitted inside `log_spend`'s
+/// fire-and-forget `tokio::spawn`) until at least one JSON event whose
+/// `fields.message` equals `message` appears, or ~2s elapse. Returns every
+/// matching event (full JSON, so callers can assert on `level` too).
+async fn wait_for_events(capture: &CaptureWriter, message: &str) -> Vec<serde_json::Value> {
+    for _ in 0..100 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let bytes = capture.0.lock().unwrap().clone();
+        let events: Vec<serde_json::Value> = String::from_utf8(bytes)
+            .expect("captured tracing output is UTF-8")
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|v| v["fields"]["message"] == message)
+            .collect();
+        if !events.is_empty() {
+            return events;
+        }
+    }
+    Vec::new()
+}
+
+fn vendor_failure_entry(vendor: Option<VendorSettlement>) -> SpendLogEntry {
+    SpendLogEntry {
+        wallet_address: WALLET_A.to_string(),
+        model: "vendor-data-api".to_string(),
+        provider: "external-service".to_string(),
+        input_tokens: 0,
+        output_tokens: 0,
+        cost_usdc: 0.02,
+        tx_signature: Some("tx-vendor-fail".to_string()),
+        request_id: Some("req-vendor-fail".to_string()),
+        session_id: None,
+        tenant: None,
+        tenant_enforced: false,
+        estimated_cost_usdc: None,
+        vendor,
+    }
+}
+
+/// A failed INSERT of a VENDOR row must emit an ERROR event with every field
+/// needed to reconcile the lost receivable (vendor wallet, settled +
+/// receivable atomic amounts, service id), and a failed non-vendor row must
+/// keep the existing plain warn with no vendor fields.
+///
+/// The failure events fire inside the fire-and-forget `tokio::spawn`, which
+/// does not inherit a thread-local subscriber — so this test installs a
+/// process-GLOBAL JSON capture subscriber. It is the only test in this binary
+/// that sets one; events from concurrently running tests are filtered out by
+/// message in `wait_for_events`.
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_vendor_insert_failure_emits_reconcilable_loss_event(pool: PgPool) {
+    // Break the INSERT target. `#[sqlx::test]` provisions a dedicated
+    // database for this test, so the rename is fully isolated.
+    sqlx::query("ALTER TABLE spend_logs RENAME TO spend_logs_broken")
+        .execute(&pool)
+        .await
+        .expect("rename spend_logs out of the way");
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("no other test in this binary installs a global subscriber");
+
+    let tracker = UsageTracker::new(Some(pool.clone()), None);
+
+    // 1) Vendor row → dedicated ERROR event with reconciliation fields.
+    tracker.log_spend(vendor_failure_entry(Some(VendorSettlement {
+        vendor_wallet: WALLET_B.to_string(),
+        settled_atomic: 20_000,
+        fee_receivable_atomic: 1_000,
+    })));
+
+    let events = wait_for_events(
+        &capture,
+        "failed to write vendor spend log to database — fee receivable may be lost",
+    )
+    .await;
+    assert_eq!(
+        events.len(),
+        1,
+        "a failed vendor INSERT must emit exactly one receivable-loss event \
+         (got {}): the vendor was already paid on-chain and the 5% receivable \
+         exists only in the lost row",
+        events.len()
+    );
+    let fields = &events[0]["fields"];
+    assert_eq!(
+        events[0]["level"], "ERROR",
+        "receivable loss is error-level"
+    );
+    assert_eq!(fields["vendor_wallet"], WALLET_B);
+    assert_eq!(fields["settled_atomic"].as_i64(), Some(20_000));
+    assert_eq!(fields["fee_receivable_atomic"].as_i64(), Some(1_000));
+    assert_eq!(
+        fields["service_id"], "vendor-data-api",
+        "vendor rows come from the service proxy path, where model == service id"
+    );
+    assert!(
+        fields["error"].as_str().is_some_and(|e| !e.is_empty()),
+        "the DB error must be carried on the event"
+    );
+
+    // 2) Non-vendor row → the existing single warn, unchanged, no vendor fields.
+    tracker.log_spend(vendor_failure_entry(None));
+
+    let warns = wait_for_events(&capture, "failed to write spend log to database").await;
+    assert_eq!(
+        warns.len(),
+        1,
+        "a failed non-vendor INSERT keeps the existing single warn (got {})",
+        warns.len()
+    );
+    assert_eq!(warns[0]["level"], "WARN");
+    assert!(
+        warns[0]["fields"].get("vendor_wallet").is_none(),
+        "the non-vendor warn must not grow vendor fields"
+    );
 }

--- a/crates/gateway/tests/usage_integration.rs
+++ b/crates/gateway/tests/usage_integration.rs
@@ -183,6 +183,7 @@ async fn log_spend_persists_row_when_db_configured(pool: PgPool) {
         tenant: None,
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     });
 
     // Fire-and-forget: poll briefly for the row to land.
@@ -232,6 +233,72 @@ async fn log_spend_persists_row_when_db_configured(pool: PgPool) {
     assert_eq!(row.6.as_deref(), Some("req-abc"));
 }
 
+/// (e, DB layer) a vendor-settled spend entry must persist the vendor wallet,
+/// the settled amount, and the 5% fee receivable (atomic units) so the
+/// off-chain invoice can be aggregated per vendor (settlement-platform P1,
+/// "Vendor-Settlement Fee Mechanics" RFC, 2026-06-12).
+#[sqlx::test(migrations = "../../migrations")]
+async fn log_spend_persists_vendor_fee_receivable(pool: PgPool) {
+    let tracker = UsageTracker::new(Some(pool.clone()), None);
+
+    tracker.log_spend(SpendLogEntry {
+        wallet_address: WALLET_A.to_string(),
+        model: "vendor-data-api".to_string(),
+        provider: "external-service".to_string(),
+        input_tokens: 0,
+        output_tokens: 0,
+        cost_usdc: 0.02,
+        tx_signature: Some("vendor-settle-sig".to_string()),
+        request_id: None,
+        session_id: None,
+        tenant: None,
+        tenant_enforced: false,
+        estimated_cost_usdc: None,
+        vendor: Some(gateway::usage::VendorSettlement {
+            vendor_wallet: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string(),
+            settled_atomic: 20_000,
+            // floor(20_000 × 105 / 100) − 20_000
+            fee_receivable_atomic: 1_000,
+        }),
+    });
+
+    // Fire-and-forget: poll briefly for the row to land.
+    let mut found = false;
+    for _ in 0..50 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM spend_logs WHERE wallet_address = $1")
+                .bind(WALLET_A)
+                .fetch_one(&pool)
+                .await
+                .expect("count");
+        if count == 1 {
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "log_spend should have persisted exactly one row within 1s"
+    );
+
+    let row: (Option<String>, Option<i64>, Option<i64>) = sqlx::query_as(
+        r#"SELECT vendor_wallet, vendor_settled_atomic, vendor_fee_receivable_atomic
+           FROM spend_logs WHERE wallet_address = $1"#,
+    )
+    .bind(WALLET_A)
+    .fetch_one(&pool)
+    .await
+    .expect("read back vendor columns");
+
+    assert_eq!(
+        row.0.as_deref(),
+        Some("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM")
+    );
+    assert_eq!(row.1, Some(20_000));
+    assert_eq!(row.2, Some(1_000));
+}
+
 #[tokio::test]
 async fn log_spend_with_no_backends_does_not_panic() {
     // Pure smoke: emits a tracing event without touching DB or Redis.
@@ -249,6 +316,7 @@ async fn log_spend_with_no_backends_does_not_panic() {
         tenant: None,
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     });
 }
 

--- a/crates/gateway/tests/usage_redis.rs
+++ b/crates/gateway/tests/usage_redis.rs
@@ -79,6 +79,7 @@ async fn log_spend_writes_redis_hourly_daily_monthly_counters(pool: PgPool) {
         tenant: None,
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     });
 
     let hour_key = format!("spend:{}:{}", wallet, now.format("%Y-%m-%dT%H"));
@@ -129,6 +130,7 @@ async fn log_spend_accumulates_across_calls(pool: PgPool) {
         tenant: None,
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     };
     tracker.log_spend(entry.clone());
     tracker.log_spend(entry.clone());
@@ -181,6 +183,7 @@ async fn log_spend_zero_cost_no_reservation_skips_redis_but_writes_db(pool: PgPo
         tenant: None,
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     });
 
     // The DB row must be written (observability). Poll for it.
@@ -232,6 +235,7 @@ async fn log_spend_zero_cost_no_reservation_skips_redis_but_writes_db(pool: PgPo
         tenant: None,
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     });
     let day_val = wait_for_key(&client, &day_key)
         .await
@@ -606,6 +610,7 @@ async fn log_spend_writes_team_counters_when_wallet_in_team(pool: PgPool) {
         tenant: None,
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     });
 
     let now = Utc::now();
@@ -1316,6 +1321,7 @@ async fn tenant_counter_reconciles_estimate_to_actual(pool: PgPool) {
         // counters.
         tenant_enforced: true,
         estimated_cost_usdc: Some(estimated),
+        vendor: None,
     });
 
     // Poll until the tenant counter settles to the actual.
@@ -1362,6 +1368,7 @@ async fn log_spend_writes_tenant_counters_with_correct_key(pool: PgPool) {
         // Tenant enforcement was active for this request → reconcile counters.
         tenant_enforced: true,
         estimated_cost_usdc: None,
+        vendor: None,
     });
 
     let tenant_day_key = format!("spend:{}:{}:{}", wallet, tenant, now.format("%Y-%m-%d"));
@@ -1567,6 +1574,7 @@ async fn tenant_counters_reconcile_all_three_windows(pool: PgPool) {
         tenant: Some(tenant.to_string()),
         tenant_enforced: true,
         estimated_cost_usdc: Some(estimated),
+        vendor: None,
     });
 
     // Each of the three windows must settle to the actual.
@@ -1642,6 +1650,7 @@ async fn tenant_cap_escape_blocked_end_to_end(pool: PgPool) {
         tenant: Some(tenant.to_string()),
         tenant_enforced: true,
         estimated_cost_usdc: Some(estimated),
+        vendor: None,
     });
 
     // Wait for the counter to settle to the actual (0.90).
@@ -1706,6 +1715,7 @@ async fn log_spend_skips_tenant_counter_when_not_enforced(pool: PgPool) {
         tenant: Some(tenant.to_string()),
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     });
 
     // Wallet daily counter must materialize (wallet accounting unaffected).
@@ -1754,6 +1764,7 @@ async fn wallet_daily_counter_unchanged_by_tag_on_unenforced_wallet(pool: PgPool
         // Unenforced wallet → Skip path → tenant_enforced is false either way.
         tenant_enforced: false,
         estimated_cost_usdc: None,
+        vendor: None,
     };
     tracker.log_spend(mk(&wallet_untagged, None));
     tracker.log_spend(mk(&wallet_tagged, Some("acme".to_string())));
@@ -2019,6 +2030,7 @@ async fn skip_path_reservation_flag_suppresses_tenant_counter_through_real_path(
         // Sourced from the real reservation, NOT hard-coded.
         tenant_enforced: reservation.tenant_enforced(),
         estimated_cost_usdc: Some(0.0050),
+        vendor: None,
     });
 
     // The wallet daily counter must materialize (wallet accounting unaffected)...

--- a/crates/x402/src/facilitator.rs
+++ b/crates/x402/src/facilitator.rs
@@ -89,6 +89,45 @@ impl Facilitator {
         // Then settle
         verifier.settle_payment(payload).await
     }
+
+    /// Verify a payment against a caller-supplied expected recipient, then
+    /// settle it.
+    ///
+    /// Per-service `vendor_wallet` variant of [`Facilitator::verify_and_settle`]
+    /// (settlement-platform P1): verification runs through
+    /// [`PaymentVerifier::verify_payment_to`], whose default implementation
+    /// fails closed when a verifier does not support recipient override — a
+    /// vendor-addressed payment is never silently verified against the
+    /// gateway's static recipient.
+    pub async fn verify_and_settle_to(
+        &self,
+        payload: &PaymentPayload,
+        expected_recipient: &str,
+    ) -> Result<SettlementResult, Error> {
+        let network = &payload.accepted.network;
+        let scheme = &payload.accepted.scheme;
+        info!(
+            network,
+            scheme, expected_recipient, "routing vendor-recipient settlement to chain verifier"
+        );
+
+        let verifier = self.verifier_for(network, scheme)?;
+
+        // Verify first — against the per-request recipient.
+        let verification = verifier
+            .verify_payment_to(payload, expected_recipient)
+            .await?;
+        if !verification.valid {
+            return Err(Error::InvalidTransaction(
+                verification
+                    .reason
+                    .unwrap_or_else(|| "verification failed".to_string()),
+            ));
+        }
+
+        // Then settle
+        verifier.settle_payment(payload).await
+    }
 }
 
 #[cfg(test)]
@@ -279,5 +318,106 @@ mod tests {
 
         let result = facilitator.verify(&payload).await;
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-request recipient override (settlement-platform P1, vendor_wallet)
+    // -----------------------------------------------------------------------
+
+    /// A verifier that supports the per-request recipient override and records
+    /// the recipient it was asked to verify against.
+    struct RecipientRecordingVerifier {
+        recorded: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PaymentVerifier for RecipientRecordingVerifier {
+        fn network(&self) -> &str {
+            SOLANA_NETWORK
+        }
+
+        fn scheme(&self) -> &str {
+            "exact"
+        }
+
+        async fn verify_payment(
+            &self,
+            _payload: &PaymentPayload,
+        ) -> Result<VerificationResult, Error> {
+            Ok(VerificationResult {
+                valid: true,
+                reason: None,
+                verified_amount: Some(1000),
+            })
+        }
+
+        async fn verify_payment_to(
+            &self,
+            _payload: &PaymentPayload,
+            expected_recipient: &str,
+        ) -> Result<VerificationResult, Error> {
+            *self.recorded.lock().expect("test mutex") = Some(expected_recipient.to_string());
+            Ok(VerificationResult {
+                valid: true,
+                reason: None,
+                verified_amount: Some(1000),
+            })
+        }
+
+        async fn settle_payment(
+            &self,
+            _payload: &PaymentPayload,
+        ) -> Result<SettlementResult, Error> {
+            Ok(SettlementResult {
+                success: true,
+                tx_signature: Some("MockVendorSettleSig".to_string()),
+                network: SOLANA_NETWORK.to_string(),
+                error: None,
+                verified_amount: None,
+                failure_kind: None,
+            })
+        }
+    }
+
+    /// `verify_and_settle_to` must verify against the caller-supplied expected
+    /// recipient (a marketplace service's vendor wallet), not the verifier's
+    /// statically-configured one, and then settle.
+    #[tokio::test]
+    async fn verify_and_settle_to_passes_recipient_override_to_verifier() {
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let facilitator = Facilitator::new(vec![Arc::new(RecipientRecordingVerifier {
+            recorded: std::sync::Arc::clone(&recorded),
+        })]);
+        let payload = make_test_payload();
+
+        let result = facilitator
+            .verify_and_settle_to(&payload, "VendorWalletPubkey")
+            .await
+            .expect("override-supporting verifier must verify and settle");
+
+        assert!(result.success);
+        assert_eq!(
+            recorded.lock().expect("test mutex").as_deref(),
+            Some("VendorWalletPubkey"),
+            "verification must run against the per-request recipient"
+        );
+    }
+
+    /// A verifier that does not implement the override must FAIL CLOSED via
+    /// the trait's default `verify_payment_to` — never silently verify against
+    /// its statically-configured recipient.
+    #[tokio::test]
+    async fn verify_and_settle_to_fails_closed_when_override_unsupported() {
+        let facilitator = Facilitator::new(vec![Arc::new(MockVerifier)]);
+        let payload = make_test_payload();
+
+        let result = facilitator
+            .verify_and_settle_to(&payload, "VendorWalletPubkey")
+            .await;
+
+        assert!(
+            matches!(result, Err(Error::RecipientOverrideUnsupported(_))),
+            "default verify_payment_to must fail closed, got {result:?}"
+        );
     }
 }

--- a/crates/x402/src/solana.rs
+++ b/crates/x402/src/solana.rs
@@ -222,51 +222,19 @@ impl SolanaVerifier {
             })
     }
 
-    /// Send a JSON-RPC request to the Solana cluster.
-    async fn rpc_request(
+    /// Shared verification body for [`PaymentVerifier::verify_payment`] and
+    /// [`PaymentVerifier::verify_payment_to`]: identical checks, with the
+    /// expected recipient supplied by the caller.
+    ///
+    /// The recipient check stays HARD equality (ATA-derived, with the legacy
+    /// raw-wallet fallback): a transfer to any other wallet — including the
+    /// gateway's own global recipient when a vendor wallet is expected — is
+    /// rejected as [`Error::WrongRecipient`].
+    async fn verify_payment_against(
         &self,
-        method: &str,
-        params: serde_json::Value,
-    ) -> Result<serde_json::Value, Error> {
-        let body = serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": method,
-            "params": params,
-        });
-
-        let response = self
-            .http_client
-            .post(&self.rpc_url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| Error::Rpc(e.to_string()))?;
-
-        let result: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| Error::Rpc(e.to_string()))?;
-
-        if let Some(error) = result.get("error") {
-            return Err(Error::Rpc(error.to_string()));
-        }
-
-        Ok(result)
-    }
-}
-
-#[async_trait]
-impl PaymentVerifier for SolanaVerifier {
-    fn network(&self) -> &str {
-        SOLANA_NETWORK
-    }
-
-    fn scheme(&self) -> &str {
-        "exact"
-    }
-
-    async fn verify_payment(&self, payload: &PaymentPayload) -> Result<VerificationResult, Error> {
+        payload: &PaymentPayload,
+        expected_recipient: &Pubkey,
+    ) -> Result<VerificationResult, Error> {
         info!(
             network = SOLANA_NETWORK,
             resource = %payload.resource.url,
@@ -304,17 +272,21 @@ impl PaymentVerifier for SolanaVerifier {
         //
         // SPL token transfers go between token accounts (ATAs), not wallet addresses.
         // The destination in the transaction is an ATA — we must derive the expected
-        // ATA from our recipient wallet + USDC mint and compare, not compare against
-        // the raw wallet pubkey directly.
-        let expected_ata = derive_ata(&self.recipient, &self.usdc_mint, &Pubkey::TOKEN_PROGRAM_ID)
-            .ok_or_else(|| {
-                Error::InvalidTransaction("failed to derive expected ATA address".to_string())
-            })?;
+        // ATA from the expected recipient wallet + USDC mint and compare, not compare
+        // against the raw wallet pubkey directly.
+        let expected_ata = derive_ata(
+            expected_recipient,
+            &self.usdc_mint,
+            &Pubkey::TOKEN_PROGRAM_ID,
+        )
+        .ok_or_else(|| {
+            Error::InvalidTransaction("failed to derive expected ATA address".to_string())
+        })?;
 
         if transfer.destination != expected_ata {
             // Also accept if destination == raw recipient (some older integrations
             // use the wallet address directly for wrapped SOL / native accounts).
-            if transfer.destination != self.recipient {
+            if transfer.destination != *expected_recipient {
                 return Err(Error::WrongRecipient {
                     expected: expected_ata.to_string(),
                     actual: transfer.destination.to_string(),
@@ -384,7 +356,7 @@ impl PaymentVerifier for SolanaVerifier {
         info!(
             required_amount,
             actual_amount = transfer.amount,
-            recipient = %self.recipient,
+            recipient = %expected_recipient,
             "payment verification passed"
         );
 
@@ -393,6 +365,69 @@ impl PaymentVerifier for SolanaVerifier {
             reason: None,
             verified_amount: Some(transfer.amount),
         })
+    }
+
+    /// Send a JSON-RPC request to the Solana cluster.
+    async fn rpc_request(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, Error> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        });
+
+        let response = self
+            .http_client
+            .post(&self.rpc_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::Rpc(e.to_string()))?;
+
+        let result: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| Error::Rpc(e.to_string()))?;
+
+        if let Some(error) = result.get("error") {
+            return Err(Error::Rpc(error.to_string()));
+        }
+
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl PaymentVerifier for SolanaVerifier {
+    fn network(&self) -> &str {
+        SOLANA_NETWORK
+    }
+
+    fn scheme(&self) -> &str {
+        "exact"
+    }
+
+    async fn verify_payment(&self, payload: &PaymentPayload) -> Result<VerificationResult, Error> {
+        self.verify_payment_against(payload, &self.recipient).await
+    }
+
+    async fn verify_payment_to(
+        &self,
+        payload: &PaymentPayload,
+        expected_recipient: &str,
+    ) -> Result<VerificationResult, Error> {
+        // Fail closed before any destination comparison: an unparseable
+        // expected recipient must never degrade into accepting (or comparing
+        // against) anything else. Registry validation should make this
+        // unreachable, but the verifier re-checks at its own boundary.
+        let expected = Pubkey::from_str(expected_recipient).map_err(|e| {
+            Error::InvalidTransaction(format!("invalid expected recipient pubkey: {e}"))
+        })?;
+        self.verify_payment_against(payload, &expected).await
     }
 
     async fn settle_payment(&self, payload: &PaymentPayload) -> Result<SettlementResult, Error> {
@@ -1109,6 +1144,131 @@ mod tests {
         // classifier unit tests in solana_rpc.rs).
         assert_eq!(result.failure_kind, Some(SettlementFailureKind::Submission));
         assert!(result.error.is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-request recipient override (verify_payment_to) — settlement P1
+    // -----------------------------------------------------------------------
+
+    /// Distinct vendor recipient for override tests (wrapped-SOL mint pubkey —
+    /// any valid base58 32-byte key works; only inequality with
+    /// `TEST_RECIPIENT` matters).
+    const TEST_VENDOR_RECIPIENT: &str = "So11111111111111111111111111111111111111112";
+
+    /// Signed USDC `TransferChecked` payload paying `destination` (raw wallet
+    /// form, accepted by the verifier's raw-recipient fallback branch).
+    fn signed_transfer_checked_payload_to(destination: &str) -> PaymentPayload {
+        let signer = test_signer_pubkey();
+        let destination = Pubkey::from_str(destination).expect("valid pubkey");
+        let usdc_mint = Pubkey::from_str(TEST_USDC_MINT).expect("valid pubkey");
+        let msg = build_spl_transfer_checked_message(&signer, &destination, &usdc_mint, 5000, 6);
+        let tx = encode_base64(&wrap_in_transaction(&msg));
+        PaymentPayload {
+            x402_version: 2,
+            resource: Resource {
+                url: "/v1/services/test-svc/proxy".to_string(),
+                method: "POST".to_string(),
+            },
+            accepted: PaymentAccept {
+                scheme: "exact".to_string(),
+                network: SOLANA_NETWORK.to_string(),
+                amount: "5000".to_string(),
+                asset: TEST_USDC_MINT.to_string(),
+                pay_to: destination.to_string(),
+                max_timeout_seconds: 300,
+                escrow_program_id: None,
+            },
+            payload: PayloadData::Direct(SolanaPayload { transaction: tx }),
+        }
+    }
+
+    /// Verifier whose STATIC recipient is `TEST_RECIPIENT` and whose RPC URL is
+    /// unroutable, so a verification that clears every static check fails at
+    /// the final `simulateTransaction` step with `Error::Rpc`.
+    fn unroutable_rpc_verifier() -> SolanaVerifier {
+        SolanaVerifier::new(
+            "http://127.0.0.1:1",
+            TEST_RECIPIENT,
+            TEST_USDC_MINT,
+            reqwest::Client::new(),
+        )
+        .expect("verifier")
+    }
+
+    /// With the override, a transfer paying the vendor recipient must clear
+    /// the destination check even though the verifier's static recipient is
+    /// different — proven by verification proceeding all the way to the RPC
+    /// simulation step (which fails on the unroutable URL).
+    #[tokio::test]
+    async fn verify_payment_to_accepts_transfer_to_override_recipient() {
+        let verifier = unroutable_rpc_verifier();
+        let payload = signed_transfer_checked_payload_to(TEST_VENDOR_RECIPIENT);
+
+        let err = verifier
+            .verify_payment_to(&payload, TEST_VENDOR_RECIPIENT)
+            .await
+            .expect_err("must reach (and fail at) the RPC simulation step");
+
+        assert!(
+            matches!(err, Error::Rpc(_)),
+            "expected Rpc error from the simulation step (recipient gate cleared), got {err:?}"
+        );
+    }
+
+    /// A transfer paying the GLOBAL recipient must be rejected when the
+    /// service expects the vendor wallet — hard equality, exactly like any
+    /// other wrong recipient.
+    #[tokio::test]
+    async fn verify_payment_to_rejects_transfer_to_global_recipient() {
+        let verifier = unroutable_rpc_verifier();
+        let payload = signed_transfer_checked_payload_to(TEST_RECIPIENT);
+
+        let err = verifier
+            .verify_payment_to(&payload, TEST_VENDOR_RECIPIENT)
+            .await
+            .expect_err("payment to the global recipient must be rejected for a vendor service");
+
+        assert!(
+            matches!(err, Error::WrongRecipient { .. }),
+            "expected WrongRecipient, got {err:?}"
+        );
+    }
+
+    /// Without the override, `verify_payment` keeps enforcing the verifier's
+    /// static recipient — a transfer to a vendor wallet stays rejected
+    /// (byte-for-byte fallback behavior for services without vendor_wallet).
+    #[tokio::test]
+    async fn verify_payment_still_rejects_transfer_to_vendor_recipient() {
+        let verifier = unroutable_rpc_verifier();
+        let payload = signed_transfer_checked_payload_to(TEST_VENDOR_RECIPIENT);
+
+        let err = verifier
+            .verify_payment(&payload)
+            .await
+            .expect_err("payment to a non-global recipient must be rejected without override");
+
+        assert!(
+            matches!(err, Error::WrongRecipient { .. }),
+            "expected WrongRecipient, got {err:?}"
+        );
+    }
+
+    /// An unparseable override recipient must fail closed before any
+    /// destination comparison.
+    #[tokio::test]
+    async fn verify_payment_to_rejects_unparseable_recipient() {
+        let verifier = unroutable_rpc_verifier();
+        let payload = signed_transfer_checked_payload_to(TEST_RECIPIENT);
+
+        let err = verifier
+            .verify_payment_to(&payload, "not-a-valid-pubkey")
+            .await
+            .expect_err("invalid expected recipient must be rejected");
+
+        assert!(
+            matches!(err, Error::InvalidTransaction(_)),
+            "expected InvalidTransaction, got {err:?}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/x402/src/traits.rs
+++ b/crates/x402/src/traits.rs
@@ -24,6 +24,32 @@ pub trait PaymentVerifier: Send + Sync {
     /// - Transaction simulation succeeds
     async fn verify_payment(&self, payload: &PaymentPayload) -> Result<VerificationResult, Error>;
 
+    /// Verify a payment against a CALLER-SUPPLIED expected recipient instead
+    /// of the verifier's statically-configured one.
+    ///
+    /// Used by the service marketplace's per-service `vendor_wallet`
+    /// (settlement-platform P1): a service with a vendor wallet must be paid
+    /// to that wallet, not the gateway's global recipient, with the same hard
+    /// recipient-equality check `verify_payment` applies.
+    ///
+    /// The default implementation FAILS CLOSED with
+    /// [`Error::RecipientOverrideUnsupported`]: a verifier that has not
+    /// implemented per-request recipient override must never silently verify
+    /// against its static recipient when the caller asked for a different one
+    /// — that would misdirect funds.
+    async fn verify_payment_to(
+        &self,
+        payload: &PaymentPayload,
+        expected_recipient: &str,
+    ) -> Result<VerificationResult, Error> {
+        let _ = (payload, expected_recipient);
+        Err(Error::RecipientOverrideUnsupported(format!(
+            "{}/{}",
+            self.network(),
+            self.scheme()
+        )))
+    }
+
     /// Settle a verified payment by broadcasting the transaction on-chain.
     ///
     /// Steps:
@@ -77,4 +103,10 @@ pub enum Error {
 
     #[error("payload type mismatch: {0}")]
     PayloadMismatch(String),
+
+    #[error(
+        "verifier {0} does not support per-request recipient override; \
+         refusing to verify against its static recipient"
+    )]
+    RecipientOverrideUnsupported(String),
 }

--- a/migrations/012_vendor_settlement_receivable.sql
+++ b/migrations/012_vendor_settlement_receivable.sql
@@ -9,7 +9,10 @@
 -- All three columns are NULL for non-vendor rows (chat path, plain proxy
 -- services, free tier).
 
-ALTER TABLE spend_logs ADD COLUMN IF NOT EXISTS vendor_wallet TEXT;
+-- Base58 32-byte Solana pubkeys are at most 44 characters; anything longer
+-- can never be a payable wallet, so the column refuses it outright.
+ALTER TABLE spend_logs ADD COLUMN IF NOT EXISTS vendor_wallet TEXT
+    CHECK (char_length(vendor_wallet) <= 44);
 ALTER TABLE spend_logs ADD COLUMN IF NOT EXISTS vendor_settled_atomic BIGINT
     CHECK (vendor_settled_atomic IS NULL OR vendor_settled_atomic >= 0);
 ALTER TABLE spend_logs ADD COLUMN IF NOT EXISTS vendor_fee_receivable_atomic BIGINT

--- a/migrations/012_vendor_settlement_receivable.sql
+++ b/migrations/012_vendor_settlement_receivable.sql
@@ -1,0 +1,21 @@
+-- Settlement-platform P1: per-service vendor_wallet (record + invoice).
+--
+-- "Vendor-Settlement Fee Mechanics" RFC (2026-06-12, mechanism C, vendor
+-- absorbs): for marketplace services with a vendor_wallet, the agent's single
+-- transfer settles directly to the vendor, and Solvela's 5% platform fee is
+-- RECORDED here as an off-chain receivable (atomic USDC, integer) to be
+-- invoiced to the vendor — never charged to the agent on-chain.
+--
+-- All three columns are NULL for non-vendor rows (chat path, plain proxy
+-- services, free tier).
+
+ALTER TABLE spend_logs ADD COLUMN IF NOT EXISTS vendor_wallet TEXT;
+ALTER TABLE spend_logs ADD COLUMN IF NOT EXISTS vendor_settled_atomic BIGINT
+    CHECK (vendor_settled_atomic IS NULL OR vendor_settled_atomic >= 0);
+ALTER TABLE spend_logs ADD COLUMN IF NOT EXISTS vendor_fee_receivable_atomic BIGINT
+    CHECK (vendor_fee_receivable_atomic IS NULL OR vendor_fee_receivable_atomic >= 0);
+
+-- Invoice aggregation: receivables are summed per vendor wallet.
+CREATE INDEX IF NOT EXISTS idx_spend_vendor_wallet
+    ON spend_logs (vendor_wallet)
+    WHERE vendor_wallet IS NOT NULL;


### PR DESCRIPTION
## Summary

P1 of the settlement-platform track: a marketplace service can now settle directly to its vendor's wallet instead of the gateway's global recipient — non-custodial, single-transfer, no wire-format change.

- `ServiceEntry.vendor_wallet: Option<String>` — loadable from `config/services.toml` and via the admin `POST /v1/services/register`; validated as a Solana pubkey at load/registration (fail closed), rejected on internal services and when equal to the gateway's own recipient wallet.
- **Vendor-absorbs fee semantics:** for a `vendor_wallet` service the 402 advertises the vendor wallet as `payTo` and the *bare listed price* (agent-side fee = 0). The 5% platform fee (`floor(price×5/100)`, atomic) is recorded as a **fee receivable** in `spend_logs` (migration 012) at settlement time, for off-chain invoicing. Services without `vendor_wallet` are byte-for-byte unchanged (`price×1.05` to the global wallet) and regression-pinned.
- Verification: new `PaymentVerifier::verify_payment_to` threads the per-service expected recipient into the same hard ATA-derived equality check. The trait default **fails closed** (`RecipientOverrideUnsupported`) — the escrow verifier inherits it, so escrow payments to vendor services are rejected (vendor claim-split is P4). Recipient mismatches are rejected both ways (vendor service paid to global wallet and vice versa).
- Observability: a vendor receivable whose DB write fails emits an error-level event with full reconciliation fields plus a `solvela_vendor_receivable_write_failures_total` counter — a lost receivable is never an untagged warn.
- `PaymentTarget` enum makes the vendor/non-vendor charge-shape exclusivity structural; `VendorSettlement` amounts are `u64` with a single fail-closed `i64` conversion at the persistence boundary, guarded pre-quote in the route.

`vendor_wallet` is deliberately **not** exposed on the public `GET /v1/services` listing.

## Review

Money-path two-round process: round 1 (rust-reviewer + silent-failure-hunter) — one Critical fixed (silent receivable-write loss, commit 87621f0); round 2 independent (security + test-coverage + type-design) — no Critical/High security findings; all worth-changing-now items applied in 703cca0 (must-add tests, self-recipient registration guard, u64 amounts, `PaymentTarget` enum, migration length CHECK).

## Tests

~35 new tests across unit/integration/sqlx: TOML + runtime registration validation, 402 shape on both paths (exact atomic amounts pinned), both-ways recipient rejection through the real route, escrow+vendor fail-closed (402), fee-floor (sub-$0.00002 price → zero receivable), i64-overflow pre-quote guard, receivable write through the real request path, Postgres round-trip, and insert-failure loss-event capture. `cargo test -p gateway`: 1110 passed / 0 failed (incl. sqlx suites against live Postgres); `-p solvela-x402`: 144 passed. fmt + clippy (`-D warnings`) clean.

## Follow-ups (not in this PR)

- Pre-existing (`#541`-class, on main today): on the **non-vendor** proxy path, an error between settlement and the deferred spend write (SSRF re-check race, client-build/body-read failure) drops the spend row after money moved. Vendor path logs at settlement and is not affected. Fix is moving the non-vendor write to settlement time — separate PR since it changes row-timing semantics.
- Hermetic e2e test for the deferred non-vendor spend write needs an injectable-upstream seam (SSRF validation rightly rejects every loopback/private address a mock can bind).
- Type-design follow-ups: `ValidatedVendorWallet` newtype; `PublicServiceEntry` to make the listing omission structural.
