### PR TITLE
fix(a2a): write spend_logs row + durable receipt on paid settlement (#561)

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use axum::http::HeaderMap;
 use serde_json::{json, Value};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use solvela_protocol::{ChatMessage, ChatRequest, Role, SettlementFailureKind};
 use solvela_router::profiles::{self, Profile};
@@ -19,7 +19,9 @@ use solvela_router::scorer;
 use crate::a2a::task_store::{self, new_task_id, TaskRecord};
 use crate::a2a::types::*;
 use crate::providers::fallback::chat_with_model_fallback;
-use crate::routes::chat::cost::{estimate_input_tokens, usdc_atomic_amount_checked};
+use crate::receipts;
+use crate::routes::chat::cost::{estimate_input_tokens, usdc_atomic_amount_checked, PaymentScheme};
+use crate::usage::SpendLogEntry;
 use crate::AppState;
 
 /// A2A-specific JSON-RPC error codes.
@@ -559,6 +561,12 @@ async fn handle_payment_submitted(
         tool_choice: None,
     };
 
+    // Request-side input-token estimate, computed on the SAME `ChatRequest` sent
+    // to the provider, before `chat_req` is moved into the provider call below.
+    // Used as the attribution-only fallback when the provider omits `usage`,
+    // matching the chat path's EstimateFallback arm (routes/chat/mod.rs).
+    let estimated_input_tokens = crate::routes::chat::cost::estimate_input_tokens(&chat_req);
+
     // Call provider
     let result = chat_with_model_fallback(
         &state.providers,
@@ -608,16 +616,52 @@ async fn handle_payment_submitted(
         "A2A payment verified → completed"
     );
 
-    // Build receipt metadata
+    // Ledger + durable receipt (#561). A paid A2A request settles real USDC;
+    // it must produce the same audit evidence as the chat path — a `spend_logs`
+    // row (visible to stats / budgets / tenant attribution) and a retrievable
+    // receipt. Both writes are fire-and-forget; neither blocks the response.
+    //
+    // The amount RECORDED is what the agent actually paid on this path: the
+    // gateway-quoted total stored on the task at creation
+    // (`record.payment_required.cost_breakdown.total`), which the submitted
+    // payment was validated to cover (`validate_submitted_against_offer`). The
+    // A2A path settles that quoted amount on-chain via the `exact`/`escrow`
+    // scheme — there is no reservation-reconciliation or post-hoc actual-usage
+    // re-bill here (unlike the chat route), so the ledger must record the amount
+    // COLLECTED, not a re-derived usage cost that was never charged. Provider-
+    // reported tokens are recorded for attribution only and never change the
+    // amount. See the solvela-fintech `spend_cost_atomic` rule.
+    let receipt_path = record_a2a_settlement(
+        state,
+        task_id,
+        &payload,
+        &record.payment_required,
+        &resolved_model,
+        &model_info.provider,
+        result.data.usage.as_ref(),
+        estimated_input_tokens,
+        &tx_signature,
+    );
+
+    // Build receipt metadata. In-band fields (status + tx_signature) stay for
+    // header-less A2A clients; the durable receipt path is added alongside
+    // tx_signature when a retrievable receipt was written (#561).
     let mut receipt_meta = serde_json::Map::new();
     receipt_meta.insert(
         x402_meta::STATUS_KEY.to_string(),
         json!(x402_meta::PAYMENT_COMPLETED),
     );
-    if let Some(sig) = &tx_signature {
+    if tx_signature.is_some() || receipt_path.is_some() {
+        let mut receipts_obj = serde_json::Map::new();
+        if let Some(sig) = &tx_signature {
+            receipts_obj.insert("tx_signature".to_string(), json!(sig));
+        }
+        if let Some(path) = &receipt_path {
+            receipts_obj.insert("receipt".to_string(), json!(path));
+        }
         receipt_meta.insert(
             x402_meta::RECEIPTS_KEY.to_string(),
-            json!({ "tx_signature": sig }),
+            Value::Object(receipts_obj),
         );
     }
 
@@ -648,6 +692,176 @@ async fn handle_payment_submitted(
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Record the ledger row and durable receipt for a settled A2A payment (#561),
+/// returning the public receipt path (`/v1/receipts/{uuid}`) to surface in the
+/// Task metadata, or `None` when no retrievable receipt was written.
+///
+/// Mirrors the chat path's settlement bookkeeping (`log_spend` +
+/// `record_receipt`), adapted to the A2A path where the agent settles the
+/// gateway-quoted amount on-chain (no reservation reconciliation, no actual-
+/// usage re-bill). Both writes are fire-and-forget (`log_spend` / `record_receipt`
+/// each spawn their own task) — this function never `.await`s a DB write.
+///
+/// Fail-closed (no silent $0 / no over-promise):
+/// - a stored `payment_required` that fails to parse → skip BOTH writes (warn +
+///   counter); the payment already settled, so this is a known settled-but-
+///   unledgered gap surfaced via metrics, never a $0 ledger row.
+/// - a breakdown string that fails the checked atomic conversion → skip both
+///   (warn + counter), header/path not emitted.
+/// - the scheme parses through `PaymentScheme::from_accepted_str` (unknown
+///   schemes are an error upstream at the verifier; here we record the canonical
+///   wire string and never default-route).
+#[allow(clippy::too_many_arguments)]
+fn record_a2a_settlement(
+    state: &Arc<AppState>,
+    task_id: &str,
+    payload: &solvela_x402::types::PaymentPayload,
+    payment_required_value: &serde_json::Value,
+    model: &str,
+    provider: &str,
+    usage: Option<&solvela_protocol::Usage>,
+    estimated_input_tokens: u32,
+    tx_signature: &Option<String>,
+) -> Option<String> {
+    // Parse the stored quote: it holds the cost_breakdown the agent paid against.
+    let payment_required: solvela_x402::types::PaymentRequired =
+        match serde_json::from_value(payment_required_value.clone()) {
+            Ok(pr) => pr,
+            Err(e) => {
+                metrics::counter!(
+                    "solvela_a2a_settlement_record_skipped_total",
+                    "reason" => "corrupt_payment_required"
+                )
+                .increment(1);
+                warn!(
+                    task_id,
+                    error = %e,
+                    "A2A settled but stored payment_required failed to parse — \
+                     spend row and receipt skipped (settled-but-unledgered)"
+                );
+                return None;
+            }
+        };
+    let breakdown = &payment_required.cost_breakdown;
+
+    // All amounts go through the same checked atomic conversion the 402 quote
+    // uses (rejects empty/non-numeric/negative/overflow — fail-closed). The
+    // billed amount is the quoted TOTAL (what the agent settled on-chain).
+    let atomic = |decimal: &str| -> Option<u64> {
+        usdc_atomic_amount_checked(decimal)
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+    };
+    let (Some(provider_cost_atomic), Some(platform_fee_atomic), Some(total_atomic)) = (
+        atomic(&breakdown.provider_cost),
+        atomic(&breakdown.platform_fee),
+        atomic(&breakdown.total),
+    ) else {
+        metrics::counter!(
+            "solvela_a2a_settlement_record_skipped_total",
+            "reason" => "corrupt_breakdown"
+        )
+        .increment(1);
+        warn!(
+            task_id,
+            provider_cost = %breakdown.provider_cost,
+            platform_fee = %breakdown.platform_fee,
+            total = %breakdown.total,
+            "A2A settled but cost breakdown failed the checked atomic conversion — \
+             spend row and receipt skipped"
+        );
+        return None;
+    };
+
+    let payer_wallet = crate::payment_util::extract_payer_wallet(payload);
+    // Parse the scheme through the exhaustive enum (never default-route an
+    // unknown scheme onto a financial record). The verifier already accepted
+    // this scheme; an unparseable string here means a record we cannot label
+    // truthfully — skip rather than mislabel.
+    let scheme = match PaymentScheme::from_accepted_str(&payload.accepted.scheme) {
+        Ok(s) => s,
+        Err(e) => {
+            metrics::counter!(
+                "solvela_a2a_settlement_record_skipped_total",
+                "reason" => "unknown_scheme"
+            )
+            .increment(1);
+            warn!(
+                task_id,
+                error = %e,
+                "A2A settled with an unrecognized payment scheme — \
+                 spend row and receipt skipped"
+            );
+            return None;
+        }
+    };
+
+    // Provider-reported tokens are ATTRIBUTION ONLY here; they never change the
+    // recorded amount (which is the quoted total the agent settled). When usage
+    // is absent (e.g. some providers omit it), fall back to the request-side
+    // input estimate and zero output, consistent with the chat path's usage-
+    // less EstimateFallback arm (routes/chat/mod.rs uses `estimate_input_tokens`
+    // for input and 0 for output). This keeps the spend row's input attribution
+    // from under-counting for providers that omit usage; the BILLED amount is
+    // unaffected (it is always the quoted total above).
+    let (input_tokens, output_tokens) = match usage {
+        Some(u) => (u.prompt_tokens, u.completion_tokens),
+        None => {
+            debug!(
+                task_id,
+                model,
+                provider,
+                estimated_input_tokens,
+                "A2A provider omitted usage — recording request-side input \
+                 estimate and zero output for spend attribution (billed amount \
+                 is the quoted total, unaffected)"
+            );
+            (estimated_input_tokens, 0)
+        }
+    };
+
+    // Spend ledger row (fire-and-forget). The ledger boundary converts atomic→
+    // f64 USDC exactly once here (Architectural Rule #6 / fintech §6).
+    let billed_cost = total_atomic as f64 / 1_000_000.0;
+    state.usage.log_spend(SpendLogEntry {
+        wallet_address: payer_wallet.clone(),
+        model: model.to_string(),
+        provider: provider.to_string(),
+        input_tokens,
+        output_tokens,
+        cost_usdc: billed_cost,
+        tx_signature: tx_signature.clone(),
+        request_id: Some(task_id.to_string()),
+        // A2A has no chat session / per-tenant matrix (require_tenant wallets are
+        // rejected upstream on this path), so no session or tenant attribution.
+        session_id: None,
+        tenant: None,
+        tenant_enforced: false,
+        // No Redis reservation was pre-committed on the A2A path, so log_spend
+        // increments the counters by `cost_usdc` directly (None branch).
+        estimated_cost_usdc: None,
+        vendor: None,
+    });
+
+    // Durable receipt (fire-and-forget). Returns the public path when a DB pool
+    // is configured and the row can be written; `None` otherwise (never advertise
+    // an unfetchable receipt — fail-closed, matching the chat path).
+    let record = receipts::ReceiptRecord {
+        receipt_id: uuid::Uuid::new_v4(),
+        model: model.to_string(),
+        payment_scheme: scheme.as_accepted_str().to_string(),
+        tx_signature: tx_signature.clone(),
+        payer_wallet,
+        amount_paid_atomic: total_atomic,
+        provider_cost_atomic,
+        platform_fee_atomic,
+        total_atomic,
+        // A2A is not the marketplace-vendor path — no vendor settlement leg.
+        vendor: None,
+    };
+    receipts::record_receipt(state.db_pool.as_ref(), record)
+}
 
 /// Verify that the submitted `PaymentAccept` matches one of the offers
 /// in the original `PaymentRequired` and that the submitted atomic

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -691,6 +691,61 @@ impl LLMProvider for FailingProvider {
     }
 }
 
+/// A mock LLM provider whose response carries NO `usage` block — mimics a
+/// provider that omits token accounting. Used to exercise the attribution
+/// fallback in `record_a2a_settlement` (the provider-omits-usage arm records
+/// the request-side input estimate, not 0).
+struct UsagelessProvider {
+    provider_name: String,
+}
+
+impl UsagelessProvider {
+    fn new(name: &str) -> Self {
+        Self {
+            provider_name: name.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for UsagelessProvider {
+    fn name(&self) -> &str {
+        &self.provider_name
+    }
+
+    fn supported_models(&self) -> Vec<ModelRegistration> {
+        vec![]
+    }
+
+    async fn chat_completion(
+        &self,
+        req: solvela_protocol::ChatRequest,
+    ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+        let mut resp = MockProvider::mock_response(&req.model);
+        resp.usage = None;
+        Ok(resp)
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _req: solvela_protocol::ChatRequest,
+    ) -> Result<ChatStream, Box<dyn std::error::Error + Send + Sync>> {
+        Err("UsagelessProvider does not stream".into())
+    }
+}
+
+/// A `ProviderRegistry` whose providers return responses with no `usage` block.
+fn usageless_provider_registry() -> ProviderRegistry {
+    let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+    for name in ["openai", "anthropic", "deepseek", "google"] {
+        providers.insert(
+            name.to_string(),
+            Arc::new(UsagelessProvider::new(name)) as Arc<dyn LLMProvider>,
+        );
+    }
+    ProviderRegistry::from_providers(providers)
+}
+
 /// Build a mock `ProviderRegistry` that has providers for all models in TEST_MODELS_TOML.
 fn mock_provider_registry() -> ProviderRegistry {
     let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
@@ -12086,4 +12141,435 @@ async fn receipts_vendor_co_nullability_check_rejects_partial_vendor_insert() {
     insert_receipt_row(&pool, Some("vendorwallet"), Some(20_000), Some(1_000))
         .await
         .expect("all-non-NULL vendor columns (vendor receipt) must insert");
+}
+
+// ---------------------------------------------------------------------------
+// A2A paid-request ledger + receipt parity (#561)
+//
+// A paid `POST /a2a` (message/send with x402 payment) settles real USDC and
+// MUST now produce the same audit evidence as the chat path: a `spend_logs`
+// row (observed via the synchronous `"spend logged"` event — the same seam the
+// #541 streaming tests use) AND a durable receipt retrievable via
+// `GET /v1/receipts/{uuid}`, whose path is surfaced in the Task's
+// `x402.payment.receipts` metadata alongside `tx_signature`.
+//
+// These drive the FULL two-step JSON-RPC flow through the real `/a2a` route via
+// oneshot (no seeded fixtures — per feedback_test_through_real_paths). The A2A
+// task store requires Redis, so each test self-skips when Redis is unavailable;
+// the receipt assertions additionally require Postgres and self-skip without it.
+//
+// Mutation resistance (mirrors #560): the spend-log test fails if the
+// `log_spend` call is deleted; the receipt test fails if the `record_receipt`
+// call is deleted; neither shares a fixture that would pass vacuously.
+// ---------------------------------------------------------------------------
+
+/// Build a DB + Redis + mock-provider A2A app with a passing exact verifier and
+/// `dev_bypass_payment: false`, so a submitted payment flows through real
+/// verification/settlement and the post-settlement ledger + receipt writes
+/// fire. Returns `None` (self-skip) when local Redis is unavailable. The
+/// `db_pool` is the caller-supplied dedicated receipts test DB.
+fn a2a_app_with_redis_and_db(pool: sqlx::PgPool) -> Option<(axum::Router, Arc<AppState>)> {
+    a2a_app_with_redis_db_and_providers(pool, mock_provider_registry())
+}
+
+/// As [`a2a_app_with_redis_and_db`], but with a caller-supplied provider
+/// registry — used to exercise the provider-omits-usage attribution fallback in
+/// `record_a2a_settlement` through the real `/a2a` route.
+fn a2a_app_with_redis_db_and_providers(
+    pool: sqlx::PgPool,
+    providers: ProviderRegistry,
+) -> Option<(axum::Router, Arc<AppState>)> {
+    use gateway::cache::{CacheConfig, ResponseCache};
+
+    let url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+    let redis_client = redis::Client::open(url).ok()?;
+    // from_client does not connect; probe a real connection so we self-skip
+    // cleanly (rather than failing later inside the route) when Redis is down.
+    if redis_client.get_connection().is_err() {
+        eprintln!("skipping A2A ledger/receipt test: Redis unavailable");
+        return None;
+    }
+    let cache = ResponseCache::from_client(redis_client, CacheConfig::default())
+        .expect("ResponseCache::from_client should not connect");
+
+    let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+    let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML)
+        .unwrap()
+        .with_gateway_recipient(TEST_RECIPIENT_WALLET)
+        .unwrap();
+    let facilitator =
+        solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+
+    let mut config = AppConfig::default();
+    config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+
+    let state = Arc::new(AppState {
+        config,
+        model_registry,
+        service_registry: RwLock::new(service_registry),
+        providers,
+        facilitator,
+        usage: gateway::usage::UsageTracker::new(Some(pool.clone()), None),
+        cache: Some(cache),
+        semantic_cache: None,
+        provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+        escrow_claimer: None,
+        fee_payer_pool: None,
+        nonce_pool: None,
+        db_pool: Some(pool),
+        session_secret: b"test-secret".to_vec(),
+        http_client: reqwest::Client::new(),
+        replay_set: AppState::new_replay_set(),
+        slot_cache: gateway::routes::escrow::new_slot_cache(),
+        escrow_metrics: None,
+        admin_token: Some(gateway::secret::AdminToken::new(
+            TEST_ADMIN_TOKEN.to_string(),
+        )),
+        api_key_hmac_secret: None,
+        prometheus_handle: Some(test_prometheus_handle()),
+        dev_bypass_payment: false,
+        free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+        receipts_rate_limiter: generous_receipts_limiter(),
+        free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
+    });
+    let router = build_router(
+        Arc::clone(&state),
+        RateLimiter::new(RateLimitConfig::default()),
+    );
+    Some((router, state))
+}
+
+/// POST a JSON-RPC body to the real `/a2a` route and return the parsed result
+/// object (`response["result"]`). Panics on a transport/JSON-RPC error.
+async fn a2a_call(app: &axum::Router, body: &serde_json::Value) -> serde_json::Value {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/a2a")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "/a2a must return 200");
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(
+        json.get("error").is_none() || json["error"].is_null(),
+        "/a2a JSON-RPC returned an error: {json}"
+    );
+    json["result"].clone()
+}
+
+/// Step 1: a new message/send (no taskId) → input-required Task. Returns
+/// (task_id, the first offered `accepts[0]` object) for the caller to echo back.
+async fn a2a_new_request(app: &axum::Router) -> (String, serde_json::Value) {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "id": "a2a-new",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "What is Solana?"}],
+                "metadata": {"model": "openai/gpt-4o"}
+            }
+        }
+    });
+    let result = a2a_call(app, &body).await;
+    assert_eq!(result["status"]["state"], "input-required");
+    let task_id = result["id"].as_str().expect("task id").to_string();
+    let offer =
+        result["status"]["message"]["metadata"]["x402.payment.required"]["accepts"][0].clone();
+    assert_eq!(offer["scheme"], "exact", "first offer is the exact scheme");
+    (task_id, offer)
+}
+
+/// Build the step-2 (payment-submitted) JSON-RPC body echoing the offer. Each
+/// call uses a UNIQUE transaction so the shared real Redis replay set does not
+/// cross-reject one test's payment as a replay of another's.
+fn a2a_payment_submitted_body(task_id: &str, offer: &serde_json::Value) -> serde_json::Value {
+    let tx_raw = base64::engine::general_purpose::STANDARD
+        .encode(format!("mock_signed_tx_{}", uuid::Uuid::new_v4().simple()).as_bytes());
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "id": "a2a-pay",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "pay"}],
+                "metadata": {
+                    "x402.payment.status": "payment-submitted",
+                    "x402.payment.payload": {
+                        "x402_version": 2,
+                        "resource": {"url": "/v1/chat/completions", "method": "POST"},
+                        "accepted": {
+                            "scheme": offer["scheme"],
+                            "network": offer["network"],
+                            "amount": offer["amount"],
+                            "asset": offer["asset"],
+                            "pay_to": offer["pay_to"],
+                            "max_timeout_seconds": offer["max_timeout_seconds"],
+                        },
+                        "payload": {"transaction": tx_raw}
+                    }
+                }
+            },
+            "taskId": task_id
+        }
+    })
+}
+
+/// A settled paid A2A request MUST write exactly one spend ledger row (#561).
+/// Observed through the synchronous `"spend logged"` event on the real `/a2a`
+/// route. Deleting the `log_spend` call in `record_a2a_settlement` makes this
+/// fail (zero events). Self-skips without Redis.
+#[tokio::test]
+async fn a2a_paid_request_writes_spend_log() {
+    use tracing::instrument::WithSubscriber;
+
+    // A DB pool is required for the DB-backed UsageTracker, but the spend
+    // ASSERTION is on the synchronous event, not the DB row.
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let Some((app, _state)) = a2a_app_with_redis_and_db(pool) else {
+        return;
+    };
+
+    let (task_id, offer) = a2a_new_request(&app).await;
+    let pay_body = a2a_payment_submitted_body(&task_id, &offer);
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let result = async { a2a_call(&app, &pay_body).await }
+        .with_subscriber(subscriber)
+        .await;
+    assert_eq!(
+        result["status"]["state"], "completed",
+        "paid A2A request must complete"
+    );
+
+    let events = spend_logged_events(&capture);
+    assert_eq!(
+        events.len(),
+        1,
+        "a settled paid A2A request MUST write exactly one spend entry (got {}): \
+         the agent settled USDC on-chain, so the ledger must record it",
+        events.len()
+    );
+    // The spend is billed at the quoted total (what the agent settled on-chain).
+    let logged_usdc = events[0]["cost_usdc"]
+        .as_f64()
+        .expect("spend logged event carries cost_usdc");
+    assert!(
+        logged_usdc > 0.0,
+        "A2A spend must be a real positive amount, got {logged_usdc}"
+    );
+    assert_eq!(
+        events[0]["model"], "openai/gpt-4o",
+        "spend row records the resolved model"
+    );
+}
+
+/// When the LLM provider omits `usage`, the A2A spend row must record the
+/// request-side INPUT ESTIMATE (not 0) for attribution — matching the chat
+/// path's usage-less EstimateFallback arm. The billed amount is unaffected (it
+/// is always the quoted total). Prompt "What is Solana?" (15 chars) →
+/// `estimate_input_tokens` = 15/4 = 3. Self-skips without Redis/Postgres.
+///
+/// Regression guard for the round-1 MEDIUM: the prior `None => (0, 0)` arm
+/// under-counted input tokens and contradicted its own comment.
+#[tokio::test]
+async fn a2a_paid_request_without_provider_usage_records_input_estimate() {
+    use tracing::instrument::WithSubscriber;
+
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let Some((app, _state)) =
+        a2a_app_with_redis_db_and_providers(pool, usageless_provider_registry())
+    else {
+        return;
+    };
+
+    let (task_id, offer) = a2a_new_request(&app).await;
+    let pay_body = a2a_payment_submitted_body(&task_id, &offer);
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let result = async { a2a_call(&app, &pay_body).await }
+        .with_subscriber(subscriber)
+        .await;
+    assert_eq!(
+        result["status"]["state"], "completed",
+        "paid A2A request must complete even when the provider omits usage"
+    );
+
+    let events = spend_logged_events(&capture);
+    assert_eq!(
+        events.len(),
+        1,
+        "a settled paid A2A request MUST write exactly one spend entry (got {})",
+        events.len()
+    );
+    // The fix: input attribution falls back to the request-side estimate, not 0.
+    assert_eq!(
+        events[0]["input_tokens"].as_u64(),
+        Some(3),
+        "usage-less A2A spend must record the request-side input estimate \
+         (estimate_input_tokens(\"What is Solana?\") = 3), not 0"
+    );
+    assert_eq!(
+        events[0]["output_tokens"].as_u64(),
+        Some(0),
+        "no provider usage → output_tokens recorded as 0"
+    );
+    // The billed amount is the quoted total — unaffected by the attribution.
+    let logged_usdc = events[0]["cost_usdc"]
+        .as_f64()
+        .expect("spend logged event carries cost_usdc");
+    assert!(
+        logged_usdc > 0.0,
+        "billed amount must remain the positive quoted total, got {logged_usdc}"
+    );
+}
+
+/// A settled paid A2A request MUST write a durable receipt AND surface its path
+/// in the Task `x402.payment.receipts` metadata; the path must be retrievable
+/// via `GET /v1/receipts/{uuid}` (#561). Deleting the `record_receipt` call in
+/// `record_a2a_settlement` makes this fail (no `receipt` key in metadata).
+/// Self-skips without Redis or Postgres.
+#[tokio::test]
+async fn a2a_paid_request_writes_receipt_and_metadata_path() {
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let Some((app, _state)) = a2a_app_with_redis_and_db(pool) else {
+        return;
+    };
+
+    let (task_id, offer) = a2a_new_request(&app).await;
+    let pay_body = a2a_payment_submitted_body(&task_id, &offer);
+    let result = a2a_call(&app, &pay_body).await;
+    assert_eq!(result["status"]["state"], "completed");
+
+    // The receipts metadata must carry BOTH the in-band tx_signature and the
+    // new durable receipt path (additive — in-band stays for header-less clients).
+    let receipts_meta = &result["status"]["message"]["metadata"]["x402.payment.receipts"];
+    assert!(
+        receipts_meta["tx_signature"].is_string(),
+        "in-band tx_signature must remain: {receipts_meta}"
+    );
+    let receipt_path = receipts_meta["receipt"]
+        .as_str()
+        .expect("settled A2A Task must carry the durable receipt path");
+    assert!(
+        receipt_path.starts_with("/v1/receipts/"),
+        "receipt metadata path must be the public receipt route, got: {receipt_path}"
+    );
+
+    // The advertised receipt must be fetchable through the real GET route.
+    let receipt = poll_receipt_until_ok(&app, receipt_path).await;
+    assert_eq!(receipt["model"], "openai/gpt-4o");
+    assert_eq!(receipt["payment_scheme"], "exact");
+    assert!(receipt["tx_signature"].is_string());
+    assert!(receipt["receipt_id"].is_string());
+    // Amounts are the quoted total the agent settled (positive, atomic-pinned to
+    // the breakdown triple). A2A is not the vendor path.
+    let total = receipt["cost_breakdown"]["total_atomic"]
+        .as_u64()
+        .expect("total_atomic");
+    assert!(total > 0, "receipt total must be a real positive amount");
+    assert_eq!(
+        receipt["amount_paid_atomic"].as_u64(),
+        Some(total),
+        "A2A receipt records the settled total as the amount paid"
+    );
+    assert_eq!(
+        receipt["cost_breakdown"]["provider_cost_atomic"]
+            .as_u64()
+            .unwrap()
+            + receipt["cost_breakdown"]["platform_fee_atomic"]
+                .as_u64()
+                .unwrap(),
+        total,
+        "provider_cost + platform_fee must equal total (5% fee, applied once)"
+    );
+    assert!(
+        receipt.get("vendor").is_none(),
+        "A2A receipts must not carry vendor fields: {receipt}"
+    );
+}
+
+/// An UNPAID A2A flow (step 1 only — the input-required intake that takes no
+/// payment) must write NO spend row and NO receipt: there is nothing to bill.
+/// Guards against the ledger/receipt writes leaking onto the free intake path.
+/// Self-skips without Redis/Postgres.
+#[tokio::test]
+async fn a2a_unpaid_intake_writes_no_spend_and_no_receipt() {
+    use tracing::instrument::WithSubscriber;
+
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    let Some((app, _state)) = a2a_app_with_redis_and_db(pool) else {
+        return;
+    };
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "id": "a2a-intake",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "What is Solana?"}],
+                "metadata": {"model": "openai/gpt-4o"}
+            }
+        }
+    });
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let result = async { a2a_call(&app, &body).await }
+        .with_subscriber(subscriber)
+        .await;
+    assert_eq!(
+        result["status"]["state"], "input-required",
+        "unpaid intake returns input-required"
+    );
+
+    assert!(
+        spend_logged_events(&capture).is_empty(),
+        "unpaid A2A intake must write no spend row"
+    );
+    assert!(
+        receipt_logged_events(&capture).is_empty(),
+        "unpaid A2A intake must write no receipt"
+    );
+    // No receipt path is surfaced on the unpaid Task.
+    assert!(
+        result["status"]["message"]["metadata"]["x402.payment.receipts"].is_null(),
+        "unpaid intake Task must not carry a receipts metadata object"
+    );
 }


### PR DESCRIPTION
Closes #561.

## Summary

Paid A2A requests (`POST /a2a`, `message/send` with x402 payment) settled real USDC but left **no `spend_logs` row and no retrievable receipt** — A2A revenue was invisible to the ledger, stats, budgets, and tenant attribution (the #541 settled-but-unledgered class, for an entire protocol surface), and A2A was the only paid path with no #560 receipt.

A new fire-and-forget `record_a2a_settlement` helper, called after settlement in `handle_payment_submitted`, writes both:
- **`log_spend`** — billed amount = the gateway-**quoted total** (`cost_breakdown.total` from the stored task → `usdc_atomic_amount_checked`, fail-closed), the settled `tx_signature`, model/provider attribution, `request_id = task_id`. The quoted total is the right money to record: A2A has no reservation/reconcile loop, so recording re-derived usage would mismatch what was collected on-chain. Usage-absent providers fall back to `estimate_input_tokens` on the same `ChatRequest` sent upstream (matching the chat `EstimateFallback` arm), output 0, with a debug log — attribution only, billed amount unchanged.
- **`record_receipt`** (from #560) — surfaces `/v1/receipts/{uuid}` in the Task's `x402.payment.receipts` metadata alongside the in-band `tx_signature` (additive; header-less A2A clients keep the in-band field).

Corrupt-quote / unknown-scheme branches skip **both** writes with a `warn!` + `solvela_a2a_settlement_record_skipped_total` (a $0 row would corrupt budget accounting); unreachable given the upstream validate/verify guards, kept as defense-in-depth.

## Tests
Through the real `/a2a` JSON-RPC route (oneshot), mutation-resistant (deleting either write fails its test): paid settlement → exactly one spend row + one receipt, metadata path round-trips via `GET /v1/receipts/{id}`; usage-less provider → input estimate recorded (not 0); unpaid intake → neither write.

## Review
Two-round money-path review: round 1 (rust-reviewer + silent-failure-hunter) APPROVE, one MEDIUM fixed (the usage-absent token fallback now uses the estimate, matching its own comment + the chat path). Independent round 2 (code-reviewer) APPROVE — flagged a **pre-existing** concurrent-settlement gap in the A2A state machine (two different txs on one `taskId` could double-write), filed as **#566**, out of scope here.

`gateway` lib 782 + a2a integration 10 green; `fmt` + `clippy -D warnings` clean. Not yet deployed — rides the next Fly release.