### PR TITLE
feat(gateway): client-facing payment receipts (settlement-platform P2)

### DIFF
--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -126,6 +126,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -892,6 +892,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -1396,6 +1399,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -1455,6 +1461,9 @@ supports_vision = false
             dev_bypass_payment: true,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
@@ -1944,6 +1953,9 @@ supports_vision = false
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,

--- a/crates/gateway/src/a2a/jsonrpc.rs
+++ b/crates/gateway/src/a2a/jsonrpc.rs
@@ -126,6 +126,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -88,6 +88,23 @@ pub enum GatewayError {
     #[error("rate limited")]
     RateLimited,
 
+    /// A resource (currently a receipt) does not exist. Maps to 404 with the
+    /// generic `not_found` error type — distinct from `ModelNotFound`, whose
+    /// `model_not_found` type is model/service-catalog specific. For the
+    /// receipts route the inner message MUST be a fixed string used for both
+    /// unknown and malformed ids (no existence/format oracle — the UUID is a
+    /// bearer capability).
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// A feature this route depends on is not configured on this gateway
+    /// (currently: receipt storage with no `DATABASE_URL`). Maps to 503
+    /// Service Unavailable — distinct from `UpstreamUnavailable`, which means
+    /// a transient provider outage. The inner message is forwarded verbatim
+    /// and must stay free of internal detail.
+    #[error("service unavailable: {0}")]
+    ServiceUnavailable(String),
+
     /// No provider could fulfil the request (every provider in the fallback
     /// chain failed or its circuit is open). Maps to 503 Service Unavailable —
     /// a RETRYABLE status, distinct from the 500 used for genuine internal
@@ -163,6 +180,12 @@ impl IntoResponse for GatewayError {
                 StatusCode::TOO_MANY_REQUESTS,
                 "rate_limited",
                 "Too many requests".to_string(),
+            ),
+            GatewayError::NotFound(msg) => (StatusCode::NOT_FOUND, "not_found", msg.clone()),
+            GatewayError::ServiceUnavailable(msg) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "service_unavailable",
+                msg.clone(),
             ),
             GatewayError::UpstreamUnavailable(msg) => (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -358,6 +381,33 @@ mod tests {
         let (status, json) = error_response(GatewayError::RateLimited).await;
         assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(json["error"]["type"], "rate_limited");
+    }
+
+    #[tokio::test]
+    async fn test_not_found_returns_404() {
+        // Receipts route: unknown AND malformed ids share one fixed message.
+        let (status, json) =
+            error_response(GatewayError::NotFound("receipt not found".to_string())).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(json["error"]["type"], "not_found");
+        assert_eq!(json["error"]["message"], "receipt not found");
+    }
+
+    #[tokio::test]
+    async fn test_service_unavailable_returns_503() {
+        // Receipts route with no DATABASE_URL: an honest 503, distinct from
+        // `upstream_unavailable` (transient provider outage).
+        let (status, json) = error_response(GatewayError::ServiceUnavailable(
+            "receipts are not available: this gateway has no receipt storage configured"
+                .to_string(),
+        ))
+        .await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(json["error"]["type"], "service_unavailable");
+        assert!(json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("no receipt storage"));
     }
 
     #[tokio::test]

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -13,6 +13,7 @@ pub mod middleware;
 pub mod orgs;
 pub mod payment_util;
 pub mod providers;
+pub mod receipts;
 pub mod routes;
 pub mod secret;
 pub mod security;
@@ -257,6 +258,10 @@ pub fn build_router(state: Arc<AppState>, rate_limiter: RateLimiter) -> Router {
         .route(
             "/v1/services/{service_id}/proxy",
             post(routes::proxy::proxy_service),
+        )
+        .route(
+            "/v1/receipts/{receipt_id}",
+            get(routes::receipts::get_receipt),
         )
         .route("/v1/supported", get(routes::supported::supported))
         .route("/v1/nonce", get(routes::nonce::get_nonce))
@@ -513,6 +518,9 @@ fn build_cors() -> CorsLayer {
             "x-solvela-fallback"
                 .parse()
                 .expect("'x-solvela-fallback' is a valid header name"),
+            "x-solvela-receipt"
+                .parse()
+                .expect("'x-solvela-receipt' is a valid header name"),
             // Legacy x-rcr-* headers (backward compat)
             "x-rcr-request-id"
                 .parse()

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -128,6 +128,17 @@ pub struct AppState {
     /// [`FREE_TIER_GLOBAL_RPM_DEFAULT`](crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT);
     /// override via `SOLVELA_FREE_TIER_GLOBAL_RPM`.
     pub free_global_cap: FreeTierGlobalCap,
+    /// Per-client (IP) rate limiter for the public, unauthenticated
+    /// `GET /v1/receipts/{id}` route.
+    ///
+    /// Same in-handler pattern as [`free_rate_limiter`](Self::free_rate_limiter):
+    /// every receipts GET is a DB query gated only by an unguessable-UUID
+    /// capability, so this cap bounds enumeration/scanning per peer IP, STRICTER
+    /// than the generic outer limiter ([`RateLimitConfig::receipts_default`]).
+    /// Keyed on the TCP peer IP, never a client-supplied header
+    /// (GHSA-6ggq-cvwx-4f67); absent `ConnectInfo` falls back to the shared
+    /// stricter "unknown" bucket.
+    pub receipts_rate_limiter: RateLimiter,
 }
 
 impl AppState {

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -680,6 +680,11 @@ async fn main() -> anyhow::Result<()> {
         dev_bypass_payment,
         free_rate_limiter: free_rate_limiter.clone(),
         free_global_cap,
+        // Public receipts GET: fixed stricter per-IP cap (20/min). Deliberately
+        // NOT env-tunable — the receipt id is already an unguessable capability,
+        // so the cap only needs to bound scan/enumeration throughput; tune
+        // `RateLimitConfig::receipts_default` in code if that ever changes.
+        receipts_rate_limiter: RateLimiter::new(RateLimitConfig::receipts_default()),
     });
 
     // ── Shutdown signal for background tasks ────────────────────────────────

--- a/crates/gateway/src/middleware/api_key.rs
+++ b/crates/gateway/src/middleware/api_key.rs
@@ -230,6 +230,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/middleware/rate_limit.rs
+++ b/crates/gateway/src/middleware/rate_limit.rs
@@ -91,6 +91,24 @@ impl RateLimitConfig {
             unknown_max_requests: 2,
         }
     }
+
+    /// Default rate-limit budget for the public, unauthenticated
+    /// `GET /v1/receipts/{id}` route.
+    ///
+    /// Every receipts GET is a database query keyed by an unguessable UUID
+    /// capability, so the threat is enumeration/scanning, not legitimate use:
+    /// an agent fetches its own receipt once (maybe a handful of times across
+    /// retries). 20 per 60s window per client IP is generous for real agents
+    /// and hostile to scanners; it is STRICTER than the generic outer limiter
+    /// (60/min) which still applies first. The `unknown` bucket (no
+    /// `ConnectInfo`) is stricter still, matching the free-tier policy.
+    pub fn receipts_default() -> Self {
+        Self {
+            max_requests: 20,
+            window: Duration::from_secs(60),
+            unknown_max_requests: 5,
+        }
+    }
 }
 
 /// Per-client rate limit state.
@@ -649,6 +667,21 @@ mod tests {
         assert_eq!(free.max_requests, 5);
         assert_eq!(free.unknown_max_requests, 2);
         assert_eq!(free.window, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_receipts_default_is_stricter_than_paid() {
+        let receipts = RateLimitConfig::receipts_default();
+        let paid = RateLimitConfig::default();
+        assert!(
+            receipts.max_requests < paid.max_requests,
+            "receipts per-IP limit ({}) must be stricter than the generic outer limit ({})",
+            receipts.max_requests,
+            paid.max_requests
+        );
+        assert_eq!(receipts.max_requests, 20);
+        assert_eq!(receipts.unknown_max_requests, 5);
+        assert_eq!(receipts.window, Duration::from_secs(60));
     }
 
     #[test]

--- a/crates/gateway/src/receipts.rs
+++ b/crates/gateway/src/receipts.rs
@@ -165,7 +165,9 @@ fn receipt_binds(record: &ReceiptRecord) -> Option<ReceiptBinds> {
 ///
 /// Emits a synchronous `info!("receipt logged")` event before spawning the
 /// write, mirroring `UsageTracker::log_spend`, so integration tests observe
-/// the production write through the real route.
+/// the production write through the real route. The event carries the money
+/// fields but never the receipt_id (a bearer capability — see the
+/// de-correlation comment at the event).
 pub fn record_receipt(pool: Option<&sqlx::PgPool>, record: ReceiptRecord) -> Option<String> {
     let pool = pool?;
     let Some(binds) = receipt_binds(&record) else {
@@ -182,8 +184,13 @@ pub fn record_receipt(pool: Option<&sqlx::PgPool>, record: ReceiptRecord) -> Opt
     };
     let created_at = Utc::now();
 
+    // De-correlation (round-2 security review): the happy-path event carries
+    // the payer wallet and the money fields but deliberately NOT the
+    // receipt_id — the id is a bearer capability, and logging it next to the
+    // wallet would turn server logs into a wallet→capability-URL lookup
+    // table. The id appears only in the `error!` failure events below, where
+    // it is needed to reconcile a lost/unadvertised receipt by hand.
     info!(
-        receipt_id = %record.receipt_id,
         model = %record.model,
         payment_scheme = %record.payment_scheme,
         payer_wallet = %record.payer_wallet,
@@ -284,6 +291,16 @@ pub async fn fetch_receipt(pool: &sqlx::PgPool, id: Uuid) -> Result<Option<Recei
         return Ok(None);
     };
 
+    Ok(Some(build_receipt_from_row(&row)?))
+}
+
+/// Assemble the wire [`Receipt`] from one `receipts` DB row.
+///
+/// The single place a schema field addition must touch on the read side
+/// (mirrored by the INSERT in [`record_receipt`] on the write side). Fails
+/// closed on any invariant violation (negative amount, partial vendor
+/// triple) — never serve a half-truth receipt.
+fn build_receipt_from_row(row: &sqlx::postgres::PgRow) -> Result<Receipt, ReceiptError> {
     let atomic = |column: &str| -> Result<u64, ReceiptError> {
         let value: i64 = row.try_get(column)?;
         u64::try_from(value)
@@ -324,7 +341,7 @@ pub async fn fetch_receipt(pool: &sqlx::PgPool, id: Uuid) -> Result<Option<Recei
         }
     };
 
-    Ok(Some(Receipt {
+    Ok(Receipt {
         receipt_id: row.try_get("id")?,
         created_at: row.try_get("created_at")?,
         model: row.try_get("model")?,
@@ -343,7 +360,7 @@ pub async fn fetch_receipt(pool: &sqlx::PgPool, id: Uuid) -> Result<Option<Recei
             currency: "USDC".to_string(),
         },
         vendor,
-    }))
+    })
 }
 
 #[cfg(test)]

--- a/crates/gateway/src/receipts.rs
+++ b/crates/gateway/src/receipts.rs
@@ -1,0 +1,416 @@
+//! Client-facing payment receipts (settlement-platform P2).
+//!
+//! A receipt is the client-facing audit artifact for a PAID request: who
+//! paid, what was actually charged (atomic USDC is canonical — see the
+//! solvela-fintech rules), which x402 scheme settled it, and — for
+//! vendor-settled marketplace services (settlement-platform P1) — the vendor
+//! settlement leg plus Solvela's 5% fee receivable.
+//!
+//! Receipts are written **fire-and-forget** (`tokio::spawn`, never awaited on
+//! the hot path) at the same points where spend logging fires: every paid
+//! completion that writes a spend row writes a receipt row (the #541
+//! streaming-spend-log bug class is the cautionary tale). They are served
+//! back via `GET /v1/receipts/{receipt_id}`.
+//!
+//! The receipt id is **capability-by-unguessable-UUID**: knowing the UUIDv4
+//! IS the authorization to read the receipt (agents have no other auth on the
+//! public path). There is deliberately no listing/enumeration endpoint, and
+//! unknown/malformed ids return one identical 404.
+//!
+//! Receipts exist only when PostgreSQL is configured (Architectural Rule
+//! #12): with no `DATABASE_URL` the gateway never emits the
+//! `x-solvela-receipt` header — a header promising an unfetchable receipt
+//! would be a lie — and the GET route returns an honest 503.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::Row;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::usage::VendorSettlement;
+
+/// Response header advertising the receipt path on paid responses.
+pub const RECEIPT_HEADER: &str = "x-solvela-receipt";
+
+/// Public path at which a receipt can be fetched.
+pub fn receipt_path(id: &Uuid) -> String {
+    format!("/v1/receipts/{id}")
+}
+
+/// Format an atomic-USDC amount (6 decimals) as a decimal string using pure
+/// integer math — no f64 anywhere near the money value.
+pub fn atomic_to_usdc_string(atomic: u64) -> String {
+    format!("{}.{:06}", atomic / 1_000_000, atomic % 1_000_000)
+}
+
+/// Everything needed to persist one receipt row. All amounts are atomic USDC.
+///
+/// `amount_paid_atomic` mirrors the spend ledger (discounted on an escrow
+/// semantic-cache hit, full otherwise); the breakdown triple is the pricing
+/// computation that produced the bill.
+#[derive(Debug, Clone)]
+pub struct ReceiptRecord {
+    pub receipt_id: Uuid,
+    /// Model id (chat path) or marketplace service id (proxy path).
+    pub model: String,
+    /// x402 scheme that settled the payment (`exact` / `escrow`).
+    pub payment_scheme: String,
+    /// Payment transaction reference as recorded on the spend ledger.
+    pub tx_signature: Option<String>,
+    pub payer_wallet: String,
+    pub amount_paid_atomic: u64,
+    pub provider_cost_atomic: u64,
+    pub platform_fee_atomic: u64,
+    pub total_atomic: u64,
+    /// Vendor settlement + fee receivable for vendor-settled marketplace
+    /// requests; `None` on every other path.
+    pub vendor: Option<VendorSettlement>,
+}
+
+/// Errors from reading a receipt back.
+#[derive(Debug, thiserror::Error)]
+pub enum ReceiptError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    /// The stored row violates a receipt invariant (negative amount, partial
+    /// vendor fields). Fail closed: never serve a half-truth receipt.
+    #[error("stored receipt is corrupt: {0}")]
+    Corrupt(String),
+}
+
+/// Wire shape returned by `GET /v1/receipts/{receipt_id}`.
+///
+/// Atomic integers are canonical; the `*_usdc` decimal strings are derived
+/// from them at read time via [`atomic_to_usdc_string`].
+#[derive(Debug, Clone, Serialize)]
+pub struct Receipt {
+    pub receipt_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub model: String,
+    pub payment_scheme: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_signature: Option<String>,
+    pub payer_wallet: String,
+    pub amount_paid_atomic: u64,
+    pub amount_paid_usdc: String,
+    pub cost_breakdown: ReceiptCostBreakdown,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vendor: Option<ReceiptVendor>,
+}
+
+/// Agent-facing cost breakdown of a receipt (what the agent was quoted /
+/// billed against — rule #5).
+#[derive(Debug, Clone, Serialize)]
+pub struct ReceiptCostBreakdown {
+    pub provider_cost_atomic: u64,
+    pub provider_cost_usdc: String,
+    pub platform_fee_atomic: u64,
+    pub platform_fee_usdc: String,
+    pub total_atomic: u64,
+    pub total_usdc: String,
+    pub currency: String,
+}
+
+/// Vendor-settlement evidence on a receipt (settlement-platform P1): the
+/// amount settled on-chain to the vendor wallet and Solvela's off-chain 5%
+/// fee receivable.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReceiptVendor {
+    pub vendor_wallet: String,
+    pub settled_atomic: u64,
+    pub settled_usdc: String,
+    pub fee_receivable_atomic: u64,
+    pub fee_receivable_usdc: String,
+}
+
+/// All BIGINT binds for one receipt row, converted fail-closed from `u64`.
+struct ReceiptBinds {
+    amount_paid: i64,
+    provider_cost: i64,
+    platform_fee: i64,
+    total: i64,
+    vendor: Option<(String, i64, i64)>,
+}
+
+/// Convert every amount to `i64` up front, or `None` if any exceeds the
+/// BIGINT range. Running this BEFORE the header is emitted means the header
+/// is only ever advertised for a row that can actually be written.
+fn receipt_binds(record: &ReceiptRecord) -> Option<ReceiptBinds> {
+    let vendor = match &record.vendor {
+        None => None,
+        Some(v) => Some((
+            v.vendor_wallet.clone(),
+            i64::try_from(v.settled_atomic).ok()?,
+            i64::try_from(v.fee_receivable_atomic).ok()?,
+        )),
+    };
+    Some(ReceiptBinds {
+        amount_paid: i64::try_from(record.amount_paid_atomic).ok()?,
+        provider_cost: i64::try_from(record.provider_cost_atomic).ok()?,
+        platform_fee: i64::try_from(record.platform_fee_atomic).ok()?,
+        total: i64::try_from(record.total_atomic).ok()?,
+        vendor,
+    })
+}
+
+/// Persist a receipt fire-and-forget and return its public path, or `None`
+/// when no receipt will be retrievable (no DB pool, or an amount the BIGINT
+/// ledger cannot record — fail closed, never advertise an unfetchable
+/// receipt).
+///
+/// Emits a synchronous `info!("receipt logged")` event before spawning the
+/// write, mirroring `UsageTracker::log_spend`, so integration tests observe
+/// the production write through the real route.
+pub fn record_receipt(pool: Option<&sqlx::PgPool>, record: ReceiptRecord) -> Option<String> {
+    let pool = pool?;
+    let Some(binds) = receipt_binds(&record) else {
+        metrics::counter!("solvela_receipt_write_failures_total", "reason" => "amount_overflow")
+            .increment(1);
+        error!(
+            receipt_id = %record.receipt_id,
+            model = %record.model,
+            amount_paid_atomic = record.amount_paid_atomic,
+            total_atomic = record.total_atomic,
+            "receipt amounts exceed the BIGINT range — receipt not written, header not emitted"
+        );
+        return None;
+    };
+    let created_at = Utc::now();
+
+    info!(
+        receipt_id = %record.receipt_id,
+        model = %record.model,
+        payment_scheme = %record.payment_scheme,
+        payer_wallet = %record.payer_wallet,
+        amount_paid_atomic = record.amount_paid_atomic,
+        provider_cost_atomic = record.provider_cost_atomic,
+        platform_fee_atomic = record.platform_fee_atomic,
+        total_atomic = record.total_atomic,
+        vendor_wallet = record
+            .vendor
+            .as_ref()
+            .map(|v| v.vendor_wallet.as_str())
+            .unwrap_or("none"),
+        vendor_settled_atomic = record.vendor.as_ref().map_or(0, |v| v.settled_atomic),
+        vendor_fee_receivable_atomic =
+            record.vendor.as_ref().map_or(0, |v| v.fee_receivable_atomic),
+        "receipt logged"
+    );
+
+    let path = receipt_path(&record.receipt_id);
+    let pool = pool.clone();
+    tokio::spawn(async move {
+        let result = sqlx::query(
+            r#"INSERT INTO receipts (id, created_at, model, payment_scheme, tx_signature, payer_wallet, amount_paid_atomic, provider_cost_atomic, platform_fee_atomic, total_atomic, vendor_wallet, vendor_settled_atomic, vendor_fee_receivable_atomic)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)"#,
+        )
+        .bind(record.receipt_id)
+        .bind(created_at)
+        .bind(&record.model)
+        .bind(&record.payment_scheme)
+        .bind(&record.tx_signature)
+        .bind(&record.payer_wallet)
+        .bind(binds.amount_paid)
+        .bind(binds.provider_cost)
+        .bind(binds.platform_fee)
+        .bind(binds.total)
+        .bind(binds.vendor.as_ref().map(|(w, _, _)| w.clone()))
+        .bind(binds.vendor.as_ref().map(|(_, s, _)| *s))
+        .bind(binds.vendor.as_ref().map(|(_, _, f)| *f))
+        .execute(&pool)
+        .await;
+
+        if let Err(e) = result {
+            // The header already promised this receipt; a lost write means a
+            // 404 on a legitimately-issued id. Emit every field needed to
+            // reconstruct the receipt by hand and count it for alerting.
+            metrics::counter!("solvela_receipt_write_failures_total", "reason" => "db_error")
+                .increment(1);
+            error!(
+                error = %e,
+                receipt_id = %record.receipt_id,
+                model = %record.model,
+                payment_scheme = %record.payment_scheme,
+                payer_wallet = %record.payer_wallet,
+                amount_paid_atomic = record.amount_paid_atomic,
+                provider_cost_atomic = record.provider_cost_atomic,
+                platform_fee_atomic = record.platform_fee_atomic,
+                total_atomic = record.total_atomic,
+                "failed to write receipt to database — advertised receipt will 404"
+            );
+        }
+    });
+    Some(path)
+}
+
+/// Insert the [`RECEIPT_HEADER`] onto `response` when a receipt path exists.
+/// No-op when `path` is `None` (no DB / receipt skipped) — the header is only
+/// ever emitted for a retrievable receipt.
+pub fn insert_receipt_header(response: &mut axum::response::Response, path: &Option<String>) {
+    let Some(path) = path else { return };
+    let Ok(value) = axum::http::HeaderValue::from_str(path) else {
+        return;
+    };
+    response
+        .headers_mut()
+        .insert(axum::http::HeaderName::from_static(RECEIPT_HEADER), value);
+}
+
+/// Fetch a receipt by id. `Ok(None)` when no row exists (the route's 404).
+pub async fn fetch_receipt(pool: &sqlx::PgPool, id: Uuid) -> Result<Option<Receipt>, ReceiptError> {
+    let row = sqlx::query(
+        r#"SELECT id, created_at, model, payment_scheme, tx_signature, payer_wallet, amount_paid_atomic, provider_cost_atomic, platform_fee_atomic, total_atomic, vendor_wallet, vendor_settled_atomic, vendor_fee_receivable_atomic
+           FROM receipts WHERE id = $1"#,
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+
+    let atomic = |column: &str| -> Result<u64, ReceiptError> {
+        let value: i64 = row.try_get(column)?;
+        u64::try_from(value)
+            .map_err(|_| ReceiptError::Corrupt(format!("negative amount in column {column}")))
+    };
+
+    let amount_paid_atomic = atomic("amount_paid_atomic")?;
+    let provider_cost_atomic = atomic("provider_cost_atomic")?;
+    let platform_fee_atomic = atomic("platform_fee_atomic")?;
+    let total_atomic = atomic("total_atomic")?;
+
+    let vendor_wallet: Option<String> = row.try_get("vendor_wallet")?;
+    let vendor_settled: Option<i64> = row.try_get("vendor_settled_atomic")?;
+    let vendor_fee: Option<i64> = row.try_get("vendor_fee_receivable_atomic")?;
+    let vendor = match (vendor_wallet, vendor_settled, vendor_fee) {
+        (None, None, None) => None,
+        (Some(wallet), Some(settled), Some(fee)) => {
+            let settled = u64::try_from(settled)
+                .map_err(|_| ReceiptError::Corrupt("negative vendor_settled_atomic".to_string()))?;
+            let fee = u64::try_from(fee).map_err(|_| {
+                ReceiptError::Corrupt("negative vendor_fee_receivable_atomic".to_string())
+            })?;
+            Some(ReceiptVendor {
+                vendor_wallet: wallet,
+                settled_atomic: settled,
+                settled_usdc: atomic_to_usdc_string(settled),
+                fee_receivable_atomic: fee,
+                fee_receivable_usdc: atomic_to_usdc_string(fee),
+            })
+        }
+        // The three vendor fields travel together (a receivable without its
+        // wallet is uninvoiceable evidence) — a partial set is corruption,
+        // not a servable receipt.
+        _ => {
+            return Err(ReceiptError::Corrupt(
+                "partial vendor settlement fields".to_string(),
+            ))
+        }
+    };
+
+    Ok(Some(Receipt {
+        receipt_id: row.try_get("id")?,
+        created_at: row.try_get("created_at")?,
+        model: row.try_get("model")?,
+        payment_scheme: row.try_get("payment_scheme")?,
+        tx_signature: row.try_get("tx_signature")?,
+        payer_wallet: row.try_get("payer_wallet")?,
+        amount_paid_atomic,
+        amount_paid_usdc: atomic_to_usdc_string(amount_paid_atomic),
+        cost_breakdown: ReceiptCostBreakdown {
+            provider_cost_atomic,
+            provider_cost_usdc: atomic_to_usdc_string(provider_cost_atomic),
+            platform_fee_atomic,
+            platform_fee_usdc: atomic_to_usdc_string(platform_fee_atomic),
+            total_atomic,
+            total_usdc: atomic_to_usdc_string(total_atomic),
+            currency: "USDC".to_string(),
+        },
+        vendor,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_record() -> ReceiptRecord {
+        ReceiptRecord {
+            receipt_id: Uuid::new_v4(),
+            model: "openai/gpt-4o".to_string(),
+            payment_scheme: "exact".to_string(),
+            tx_signature: Some("tx".to_string()),
+            payer_wallet: "wallet".to_string(),
+            amount_paid_atomic: 2625,
+            provider_cost_atomic: 2500,
+            platform_fee_atomic: 125,
+            total_atomic: 2625,
+            vendor: None,
+        }
+    }
+
+    #[test]
+    fn atomic_to_usdc_string_is_pure_integer_math() {
+        assert_eq!(atomic_to_usdc_string(0), "0.000000");
+        assert_eq!(atomic_to_usdc_string(1), "0.000001");
+        assert_eq!(atomic_to_usdc_string(79), "0.000079");
+        assert_eq!(atomic_to_usdc_string(1_050_000), "1.050000");
+        assert_eq!(atomic_to_usdc_string(2625), "0.002625");
+        // The full u64 range formats without panic or wrap.
+        assert_eq!(atomic_to_usdc_string(u64::MAX), "18446744073709.551615");
+    }
+
+    #[test]
+    fn receipt_path_is_the_public_get_route() {
+        let id = Uuid::new_v4();
+        assert_eq!(receipt_path(&id), format!("/v1/receipts/{id}"));
+    }
+
+    #[tokio::test]
+    async fn record_receipt_without_pool_returns_none() {
+        // No DB → no receipt and no path (the caller must not emit a header).
+        assert!(record_receipt(None, sample_record()).is_none());
+    }
+
+    #[test]
+    fn receipt_binds_fail_closed_on_bigint_overflow() {
+        let mut record = sample_record();
+        record.amount_paid_atomic = u64::MAX;
+        assert!(
+            receipt_binds(&record).is_none(),
+            "amounts beyond i64 must refuse, not wrap"
+        );
+
+        let mut record = sample_record();
+        record.vendor = Some(crate::usage::VendorSettlement {
+            vendor_wallet: "v".to_string(),
+            settled_atomic: u64::MAX,
+            fee_receivable_atomic: 0,
+        });
+        assert!(
+            receipt_binds(&record).is_none(),
+            "vendor amounts beyond i64 must refuse, not wrap"
+        );
+    }
+
+    #[test]
+    fn insert_receipt_header_noop_without_path() {
+        let mut response = axum::response::Response::new(axum::body::Body::empty());
+        insert_receipt_header(&mut response, &None);
+        assert!(response.headers().get(RECEIPT_HEADER).is_none());
+
+        let path = Some("/v1/receipts/abc".to_string());
+        insert_receipt_header(&mut response, &path);
+        assert_eq!(
+            response
+                .headers()
+                .get(RECEIPT_HEADER)
+                .and_then(|v| v.to_str().ok()),
+            Some("/v1/receipts/abc")
+        );
+    }
+}

--- a/crates/gateway/src/receipts.rs
+++ b/crates/gateway/src/receipts.rs
@@ -93,6 +93,9 @@ pub struct Receipt {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx_signature: Option<String>,
     pub payer_wallet: String,
+    /// The BILLED amount from the gateway ledger's perspective — identical to
+    /// the spend ledger — which can differ from the raw on-chain transfer when
+    /// an agent overpays the 402 quote (`client_amount` > expected).
     pub amount_paid_atomic: u64,
     pub amount_paid_usdc: String,
     pub cost_breakdown: ReceiptCostBreakdown,
@@ -251,6 +254,15 @@ pub fn record_receipt(pool: Option<&sqlx::PgPool>, record: ReceiptRecord) -> Opt
 pub fn insert_receipt_header(response: &mut axum::response::Response, path: &Option<String>) {
     let Some(path) = path else { return };
     let Ok(value) = axum::http::HeaderValue::from_str(path) else {
+        // Unreachable today (`receipt_path` yields ASCII `/v1/receipts/{uuid}`),
+        // but if it ever fires the receipt row was already written and is now
+        // stranded — the client never learns the id. Make that loud, not silent.
+        metrics::counter!("solvela_receipt_write_failures_total", "reason" => "invalid_header_value")
+            .increment(1);
+        error!(
+            path = %path,
+            "receipt path is not a valid header value — written receipt not advertised"
+        );
         return;
     };
     response

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -33,6 +33,16 @@ impl PaymentScheme {
             other => Err(format!("unknown payment scheme: {other}")),
         }
     }
+
+    /// The canonical `accepted.scheme` wire string for this scheme — the
+    /// inverse of [`from_accepted_str`], used when recording the scheme on a
+    /// client-facing receipt.
+    pub(crate) fn as_accepted_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Escrow => "escrow",
+        }
+    }
 }
 
 /// Hard ceiling on `completion_tokens` when neither the request nor the model
@@ -1701,6 +1711,19 @@ supports_vision = false
         assert!(PaymentScheme::from_accepted_str("Escrow").is_err());
         assert!(PaymentScheme::from_accepted_str("escrow ").is_err());
         assert!(PaymentScheme::from_accepted_str("escr0w").is_err());
+    }
+
+    #[test]
+    fn payment_scheme_as_accepted_str_round_trips() {
+        // The receipt records `as_accepted_str`; it must stay the exact
+        // inverse of the boundary parser so a recorded scheme is always a
+        // valid wire scheme.
+        for scheme in [PaymentScheme::Exact, PaymentScheme::Escrow] {
+            assert_eq!(
+                PaymentScheme::from_accepted_str(scheme.as_accepted_str()),
+                Ok(scheme)
+            );
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -1303,7 +1303,17 @@ pub async fn chat_completions(
                 cost_outcome.is_some(),
             ) {
                 SpendLogArm::SkipSettleFailed => {
-                    // No-op: reservation already released, no spend to record.
+                    // No spend: reservation already released at the settle-failure
+                    // branch above, nothing was collected.
+                    //
+                    // No receipt either: the payment was NOT collected on-chain
+                    // (the post-delivery `exact` settle failed), so a receipt
+                    // header would promise audit evidence of a payment that
+                    // didn't happen. The settle-failure branch already counted
+                    // `solvela_payments_total{status="settle_after_deliver_failed"}`;
+                    // this counter completes the receipt-skip taxonomy.
+                    counter!("solvela_receipt_skipped_total", "reason" => "settle_failed")
+                        .increment(1);
                 }
                 SpendLogArm::ActualUsage(u) => {
                     match state
@@ -1403,6 +1413,16 @@ pub async fn chat_completions(
                                 wallet = %wallet_address,
                                 "failed to compute actual cost — skipping spend log to avoid $0 entry"
                             );
+                            // P2 receipt: intentionally OMITTED so receipts stay
+                            // lock-step with the spend ledger (no spend row → no
+                            // receipt; a receipt here would attest to a bill the
+                            // ledger never recorded). The exact payment DID
+                            // settle, so this settled-but-unledgered arm is a
+                            // known pre-existing gap (#541 family — the spend
+                            // half is deliberately left unchanged here); the
+                            // counter makes the receipt gap observable.
+                            counter!("solvela_receipt_skipped_total", "reason" => "cost_estimation_error")
+                                .increment(1);
                         }
                     }
                 }
@@ -1635,6 +1655,11 @@ struct ChatReceiptInputs<'a> {
     payer_wallet: &'a str,
     /// Amount actually billed (mirrors the spend ledger: discounted on an
     /// escrow semantic-cache hit, full otherwise), atomic USDC.
+    ///
+    /// This is the BILLED amount from the gateway ledger's perspective —
+    /// identical to the spend ledger — and can differ from the raw on-chain
+    /// transfer when an agent overpays the 402 quote (`client_amount` >
+    /// expected): the receipt records what was billed, not what moved.
     amount_paid_atomic: u64,
     /// The registry CostBreakdown that produced the bill (actual usage on the
     /// non-streaming arm; the C1 estimate on the usage-less/streaming arms).

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -27,6 +27,7 @@ use solvela_router::scorer;
 
 use crate::error::GatewayError;
 use crate::middleware::prompt_guard::{self, GuardResult, PromptGuardConfig};
+use crate::receipts;
 use crate::routes::debug_headers::{is_debug_enabled, PaymentStatus};
 use crate::usage::SpendLogEntry;
 use crate::AppState;
@@ -623,6 +624,11 @@ pub async fn chat_completions(
     let wallet_address: String;
     let tx_signature: Option<String>;
     let estimated_cost: f64;
+    // P2 receipts: the estimate's full CostBreakdown (the C1 `expected_cost`
+    // the 402 quote, payment validation, and budget reservation all derive
+    // from). The streaming / usage-less receipt arms record THIS breakdown —
+    // the same figure the spend ledger bills on those paths.
+    let estimated_cost_breakdown: solvela_protocol::CostBreakdown;
     let budget_reservation: crate::usage::BudgetReservation;
 
     match payment_payload {
@@ -895,6 +901,7 @@ pub async fn chat_completions(
             estimated_cost = expected_cost.total.parse::<f64>().map_err(|_| {
                 GatewayError::Internal("failed to parse estimated cost as f64".to_string())
             })?;
+            estimated_cost_breakdown = expected_cost;
 
             // GHSA-86cr-h3rx-vj6j: budget-enforcement guard. A corrupted model
             // registry entry can produce NaN or ±Infinity in the cost total. NaN
@@ -1303,13 +1310,16 @@ pub async fn chat_completions(
                         .model_registry
                         .estimate_cost(&req.model, u.prompt_tokens, u.completion_tokens)
                         .and_then(|c| {
-                            c.total.parse::<f64>().map_err(|e| {
+                            // Keep the full breakdown alongside the parsed
+                            // total: the P2 receipt records the same pricing
+                            // computation the bill derives from.
+                            c.total.parse::<f64>().map(|total| (c, total)).map_err(|e| {
                                 solvela_router::models::ModelRegistryError::ParseError(
                                     e.to_string(),
                                 )
                             })
                         }) {
-                        Ok(cost) => {
+                        Ok((actual_cost_breakdown, cost)) => {
                             // On an ESCROW semantic-cache hit the agent is billed the
                             // discounted price, so the spend ledger must record that —
                             // not the full computed `cost`. On the exact scheme
@@ -1370,6 +1380,21 @@ pub async fn chat_completions(
                                 estimated_cost_usdc: Some(estimated_cost),
                                 vendor: None,
                             });
+                            // P2 receipt: same write point as the spend row —
+                            // every paid completion that records spend records
+                            // a receipt (and advertises it via the header).
+                            emit_chat_receipt(
+                                &state,
+                                &mut response,
+                                ChatReceiptInputs {
+                                    model: &req.model,
+                                    scheme: payment_scheme,
+                                    tx_signature: &tx_signature,
+                                    payer_wallet: &wallet_address,
+                                    amount_paid_atomic: billed_atomic,
+                                    breakdown: &actual_cost_breakdown,
+                                },
+                            );
                         }
                         Err(e) => {
                             warn!(
@@ -1431,6 +1456,21 @@ pub async fn chat_completions(
                         estimated_cost_usdc: Some(estimated_cost),
                         vendor: None,
                     });
+                    // P2 receipt: billed amount mirrors the ledger (discounted
+                    // on an escrow semantic hit); the breakdown is the C1
+                    // estimate the reservation/settlement derived from.
+                    emit_chat_receipt(
+                        &state,
+                        &mut response,
+                        ChatReceiptInputs {
+                            model: &req.model,
+                            scheme: payment_scheme,
+                            tx_signature: &tx_signature,
+                            payer_wallet: &wallet_address,
+                            amount_paid_atomic: billed_atomic,
+                            breakdown: &estimated_cost_breakdown,
+                        },
+                    );
                 }
                 SpendLogArm::EstimateFallback => {
                     // Delivered + settled, but usage AND cost_outcome are both
@@ -1492,6 +1532,23 @@ pub async fn chat_completions(
                         estimated_cost_usdc: Some(estimated_cost),
                         vendor: None,
                     });
+                    // P2 receipt — the STREAMING arm (the #541 bug class):
+                    // every settled streaming completion records a receipt at
+                    // the billed estimate. `response` is the constructed (not
+                    // yet transmitted) SSE response, so the receipt header is
+                    // decided BEFORE the body starts.
+                    emit_chat_receipt(
+                        &state,
+                        &mut response,
+                        ChatReceiptInputs {
+                            model: &req.model,
+                            scheme: payment_scheme,
+                            tx_signature: &tx_signature,
+                            payer_wallet: &wallet_address,
+                            amount_paid_atomic: billed_atomic,
+                            breakdown: &estimated_cost_breakdown,
+                        },
+                    );
                 }
             }
 
@@ -1566,6 +1623,87 @@ pub async fn chat_completions(
             Err(GatewayError::Internal(msg))
         }
     }
+}
+
+/// Inputs for one chat-path receipt (settlement-platform P2). Groups the
+/// money-relevant fields so [`emit_chat_receipt`] stays a single, reviewable
+/// signature across the three spend-log arms.
+struct ChatReceiptInputs<'a> {
+    model: &'a str,
+    scheme: PaymentScheme,
+    tx_signature: &'a Option<String>,
+    payer_wallet: &'a str,
+    /// Amount actually billed (mirrors the spend ledger: discounted on an
+    /// escrow semantic-cache hit, full otherwise), atomic USDC.
+    amount_paid_atomic: u64,
+    /// The registry CostBreakdown that produced the bill (actual usage on the
+    /// non-streaming arm; the C1 estimate on the usage-less/streaming arms).
+    breakdown: &'a solvela_protocol::CostBreakdown,
+}
+
+/// Allocate, persist (fire-and-forget), and advertise a client-facing receipt
+/// for a PAID chat completion.
+///
+/// Called at exactly the points where spend logging fires — every paid
+/// completion that writes a spend row writes a receipt row (the #541
+/// streaming bug class). For STREAMING responses this runs while the SSE
+/// `Response` is constructed but not yet transmitted, so the
+/// `x-solvela-receipt` header is decided BEFORE the body starts; the recorded
+/// amounts are the same estimate the spend ledger bills on that path.
+///
+/// Fail-closed, never over-promise:
+/// - no `DATABASE_URL` → no receipt row and NO header (rule 12 graceful
+///   degradation — never advertise an unfetchable receipt);
+/// - a breakdown string that fails the checked atomic conversion → skip the
+///   receipt (counter + warn), header not emitted; the spend row and billing
+///   are unaffected.
+fn emit_chat_receipt(
+    state: &Arc<AppState>,
+    response: &mut Response,
+    inputs: ChatReceiptInputs<'_>,
+) {
+    if state.db_pool.is_none() {
+        return;
+    }
+    // Convert the breakdown's decimal strings to canonical atomic units via
+    // the same checked conversion the 402 quote uses (rejects empty/
+    // non-numeric/negative/overflow — solvela-fintech fail-closed rule).
+    let atomic = |decimal: &str| -> Option<u64> {
+        usdc_atomic_amount_checked(decimal)
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+    };
+    let (Some(provider_cost_atomic), Some(platform_fee_atomic), Some(total_atomic)) = (
+        atomic(&inputs.breakdown.provider_cost),
+        atomic(&inputs.breakdown.platform_fee),
+        atomic(&inputs.breakdown.total),
+    ) else {
+        counter!("solvela_receipt_skipped_total", "reason" => "corrupt_breakdown").increment(1);
+        warn!(
+            model = %inputs.model,
+            provider_cost = %inputs.breakdown.provider_cost,
+            platform_fee = %inputs.breakdown.platform_fee,
+            total = %inputs.breakdown.total,
+            "skipping receipt: cost breakdown failed the checked atomic conversion — header not emitted"
+        );
+        return;
+    };
+    let record = receipts::ReceiptRecord {
+        receipt_id: uuid::Uuid::new_v4(),
+        model: inputs.model.to_string(),
+        payment_scheme: inputs.scheme.as_accepted_str().to_string(),
+        tx_signature: inputs.tx_signature.clone(),
+        payer_wallet: inputs.payer_wallet.to_string(),
+        amount_paid_atomic: inputs.amount_paid_atomic,
+        provider_cost_atomic,
+        platform_fee_atomic,
+        total_atomic,
+        // Chat-path receipts never carry vendor settlement — that is the
+        // services-proxy P1 path.
+        vendor: None,
+    };
+    let path = receipts::record_receipt(state.db_pool.as_ref(), record);
+    receipts::insert_receipt_header(response, &path);
 }
 
 /// Resolve model ID from aliases, smart routing profiles, or direct model IDs.

--- a/crates/gateway/src/routes/health.rs
+++ b/crates/gateway/src/routes/health.rs
@@ -165,6 +165,9 @@ supports_vision = false
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -243,6 +246,9 @@ supports_vision = false
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,

--- a/crates/gateway/src/routes/mod.rs
+++ b/crates/gateway/src/routes/mod.rs
@@ -11,6 +11,7 @@ pub mod nonce;
 pub mod orgs;
 pub mod pricing;
 pub mod proxy;
+pub mod receipts;
 pub mod services;
 pub mod stats;
 pub mod supported;

--- a/crates/gateway/src/routes/orgs/api_keys.rs
+++ b/crates/gateway/src/routes/orgs/api_keys.rs
@@ -254,6 +254,9 @@ mod tests {
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/routes/orgs/mod.rs
+++ b/crates/gateway/src/routes/orgs/mod.rs
@@ -404,6 +404,9 @@ supports_vision = true
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -572,6 +575,9 @@ mod tests {
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -622,6 +628,9 @@ mod tests {
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
@@ -676,6 +685,9 @@ mod tests {
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,

--- a/crates/gateway/src/routes/orgs/teams.rs
+++ b/crates/gateway/src/routes/orgs/teams.rs
@@ -432,6 +432,9 @@ mod tests {
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
             ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -185,8 +185,15 @@ impl PaymentTarget {
         scheme: &str,
         tx_signature: Option<String>,
         payer_wallet: String,
-        provider_cost_atomic: u64,
     ) -> receipts::ReceiptRecord {
+        // Definitionally consistent on both variants — the provider/vendor leg
+        // is what the agent pays minus the agent-facing fee (Gateway: total −
+        // 5% fee = provider cost; Vendor: listed price − 0). Computed here, not
+        // caller-supplied, so a call site can never record an inconsistent
+        // provider/total pair. `expected_atomic ≥ agent_fee_atomic` holds by
+        // construction (Gateway totals come from `compute_service_cost`, where
+        // total = provider + fee).
+        let provider_cost_atomic = self.expected_atomic() - self.agent_fee_atomic();
         receipts::ReceiptRecord {
             receipt_id: Uuid::new_v4(),
             model: service_id.to_string(),
@@ -694,7 +701,6 @@ pub async fn proxy_service(
         &payload.accepted.scheme,
         tx_signature.clone(),
         wallet_address.clone(),
-        provider_atomic,
     );
 
     let spend_entry = SpendLogEntry {
@@ -1900,7 +1906,6 @@ mod tests {
             "exact",
             Some("tx".to_string()),
             "payer".to_string(),
-            20_000,
         );
         assert_eq!(record.model, "vendor-svc");
         assert_eq!(record.payment_scheme, "exact");
@@ -1927,7 +1932,6 @@ mod tests {
             "exact",
             Some("tx".to_string()),
             "payer".to_string(),
-            10_000,
         );
         assert_eq!(record.amount_paid_atomic, 10_500);
         assert_eq!(record.provider_cost_atomic, 10_000);
@@ -1951,7 +1955,6 @@ mod tests {
             "a-very-long-unknown-scheme-string",
             None,
             "payer".to_string(),
-            10_000,
         );
         assert_eq!(record.payment_scheme.chars().count(), 16);
     }

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -14,6 +14,7 @@ use axum::response::{IntoResponse, Response};
 use metrics::{counter, histogram};
 use serde_json::json;
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use solvela_x402::types::{
     CostBreakdown, PaymentAccept, PaymentRequired, Resource, PLATFORM_FEE_PERCENT, SOLANA_NETWORK,
@@ -23,6 +24,7 @@ use solvela_x402::types::{
 use crate::error::GatewayError;
 use crate::middleware::x402::decode_payment_header;
 use crate::payment_util::extract_payer_wallet;
+use crate::receipts;
 use crate::security;
 use crate::usage::{SpendLogEntry, VendorSettlement};
 use crate::AppState;
@@ -165,6 +167,40 @@ impl PaymentTarget {
         match self {
             Self::Gateway { .. } => None,
             Self::Vendor { settlement, .. } => Some(settlement),
+        }
+    }
+
+    /// Build the client-facing receipt record (settlement-platform P2) for
+    /// this settlement target. The amounts are AGENT-facing (rule #5 — the
+    /// breakdown stays truthful to what the agent pays): on the vendor path
+    /// the fee shown is 0 (the vendor absorbs it; the 5% rides as the
+    /// receivable inside `vendor`), on the gateway path the fee is on top.
+    ///
+    /// `scheme` passed the scheme/payload-variant check and was settled by
+    /// the facilitator; it is still client-originated, so it is capped before
+    /// recording.
+    fn receipt_record(
+        &self,
+        service_id: &str,
+        scheme: &str,
+        tx_signature: Option<String>,
+        payer_wallet: String,
+        provider_cost_atomic: u64,
+    ) -> receipts::ReceiptRecord {
+        receipts::ReceiptRecord {
+            receipt_id: Uuid::new_v4(),
+            model: service_id.to_string(),
+            payment_scheme: scheme.chars().take(16).collect(),
+            tx_signature,
+            payer_wallet,
+            amount_paid_atomic: self.expected_atomic(),
+            provider_cost_atomic,
+            platform_fee_atomic: self.agent_fee_atomic(),
+            total_atomic: self.expected_atomic(),
+            vendor: match self {
+                Self::Gateway { .. } => None,
+                Self::Vendor { settlement, .. } => Some(settlement.clone()),
+            },
         }
     }
 }
@@ -649,6 +685,18 @@ pub async fn proxy_service(
     //   settled requests whose upstream then times out or is unreachable.
     // - Non-vendor services keep the legacy post-upstream write below,
     //   byte-for-byte today's behavior.
+    // P2 receipt: built from the same settlement facts as the spend entry and
+    // written at the same point(s) — vendor services NOW (the vendor was just
+    // paid on-chain), plain services post-upstream below — so every paid
+    // request that writes a spend row also writes a receipt row.
+    let receipt_record = payment_target.receipt_record(
+        &service_id,
+        &payload.accepted.scheme,
+        tx_signature.clone(),
+        wallet_address.clone(),
+        provider_atomic,
+    );
+
     let spend_entry = SpendLogEntry {
         wallet_address,
         model: service_id.clone(),
@@ -673,11 +721,16 @@ pub async fn proxy_service(
         estimated_cost_usdc: None,
         vendor: payment_target.into_vendor_settlement(),
     };
-    let deferred_spend_entry = if spend_entry.vendor.is_some() {
+    // `receipt_header_path` is `Some` once a retrievable receipt exists (DB
+    // configured AND the row write was dispatched); it is attached to every
+    // response built after that point. With no DATABASE_URL it stays `None`
+    // and no header is ever emitted (never promise an unfetchable receipt).
+    let (deferred_spend_entry, mut receipt_header_path) = if spend_entry.vendor.is_some() {
         state.usage.log_spend(spend_entry);
-        None
+        let path = receipts::record_receipt(state.db_pool.as_ref(), receipt_record);
+        (None, path)
     } else {
-        Some(spend_entry)
+        (Some((spend_entry, receipt_record)), None)
     };
 
     // Step 5: SSRF check — resolve DNS once, validate all addresses are public,
@@ -761,13 +814,20 @@ pub async fn proxy_service(
                 error = %e,
                 "upstream service timed out"
             );
-            return Ok((
+            // Vendor services already settled AND recorded their receipt at
+            // settlement time above, so the paid (504) response still carries
+            // it. Plain services have not written spend or receipt yet —
+            // `receipt_header_path` is `None` and no header is emitted
+            // (mirrors the legacy spend-log behavior on this arm).
+            let mut response = (
                 StatusCode::GATEWAY_TIMEOUT,
                 axum::Json(json!({
                     "error": "upstream service timed out"
                 })),
             )
-                .into_response());
+                .into_response();
+            receipts::insert_receipt_header(&mut response, &receipt_header_path);
+            return Ok(response);
         }
         Err(e) => {
             warn!(
@@ -775,23 +835,27 @@ pub async fn proxy_service(
                 error = %e,
                 "failed to reach upstream service"
             );
-            return Ok((
+            // Same receipt-header semantics as the timeout arm above.
+            let mut response = (
                 StatusCode::BAD_GATEWAY,
                 axum::Json(json!({
                     "error": "service unreachable"
                 })),
             )
-                .into_response());
+                .into_response();
+            receipts::insert_receipt_header(&mut response, &receipt_header_path);
+            return Ok(response);
         }
     };
 
     let upstream_status = upstream_response.status();
 
-    // Step 7: Fire-and-forget spend log (log_spend internally uses
+    // Step 7: Fire-and-forget spend log + receipt (both internally use
     // tokio::spawn). Non-vendor services only — vendor services already
     // logged at settlement time above (one row per request either way).
-    if let Some(entry) = deferred_spend_entry {
+    if let Some((entry, record)) = deferred_spend_entry {
         state.usage.log_spend(entry);
+        receipt_header_path = receipts::record_receipt(state.db_pool.as_ref(), record);
     }
 
     // Handle upstream response based on status
@@ -801,13 +865,15 @@ pub async fn proxy_service(
             upstream_status = %upstream_status,
             "upstream service returned server error"
         );
-        return Ok((
+        let mut response = (
             StatusCode::BAD_GATEWAY,
             axum::Json(json!({
                 "error": "upstream service error"
             })),
         )
-            .into_response());
+            .into_response();
+        receipts::insert_receipt_header(&mut response, &receipt_header_path);
+        return Ok(response);
     }
 
     // For 2xx and 4xx, forward the response as-is
@@ -824,9 +890,11 @@ pub async fn proxy_service(
         builder = builder.header("content-type", ct);
     }
 
-    builder
+    let mut response = builder
         .body(Body::from(response_bytes))
-        .map_err(|e| GatewayError::Internal(format!("failed to build response: {e}")))
+        .map_err(|e| GatewayError::Internal(format!("failed to build response: {e}")))?;
+    receipts::insert_receipt_header(&mut response, &receipt_header_path);
+    Ok(response)
 }
 
 #[cfg(test)]
@@ -1804,6 +1872,88 @@ mod tests {
             matches!(err, GatewayError::PaymentChallenge(_)),
             "non-vendor path must keep today's behavior, got {err:?}"
         );
+    }
+
+    // ── Receipt records (settlement-platform P2) ──────────────────────────
+    //
+    // The plain-service receipt write fires post-upstream (step 7), which the
+    // SSRF guard makes unreachable in tests (no public upstream); the record
+    // CONTENT is pinned here at the unit level, and the vendor-path wiring is
+    // pinned end-to-end in `tests/integration.rs`
+    // (`vendor_paid_proxy_request_records_receipt_with_fee_receivable`).
+
+    /// A vendor-path receipt must carry the vendor settlement + receivable,
+    /// bill the agent exactly the listed price, and show a ZERO agent fee
+    /// (vendor absorbs — rule #5 truthful breakdown).
+    #[test]
+    fn receipt_record_vendor_carries_receivable_and_zero_agent_fee() {
+        let target = PaymentTarget::Vendor {
+            price_atomic: 20_000,
+            settlement: VendorSettlement {
+                vendor_wallet: TEST_VENDOR_WALLET.to_string(),
+                settled_atomic: 20_000,
+                fee_receivable_atomic: 1_000,
+            },
+        };
+        let record = target.receipt_record(
+            "vendor-svc",
+            "exact",
+            Some("tx".to_string()),
+            "payer".to_string(),
+            20_000,
+        );
+        assert_eq!(record.model, "vendor-svc");
+        assert_eq!(record.payment_scheme, "exact");
+        assert_eq!(record.amount_paid_atomic, 20_000);
+        assert_eq!(record.provider_cost_atomic, 20_000);
+        assert_eq!(record.platform_fee_atomic, 0, "vendor absorbs the 5%");
+        assert_eq!(record.total_atomic, 20_000);
+        let vendor = record.vendor.expect("vendor receipt carries settlement");
+        assert_eq!(vendor.vendor_wallet, TEST_VENDOR_WALLET);
+        assert_eq!(vendor.settled_atomic, 20_000);
+        assert_eq!(vendor.fee_receivable_atomic, 1_000);
+    }
+
+    /// A plain (gateway-recipient) receipt bills `price × 1.05` with the 5%
+    /// fee on top and carries NO vendor fields.
+    #[test]
+    fn receipt_record_plain_service_has_fee_on_top_and_no_vendor_fields() {
+        let target = PaymentTarget::Gateway {
+            total_atomic: 10_500,
+            fee_atomic: 500,
+        };
+        let record = target.receipt_record(
+            "plain-svc",
+            "exact",
+            Some("tx".to_string()),
+            "payer".to_string(),
+            10_000,
+        );
+        assert_eq!(record.amount_paid_atomic, 10_500);
+        assert_eq!(record.provider_cost_atomic, 10_000);
+        assert_eq!(record.platform_fee_atomic, 500);
+        assert_eq!(record.total_atomic, 10_500);
+        assert!(
+            record.vendor.is_none(),
+            "plain services must not carry vendor settlement fields"
+        );
+    }
+
+    /// A client-originated scheme string is capped before recording.
+    #[test]
+    fn receipt_record_caps_scheme_length() {
+        let target = PaymentTarget::Gateway {
+            total_atomic: 10_500,
+            fee_atomic: 500,
+        };
+        let record = target.receipt_record(
+            "svc",
+            "a-very-long-unknown-scheme-string",
+            None,
+            "payer".to_string(),
+            10_000,
+        );
+        assert_eq!(record.payment_scheme.chars().count(), 16);
     }
 
     #[tokio::test]

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -1218,6 +1218,7 @@ mod tests {
             prometheus_handle: None,
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(crate::middleware::rate_limit::RateLimitConfig::free_default()),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(crate::middleware::rate_limit::RateLimitConfig::receipts_default()),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT),
         });
 
@@ -1366,6 +1367,9 @@ mod tests {
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,

--- a/crates/gateway/src/routes/receipts.rs
+++ b/crates/gateway/src/routes/receipts.rs
@@ -1,0 +1,56 @@
+//! GET /v1/receipts/{receipt_id} — fetch a client-facing payment receipt.
+//!
+//! Public route with a capability-by-unguessable-UUID auth model: the UUIDv4
+//! receipt id (issued in the `x-solvela-receipt` header on paid responses) IS
+//! the bearer credential — agents have no other auth on the public path.
+//! Unknown and malformed ids return one identical 404 (no existence or format
+//! oracle), and there is deliberately no listing/enumeration endpoint.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::Json;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::error::GatewayError;
+use crate::receipts::{self, Receipt};
+use crate::AppState;
+
+/// Fixed 404 body shared by unknown and malformed ids — the single signal.
+const RECEIPT_NOT_FOUND: &str = "receipt not found";
+
+/// GET /v1/receipts/{receipt_id}
+pub async fn get_receipt(
+    State(state): State<Arc<AppState>>,
+    Path(receipt_id): Path<String>,
+) -> Result<Json<Receipt>, GatewayError> {
+    // Rule 12 graceful degradation, honestly surfaced: with no DATABASE_URL
+    // receipts cannot exist on this gateway AT ALL (the header is never
+    // emitted), so the truthful answer is a 503 about the service — not a 404
+    // pretending the specific id was looked up and missed.
+    let Some(pool) = &state.db_pool else {
+        return Err(GatewayError::ServiceUnavailable(
+            "receipts are not available: this gateway has no receipt storage configured"
+                .to_string(),
+        ));
+    };
+
+    // A non-UUID id can never match a stored receipt; reject it with the SAME
+    // 404 as an unknown id so the response shape leaks nothing about format
+    // validity.
+    let Ok(id) = Uuid::parse_str(&receipt_id) else {
+        return Err(GatewayError::NotFound(RECEIPT_NOT_FOUND.to_string()));
+    };
+
+    match receipts::fetch_receipt(pool, id).await {
+        Ok(Some(receipt)) => Ok(Json(receipt)),
+        Ok(None) => Err(GatewayError::NotFound(RECEIPT_NOT_FOUND.to_string())),
+        Err(e) => {
+            // Database/corruption detail stays server-side; the client gets
+            // the generic 500 envelope.
+            warn!(error = %e, "failed to load receipt");
+            Err(GatewayError::Internal("failed to load receipt".to_string()))
+        }
+    }
+}

--- a/crates/gateway/src/routes/receipts.rs
+++ b/crates/gateway/src/routes/receipts.rs
@@ -10,11 +10,11 @@ use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::Json;
-use tracing::warn;
+use tracing::{error, warn};
 use uuid::Uuid;
 
 use crate::error::GatewayError;
-use crate::receipts::{self, Receipt};
+use crate::receipts::{self, Receipt, ReceiptError};
 use crate::AppState;
 
 /// Fixed 404 body shared by unknown and malformed ids — the single signal.
@@ -48,8 +48,29 @@ pub async fn get_receipt(
         Ok(None) => Err(GatewayError::NotFound(RECEIPT_NOT_FOUND.to_string())),
         Err(e) => {
             // Database/corruption detail stays server-side; the client gets
-            // the generic 500 envelope.
-            warn!(error = %e, "failed to load receipt");
+            // the generic 500 envelope. Severity is split by variant: a DB
+            // error is infrastructure (error!), a Corrupt row is a
+            // data-integrity violation fetch_receipt refused to serve (warn!).
+            match &e {
+                ReceiptError::Database(_) => {
+                    metrics::counter!("solvela_receipt_read_failures_total", "reason" => "db_error")
+                        .increment(1);
+                    error!(
+                        error = %e,
+                        receipt_id = %receipt_id,
+                        "failed to load receipt — database error"
+                    );
+                }
+                ReceiptError::Corrupt(_) => {
+                    metrics::counter!("solvela_receipt_read_failures_total", "reason" => "corrupt")
+                        .increment(1);
+                    warn!(
+                        error = %e,
+                        receipt_id = %receipt_id,
+                        "failed to load receipt — stored row violates a receipt invariant"
+                    );
+                }
+            }
             Err(GatewayError::Internal("failed to load receipt".to_string()))
         }
     }

--- a/crates/gateway/src/routes/receipts.rs
+++ b/crates/gateway/src/routes/receipts.rs
@@ -9,12 +9,15 @@
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
+use axum::response::{IntoResponse, Response};
 use axum::Json;
+use metrics::counter;
 use tracing::{error, warn};
 use uuid::Uuid;
 
 use crate::error::GatewayError;
-use crate::receipts::{self, Receipt, ReceiptError};
+use crate::middleware::rate_limit::{connect_info_client_id, rate_limited_response, PeerAddr};
+use crate::receipts::{self, ReceiptError};
 use crate::AppState;
 
 /// Fixed 404 body shared by unknown and malformed ids — the single signal.
@@ -23,8 +26,28 @@ const RECEIPT_NOT_FOUND: &str = "receipt not found";
 /// GET /v1/receipts/{receipt_id}
 pub async fn get_receipt(
     State(state): State<Arc<AppState>>,
+    // Infallible peer-address extractor (same as the free-tier path): `None`
+    // when `ConnectInfo` is absent, degrading to the stricter "unknown" bucket
+    // rather than 500-ing.
+    peer_addr: PeerAddr,
     Path(receipt_id): Path<String>,
-) -> Result<Json<Receipt>, GatewayError> {
+) -> Result<Response, GatewayError> {
+    // Anti-abuse: this route is public and unauthenticated (the unguessable
+    // UUID is the only credential) and the lookup is a DB query, so it gets a
+    // per-IP cap STRICTER than the generic outer limiter — hostile to receipt
+    // scanners, generous for an agent fetching its own receipts. Enforced
+    // FIRST (before the storage check and the UUID parse) so a limited client
+    // is rejected at the cheapest point. Keyed on the TCP peer IP, never a
+    // client-supplied header (GHSA-6ggq-cvwx-4f67); absent ConnectInfo falls
+    // back to the shared stricter "unknown" bucket. Mirrors the free-tier
+    // in-handler limiter in routes/chat.
+    let client_id = connect_info_client_id(peer_addr.0);
+    if state.receipts_rate_limiter.check(&client_id).await.is_err() {
+        counter!("solvela_receipts_rate_limited_total").increment(1);
+        warn!(client_id = %client_id, "receipts GET rate limit exceeded");
+        return Ok(rate_limited_response(state.receipts_rate_limiter.config()));
+    }
+
     // Rule 12 graceful degradation, honestly surfaced: with no DATABASE_URL
     // receipts cannot exist on this gateway AT ALL (the header is never
     // emitted), so the truthful answer is a 503 about the service — not a 404
@@ -44,7 +67,7 @@ pub async fn get_receipt(
     };
 
     match receipts::fetch_receipt(pool, id).await {
-        Ok(Some(receipt)) => Ok(Json(receipt)),
+        Ok(Some(receipt)) => Ok(Json(receipt).into_response()),
         Ok(None) => Err(GatewayError::NotFound(RECEIPT_NOT_FOUND.to_string())),
         Err(e) => {
             // Database/corruption detail stays server-side; the client gets

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -10995,3 +10995,564 @@ async fn test_chat_canonical_wrong_network_rejected() {
         "must hit the network validation: {json}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Client-facing payment receipts (settlement-platform P2)
+//
+// Every PAID, delivered + settled request that writes a spend row must also
+// write a `receipts` row (the #541 streaming-spend-log bug class) and
+// advertise it via the `x-solvela-receipt` response header. The header is
+// emitted ONLY when receipt storage (PostgreSQL) is configured — a header
+// promising an unfetchable receipt would be a lie (rule 12 graceful
+// degradation). Free-tier ($0) requests produce no payment and no receipt.
+//
+// The receipt id is capability-by-unguessable-UUID: GET /v1/receipts/{id} is
+// public, 404s identically on unknown AND malformed ids (no existence oracle),
+// and there is deliberately no listing endpoint.
+//
+// The DB-backed tests below self-skip when Postgres is unavailable (same
+// pattern as `test_chat_enforced_wallet_unprovisioned_tenant_returns_400_e2e`).
+// ---------------------------------------------------------------------------
+
+/// Compose-default DATABASE_URL fallback (docker-compose.yml credentials) so
+/// the receipts round-trip tests run against a default `docker compose up -d`
+/// stack even when the env var is unset.
+const COMPOSE_DEFAULT_DATABASE_URL: &str =
+    "postgres://solvela:solvela_dev_password@localhost:5432/solvela";
+
+/// Dedicated database for the receipts suite, recreated fresh once per test
+/// process — immune to migration-checksum drift and stale rows in the shared
+/// dev database.
+const RECEIPTS_TEST_DB_NAME: &str = "solvela_receipts_test";
+
+/// Resolve (once per process) the URL of a freshly-recreated, dedicated test
+/// database. `None` (self-skip) when Postgres is unavailable.
+async fn receipts_test_db_url() -> Option<String> {
+    static URL: tokio::sync::OnceCell<Option<String>> = tokio::sync::OnceCell::const_new();
+    URL.get_or_init(|| async {
+        let admin_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| COMPOSE_DEFAULT_DATABASE_URL.to_string());
+        let admin_pool = match sqlx::postgres::PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&admin_url)
+            .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("skipping receipts tests: Postgres unavailable ({e})");
+                return None;
+            }
+        };
+        // DROP/CREATE DATABASE must run as simple (non-prepared) statements;
+        // sqlx 0.9's `raw_sql` requires 'static literals (SqlSafeStr), so the
+        // database name is spelled out (it must match RECEIPTS_TEST_DB_NAME).
+        if let Err(e) = sqlx::raw_sql("DROP DATABASE IF EXISTS solvela_receipts_test WITH (FORCE)")
+            .execute(&admin_pool)
+            .await
+        {
+            eprintln!("skipping receipts tests: cannot drop test database ({e})");
+            return None;
+        }
+        if let Err(e) = sqlx::raw_sql("CREATE DATABASE solvela_receipts_test")
+            .execute(&admin_pool)
+            .await
+        {
+            eprintln!("skipping receipts tests: cannot create test database ({e})");
+            return None;
+        }
+        admin_pool.close().await;
+
+        let mut url = match url::Url::parse(&admin_url) {
+            Ok(u) => u,
+            Err(e) => {
+                eprintln!("skipping receipts tests: unparseable DATABASE_URL ({e})");
+                return None;
+            }
+        };
+        url.set_path(RECEIPTS_TEST_DB_NAME);
+        Some(url.to_string())
+    })
+    .await
+    .clone()
+}
+
+/// Open a PER-TEST pool (each `#[tokio::test]` has its own runtime, so pools
+/// must not be shared across tests) on the dedicated test database and apply
+/// migrations; `None` (self-skip) when unavailable.
+async fn try_receipts_db_pool() -> Option<sqlx::PgPool> {
+    let url = receipts_test_db_url().await?;
+    let pool = match sqlx::PgPool::connect(&url).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("skipping receipts test: test database connect failed ({e})");
+            return None;
+        }
+    };
+    // Concurrent test tasks serialize here via sqlx's migration advisory lock.
+    if let Err(e) = sqlx::migrate!("../../migrations").run(&pool).await {
+        eprintln!("skipping receipts test: migrations failed ({e})");
+        return None;
+    }
+    Some(pool)
+}
+
+/// DB-backed app: mirrors [`test_app_with_provider_registry_and_exact_verifier`]
+/// but with `db_pool: Some(pool)` (and a Postgres-backed `UsageTracker`), so
+/// receipts are persisted and the `x-solvela-receipt` header is emitted.
+fn test_app_with_db_pool(
+    providers: ProviderRegistry,
+    exact_verifier: Arc<dyn PaymentVerifier>,
+    pool: sqlx::PgPool,
+) -> (axum::Router, Arc<AppState>) {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML)
+        .unwrap()
+        .with_gateway_recipient(TEST_RECIPIENT_WALLET)
+        .unwrap();
+    let facilitator = solvela_x402::facilitator::Facilitator::new(vec![exact_verifier]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers,
+        facilitator,
+        usage: gateway::usage::UsageTracker::new(Some(pool.clone()), None),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: Some(pool),
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
+    });
+    let router = build_router(
+        Arc::clone(&state),
+        RateLimiter::new(RateLimitConfig::default()),
+    );
+    (router, state)
+}
+
+/// Parse the captured JSON tracing output and return the `fields` object of
+/// every `"receipt logged"` event (one per `record_receipt` call) — the same
+/// capture mechanism the #541 spend-log tests use.
+fn receipt_logged_events(capture: &CaptureWriter) -> Vec<serde_json::Value> {
+    let bytes = capture.0.lock().unwrap().clone();
+    String::from_utf8(bytes)
+        .expect("captured tracing output is UTF-8")
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|v| v["fields"]["message"] == "receipt logged")
+        .map(|v| v["fields"].clone())
+        .collect()
+}
+
+/// Extract the `/v1/receipts/{uuid}` path from the response header.
+fn receipt_header_path(response: &axum::response::Response) -> String {
+    let value = response
+        .headers()
+        .get("x-solvela-receipt")
+        .expect("paid response must carry the x-solvela-receipt header")
+        .to_str()
+        .expect("x-solvela-receipt header is ASCII")
+        .to_string();
+    assert!(
+        value.starts_with("/v1/receipts/"),
+        "receipt header must be the receipt path, got: {value}"
+    );
+    value
+}
+
+/// GET a receipt path through the real router; returns (status, JSON body).
+async fn get_receipt_json(app: &axum::Router, path: &str) -> (StatusCode, serde_json::Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(path)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|e| panic!("receipt GET body is not JSON ({e})"));
+    (status, json)
+}
+
+/// Poll GET {path} until the fire-and-forget receipt write lands (bounded).
+async fn poll_receipt_until_ok(app: &axum::Router, path: &str) -> serde_json::Value {
+    for _ in 0..50 {
+        let (status, json) = get_receipt_json(app, path).await;
+        if status == StatusCode::OK {
+            return json;
+        }
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "while polling, only 404 (write not yet landed) is acceptable: {json}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("receipt at {path} never became fetchable — fire-and-forget write lost");
+}
+
+/// Send a paid chat request through a DB-backed app and return the response.
+async fn paid_chat_response(
+    app: &axum::Router,
+    body: &serde_json::Value,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(serde_json::to_vec(body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// A paid NON-STREAMING chat completion must emit the receipt header and the
+/// GET round-trip must return the stored receipt with the amounts that were
+/// ACTUALLY billed (mock usage 10 in / 5 out on gpt-4o: provider 25 + 50 = 75
+/// atomic; total 75 × 1.05 = 78.75 → the registry's 6-dp formatting yields 79;
+/// fee string "0.000004"). Atomic integers are canonical; decimal strings are
+/// derived.
+#[tokio::test]
+async fn paid_non_streaming_chat_emits_receipt_header_and_get_round_trip() {
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let (app, _state) =
+        test_app_with_db_pool(mock_provider_registry(), Arc::new(AlwaysPassVerifier), pool);
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = paid_chat_response(&app, &body).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let path = receipt_header_path(&response);
+
+    let receipt = poll_receipt_until_ok(&app, &path).await;
+    assert_eq!(receipt["model"], "openai/gpt-4o");
+    assert_eq!(receipt["payment_scheme"], "exact");
+    // The mock payment tx is not a decodable Solana tx, so the payer falls
+    // back to the same "unknown" sentinel the spend ledger records.
+    assert_eq!(receipt["payer_wallet"], "unknown");
+    assert!(receipt["tx_signature"].is_string());
+    assert!(receipt["receipt_id"].is_string());
+    assert!(receipt["created_at"].is_string());
+
+    // Exact atomic pins (canonical units) — must equal what was billed.
+    assert_eq!(receipt["amount_paid_atomic"], 79);
+    assert_eq!(receipt["cost_breakdown"]["provider_cost_atomic"], 75);
+    assert_eq!(receipt["cost_breakdown"]["platform_fee_atomic"], 4);
+    assert_eq!(receipt["cost_breakdown"]["total_atomic"], 79);
+    // Cross-check against the registry single source of truth (same derivation
+    // the billing path uses), so the literal pin can never silently drift.
+    assert_eq!(
+        receipt["amount_paid_atomic"].as_u64(),
+        Some(registry_quote_atomic("openai/gpt-4o", 10, 5)),
+        "receipt amount must equal the registry-billed amount"
+    );
+    // Derived decimal strings.
+    assert_eq!(receipt["amount_paid_usdc"], "0.000079");
+    assert_eq!(receipt["cost_breakdown"]["provider_cost_usdc"], "0.000075");
+    assert_eq!(receipt["cost_breakdown"]["platform_fee_usdc"], "0.000004");
+    assert_eq!(receipt["cost_breakdown"]["total_usdc"], "0.000079");
+    assert_eq!(receipt["cost_breakdown"]["currency"], "USDC");
+    // Chat receipts carry no vendor settlement.
+    assert!(
+        receipt.get("vendor").is_none(),
+        "chat receipts must not carry vendor fields: {receipt}"
+    );
+}
+
+/// A paid STREAMING chat completion (the #541 bug class) must also produce a
+/// receipt. The header must be decided BEFORE the SSE body starts (it is on
+/// the response head), and the stored amounts are the ESTIMATE — the same
+/// figure the spend ledger bills and (on `exact`) the agent settled on-chain.
+#[tokio::test]
+async fn paid_streaming_chat_emits_receipt_header_and_records_estimate() {
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": true,
+    });
+    // The 402 amount is the observable proxy for the reservation/estimate
+    // through the real path (see the #500 reservation tests).
+    let reserved_atomic = quote_402_amount_atomic(&body.to_string()).await;
+
+    let (app, _state) =
+        test_app_with_db_pool(mock_provider_registry(), Arc::new(AlwaysPassVerifier), pool);
+    let response = paid_chat_response(&app, &body).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .expect("streaming response has content-type")
+        .to_str()
+        .unwrap();
+    assert!(
+        content_type.contains("text/event-stream"),
+        "must be an SSE response, got {content_type}"
+    );
+    // Header present on the response HEAD — decided before the body streams.
+    let path = receipt_header_path(&response);
+
+    let receipt = poll_receipt_until_ok(&app, &path).await;
+    assert_eq!(receipt["payment_scheme"], "exact");
+    assert_eq!(
+        receipt["amount_paid_atomic"].as_u64(),
+        Some(reserved_atomic),
+        "streaming receipt must record the billed estimate (the 402-quoted amount)"
+    );
+    assert_eq!(
+        receipt["cost_breakdown"]["total_atomic"].as_u64(),
+        Some(reserved_atomic),
+        "streaming receipt breakdown total must equal the quoted estimate"
+    );
+    assert!(
+        receipt.get("vendor").is_none(),
+        "chat receipts must not carry vendor fields"
+    );
+}
+
+/// Free-tier ($0) requests produce no payment and therefore no receipt — the
+/// header must be ABSENT even with receipt storage configured.
+#[tokio::test]
+async fn free_tier_request_emits_no_receipt_header() {
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let (app, _state) =
+        test_app_with_db_pool(mock_provider_registry(), Arc::new(AlwaysPassVerifier), pool);
+
+    let body = serde_json::json!({
+        "model": "google/gemini-3.1-flash-lite",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("x-solvela-receipt").is_none(),
+        "a free-tier ($0) response must not advertise a receipt"
+    );
+}
+
+/// With NO database configured (rule 12 graceful degradation) a paid response
+/// must NOT emit the receipt header — never promise a receipt that can't be
+/// fetched.
+#[tokio::test]
+async fn dbless_paid_request_emits_no_receipt_header() {
+    let app = test_app_with_mock_provider();
+
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    });
+    let response = paid_chat_response(&app, &body).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("x-solvela-receipt").is_none(),
+        "a DB-less gateway must not advertise unfetchable receipts"
+    );
+}
+
+/// Unknown receipt id → 404 `not_found`, nothing more (the id is the bearer
+/// capability; the 404 is the only signal).
+#[tokio::test]
+async fn get_receipt_unknown_id_returns_404() {
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let (app, _state) =
+        test_app_with_db_pool(mock_provider_registry(), Arc::new(AlwaysPassVerifier), pool);
+
+    let path = format!("/v1/receipts/{}", uuid::Uuid::new_v4());
+    let (status, json) = get_receipt_json(&app, &path).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"]["type"], "not_found");
+}
+
+/// A malformed (non-UUID) id must 404 with the SAME body as an unknown id —
+/// no existence/format oracle.
+#[tokio::test]
+async fn get_receipt_invalid_id_returns_same_404_as_unknown() {
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let (app, _state) =
+        test_app_with_db_pool(mock_provider_registry(), Arc::new(AlwaysPassVerifier), pool);
+
+    let unknown_path = format!("/v1/receipts/{}", uuid::Uuid::new_v4());
+    let (unknown_status, unknown_json) = get_receipt_json(&app, &unknown_path).await;
+    let (invalid_status, invalid_json) = get_receipt_json(&app, "/v1/receipts/not-a-uuid").await;
+
+    assert_eq!(invalid_status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        invalid_status, unknown_status,
+        "malformed and unknown ids must be indistinguishable"
+    );
+    assert_eq!(
+        invalid_json, unknown_json,
+        "malformed and unknown ids must return identical bodies (no format oracle)"
+    );
+}
+
+/// With no database configured the GET route returns an honest 503 (`service_unavailable`)
+/// — receipts cannot exist on this gateway, which is a service-configuration
+/// fact, not a statement about any particular id.
+#[tokio::test]
+async fn get_receipt_without_database_returns_503() {
+    let app = test_app();
+    let path = format!("/v1/receipts/{}", uuid::Uuid::new_v4());
+    let (status, json) = get_receipt_json(&app, &path).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(json["error"]["type"], "service_unavailable");
+}
+
+/// A settled paid request to a VENDOR-wallet marketplace service must record a
+/// receipt carrying the vendor settlement + fee receivable — written at
+/// SETTLEMENT time (the vendor was just paid on-chain), so it must exist even
+/// though the upstream fetch then fails on the unresolvable test endpoint.
+/// $0.02 listed price: the agent pays exactly 20_000 atomic (no 5% on top —
+/// vendor absorbs), receivable = 1_000 atomic.
+#[tokio::test]
+async fn vendor_paid_proxy_request_records_receipt_with_fee_receivable() {
+    use tracing::instrument::WithSubscriber;
+
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let recorded_recipient = Arc::new(std::sync::Mutex::new(None));
+    let (app, _state) = test_app_with_db_pool(
+        ProviderRegistry::from_env(reqwest::Client::new()),
+        Arc::new(VendorRecipientRecordingVerifier {
+            recorded_recipient: Arc::clone(&recorded_recipient),
+        }),
+        pool,
+    );
+    register_vendor_service(&app, "vendor-receipt-api").await;
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/vendor-receipt-api/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header_with(
+                        "/v1/services/vendor-receipt-api/proxy",
+                        USDC_MINT,
+                        TEST_VENDOR_WALLET_B58,
+                    ),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "payment must have been accepted"
+    );
+    let response_status = response.status();
+
+    // The spend row is the P1 baseline; the receipt rides the same write
+    // point. Asserting both makes a settlement-stage failure diagnosable.
+    let spend_events = spend_logged_events(&capture);
+    assert_eq!(
+        spend_events.len(),
+        1,
+        "vendor settlement must have recorded its spend entry \
+         (response status {response_status}): {spend_events:?}"
+    );
+
+    // Exactly one receipt allocated, synchronously observable through the
+    // real route (fire-and-forget write happens in the background).
+    let events = receipt_logged_events(&capture);
+    assert_eq!(
+        events.len(),
+        1,
+        "a settled vendor request must allocate exactly one receipt (got {})",
+        events.len()
+    );
+    assert_eq!(events[0]["vendor_wallet"], TEST_VENDOR_WALLET_B58);
+    assert_eq!(events[0]["amount_paid_atomic"].as_u64(), Some(20_000));
+
+    let receipt_id = events[0]["receipt_id"]
+        .as_str()
+        .expect("receipt logged event carries receipt_id");
+    let path = format!("/v1/receipts/{receipt_id}");
+    let receipt = poll_receipt_until_ok(&app, &path).await;
+
+    assert_eq!(receipt["model"], "vendor-receipt-api");
+    assert_eq!(receipt["payment_scheme"], "exact");
+    // Agent-facing amounts: pays exactly the listed price, zero fee (rule #5 —
+    // the breakdown stays truthful to what the AGENT pays; the 5% is the
+    // vendor's off-chain receivable below).
+    assert_eq!(receipt["amount_paid_atomic"], 20_000);
+    assert_eq!(receipt["cost_breakdown"]["provider_cost_atomic"], 20_000);
+    assert_eq!(receipt["cost_breakdown"]["platform_fee_atomic"], 0);
+    assert_eq!(receipt["cost_breakdown"]["total_atomic"], 20_000);
+    assert_eq!(receipt["amount_paid_usdc"], "0.020000");
+    // Vendor settlement evidence (the P1 fee-receivable trail).
+    assert_eq!(receipt["vendor"]["vendor_wallet"], TEST_VENDOR_WALLET_B58);
+    assert_eq!(receipt["vendor"]["settled_atomic"], 20_000);
+    assert_eq!(receipt["vendor"]["fee_receivable_atomic"], 1_000);
+    assert_eq!(receipt["vendor"]["settled_usdc"], "0.020000");
+    assert_eq!(receipt["vendor"]["fee_receivable_usdc"], "0.001000");
+}

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -11556,3 +11556,73 @@ async fn vendor_paid_proxy_request_records_receipt_with_fee_receivable() {
     assert_eq!(receipt["vendor"]["settled_usdc"], "0.020000");
     assert_eq!(receipt["vendor"]["fee_receivable_usdc"], "0.001000");
 }
+
+/// Raw INSERT into `receipts` with the given vendor-column triple (all other
+/// columns valid) — exercises the migration-013 constraints directly.
+async fn insert_receipt_row(
+    pool: &sqlx::PgPool,
+    vendor_wallet: Option<&str>,
+    vendor_settled: Option<i64>,
+    vendor_fee: Option<i64>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"INSERT INTO receipts (id, model, payment_scheme, payer_wallet, amount_paid_atomic, provider_cost_atomic, platform_fee_atomic, total_atomic, vendor_wallet, vendor_settled_atomic, vendor_fee_receivable_atomic)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"#,
+    )
+    .bind(uuid::Uuid::new_v4())
+    .bind("co-nullability-guard")
+    .bind("exact")
+    .bind("payer")
+    .bind(20_000i64)
+    .bind(20_000i64)
+    .bind(0i64)
+    .bind(20_000i64)
+    .bind(vendor_wallet)
+    .bind(vendor_settled)
+    .bind(vendor_fee)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+/// Migration-013 guard: the table-level `receipts_vendor_co_nullability`
+/// CHECK must reject every half-written vendor row at the DB layer — the
+/// three vendor columns travel together (all NULL or all non-NULL; a
+/// receivable without its wallet is uninvoiceable evidence). This eliminates
+/// the partial-vendor-row corruption class at the source; `fetch_receipt`'s
+/// read-time Corrupt check stays as defense in depth.
+#[tokio::test]
+async fn receipts_vendor_co_nullability_check_rejects_partial_vendor_insert() {
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+
+    // Every partial combination (one or two of the three set) must be rejected.
+    let partials: &[(Option<&str>, Option<i64>, Option<i64>)] = &[
+        (Some("vendorwallet"), None, None),
+        (None, Some(20_000), None),
+        (None, None, Some(1_000)),
+        (Some("vendorwallet"), Some(20_000), None),
+        (Some("vendorwallet"), None, Some(1_000)),
+        (None, Some(20_000), Some(1_000)),
+    ];
+    for (wallet, settled, fee) in partials {
+        let err = insert_receipt_row(&pool, *wallet, *settled, *fee)
+            .await
+            .expect_err("partial vendor row must be rejected by the co-nullability CHECK");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("receipts_vendor_co_nullability"),
+            "rejection for ({wallet:?}, {settled:?}, {fee:?}) must come from the \
+             co-nullability CHECK, got: {msg}"
+        );
+    }
+
+    // The two legal shapes still insert.
+    insert_receipt_row(&pool, None, None, None)
+        .await
+        .expect("all-NULL vendor columns (chat / plain-service receipt) must insert");
+    insert_receipt_row(&pool, Some("vendorwallet"), Some(20_000), Some(1_000))
+        .await
+        .expect("all-non-NULL vendor columns (vendor receipt) must insert");
+}

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -426,6 +426,20 @@ context_window = 1000000
 supports_streaming = true
 "#;
 
+/// Receipts-GET limiter for test apps: effectively unlimited so the
+/// receipt round-trip tests (which poll `GET /v1/receipts/{id}` up to 50
+/// times waiting on the fire-and-forget write, from the `oneshot` "unknown"
+/// bucket) are never tripped by the production per-IP cap. The strict cap
+/// itself is exercised by the dedicated `test_app_with_receipts_limit`
+/// fixture below.
+fn generous_receipts_limiter() -> RateLimiter {
+    RateLimiter::new(RateLimitConfig {
+        max_requests: 10_000,
+        window: std::time::Duration::from_secs(60),
+        unknown_max_requests: 10_000,
+    })
+}
+
 /// Build a test app with the test model config (no real provider API keys).
 ///
 /// Uses `AlwaysPassVerifier` so that properly-structured PaymentPayload headers
@@ -482,6 +496,7 @@ fn test_app_with_state() -> (axum::Router, Arc<AppState>) {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
@@ -535,6 +550,7 @@ fn test_app_with_usdc_mint_and_providers(mint: &str, providers: ProviderRegistry
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -776,6 +792,7 @@ fn test_app_with_provider_registry_and_exact_verifier(
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
@@ -858,6 +875,7 @@ fn app_with_semantic_cache(sem: Arc<gateway::cache::semantic::SemanticCache>) ->
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: true,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -1169,6 +1187,84 @@ fn app_with_semantic_cache_and_escrow(
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
+    });
+    build_router(state, RateLimiter::new(RateLimitConfig::default()))
+}
+
+/// [`app_with_semantic_cache_and_escrow`] composed with a real `db_pool` (the
+/// way [`test_app_with_db_pool`] composes the exact-verifier app): semantic
+/// cache + escrow scheme + Postgres-backed receipts and spend ledger, so the
+/// `UsagelessSemanticHit` spend-log arm's receipt emission is observable
+/// end-to-end through the real route (header → GET round-trip).
+fn app_with_semantic_cache_escrow_and_db_pool(
+    sem: Arc<gateway::cache::semantic::SemanticCache>,
+    pool: sqlx::PgPool,
+) -> axum::Router {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+
+    let facilitator = solvela_x402::facilitator::Facilitator::new(vec![
+        Arc::new(AlwaysPassVerifier),
+        Arc::new(AlwaysPassEscrowVerifier),
+    ]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+    config.solana.escrow_program_id =
+        Some("9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU".to_string());
+    config.cache.semantic.enabled = true;
+
+    let test_keypair = {
+        use ed25519_dalek::SigningKey;
+        let sk = SigningKey::from_bytes(&[1u8; 32]);
+        let mut kp = [0u8; 64];
+        kp[..32].copy_from_slice(&[1u8; 32]);
+        kp[32..].copy_from_slice(sk.verifying_key().as_bytes());
+        bs58::encode(&kp).into_string()
+    };
+    let test_fee_payer_pool = Arc::new(
+        solvela_x402::fee_payer::FeePayerPool::from_keys(&[test_keypair])
+            .expect("test pool must load"),
+    );
+    let escrow_claimer = solvela_x402::escrow::EscrowClaimer::new(
+        "https://api.devnet.solana.com".to_string(),
+        test_fee_payer_pool.clone(),
+        "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
+        "11111111111111111111111111111111",
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        None,
+    )
+    .expect("test claimer must be valid");
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: mock_provider_registry(),
+        facilitator,
+        usage: gateway::usage::UsageTracker::new(Some(pool.clone()), None),
+        cache: None,
+        semantic_cache: Some(sem),
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: Some(Arc::new(escrow_claimer)),
+        fee_payer_pool: Some(test_fee_payer_pool),
+        nonce_pool: None,
+        db_pool: Some(pool),
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -1829,6 +1925,7 @@ fn test_app_with_provider_registry_and_escrow_verifier(
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -1909,6 +2006,7 @@ fn test_app_with_escrow_and_usdc_mint(mint: &str) -> axum::Router {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -2376,6 +2474,7 @@ async fn test_chat_enforced_wallet_unprovisioned_tenant_returns_400_e2e() {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
@@ -4758,6 +4857,7 @@ fn test_app_with_nonce_pool() -> axum::Router {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     gateway::build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -6791,6 +6891,7 @@ fn test_app_with_escrow_metrics() -> axum::Router {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -6956,6 +7057,7 @@ async fn test_escrow_health_reflects_incremented_metrics() {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
 
@@ -7191,6 +7293,7 @@ async fn test_escrow_health_status_down_without_claimer() {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
 
@@ -7580,6 +7683,7 @@ async fn test_proxy_require_tenant_wallet_rejected_before_settlement() {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
@@ -9099,6 +9203,7 @@ async fn test_admin_stats_returns_404_when_admin_token_not_configured() {
         api_key_hmac_secret: None,
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
@@ -9713,6 +9818,7 @@ fn test_app_with_free_limit(free_max: u32) -> axum::Router {
         // Generous aggregate cap by default so the PER-IP tests above are not
         // accidentally tripped by the global cap; the aggregate-cap tests build
         // their own app via `test_app_with_global_cap`.
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -10074,6 +10180,7 @@ async fn dev_bypass_still_works() {
         }),
         // Aggregate cap also set to 0 — if the dev-bypass branch were ever
         // (incorrectly) routed through the free gates, this PAID model would 429.
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(0),
     });
     let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
@@ -10146,6 +10253,7 @@ fn test_app_with_global_cap(global_cap: u32) -> axum::Router {
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(free_cfg),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(global_cap),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -10272,6 +10380,7 @@ async fn free_per_ip_and_global_cap_are_independent() {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(free_cfg),
         // Global cap deliberately LOOSER than the per-IP limit.
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(100),
     });
     let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
@@ -11140,6 +11249,7 @@ fn test_app_with_db_pool(
         prometheus_handle: Some(test_prometheus_handle()),
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
@@ -11348,6 +11458,195 @@ async fn paid_streaming_chat_emits_receipt_header_and_records_estimate() {
     );
 }
 
+/// An ESCROW-paid request that hits the semantic cache on a USAGE-LESS entry
+/// (the `UsagelessSemanticHit` spend-log arm) must also emit a receipt — this
+/// arm previously had zero mutation coverage (deleting its
+/// `emit_chat_receipt` call failed nothing). The receipt must record the
+/// DISCOUNTED billed amount (the escrow claim takes only
+/// `hit_price_percent` of the full price; the remainder refunds to the
+/// agent), strictly less than the 402-quoted estimate, with the breakdown
+/// being the same C1 estimate the 402 quoted.
+///
+/// Self-skips when redis-stack (semantic cache) or Postgres is unavailable.
+/// Domain ("Saturn's rings") is distinct from every other semantic-cache test
+/// domain to avoid cosine collisions in the shared Redis HNSW index.
+#[tokio::test]
+async fn escrow_semantic_hit_usageless_receipt_records_discounted_amount() {
+    let Some(sem) = try_semantic_cache().await else {
+        return;
+    };
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+
+    // Usage-less cached entry (the cached response omits `usage`, so billing
+    // must fall back to the request estimate — the UsagelessSemanticHit arm).
+    let seeded = ChatResponse {
+        id: "seeded-saturn-receipt".to_string(),
+        object: "chat.completion".to_string(),
+        created: 0,
+        model: "openai/gpt-4o".to_string(),
+        choices: vec![ChatChoice {
+            index: 0,
+            message: ChatMessage {
+                role: Role::Assistant,
+                content: "Saturn's rings are mostly water ice with traces of rocky debris.".into(),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            finish_reason: Some("stop".to_string()),
+        }],
+        usage: None,
+    };
+    let seed_req = ChatRequest {
+        model: "openai/gpt-4o".to_string(),
+        messages: vec![ChatMessage {
+            role: Role::User,
+            content: "What are the rings of Saturn made of?".into(),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }],
+        max_tokens: None,
+        temperature: None,
+        top_p: None,
+        stream: false,
+        tools: None,
+        tool_choice: None,
+    };
+    sem.store(&seed_req, &seeded).await.expect("seed store");
+
+    // Paraphrase body used for BOTH the 402 quote and the paid request, so the
+    // quoted estimate is exactly the figure the usage-less hit bills against.
+    let body = r#"{"model":"openai/gpt-4o","messages":[{"role":"user","content":"What is the composition of Saturn's rings?"}]}"#;
+
+    // Quote the 402 for this body: the exact-scheme `amount` is the atomic
+    // estimate E; `cost_breakdown` is the C1 estimate the receipt must mirror.
+    let quote_resp = test_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(quote_resp.status(), StatusCode::PAYMENT_REQUIRED);
+    let quote_bytes = quote_resp.into_body().collect().await.unwrap().to_bytes();
+    let quote: serde_json::Value = serde_json::from_slice(&quote_bytes).unwrap();
+    let quoted_atomic: u64 = quote["accepts"]
+        .as_array()
+        .and_then(|a| a.iter().find(|s| s["scheme"] == "exact"))
+        .and_then(|s| s["amount"].as_str())
+        .expect("402 quotes an exact amount")
+        .parse()
+        .expect("quoted amount parses as u64");
+    let quoted_total = quote["cost_breakdown"]["total"]
+        .as_str()
+        .expect("402 carries cost_breakdown.total")
+        .to_string();
+
+    // Expected DISCOUNTED bill: the production hit path derives the full price
+    // via `estimated_atomic_cost` (f64 parse of the breakdown total × 1e6,
+    // truncating cast) and then takes `hit_price_percent` of it
+    // (`apply_hit_price`: floor(full × pct / 100)). Replicate that derivation
+    // from the SAME quoted total string so the pin is exact, not fuzzy.
+    let pct = AppConfig::default().cache.semantic.hit_price_percent;
+    let full_atomic =
+        (quoted_total.parse::<f64>().expect("total parses as f64") * 1_000_000.0) as u64;
+    let expected_billed = ((full_atomic as u128) * (pct as u128) / 100) as u64;
+    assert!(
+        expected_billed > 0 && expected_billed < quoted_atomic,
+        "test premise: the discounted bill ({expected_billed}) must be a positive amount \
+         strictly below the quoted estimate ({quoted_atomic})"
+    );
+
+    let app = app_with_semantic_cache_escrow_and_db_pool(Arc::clone(&sem), pool);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("x-solvela-debug", "true")
+                .header(
+                    "PAYMENT-SIGNATURE",
+                    valid_escrow_payment_header("/v1/chat/completions"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "escrow-paid usage-less semantic hit must serve 200"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-solvela-cache")
+            .and_then(|v| v.to_str().ok()),
+        Some("semantic-hit"),
+        "request must be served from the semantic cache (the UsagelessSemanticHit arm)"
+    );
+    // The receipt header is the mutation-coverage pin: deleting the
+    // `emit_chat_receipt` call in the UsagelessSemanticHit arm makes this
+    // panic (header absent).
+    let path = receipt_header_path(&resp);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["id"], "seeded-saturn-receipt");
+
+    let receipt = poll_receipt_until_ok(&app, &path).await;
+    assert_eq!(receipt["model"], "openai/gpt-4o");
+    assert_eq!(receipt["payment_scheme"], "escrow");
+    assert!(receipt["tx_signature"].is_string());
+
+    // The DISCOUNTED billed amount — identical to the spend ledger and the
+    // escrow claim; strictly below the 402-quoted estimate.
+    assert_eq!(
+        receipt["amount_paid_atomic"].as_u64(),
+        Some(expected_billed),
+        "receipt must record the discounted escrow bill ({pct}% of the full price)"
+    );
+    assert!(
+        receipt["amount_paid_atomic"].as_u64().unwrap() < quoted_atomic,
+        "discounted bill must be strictly less than the 402-quoted estimate"
+    );
+
+    // Breakdown consistency: the receipt's breakdown is the same C1 estimate
+    // the 402 quoted (string-identical decimals, atomic = checked conversion
+    // of the same strings; total equals the quoted atomic estimate).
+    assert_eq!(
+        receipt["cost_breakdown"]["total_atomic"].as_u64(),
+        Some(quoted_atomic)
+    );
+    assert_eq!(
+        receipt["cost_breakdown"]["total_usdc"],
+        quoted_total.as_str()
+    );
+    assert_eq!(
+        receipt["cost_breakdown"]["provider_cost_usdc"],
+        quote["cost_breakdown"]["provider_cost"]
+    );
+    assert_eq!(
+        receipt["cost_breakdown"]["platform_fee_usdc"],
+        quote["cost_breakdown"]["platform_fee"]
+    );
+    assert_eq!(receipt["cost_breakdown"]["currency"], "USDC");
+    assert!(
+        receipt.get("vendor").is_none(),
+        "chat receipts must not carry vendor fields"
+    );
+}
+
 /// Free-tier ($0) requests produce no payment and therefore no receipt — the
 /// header must be ABSENT even with receipt storage configured.
 #[tokio::test]
@@ -11452,6 +11751,142 @@ async fn get_receipt_without_database_returns_503() {
     assert_eq!(json["error"]["type"], "service_unavailable");
 }
 
+/// DB-less app whose RECEIPTS limiter allows `max` GETs per (named-IP) window.
+/// The outer paid limiter stays at its generous default so the two limiters
+/// can be shown not to cross-contaminate (mirrors `test_app_with_free_limit`).
+fn test_app_with_receipts_limit(max: u32) -> axum::Router {
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML).unwrap();
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+
+    // Strict receipts config: `max` for NAMED ip buckets, and the same for the
+    // "unknown" bucket so a no-ConnectInfo request is deterministic.
+    let receipts_cfg = RateLimitConfig {
+        max_requests: max,
+        window: std::time::Duration::from_secs(60),
+        unknown_max_requests: max,
+    };
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers: mock_provider_registry(),
+        facilitator,
+        usage: gateway::usage::UsageTracker::noop(),
+        cache: None,
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: None,
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
+        receipts_rate_limiter: RateLimiter::new(receipts_cfg),
+    });
+    build_router(state, RateLimiter::new(RateLimitConfig::default()))
+}
+
+/// Build a receipts GET with a fixed `ConnectInfo` peer IP so the receipts
+/// limiter keys on a NAMED bucket (not the shared "unknown" one).
+fn receipts_get_request(path: &str, ip: &str) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("GET")
+        .uri(path)
+        .body(Body::empty())
+        .unwrap();
+    let addr: std::net::SocketAddr = format!("{ip}:40000").parse().unwrap();
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo(addr));
+    req
+}
+
+/// The public receipts GET is rate-limited per client IP, STRICTER than the
+/// generic outer limiter, and the cap is consumed BEFORE any storage lookup
+/// (this app is DB-less, so under-cap requests 503 — the cap still trips).
+/// The 429 is the canonical envelope: `rate_limit_exceeded` + the standard
+/// `x-ratelimit-*` / `retry-after` headers carrying the RECEIPTS limit.
+#[tokio::test]
+async fn receipts_get_rate_limited_per_ip_with_canonical_429() {
+    let app = test_app_with_receipts_limit(2);
+    let ip = "203.0.113.77";
+    let path = format!("/v1/receipts/{}", uuid::Uuid::new_v4());
+
+    // First 2 GETs from this IP pass the limiter (DB-less → honest 503).
+    for i in 0..2 {
+        let resp = app
+            .clone()
+            .oneshot(receipts_get_request(&path, ip))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GET {i} must pass the receipts limiter (and 503 on this DB-less app)"
+        );
+    }
+
+    // The 3rd exceeds the receipts cap → 429 with the canonical envelope.
+    let resp = app
+        .clone()
+        .oneshot(receipts_get_request(&path, ip))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "exceeding the per-IP receipts cap must 429"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-ratelimit-limit")
+            .expect("429 must carry x-ratelimit-limit"),
+        "2",
+        "429 must carry the RECEIPTS limit (2), not the outer global limit (60)"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-ratelimit-remaining")
+            .expect("429 must carry x-ratelimit-remaining"),
+        "0"
+    );
+    assert!(
+        resp.headers().get("retry-after").is_some(),
+        "429 must carry retry-after"
+    );
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["error"]["type"], "rate_limit_exceeded");
+
+    // A different IP gets its own bucket — still under cap.
+    let resp = app
+        .clone()
+        .oneshot(receipts_get_request(&path, "203.0.113.78"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "an unrelated IP must not be affected by another IP's exhausted bucket"
+    );
+}
+
 /// A settled paid request to a VENDOR-wallet marketplace service must record a
 /// receipt carrying the vendor settlement + fee receivable — written at
 /// SETTLEMENT time (the vendor was just paid on-chain), so it must exist even
@@ -11471,7 +11906,7 @@ async fn vendor_paid_proxy_request_records_receipt_with_fee_receivable() {
         Arc::new(VendorRecipientRecordingVerifier {
             recorded_recipient: Arc::clone(&recorded_recipient),
         }),
-        pool,
+        pool.clone(),
     );
     register_vendor_service(&app, "vendor-receipt-api").await;
 
@@ -11532,10 +11967,36 @@ async fn vendor_paid_proxy_request_records_receipt_with_fee_receivable() {
     );
     assert_eq!(events[0]["vendor_wallet"], TEST_VENDOR_WALLET_B58);
     assert_eq!(events[0]["amount_paid_atomic"].as_u64(), Some(20_000));
+    // De-correlation guard (round-2 security review): the happy-path event
+    // must NOT carry the receipt_id — wallet + capability-URL together would
+    // make server logs a lookup table (the id is a bearer capability). Logs
+    // keep the money fields; the id reaches the client only via the response
+    // header (not emitted on THIS response — the test endpoint fails the
+    // pre-upstream SSRF/DNS check, whose error arm carries no headers), so
+    // the test recovers the id from the receipts table it owns.
+    assert!(
+        events[0].get("receipt_id").is_none(),
+        "happy-path 'receipt logged' event must not carry receipt_id: {:?}",
+        events[0]
+    );
 
-    let receipt_id = events[0]["receipt_id"]
-        .as_str()
-        .expect("receipt logged event carries receipt_id");
+    // Recover the settlement-time receipt id from storage (the model column
+    // is unique to this test) — polling because the write is fire-and-forget.
+    let mut receipt_id: Option<uuid::Uuid> = None;
+    for _ in 0..50 {
+        if let Some(row) = sqlx::query("SELECT id FROM receipts WHERE model = $1")
+            .bind("vendor-receipt-api")
+            .fetch_optional(&pool)
+            .await
+            .expect("query receipts table")
+        {
+            use sqlx::Row;
+            receipt_id = Some(row.get("id"));
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let receipt_id = receipt_id.expect("settlement-time vendor receipt row never landed");
     let path = format!("/v1/receipts/{receipt_id}");
     let receipt = poll_receipt_until_ok(&app, &path).await;
 

--- a/crates/gateway/tests/migrations.rs
+++ b/crates/gateway/tests/migrations.rs
@@ -27,18 +27,22 @@ const EXPECTED_TABLES: &[&str] = &[
     "audit_logs",
     "team_budgets",
     "tenant_budgets", // migration 011
+    "receipts",       // migration 013
 ];
 
 /// Columns whose presence proves the right ALTER TABLE migrations ran.
 const EXPECTED_COLUMNS: &[(&str, &str)] = &[
-    ("spend_logs", "request_id"),            // migration 003
-    ("spend_logs", "session_id"),            // migration 003
-    ("spend_logs", "tenant"),                // migration 010
-    ("escrow_claim_queue", "next_retry_at"), // migration 004
-    ("wallet_budgets", "updated_at"),        // migration 001
-    ("wallet_budgets", "hourly_limit_usdc"), // migration 007
-    ("wallet_budgets", "require_tenant"),    // migration 011
-    ("tenant_budgets", "hourly_limit_usdc"), // migration 011
+    ("spend_logs", "request_id"),                 // migration 003
+    ("spend_logs", "session_id"),                 // migration 003
+    ("spend_logs", "tenant"),                     // migration 010
+    ("escrow_claim_queue", "next_retry_at"),      // migration 004
+    ("wallet_budgets", "updated_at"),             // migration 001
+    ("wallet_budgets", "hourly_limit_usdc"),      // migration 007
+    ("wallet_budgets", "require_tenant"),         // migration 011
+    ("tenant_budgets", "hourly_limit_usdc"),      // migration 011
+    ("spend_logs", "vendor_wallet"),              // migration 012
+    ("receipts", "amount_paid_atomic"),           // migration 013
+    ("receipts", "vendor_fee_receivable_atomic"), // migration 013
 ];
 
 #[tokio::test]

--- a/crates/gateway/tests/openapi_contract.rs
+++ b/crates/gateway/tests/openapi_contract.rs
@@ -529,3 +529,86 @@ async fn unknown_model_404_conforms_to_error_schema() {
         "spec documents `model_not_found` for an unknown model: {body}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// GET /v1/receipts/{receipt_id} — settlement-platform P2 contract checks
+// ---------------------------------------------------------------------------
+
+/// With no database configured the receipts route returns an honest 503 whose
+/// body conforms to the standard `Error` envelope with `error.type` =
+/// `service_unavailable` (the spec's documented DB-less behavior).
+#[tokio::test]
+async fn receipts_dbless_503_conforms_to_error_schema() {
+    let response = quote_app()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/receipts/{}", uuid::Uuid::new_v4()))
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("oneshot");
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = response_json(response).await;
+    assert_conforms(
+        &component_validator("Error"),
+        &body,
+        "GET /v1/receipts/{id} 503 DB-less body",
+    );
+    assert_eq!(
+        body["error"]["type"], "service_unavailable",
+        "spec documents `service_unavailable` for a DB-less receipts route: {body}"
+    );
+}
+
+/// The `gateway::receipts::Receipt` wire type is exactly what the GET route
+/// serializes; validating constructed samples (vendor and plain) against the
+/// spec's `Receipt` schema pins the wire shape without a live database.
+#[test]
+fn receipt_wire_type_conforms_to_receipt_schema() {
+    let validator = component_validator("Receipt");
+
+    let plain = gateway::receipts::Receipt {
+        receipt_id: uuid::Uuid::new_v4(),
+        created_at: chrono::Utc::now(),
+        model: "openai/gpt-4o".to_string(),
+        payment_scheme: "exact".to_string(),
+        tx_signature: Some("base64-signed-tx".to_string()),
+        payer_wallet: "AgentWallet11111111111111111111111111111111".to_string(),
+        amount_paid_atomic: 2625,
+        amount_paid_usdc: "0.002625".to_string(),
+        cost_breakdown: gateway::receipts::ReceiptCostBreakdown {
+            provider_cost_atomic: 2500,
+            provider_cost_usdc: "0.002500".to_string(),
+            platform_fee_atomic: 125,
+            platform_fee_usdc: "0.000125".to_string(),
+            total_atomic: 2625,
+            total_usdc: "0.002625".to_string(),
+            currency: "USDC".to_string(),
+        },
+        vendor: None,
+    };
+    assert_conforms(
+        &validator,
+        &serde_json::to_value(&plain).expect("serialize plain receipt"),
+        "plain (no-vendor) Receipt wire shape",
+    );
+
+    let vendor = gateway::receipts::Receipt {
+        vendor: Some(gateway::receipts::ReceiptVendor {
+            vendor_wallet: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string(),
+            settled_atomic: 20_000,
+            settled_usdc: "0.020000".to_string(),
+            fee_receivable_atomic: 1_000,
+            fee_receivable_usdc: "0.001000".to_string(),
+        }),
+        tx_signature: None,
+        ..plain
+    };
+    assert_conforms(
+        &validator,
+        &serde_json::to_value(&vendor).expect("serialize vendor receipt"),
+        "vendor-settled Receipt wire shape",
+    );
+}

--- a/crates/gateway/tests/openapi_contract.rs
+++ b/crates/gateway/tests/openapi_contract.rs
@@ -237,6 +237,15 @@ impl LLMProvider for MockProvider {
 
 /// Build the full router with a caller-supplied provider registry.
 fn contract_app(providers: ProviderRegistry) -> axum::Router {
+    contract_app_with_db(providers, None)
+}
+
+/// [`contract_app`] with a caller-supplied `db_pool`, for routes whose
+/// contract depends on storage being configured (the receipts 404).
+fn contract_app_with_db(
+    providers: ProviderRegistry,
+    db_pool: Option<sqlx::PgPool>,
+) -> axum::Router {
     let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).expect("test models toml");
     let facilitator =
         solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
@@ -257,7 +266,7 @@ fn contract_app(providers: ProviderRegistry) -> axum::Router {
         escrow_claimer: None,
         fee_payer_pool: None,
         nonce_pool: None,
-        db_pool: None,
+        db_pool,
         session_secret: b"test-secret".to_vec(),
         http_client: reqwest::Client::new(),
         replay_set: AppState::new_replay_set(),
@@ -268,6 +277,7 @@ fn contract_app(providers: ProviderRegistry) -> axum::Router {
         prometheus_handle: None,
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: RateLimiter::new(RateLimitConfig::receipts_default()),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -559,6 +569,48 @@ async fn receipts_dbless_503_conforms_to_error_schema() {
     assert_eq!(
         body["error"]["type"], "service_unavailable",
         "spec documents `service_unavailable` for a DB-less receipts route: {body}"
+    );
+}
+
+/// A malformed receipt id on a storage-configured gateway → HTTP 404 with the
+/// standard error envelope (`error.type` = `not_found`), conforming to the
+/// spec's `Error` schema (mirrors `unknown_model_404_conforms_to_error_schema`).
+///
+/// The spec documents one indistinguishable 404 for unknown AND malformed
+/// ids; the malformed-id arm rejects before any query is issued, so a LAZY
+/// pool (never connected — the URL points at a closed port) is enough to put
+/// the route into its storage-configured mode without a live Postgres. This
+/// keeps the contract check deterministic in every CI environment.
+#[tokio::test]
+async fn receipts_404_conforms_to_error_schema() {
+    let lazy_pool = sqlx::postgres::PgPoolOptions::new()
+        .connect_lazy("postgres://contract:contract@127.0.0.1:1/never_connected")
+        .expect("lazy pool construction does not connect");
+    let app = contract_app_with_db(
+        ProviderRegistry::from_env(reqwest::Client::new()),
+        Some(lazy_pool),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/receipts/not-a-uuid")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("oneshot");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = response_json(response).await;
+    assert_conforms(
+        &component_validator("Error"),
+        &body,
+        "GET /v1/receipts/{id} 404 body",
+    );
+    assert_eq!(
+        body["error"]["type"], "not_found",
+        "spec documents `not_found` for an unknown/malformed receipt id: {body}"
     );
 }
 

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -88,6 +88,9 @@ fn router_with_pool(pool: PgPool) -> Router {
         free_rate_limiter: gateway::middleware::rate_limit::RateLimiter::new(
             gateway::middleware::rate_limit::RateLimitConfig::free_default(),
         ),
+        receipts_rate_limiter: gateway::middleware::rate_limit::RateLimiter::new(
+            gateway::middleware::rate_limit::RateLimitConfig::receipts_default(),
+        ),
         free_global_cap: gateway::middleware::rate_limit::FreeTierGlobalCap::new(
             gateway::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
         ),

--- a/crates/gateway/tests/stats_http_redis.rs
+++ b/crates/gateway/tests/stats_http_redis.rs
@@ -98,6 +98,7 @@ fn stats_router(usage: UsageTracker, db_pool: Option<PgPool>) -> axum::Router {
         prometheus_handle: None,
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: RateLimiter::new(RateLimitConfig::receipts_default()),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -146,6 +146,16 @@
               }
             }
           },
+          "429": {
+            "description": "Rate limited (`error.type`: `rate_limit_exceeded`). This public route carries a stricter per-client-IP cap than the generic limiter (default 20/min) to bound receipt-id scanning. Honor `retry-after` before retrying.",
+            "headers": {
+              "retry-after": { "description": "Seconds until the rate-limit window resets.", "schema": { "type": "integer" } },
+              "x-ratelimit-limit": { "description": "Requests allowed per window.", "schema": { "type": "integer" } },
+              "x-ratelimit-remaining": { "description": "Requests remaining in the current window (always 0 on a 429).", "schema": { "type": "integer" } },
+              "x-ratelimit-reset": { "description": "Seconds until the window resets.", "schema": { "type": "integer" } }
+            },
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+          },
           "503": {
             "description": "Receipt storage is not configured on this gateway (`error.type` = `service_unavailable`) — receipts cannot exist here at all, so no per-id 404 is implied.",
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -371,7 +371,7 @@
       },
       "Receipt": {
         "type": "object",
-        "description": "Client-facing payment receipt for a paid request. Atomic-USDC integers (6 decimals) are canonical; the `*_usdc` decimal strings are derived from them. `amount_paid_atomic` is what the payer was actually billed and equals `cost_breakdown.total_atomic` except when an escrow semantic-cache discount realised on-chain.",
+        "description": "Client-facing payment receipt for a paid request. Atomic-USDC integers (6 decimals) are canonical; the `*_usdc` decimal strings are derived from them. `amount_paid_atomic` is what the payer was actually billed and equals `cost_breakdown.total_atomic` except when an escrow semantic-cache discount realised on-chain. It is the billed amount from the gateway ledger's perspective — identical to the spend ledger — and can differ from the raw on-chain transfer amount when an agent overpays the 402 quote.",
         "required": ["receipt_id", "created_at", "model", "payment_scheme", "payer_wallet", "amount_paid_atomic", "amount_paid_usdc", "cost_breakdown"],
         "properties": {
           "receipt_id": { "type": "string", "format": "uuid" },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -33,6 +33,12 @@
         "responses": {
           "200": {
             "description": "Chat completion (or an SSE stream when `stream` is true).",
+            "headers": {
+              "X-Solvela-Receipt": {
+                "description": "Path of the retrievable payment receipt (`/v1/receipts/{receipt_id}`) for this PAID completion. Present only when the request settled a payment AND the gateway has receipt storage configured; absent on free-tier ($0) responses and on gateways without a database. For SSE streams the header is decided before the body starts. The UUIDv4 id is a bearer capability — anyone holding it can read the receipt.",
+                "schema": { "type": "string" }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ChatCompletionResponse" }
@@ -102,6 +108,49 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ModelList" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/receipts/{receipt_id}": {
+      "get": {
+        "operationId": "getReceipt",
+        "summary": "Fetch a payment receipt by id",
+        "description": "Returns the client-facing receipt for a paid request: payer wallet, payment scheme, transaction reference, and the amounts actually charged (atomic USDC integers are canonical; decimal strings are derived). The unguessable UUIDv4 receipt id — issued in the `X-Solvela-Receipt` response header on paid responses — is the only credential: treat it as a bearer capability. Unknown and malformed ids both return the same 404, and there is no listing endpoint. Free ($0) requests produce no payment and therefore no receipt.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "receipt_id",
+            "in": "path",
+            "required": true,
+            "description": "UUIDv4 receipt id from the `X-Solvela-Receipt` header.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The receipt.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Receipt" }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown or malformed receipt id (`error.type` = `not_found`). The two cases are deliberately indistinguishable.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "503": {
+            "description": "Receipt storage is not configured on this gateway (`error.type` = `service_unavailable`) — receipts cannot exist here at all, so no per-id 404 is implied.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
               }
             }
           }
@@ -320,6 +369,49 @@
           }
         }
       },
+      "Receipt": {
+        "type": "object",
+        "description": "Client-facing payment receipt for a paid request. Atomic-USDC integers (6 decimals) are canonical; the `*_usdc` decimal strings are derived from them. `amount_paid_atomic` is what the payer was actually billed and equals `cost_breakdown.total_atomic` except when an escrow semantic-cache discount realised on-chain.",
+        "required": ["receipt_id", "created_at", "model", "payment_scheme", "payer_wallet", "amount_paid_atomic", "amount_paid_usdc", "cost_breakdown"],
+        "properties": {
+          "receipt_id": { "type": "string", "format": "uuid" },
+          "created_at": { "type": "string", "format": "date-time", "description": "When the receipt was recorded (request completion time, UTC)." },
+          "model": { "type": "string", "description": "Model ID (chat path) or marketplace service ID (services proxy path).", "example": "openai/gpt-4o" },
+          "payment_scheme": { "type": "string", "description": "x402 scheme that settled the payment.", "example": "exact" },
+          "tx_signature": { "type": "string", "description": "Payment transaction reference as recorded on the spend ledger (the signed transaction carried in the payment payload). Absent when no reference was extractable." },
+          "payer_wallet": { "type": "string", "description": "Payer wallet (base58 pubkey) extracted from the signed payment." },
+          "amount_paid_atomic": { "type": "integer", "minimum": 0, "description": "Amount actually billed, atomic USDC. Canonical." },
+          "amount_paid_usdc": { "type": "string", "example": "0.002625" },
+          "cost_breakdown": { "$ref": "#/components/schemas/ReceiptCostBreakdown" },
+          "vendor": { "$ref": "#/components/schemas/ReceiptVendorSettlement" }
+        }
+      },
+      "ReceiptCostBreakdown": {
+        "type": "object",
+        "description": "Agent-facing cost breakdown that produced the bill: provider cost + platform fee = total. On vendor-settled services the agent fee is 0 (the vendor absorbs the 5% — see `vendor`).",
+        "required": ["provider_cost_atomic", "provider_cost_usdc", "platform_fee_atomic", "platform_fee_usdc", "total_atomic", "total_usdc", "currency"],
+        "properties": {
+          "provider_cost_atomic": { "type": "integer", "minimum": 0 },
+          "provider_cost_usdc": { "type": "string", "example": "0.002500" },
+          "platform_fee_atomic": { "type": "integer", "minimum": 0 },
+          "platform_fee_usdc": { "type": "string", "example": "0.000125" },
+          "total_atomic": { "type": "integer", "minimum": 0 },
+          "total_usdc": { "type": "string", "example": "0.002625" },
+          "currency": { "type": "string", "example": "USDC" }
+        }
+      },
+      "ReceiptVendorSettlement": {
+        "type": "object",
+        "description": "Vendor-settlement evidence, present only when the request hit a marketplace service with a per-service `vendor_wallet`: the agent's transfer settled `settled_atomic` directly to the vendor on-chain, and Solvela's 5% platform fee is recorded as an off-chain receivable against the vendor (never charged to the agent).",
+        "required": ["vendor_wallet", "settled_atomic", "settled_usdc", "fee_receivable_atomic", "fee_receivable_usdc"],
+        "properties": {
+          "vendor_wallet": { "type": "string", "description": "Vendor wallet (base58 pubkey) the payment settled to." },
+          "settled_atomic": { "type": "integer", "minimum": 0 },
+          "settled_usdc": { "type": "string", "example": "0.020000" },
+          "fee_receivable_atomic": { "type": "integer", "minimum": 0 },
+          "fee_receivable_usdc": { "type": "string", "example": "0.001000" }
+        }
+      },
       "Error": {
         "type": "object",
         "required": ["error"],
@@ -330,7 +422,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "description": "Machine-readable error kind. Known values: `bad_request`, `model_not_found`, `payment_required`, `invalid_payment`, `settlement_failed`, `forbidden`, `unsupported_media_type`, `rate_limited`, `rate_limit_exceeded`, `provider_error`, `upstream_unavailable`, `internal_error`. New values may be added; treat unknown values as retriable-or-not by HTTP status.",
+                "description": "Machine-readable error kind. Known values: `bad_request`, `model_not_found`, `not_found`, `payment_required`, `invalid_payment`, `settlement_failed`, `forbidden`, `unsupported_media_type`, `rate_limited`, `rate_limit_exceeded`, `provider_error`, `upstream_unavailable`, `service_unavailable`, `internal_error`. New values may be added; treat unknown values as retriable-or-not by HTTP status.",
                 "example": "invalid_payment"
               },
               "message": { "type": "string" }

--- a/migrations/013_receipts.sql
+++ b/migrations/013_receipts.sql
@@ -1,0 +1,49 @@
+-- Settlement-platform P2: client-facing payment receipts.
+--
+-- One row per PAID, delivered + settled request — written fire-and-forget
+-- (tokio::spawn, never awaited on the hot path) at the same points where
+-- spend logging fires: the chat path (streaming AND non-streaming — the #541
+-- bug class) and the services proxy (vendor services at settlement time,
+-- plain services post-upstream). Free-tier ($0) requests produce no payment
+-- and no receipt.
+--
+-- The row id is the capability: an unguessable UUIDv4 returned to the payer
+-- in the `x-solvela-receipt` response header and fetched via
+-- GET /v1/receipts/{receipt_id}. There is deliberately no listing endpoint,
+-- so the primary-key index is the only lookup path needed.
+--
+-- All amounts are atomic USDC (6 decimals, integer math — solvela-fintech);
+-- the decimal strings in the wire shape are derived at read time.
+
+CREATE TABLE IF NOT EXISTS receipts (
+    id UUID PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Model id (chat path) or marketplace service id (proxy path) — same
+    -- convention as spend_logs.model.
+    model TEXT NOT NULL,
+    -- x402 scheme that settled the payment ('exact' / 'escrow'). TEXT with a
+    -- length cap rather than an enum CHECK so a future scheme stays
+    -- recordable without a migration.
+    payment_scheme TEXT NOT NULL CHECK (char_length(payment_scheme) <= 16),
+    -- Payment transaction reference as recorded on the spend ledger (the
+    -- signed transaction carried in the payment payload).
+    tx_signature TEXT,
+    payer_wallet TEXT NOT NULL,
+    -- What the agent was actually billed (mirrors the spend ledger; equals
+    -- total_atomic except when an escrow semantic-cache discount realised).
+    amount_paid_atomic BIGINT NOT NULL CHECK (amount_paid_atomic >= 0),
+    -- The cost breakdown that produced the bill (rule #5: provider cost +
+    -- platform fee = total, truthful to what the agent pays).
+    provider_cost_atomic BIGINT NOT NULL CHECK (provider_cost_atomic >= 0),
+    platform_fee_atomic BIGINT NOT NULL CHECK (platform_fee_atomic >= 0),
+    total_atomic BIGINT NOT NULL CHECK (total_atomic >= 0),
+    -- Vendor-settled marketplace requests only (settlement-platform P1): the
+    -- on-chain settlement leg plus Solvela's off-chain 5% fee receivable.
+    -- All three are NULL on the chat path and for plain (gateway-recipient)
+    -- services. Base58 32-byte Solana pubkeys are at most 44 characters.
+    vendor_wallet TEXT CHECK (char_length(vendor_wallet) <= 44),
+    vendor_settled_atomic BIGINT
+        CHECK (vendor_settled_atomic IS NULL OR vendor_settled_atomic >= 0),
+    vendor_fee_receivable_atomic BIGINT
+        CHECK (vendor_fee_receivable_atomic IS NULL OR vendor_fee_receivable_atomic >= 0)
+);

--- a/migrations/013_receipts.sql
+++ b/migrations/013_receipts.sql
@@ -45,5 +45,14 @@ CREATE TABLE IF NOT EXISTS receipts (
     vendor_settled_atomic BIGINT
         CHECK (vendor_settled_atomic IS NULL OR vendor_settled_atomic >= 0),
     vendor_fee_receivable_atomic BIGINT
-        CHECK (vendor_fee_receivable_atomic IS NULL OR vendor_fee_receivable_atomic >= 0)
+        CHECK (vendor_fee_receivable_atomic IS NULL OR vendor_fee_receivable_atomic >= 0),
+    -- The three vendor columns travel together: all NULL (chat path, plain
+    -- services) or all non-NULL (vendor-settled services). A half-written
+    -- vendor row (e.g. a receivable without its wallet) is uninvoiceable
+    -- corruption — reject it at the DB layer. fetch_receipt's read-time
+    -- Corrupt check stays as defense in depth.
+    CONSTRAINT receipts_vendor_co_nullability CHECK (
+        (vendor_wallet IS NULL) = (vendor_settled_atomic IS NULL)
+        AND (vendor_wallet IS NULL) = (vendor_fee_receivable_atomic IS NULL)
+    )
 );


### PR DESCRIPTION
## Summary

P2 of the settlement-platform track: every paid request now produces client-facing audit evidence — a retrievable receipt.

- **`receipts` table** (migration 013): UUID PK, atomic-integer amounts with `>= 0` CHECKs, `payment_scheme` length cap, and a vendor co-nullability CHECK (the three vendor columns are all-NULL or all-non-NULL — half-written vendor rows are unrepresentable at the DB layer).
- **Receipt writes in lock-step with the spend ledger** (fire-and-forget, never on the hot path): all three chat settling arms — `ActualUsage`, `UsagelessSemanticHit`, and the streaming `EstimateFallback` (#541's write point, mutation-tested) — plus the proxy path (vendor receipts at settlement time carrying the #555 fee-receivable fields; plain services at the legacy post-upstream point). No spend row → no receipt, by design; every skip path is observable (`solvela_receipt_skipped_total` by reason).
- **`X-Solvela-Receipt` response header** with `/v1/receipts/{uuid}` — emitted only when the receipt is actually retrievable. No header on free-tier ($0, no payment), DB-less gateways (rule 12), or uncollected-payment (`SkipSettleFailed`) responses. For SSE the id is allocated and the header set before the body streams; the row is written when settled amounts are known.
- **`GET /v1/receipts/{receipt_id}`**: public, capability-by-unguessable-UUIDv4. Unknown and malformed ids return byte-identical 404s (no existence oracle); DB-less → 503; corrupt row → generic 500 with structured server-side logging + read-failure counters. **Rate-capped at 20/min per IP** (5/min for the unknown bucket) via the existing free-tier limiter pattern, checked before any DB work, canonical 429 envelope.
- **Amount truthfulness**: receipts record the billed amount exactly as the spend ledger does (canonical atomic integers; USDC strings derived by pure integer formatting). The escrow semantic-cache discount is reflected (billed < quoted, pinned by test); the documented divergence from the raw on-chain transfer on agent overpayment is doc-commented and in the OpenAPI description. Vendor receipts attest `settled`, `fee_receivable` (= floor(settled×5%), the vendor-absorbs invoice trail), and agent fee 0.
- Wire types are gateway-local (not `solvela-protocol`) to avoid an SDK-visible version bump; revisit before any SDK ships receipt support.
- `docs/openapi.json` updated (new endpoint with 200/404/429/503, response header, three schemas); the #539 contract guard passes with new conformance tests incl. the live 404.
- Server logs no longer correlate `receipt_id` with `payer_wallet` (capability URLs can't be harvested from log access); receipt_id appears only in failure-reconciliation events.

## Review

Two-round money-path process. Round 1 (rust-reviewer + silent-failure-hunter): two Criticals fixed (silent header-drop path, unobservable corrupt-read branch) plus the co-nullability CHECK and `receipt_record` self-consistency (commit 00607a3). Round 2 independent (security + test-coverage + type-design): the unthrottled public GET (High) fixed with the per-route cap; log de-correlation; the zero-coverage `UsagelessSemanticHit` arm now mutation-tested (commit 7f14cc8).

One finding rejected deliberately: removing `fee_receivable` from the public receipt — it equals floor(settled × 5%) with the fee percentage publicly documented, so it discloses nothing non-derivable, and attesting the receivable is the receipt's purpose as invoice evidence.

## Tests

~25 new tests: real-route round-trips for non-streaming/streaming/semantic-hit/vendor receipts (exact atomics pinned), header negative-space (free-tier, DB-less), identical-404, 503, per-IP 429, co-nullability (all six partial combinations), OpenAPI conformance (wire shape, 404, 503), fee-floor and overflow guards. `cargo test -p gateway`: 1,136 passed / 0 failed (incl. sqlx suites against live Postgres); fmt + clippy `-D warnings` clean.

## Follow-ups (not in this PR)

- A2A paid requests write no spend rows and therefore no receipts — pre-existing gap, issue to follow.
- Plain-proxy post-upstream receipt write can't be tested end-to-end (same injectable-upstream seam as #556).
- pay-skills catalog sidecar needs the cross-repo OpenAPI re-sync (`pay catalog check`).
- Type-design follow-ups: `build_receipt_from_row` landed; `ReceiptHandle`/`ReceiptScheme` newtypes and `ChatReceiptInputs`↔`SpendLogEntry` structural coupling deferred.
