### PR TITLE
feat(gateway): org budget rollups + analytics polish (E1)

### DIFF
--- a/crates/gateway/src/routes/orgs/analytics.rs
+++ b/crates/gateway/src/routes/orgs/analytics.rs
@@ -7,11 +7,24 @@ use super::*;
 pub struct StatsQuery {
     #[serde(default = "default_stats_days")]
     pub days: i32,
+    /// Max number of rows for paginated lists (`top_wallets`). Clamped to
+    /// `1..=MAX_STATS_LIMIT`; defaults to `DEFAULT_STATS_LIMIT`.
+    #[serde(default)]
+    pub limit: Option<i64>,
+    /// Row offset for paginated lists. Clamped to `>= 0`; defaults to 0.
+    #[serde(default)]
+    pub offset: Option<i64>,
 }
 
 fn default_stats_days() -> i32 {
     7
 }
+
+/// Default page size for `top_wallets` (preserves the historical LIMIT 10).
+const DEFAULT_STATS_LIMIT: i64 = 10;
+/// Hard ceiling on a single page of `top_wallets` rows. Bounds the response
+/// size regardless of client input (fail-safe; mirrors the `days` clamp).
+const MAX_STATS_LIMIT: i64 = 100;
 
 /// Response for team-scoped spend analytics.
 #[derive(Debug, Serialize)]
@@ -56,7 +69,16 @@ pub struct OrgStatsResponse {
     pub period_days: i32,
     pub total_spend_usdc: f64,
     pub total_requests: i64,
+    /// Derived org budget rollup (sum of team budgets — see [`OrgBudgetRollup`]).
+    pub budget: OrgBudgetRollup,
     pub by_team: Vec<TeamBreakdown>,
+    /// Daily spend time series over the period (ascending by date).
+    pub by_day: Vec<DayBucket>,
+    /// Per-tenant breakdown (only rows tagged with a tenant).
+    pub by_tenant: Vec<TenantBreakdown>,
+    /// Per-vendor settlement/fee-receivable breakdown (vendor-settled rows).
+    pub by_vendor: Vec<VendorBreakdown>,
+    /// Top wallets by spend, paginated via `limit`/`offset`.
     pub top_wallets: Vec<WalletBreakdown>,
 }
 
@@ -67,6 +89,70 @@ pub struct TeamBreakdown {
     pub team_name: String,
     pub request_count: i64,
     pub total_cost_usdc: f64,
+}
+
+/// Derived org-level budget figure.
+///
+/// **This is NOT an enforced org budget.** Solvela has no `org_budgets` table:
+/// enforcement lives at the leaf (wallet/team) level. This rollup is a
+/// reporting-only **sum of the org's team budgets**, computed per period from
+/// `team_budgets`. A team with no budget row (or a NULL limit for a given
+/// period) is treated as **unlimited** and contributes nothing to the sum —
+/// exactly as Postgres `SUM` skips NULLs. Because of that, the aggregate limit
+/// for a period is only a meaningful ceiling when **every** team has a budget
+/// for that period; otherwise it understates the true (partly-unlimited) cap.
+/// The `teams_with_*_budget` counts (vs `teams_total`) make that gap explicit
+/// so the number is never silently misleading.
+///
+/// All limits are nullable: `None` means "no team in the org set a limit for
+/// this period" — never `0.0`, which would falsely read as a zero cap.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct OrgBudgetRollup {
+    /// Sum of teams' hourly limits (USDC). `None` if no team set one.
+    pub hourly_limit_usdc: Option<f64>,
+    /// Sum of teams' daily limits (USDC). `None` if no team set one.
+    pub daily_limit_usdc: Option<f64>,
+    /// Sum of teams' monthly limits (USDC). `None` if no team set one.
+    pub monthly_limit_usdc: Option<f64>,
+    /// Total number of teams in the org (the denominator for the counts below).
+    pub teams_total: i64,
+    /// Teams contributing a non-NULL hourly limit to the sum.
+    pub teams_with_hourly_budget: i64,
+    /// Teams contributing a non-NULL daily limit to the sum.
+    pub teams_with_daily_budget: i64,
+    /// Teams contributing a non-NULL monthly limit to the sum.
+    pub teams_with_monthly_budget: i64,
+}
+
+/// One day of the org spend time series.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct DayBucket {
+    /// Calendar day (UTC), formatted `YYYY-MM-DD`.
+    pub date: String,
+    pub spend_usdc: f64,
+    pub requests: i64,
+}
+
+/// Per-tenant breakdown for org analytics (tagged rows only).
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct TenantBreakdown {
+    pub tenant: String,
+    pub request_count: i64,
+    pub total_cost_usdc: f64,
+}
+
+/// Per-vendor settlement breakdown for org analytics.
+///
+/// `settled_usdc` and `fee_receivable_usdc` are summed from the integer atomic
+/// columns (`vendor_settled_atomic`, `vendor_fee_receivable_atomic`) and
+/// rendered to a fixed-6-decimal USDC string via the canonical receipts helper
+/// — no f64 ever touches these money values (solvela-fintech).
+#[derive(Debug, Serialize)]
+pub struct VendorBreakdown {
+    pub vendor_wallet: String,
+    pub request_count: i64,
+    pub settled_usdc: String,
+    pub fee_receivable_usdc: String,
 }
 
 /// `GET /v1/orgs/:id/teams/:tid/stats?days=7`
@@ -270,17 +356,34 @@ pub async fn get_org_stats(
     let pool = require_db!(state);
 
     let days = params.days.clamp(1, 90);
+    // Pagination for top_wallets: clamp to a bounded page and non-negative
+    // offset so a client can never request an unbounded scan or a negative
+    // bind (which Postgres would reject). Mirrors the `days` clamp pattern.
+    let limit = params
+        .limit
+        .unwrap_or(DEFAULT_STATS_LIMIT)
+        .clamp(1, MAX_STATS_LIMIT);
+    let offset = params.offset.unwrap_or(0).max(0);
 
-    tracing::info!(org_id = %org_id, days = %days, "org stats request");
+    tracing::info!(org_id = %org_id, days = %days, limit = %limit, offset = %offset, "org stats request");
 
-    // Summary query
+    // ── Summary ─────────────────────────────────────────────────────────────
+    // Count each spend row ONCE even when its wallet belongs to multiple teams
+    // of the org. The naive `spend_logs JOIN team_wallets` fans a row out once
+    // per team membership and double-counts the org total (team_wallets only
+    // has UNIQUE(team_id, wallet_address), so multi-team membership is legal).
+    // Restricting to the org's DISTINCT wallet set keeps the row multiplicity
+    // at exactly one. See `org_stats_does_not_double_count_multi_team_wallet`.
     let summary = sqlx::query_as::<_, (i64, f64)>(
         r#"SELECT COUNT(*) AS total_requests,
                   COALESCE(SUM(s.cost_usdc), 0.0)::DOUBLE PRECISION AS total_spend_usdc
            FROM spend_logs s
-           JOIN team_wallets tw ON tw.wallet_address = s.wallet_address
-           JOIN teams t ON t.id = tw.team_id
-           WHERE t.org_id = $1
+           WHERE s.wallet_address IN (
+                   SELECT DISTINCT tw.wallet_address
+                   FROM team_wallets tw
+                   JOIN teams t ON t.id = tw.team_id
+                   WHERE t.org_id = $1
+                 )
              AND s.created_at >= NOW() - make_interval(days => $2)"#,
     )
     .bind(org_id)
@@ -295,6 +398,39 @@ pub async fn get_org_stats(
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({ "error": "failed to fetch org stats" })),
+            )
+                .into_response();
+        }
+    };
+
+    // ── Budget rollup (derived sum-of-team-budgets; reporting only) ──────────
+    // NOT an enforced org budget — see OrgBudgetRollup docs. SUM skips NULLs,
+    // so absent/period-NULL team budgets count as unlimited and the
+    // teams_with_*_budget counts vs teams_total expose any partial coverage.
+    let budget = sqlx::query_as::<_, OrgBudgetRollup>(
+        r#"SELECT
+               SUM(tb.hourly_limit_usdc)::DOUBLE PRECISION  AS hourly_limit_usdc,
+               SUM(tb.daily_limit_usdc)::DOUBLE PRECISION   AS daily_limit_usdc,
+               SUM(tb.monthly_limit_usdc)::DOUBLE PRECISION AS monthly_limit_usdc,
+               COUNT(t.id)                                  AS teams_total,
+               COUNT(tb.hourly_limit_usdc)                  AS teams_with_hourly_budget,
+               COUNT(tb.daily_limit_usdc)                   AS teams_with_daily_budget,
+               COUNT(tb.monthly_limit_usdc)                 AS teams_with_monthly_budget
+           FROM teams t
+           LEFT JOIN team_budgets tb ON tb.team_id = t.id
+           WHERE t.org_id = $1"#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await;
+
+    let budget = match budget {
+        Ok(row) => row,
+        Err(e) => {
+            tracing::error!(org_id = %org_id, error = %e, "failed to fetch org budget rollup");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to fetch org budget rollup" })),
             )
                 .into_response();
         }
@@ -331,22 +467,29 @@ pub async fn get_org_stats(
         }
     };
 
-    // Top wallets (top 10 by spend)
+    // Top wallets by spend, paginated. Aggregate over the org's DISTINCT wallet
+    // set (subquery) so a multi-team wallet is one row with its true total — not
+    // multiplied by the team_wallets fan-out (the same bug fixed in the summary).
     let top_wallets = sqlx::query_as::<_, WalletBreakdown>(
-        r#"SELECT tw.wallet_address,
+        r#"SELECT ow.wallet_address,
                   COUNT(s.id) AS request_count,
                   COALESCE(SUM(s.cost_usdc), 0.0)::DOUBLE PRECISION AS total_cost_usdc
-           FROM team_wallets tw
-           JOIN teams t ON t.id = tw.team_id
-           LEFT JOIN spend_logs s ON s.wallet_address = tw.wallet_address
+           FROM (
+                   SELECT DISTINCT tw.wallet_address
+                   FROM team_wallets tw
+                   JOIN teams t ON t.id = tw.team_id
+                   WHERE t.org_id = $1
+                 ) ow
+           LEFT JOIN spend_logs s ON s.wallet_address = ow.wallet_address
                AND s.created_at >= NOW() - make_interval(days => $2)
-           WHERE t.org_id = $1
-           GROUP BY tw.wallet_address
-           ORDER BY total_cost_usdc DESC
-           LIMIT 10"#,
+           GROUP BY ow.wallet_address
+           ORDER BY total_cost_usdc DESC, ow.wallet_address ASC
+           LIMIT $3 OFFSET $4"#,
     )
     .bind(org_id)
     .bind(days)
+    .bind(limit)
+    .bind(offset)
     .fetch_all(pool)
     .await;
 
@@ -362,6 +505,148 @@ pub async fn get_org_stats(
         }
     };
 
+    // Daily time series (mirrors usage::get_stats_by_day). Aggregated over the
+    // org's DISTINCT wallet set so days are not double-counted either.
+    let by_day = sqlx::query_as::<_, DayBucket>(
+        r#"SELECT TO_CHAR(DATE(s.created_at), 'YYYY-MM-DD') AS date,
+                  COALESCE(SUM(s.cost_usdc), 0.0)::DOUBLE PRECISION AS spend_usdc,
+                  COUNT(*) AS requests
+           FROM spend_logs s
+           WHERE s.wallet_address IN (
+                   SELECT DISTINCT tw.wallet_address
+                   FROM team_wallets tw
+                   JOIN teams t ON t.id = tw.team_id
+                   WHERE t.org_id = $1
+                 )
+             AND s.created_at >= NOW() - make_interval(days => $2)
+           GROUP BY DATE(s.created_at)
+           ORDER BY DATE(s.created_at) ASC"#,
+    )
+    .bind(org_id)
+    .bind(days)
+    .fetch_all(pool)
+    .await;
+
+    let by_day = match by_day {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!(org_id = %org_id, error = %e, "failed to fetch org stats by day");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to fetch org stats by day" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Per-tenant breakdown (tagged rows only; mirrors usage::get_stats_by_tenant).
+    let by_tenant = sqlx::query_as::<_, TenantBreakdown>(
+        r#"SELECT s.tenant,
+                  COUNT(*) AS request_count,
+                  COALESCE(SUM(s.cost_usdc), 0.0)::DOUBLE PRECISION AS total_cost_usdc
+           FROM spend_logs s
+           WHERE s.wallet_address IN (
+                   SELECT DISTINCT tw.wallet_address
+                   FROM team_wallets tw
+                   JOIN teams t ON t.id = tw.team_id
+                   WHERE t.org_id = $1
+                 )
+             AND s.created_at >= NOW() - make_interval(days => $2)
+             AND s.tenant IS NOT NULL
+           GROUP BY s.tenant
+           ORDER BY total_cost_usdc DESC, s.tenant ASC"#,
+    )
+    .bind(org_id)
+    .bind(days)
+    .fetch_all(pool)
+    .await;
+
+    let by_tenant = match by_tenant {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!(org_id = %org_id, error = %e, "failed to fetch org stats by tenant");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to fetch org stats by tenant" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Per-vendor settlement breakdown. The atomic columns are integers; sum
+    // them in SQL as BIGINT, then format atomic->USDC string with the canonical
+    // receipts helper (no f64 on the money value — solvela-fintech). The summed
+    // BIGINT could in principle exceed u64 only past ~1.8e13 USDC, which the
+    // per-column CHECK(>=0) and realistic volumes preclude; a negative or
+    // out-of-range sum is rejected via try_from rather than silently wrapped.
+    let by_vendor_rows = sqlx::query_as::<_, (String, i64, i64, i64)>(
+        // SUM over BIGINT returns NUMERIC in Postgres; cast back to BIGINT so
+        // it decodes as i64 (volumes are far below the i64 ceiling, and the
+        // out-of-range guard below fails closed if that ever changes).
+        r#"SELECT s.vendor_wallet,
+                  COUNT(*) AS request_count,
+                  COALESCE(SUM(s.vendor_settled_atomic), 0)::BIGINT AS settled_atomic,
+                  COALESCE(SUM(s.vendor_fee_receivable_atomic), 0)::BIGINT AS fee_atomic
+           FROM spend_logs s
+           WHERE s.wallet_address IN (
+                   SELECT DISTINCT tw.wallet_address
+                   FROM team_wallets tw
+                   JOIN teams t ON t.id = tw.team_id
+                   WHERE t.org_id = $1
+                 )
+             AND s.created_at >= NOW() - make_interval(days => $2)
+             AND s.vendor_wallet IS NOT NULL
+           GROUP BY s.vendor_wallet
+           ORDER BY settled_atomic DESC, s.vendor_wallet ASC"#,
+    )
+    .bind(org_id)
+    .bind(days)
+    .fetch_all(pool)
+    .await;
+
+    let by_vendor = match by_vendor_rows {
+        Ok(rows) => {
+            let mut out = Vec::with_capacity(rows.len());
+            for (vendor_wallet, request_count, settled_atomic, fee_atomic) in rows {
+                // Fail-closed: a negative/out-of-range sum must not silently
+                // wrap into a tiny or huge USDC figure (solvela-fintech).
+                let (settled_u64, fee_u64) =
+                    match (u64::try_from(settled_atomic), u64::try_from(fee_atomic)) {
+                        (Ok(s), Ok(f)) => (s, f),
+                        _ => {
+                            tracing::error!(
+                                org_id = %org_id,
+                                vendor_wallet = %vendor_wallet,
+                                settled_atomic,
+                                fee_atomic,
+                                "vendor receivable sum out of u64 range"
+                            );
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                Json(json!({ "error": "failed to fetch org stats by vendor" })),
+                            )
+                                .into_response();
+                        }
+                    };
+                out.push(VendorBreakdown {
+                    vendor_wallet,
+                    request_count,
+                    settled_usdc: crate::receipts::atomic_to_usdc_string(settled_u64),
+                    fee_receivable_usdc: crate::receipts::atomic_to_usdc_string(fee_u64),
+                });
+            }
+            out
+        }
+        Err(e) => {
+            tracing::error!(org_id = %org_id, error = %e, "failed to fetch org stats by vendor");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to fetch org stats by vendor" })),
+            )
+                .into_response();
+        }
+    };
+
     (
         StatusCode::OK,
         Json(OrgStatsResponse {
@@ -369,7 +654,11 @@ pub async fn get_org_stats(
             period_days: days,
             total_spend_usdc,
             total_requests,
+            budget,
             by_team,
+            by_day,
+            by_tenant,
+            by_vendor,
             top_wallets,
         }),
     )

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -744,3 +744,388 @@ async fn org_stats_endpoint_returns_200(pool: PgPool) {
     assert_eq!(resp.status(), StatusCode::OK);
     let _json = body_to_json(resp).await;
 }
+
+// ---------------------------------------------------------------------------
+// E1: org budget rollups + analytics polish
+//
+// Shared helpers for the org-stats E1 tests below: create a team, assign a
+// wallet, set a team budget, and seed a raw spend row. All go through the real
+// HTTP handlers where one exists (so the test exercises the production wiring),
+// and direct SQL only for spend_logs (there is no public spend-write route).
+// ---------------------------------------------------------------------------
+
+async fn mk_team(app: &Router, org_id: Uuid, name: &str) -> Uuid {
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams"),
+            &format!(r#"{{"name":"{name}"}}"#),
+        ))
+        .await
+        .expect("create team");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "team create must succeed"
+    );
+    Uuid::parse_str(body_to_json(resp).await["id"].as_str().unwrap()).expect("uuid")
+}
+
+async fn assign_team_wallet(app: &Router, org_id: Uuid, team_id: Uuid, wallet: &str) {
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/wallets"),
+            &format!(r#"{{"wallet_address":"{wallet}"}}"#),
+        ))
+        .await
+        .expect("assign wallet");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "wallet assign must succeed"
+    );
+}
+
+async fn set_team_budget_http(app: &Router, org_id: Uuid, team_id: Uuid, body: &str) {
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "PUT",
+            &format!("/v1/orgs/{org_id}/teams/{team_id}/budget"),
+            body,
+        ))
+        .await
+        .expect("set budget");
+    assert_eq!(resp.status(), StatusCode::OK, "budget set must succeed");
+}
+
+/// Seed a plain (non-vendor) chat spend row.
+async fn seed_spend(pool: &PgPool, wallet: &str, model: &str, provider: &str, cost: f64) {
+    sqlx::query(
+        r#"INSERT INTO spend_logs
+               (wallet_address, model, provider, input_tokens, output_tokens, cost_usdc)
+           VALUES ($1, $2, $3, 10, 20, $4)"#,
+    )
+    .bind(wallet)
+    .bind(model)
+    .bind(provider)
+    .bind(cost)
+    .execute(pool)
+    .await
+    .expect("seed spend_log");
+}
+
+/// Seed a spend row with a tenant tag and vendor-settlement legs.
+#[allow(clippy::too_many_arguments)]
+async fn seed_spend_full(
+    pool: &PgPool,
+    wallet: &str,
+    model: &str,
+    provider: &str,
+    cost: f64,
+    tenant: Option<&str>,
+    vendor_wallet: Option<&str>,
+    vendor_settled_atomic: Option<i64>,
+    vendor_fee_receivable_atomic: Option<i64>,
+) {
+    sqlx::query(
+        r#"INSERT INTO spend_logs
+               (wallet_address, model, provider, input_tokens, output_tokens, cost_usdc,
+                tenant, vendor_wallet, vendor_settled_atomic, vendor_fee_receivable_atomic)
+           VALUES ($1, $2, $3, 10, 20, $4, $5, $6, $7, $8)"#,
+    )
+    .bind(wallet)
+    .bind(model)
+    .bind(provider)
+    .bind(cost)
+    .bind(tenant)
+    .bind(vendor_wallet)
+    .bind(vendor_settled_atomic)
+    .bind(vendor_fee_receivable_atomic)
+    .execute(pool)
+    .await
+    .expect("seed spend_log full");
+}
+
+/// Item 2 (the headline bug): a wallet assigned to TWO teams of the same org,
+/// with ONE paid request, must be counted ONCE in the org summary total — not
+/// doubled by the spend_logs -> team_wallets fan-out. by_team legitimately
+/// shows the row under both teams (each team's slice is real membership), but
+/// the org-level total_requests / total_spend must not double.
+#[sqlx::test(migrations = "../../migrations")]
+async fn org_stats_does_not_double_count_multi_team_wallet(pool: PgPool) {
+    let app = router_with_pool(pool.clone());
+    let org_id = create_test_org(&app, "acme").await;
+
+    let team_a = mk_team(&app, org_id, "Eng").await;
+    let team_b = mk_team(&app, org_id, "Ops").await;
+    // Same wallet in BOTH teams.
+    assign_team_wallet(&app, org_id, team_a, TEST_MEMBER_WALLET).await;
+    assign_team_wallet(&app, org_id, team_b, TEST_MEMBER_WALLET).await;
+
+    // Exactly one paid request.
+    seed_spend(&pool, TEST_MEMBER_WALLET, "openai/gpt-4o", "openai", 0.40).await;
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/stats")))
+        .await
+        .expect("org stats");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+
+    // The summary must count the single row once, despite two-team membership.
+    assert_eq!(json["total_requests"], 1, "row counted once at org level");
+    assert!(
+        (json["total_spend_usdc"].as_f64().unwrap() - 0.40).abs() < 1e-9,
+        "org total must be 0.40 (not doubled), got {}",
+        json["total_spend_usdc"]
+    );
+
+    // top_wallets must also dedupe: one wallet, one row, count 1, spend 0.40.
+    let top = json["top_wallets"].as_array().expect("top_wallets array");
+    assert_eq!(top.len(), 1, "one distinct wallet");
+    assert_eq!(top[0]["request_count"], 1, "wallet row counted once");
+    assert!(
+        (top[0]["total_cost_usdc"].as_f64().unwrap() - 0.40).abs() < 1e-9,
+        "top wallet spend not doubled"
+    );
+
+    // by_team legitimately attributes the row under both teams.
+    let by_team = json["by_team"].as_array().expect("by_team array");
+    assert_eq!(by_team.len(), 2, "both teams present");
+    for t in by_team {
+        assert_eq!(
+            t["request_count"], 1,
+            "each team sees the membership row once"
+        );
+    }
+}
+
+/// Item 1: org budget-vs-spend is the SUM of the teams' team_budgets limits per
+/// period, with absent budgets treated as unlimited (contributing nothing) and
+/// surfaced via a teams-with-budget count so the figure is not silently
+/// misleading.
+#[sqlx::test(migrations = "../../migrations")]
+async fn org_stats_budget_is_sum_of_team_budgets(pool: PgPool) {
+    let app = router_with_pool(pool.clone());
+    let org_id = create_test_org(&app, "acme").await;
+
+    let team_a = mk_team(&app, org_id, "Eng").await;
+    let team_b = mk_team(&app, org_id, "Ops").await;
+    let _team_c = mk_team(&app, org_id, "NoBudget").await;
+
+    // team_a: daily 10, monthly 100 (no hourly). team_b: hourly 1, daily 5.
+    set_team_budget_http(&app, org_id, team_a, r#"{"daily":10.0,"monthly":100.0}"#).await;
+    set_team_budget_http(&app, org_id, team_b, r#"{"hourly":1.0,"daily":5.0}"#).await;
+    // team_c: no budget row at all -> contributes nothing.
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/stats")))
+        .await
+        .expect("org stats");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+
+    let budget = &json["budget"];
+    // hourly: only team_b set (1.0); 1 of 3 teams.
+    assert!((budget["hourly_limit_usdc"].as_f64().unwrap() - 1.0).abs() < 1e-9);
+    assert_eq!(budget["teams_with_hourly_budget"], 1);
+    // daily: 10 + 5 = 15; 2 of 3 teams.
+    assert!((budget["daily_limit_usdc"].as_f64().unwrap() - 15.0).abs() < 1e-9);
+    assert_eq!(budget["teams_with_daily_budget"], 2);
+    // monthly: only team_a set (100.0); 1 of 3 teams.
+    assert!((budget["monthly_limit_usdc"].as_f64().unwrap() - 100.0).abs() < 1e-9);
+    assert_eq!(budget["teams_with_monthly_budget"], 1);
+    // total teams in the org for context.
+    assert_eq!(budget["teams_total"], 3);
+}
+
+/// Item 1 (empty case): an org with no team budgets at all reports NULL limits
+/// and zero teams-with-budget, never a misleading 0.0 that looks like a cap.
+#[sqlx::test(migrations = "../../migrations")]
+async fn org_stats_budget_absent_reports_null_not_zero(pool: PgPool) {
+    let app = router_with_pool(pool.clone());
+    let org_id = create_test_org(&app, "acme").await;
+    let _team = mk_team(&app, org_id, "Eng").await;
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/stats")))
+        .await
+        .expect("org stats");
+    let json = body_to_json(resp).await;
+    let budget = &json["budget"];
+    assert!(
+        budget["hourly_limit_usdc"].is_null(),
+        "no cap -> null, not 0"
+    );
+    assert!(budget["daily_limit_usdc"].is_null());
+    assert!(budget["monthly_limit_usdc"].is_null());
+    assert_eq!(budget["teams_with_daily_budget"], 0);
+    assert_eq!(budget["teams_total"], 1);
+}
+
+/// Item 3: org stats include a daily time series mirroring get_stats_by_day.
+#[sqlx::test(migrations = "../../migrations")]
+async fn org_stats_includes_by_day_time_series(pool: PgPool) {
+    let app = router_with_pool(pool.clone());
+    let org_id = create_test_org(&app, "acme").await;
+    let team = mk_team(&app, org_id, "Eng").await;
+    assign_team_wallet(&app, org_id, team, TEST_MEMBER_WALLET).await;
+
+    // Two rows today, one row dated 3 days ago.
+    seed_spend(&pool, TEST_MEMBER_WALLET, "openai/gpt-4o", "openai", 0.10).await;
+    seed_spend(&pool, TEST_MEMBER_WALLET, "openai/gpt-4o", "openai", 0.20).await;
+    sqlx::query(
+        r#"INSERT INTO spend_logs
+               (wallet_address, model, provider, input_tokens, output_tokens, cost_usdc, created_at)
+           VALUES ($1, 'openai/gpt-4o', 'openai', 10, 20, 0.05, NOW() - INTERVAL '3 days')"#,
+    )
+    .bind(TEST_MEMBER_WALLET)
+    .execute(&pool)
+    .await
+    .expect("seed dated spend");
+
+    let resp = app
+        .oneshot(bare_request(
+            "GET",
+            &format!("/v1/orgs/{org_id}/stats?days=7"),
+        ))
+        .await
+        .expect("org stats");
+    let json = body_to_json(resp).await;
+    let by_day = json["by_day"].as_array().expect("by_day array");
+    // Two distinct days.
+    assert_eq!(by_day.len(), 2, "two distinct spend days");
+    // Ascending by date: oldest first.
+    let day0_spend = by_day[0]["spend_usdc"].as_f64().unwrap();
+    let day1_spend = by_day[1]["spend_usdc"].as_f64().unwrap();
+    assert!((day0_spend - 0.05).abs() < 1e-9, "older day = 0.05");
+    assert!((day1_spend - 0.30).abs() < 1e-9, "today = 0.10 + 0.20");
+    assert_eq!(by_day[1]["requests"], 2);
+}
+
+/// Item 4: top_wallets pagination via clamped limit/offset.
+#[sqlx::test(migrations = "../../migrations")]
+async fn org_stats_top_wallets_pagination(pool: PgPool) {
+    let app = router_with_pool(pool.clone());
+    let org_id = create_test_org(&app, "acme").await;
+    let team = mk_team(&app, org_id, "Eng").await;
+
+    // Three distinct wallets with descending spend.
+    let wallets = [
+        ("So11111111111111111111111111111111111111112", 0.30),
+        ("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", 0.20),
+        ("9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9A", 0.10),
+    ];
+    for (w, cost) in wallets {
+        assign_team_wallet(&app, org_id, team, w).await;
+        seed_spend(&pool, w, "openai/gpt-4o", "openai", cost).await;
+    }
+
+    // limit=1 -> only the top wallet (0.30).
+    let resp = app
+        .clone()
+        .oneshot(bare_request(
+            "GET",
+            &format!("/v1/orgs/{org_id}/stats?limit=1"),
+        ))
+        .await
+        .expect("limit=1");
+    let json = body_to_json(resp).await;
+    let top = json["top_wallets"].as_array().unwrap();
+    assert_eq!(top.len(), 1);
+    assert!((top[0]["total_cost_usdc"].as_f64().unwrap() - 0.30).abs() < 1e-9);
+
+    // limit=1&offset=1 -> the second wallet (0.20).
+    let resp = app
+        .oneshot(bare_request(
+            "GET",
+            &format!("/v1/orgs/{org_id}/stats?limit=1&offset=1"),
+        ))
+        .await
+        .expect("offset=1");
+    let json = body_to_json(resp).await;
+    let top = json["top_wallets"].as_array().unwrap();
+    assert_eq!(top.len(), 1);
+    assert!((top[0]["total_cost_usdc"].as_f64().unwrap() - 0.20).abs() < 1e-9);
+}
+
+/// Item 5: org stats include by_tenant and by_vendor breakdowns. Vendor amounts
+/// are atomic integers formatted to USDC strings via the receipts helper.
+#[sqlx::test(migrations = "../../migrations")]
+async fn org_stats_includes_tenant_and_vendor_breakdowns(pool: PgPool) {
+    let app = router_with_pool(pool.clone());
+    let org_id = create_test_org(&app, "acme").await;
+    let team = mk_team(&app, org_id, "Eng").await;
+    assign_team_wallet(&app, org_id, team, TEST_MEMBER_WALLET).await;
+
+    let vendor = "GDDMwNyyx8uB6zrqwBFHjLLG3TBYk2F8Az4yrQC5RzMp";
+    // tenant "alpha": two rows; tenant "beta": one row; plus one untagged row.
+    seed_spend_full(
+        &pool,
+        TEST_MEMBER_WALLET,
+        "openai/gpt-4o",
+        "openai",
+        0.10,
+        Some("alpha"),
+        Some(vendor),
+        Some(1_000_000),
+        Some(50_000),
+    )
+    .await;
+    seed_spend_full(
+        &pool,
+        TEST_MEMBER_WALLET,
+        "openai/gpt-4o",
+        "openai",
+        0.20,
+        Some("alpha"),
+        Some(vendor),
+        Some(2_000_000),
+        Some(100_000),
+    )
+    .await;
+    seed_spend_full(
+        &pool,
+        TEST_MEMBER_WALLET,
+        "openai/gpt-4o",
+        "openai",
+        0.05,
+        Some("beta"),
+        None,
+        None,
+        None,
+    )
+    .await;
+    seed_spend(&pool, TEST_MEMBER_WALLET, "openai/gpt-4o", "openai", 0.07).await;
+
+    let resp = app
+        .oneshot(bare_request("GET", &format!("/v1/orgs/{org_id}/stats")))
+        .await
+        .expect("org stats");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp).await;
+
+    // by_tenant: only tagged rows; alpha (0.30, 2 reqs) before beta (0.05, 1).
+    let by_tenant = json["by_tenant"].as_array().expect("by_tenant array");
+    assert_eq!(
+        by_tenant.len(),
+        2,
+        "two distinct tenants (untagged excluded)"
+    );
+    assert_eq!(by_tenant[0]["tenant"], "alpha");
+    assert_eq!(by_tenant[0]["request_count"], 2);
+    assert!((by_tenant[0]["total_cost_usdc"].as_f64().unwrap() - 0.30).abs() < 1e-9);
+    assert_eq!(by_tenant[1]["tenant"], "beta");
+
+    // by_vendor: one vendor; settled 3.000000, fee 0.150000 (atomic-summed).
+    let by_vendor = json["by_vendor"].as_array().expect("by_vendor array");
+    assert_eq!(by_vendor.len(), 1, "one vendor wallet");
+    assert_eq!(by_vendor[0]["vendor_wallet"], vendor);
+    assert_eq!(by_vendor[0]["request_count"], 2);
+    assert_eq!(by_vendor[0]["settled_usdc"], "3.000000");
+    assert_eq!(by_vendor[0]["fee_receivable_usdc"], "0.150000");
+}

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -902,6 +902,25 @@ async fn org_stats_does_not_double_count_multi_team_wallet(pool: PgPool) {
             "each team sees the membership row once"
         );
     }
+
+    // Counterpart to the dedupe above: by_team INTENTIONALLY attributes the
+    // shared wallet's 0.40 under BOTH teams, so the sum of by_team totals
+    // (0.40 + 0.40 = 0.80) deliberately EXCEEDS the deduped org summary total
+    // (0.40). Pinning the exact sum guards documented semantics against a future
+    // refactor that dedupes by_team (which would silently pass every other
+    // assertion here).
+    let by_team_sum: f64 = by_team
+        .iter()
+        .map(|t| t["total_cost_usdc"].as_f64().expect("total_cost_usdc"))
+        .sum();
+    assert!(
+        (by_team_sum - 0.80).abs() < 1e-9,
+        "by_team totals must sum to 0.80 (shared wallet counted under each team), got {by_team_sum}"
+    );
+    assert!(
+        by_team_sum > json["total_spend_usdc"].as_f64().unwrap(),
+        "by_team sum must exceed the deduped org summary total"
+    );
 }
 
 /// Item 1: org budget-vs-spend is the SUM of the teams' team_budgets limits per

--- a/dashboard/content/docs/enterprise/analytics.mdx
+++ b/dashboard/content/docs/enterprise/analytics.mdx
@@ -72,14 +72,24 @@ Authorization: Bearer <admin-token | solvela_k_...>
 
 ## Org stats
 
-Returns spend and requests for the entire organization, broken down by team and by top wallets.
+Returns spend and requests for the entire organization, with a derived budget
+rollup, a daily time series, per-team / per-tenant / per-vendor breakdowns, and
+a paginated list of top wallets.
 
 Requires `member` role or higher.
 
 ```http title="GET /v1/orgs/:id/stats"
-GET /v1/orgs/018f1a2b-.../stats?days=7
+GET /v1/orgs/018f1a2b-.../stats?days=7&limit=10&offset=0
 Authorization: Bearer <admin-token | solvela_k_...>
 ```
+
+**Query parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `days` | integer | 7 | Rolling window in days. Clamped to 1–90. |
+| `limit` | integer | 10 | Page size for `top_wallets`. Clamped to 1–100. |
+| `offset` | integer | 0 | Row offset for `top_wallets`. Negative values clamp to 0. |
 
 **Response** — `200 OK`
 
@@ -89,6 +99,15 @@ Authorization: Bearer <admin-token | solvela_k_...>
   "period_days": 7,
   "total_spend_usdc": 38.20,
   "total_requests": 1104,
+  "budget": {
+    "hourly_limit_usdc": null,
+    "daily_limit_usdc": 150.0,
+    "monthly_limit_usdc": 4000.0,
+    "teams_total": 3,
+    "teams_with_hourly_budget": 0,
+    "teams_with_daily_budget": 2,
+    "teams_with_monthly_budget": 3
+  },
   "by_team": [
     {
       "team_id": "019c3d4e-...",
@@ -103,6 +122,22 @@ Authorization: Bearer <admin-token | solvela_k_...>
       "total_cost_usdc": 8.10
     }
   ],
+  "by_day": [
+    { "date": "2026-06-06", "spend_usdc": 5.40, "requests": 160 },
+    { "date": "2026-06-07", "spend_usdc": 7.10, "requests": 201 }
+  ],
+  "by_tenant": [
+    { "tenant": "customer-a", "request_count": 600, "total_cost_usdc": 21.00 },
+    { "tenant": "customer-b", "request_count": 290, "total_cost_usdc": 9.10 }
+  ],
+  "by_vendor": [
+    {
+      "vendor_wallet": "VendoRwALLetAddReSs...",
+      "request_count": 312,
+      "settled_usdc": "12.480000",
+      "fee_receivable_usdc": "0.624000"
+    }
+  ],
   "top_wallets": [
     {
       "wallet_address": "AgEnTwALLetAddReSs...",
@@ -112,5 +147,37 @@ Authorization: Bearer <admin-token | solvela_k_...>
   ]
 }
 ```
+
+### Budget rollup (`budget`)
+
+The `budget` object is a **derived, reporting-only** figure: the per-period
+**sum of the org's team budgets** (see [Budgets](/docs/enterprise/budgets#org-budget-rollup)).
+It is **not** an enforced org-level cap — Solvela enforces budgets at the leaf
+(wallet and team) level only. A team with no limit for a period is treated as
+**unlimited** and contributes nothing to the sum. Because of that, a limit is a
+meaningful ceiling for a period only when **every** team has a budget for it;
+the `teams_with_*_budget` counts (against `teams_total`) make any partial
+coverage explicit. A `null` limit means no team set one for that period — never
+read it as a `0` cap.
+
+### Breakdowns and time series
+
+- **`by_day`** — daily spend and request totals over the window, ascending by
+  date (`YYYY-MM-DD`, UTC).
+- **`by_tenant`** — spend grouped by the `x-tenant` attribution tag; rows with
+  no tenant tag are omitted.
+- **`by_vendor`** — for marketplace services that settle directly to a vendor
+  wallet, the summed vendor settlement and Solvela's 5% fee receivable. Both
+  are USDC strings with six decimal places, summed from integer atomic units
+  (no floating-point rounding on the money value).
+
+### Counting semantics
+
+A wallet may belong to multiple teams of an organization. The org **summary
+total**, `by_day`, `by_tenant`, `by_vendor`, and `top_wallets` count each spend
+row **exactly once** regardless of how many teams the wallet is in. `by_team`
+intentionally attributes a wallet's spend under **every** team it belongs to, so
+the per-team slices can legitimately sum to more than the org total when wallets
+are shared across teams.
 
 <UpgradeCta />

--- a/dashboard/content/docs/enterprise/budgets.mdx
+++ b/dashboard/content/docs/enterprise/budgets.mdx
@@ -65,6 +65,40 @@ Authorization: Bearer <admin-token | solvela_k_...>
 
 Response shape is the same as the set response above.
 
+## Org budget rollup
+
+There is **no org-level budget**, and setting one is intentionally not
+supported: Solvela enforces spend caps at the leaf (team and wallet) level only.
+For reporting, the [org stats endpoint](/docs/enterprise/analytics#org-stats)
+surfaces a derived `budget` object that is the **per-period sum of the org's
+team budgets** — useful for answering "how much of its aggregate budget has the
+org spent?" without introducing a second enforcement layer.
+
+```json
+"budget": {
+  "hourly_limit_usdc": null,
+  "daily_limit_usdc": 150.0,
+  "monthly_limit_usdc": 4000.0,
+  "teams_total": 3,
+  "teams_with_hourly_budget": 0,
+  "teams_with_daily_budget": 2,
+  "teams_with_monthly_budget": 3
+}
+```
+
+Semantics to keep in mind:
+
+- A team with **no limit for a period** is treated as **unlimited** and adds
+  nothing to that period's sum (matching how the limit behaves in enforcement).
+- Therefore the sum is a true ceiling for a period only when **every** team has
+  a budget for it. The `teams_with_*_budget` counts (against `teams_total`)
+  expose partial coverage so the figure is never silently misleading.
+- A `null` limit means **no team set one** for that period — it is *not* a `0`
+  cap. Do not render `null` as "$0".
+
+This figure is reporting-only and is computed live from team budgets; there is
+nothing extra to configure.
+
 ## Wallet budgets
 
 Wallet budgets are set and read using the admin token only.


### PR DESCRIPTION
## Summary

E1 of the Agent Spend Control Plane: org-level budget rollups + analytics polish. **Read-only reporting** over `spend_logs` — no hot-path change, no budget-enforcement change, no migration. Extends the already-public `get_org_stats` endpoint.

- **Org budget-vs-spend rollup**: the org's aggregate budget as the SUM of its teams' `team_budgets` limits (per period), surfaced alongside spend so a response answers "org spent X of its Y budget." No `org_budgets` table. Honest about partial coverage: an absent team budget = unlimited (contributes nothing, reported as `null` not `0.0`), and `teams_total` + `teams_with_{hourly,daily,monthly}_budget` counts are returned so a partial-coverage sum can't be silently misread as a real ceiling.
- **Double-count fix** (correctness): a wallet in multiple teams of one org was multiplied by the `spend_logs → team_wallets` join fan-out, inflating org totals. All row-once aggregations (summary, top_wallets, by_day, by_tenant, by_vendor) now dedupe via `wallet_address IN (SELECT DISTINCT ...)`, counting each spend row once. `by_team` deliberately still attributes a shared wallet under each team (documented, and pinned by test against silent dedup refactors).
- **Time series**: `by_day` daily spend/requests buckets.
- **Pagination**: clamped `limit`/`offset` (1–100) replacing the hardcoded `LIMIT 10` on top_wallets, with a stable tie-break for deterministic offset paging.
- **Tenant + vendor breakdowns**: `by_tenant`, and `by_vendor` summing the P1/P2 vendor settled/fee-receivable atomic columns per vendor wallet (surfaces the vendor-receivable trail at org scope). Atomic integers formatted via the canonical `atomic_to_usdc_string` — no f64 on money, fail-closed `u64::try_from`.
- **Docs**: `enterprise/budgets.mdx` (org rollup) + `enterprise/analytics.mdx` (breakdowns, time series, pagination, counting semantics).

All new response fields are additive; existing `get_org_stats`/`get_team_stats` shape is unchanged.

## Placement

Stays in the public gateway repo: it extends endpoints (`get_org_stats`/`get_team_stats`, team/wallet budget management) that are **already public on main** — you can't split a response struct across repos. The open-core line is drawn one layer up at E2 (invoicing) / E3 (cost-center chargeback), which are net-new surfaces consuming this public data. Gateway is BUSL-1.1, so public ≠ runnable-as-a-competing-service.

## Review

Single review round (rust-reviewer), deliberate step-down from the P1/P2 two-round money-path process because this is read-only reporting — it cannot gate, charge, or deny a request (no money-path). Reviewer approved: verified the dedupe is consistent across all row-once aggregations, the budget-rollup NULL-honesty, the vendor atomic SUM (`::BIGINT` cast + fail-closed `try_from`), pagination clamping/binds, and no response-shape regression. One Minor (pin the intentional `by_team` double-count) applied in the second commit.

## Tests

6 new DB-backed tests through the real route (`#[sqlx::test]` + oneshot): the multi-team-wallet double-count fix (org total counts once; by_team sum pinned exactly), budget = sum of team budgets, absent budget → null not zero, by_day time series, top_wallets pagination, tenant + vendor breakdowns with exact values. `cargo test -p gateway`: all green (orgs_routes 26/26); fmt + clippy `-D warnings` clean.

## Out of scope (decided 2026-06-12 after a research pass)

Org-level budget **enforcement** is deliberately not built: across Ramp/Brex/AWS/GCP and the agent-wallet products, the org tier is a reporting/alerting boundary, not an enforcement one — hard caps live at the leaf (wallet/team), which Solvela already enforces. An org hard-cap would also hit a real schema ambiguity (`team_wallets` permits a wallet across teams in different orgs, so "which org caps this request" is undefined). If org governance is wanted later, the low-risk form is alert/forecast-against-tracked-total, not a competing hard running-total cap. E2 (invoicing) / E3 (cost-center) are the next enterprise-repo phases.
