### PR TITLE
ci(docs): type-check opt-in doc code examples against in-repo SDK source

### DIFF
--- a/.github/workflows/docs-doctest.yml
+++ b/.github/workflows/docs-doctest.yml
@@ -1,0 +1,50 @@
+name: docs-doctest
+
+# Type-checks opt-in (```lang doctest```) code examples in the docs against the
+# in-repo SDK sources. A PR that changes an SDK's public API breaks the matching
+# doc example here, in the same PR — closing the gap where doc examples were
+# verified once by hand (#369) but never guarded in CI.
+#
+# Fires when the docs, the TypeScript SDK source, or the doctest harness change.
+
+on:
+  push:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'sdks/typescript/src/**'
+      - 'sdks/typescript/package.json'
+      - 'sdks/typescript/package-lock.json'
+      - 'sdks/typescript/tsconfig.json'
+      - 'scripts/audit-docs/doc_examples/**'
+      - '.github/workflows/docs-doctest.yml'
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'sdks/typescript/src/**'
+      - 'sdks/typescript/package.json'
+      - 'sdks/typescript/package-lock.json'
+      - 'sdks/typescript/tsconfig.json'
+      - 'scripts/audit-docs/doc_examples/**'
+      - '.github/workflows/docs-doctest.yml'
+
+jobs:
+  typescript:
+    name: doctest (typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/typescript/package-lock.json
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install TypeScript SDK deps
+        working-directory: sdks/typescript
+        run: npm ci --no-audit --no-fund
+      - name: Type-check doc examples against @solvela/sdk source
+        run: python3 scripts/audit-docs/doc_examples/run_ts.py

--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -172,7 +172,7 @@ data: [DONE]
     ```
   </Tab>
   <Tab value="TypeScript">
-    ```typescript
+    ```typescript doctest
     import { SolvelaClient, ChatRequest, ChatMessage, Wallet, KeypairSigner } from '@solvela/sdk';
 
     // Construct the wallet + signer explicitly — the SDK does not read

--- a/dashboard/content/docs/concepts/payment-flow.mdx
+++ b/dashboard/content/docs/concepts/payment-flow.mdx
@@ -199,7 +199,7 @@ The official SDKs expose a **per-call** payment cap (the maximum amount they wil
 
 <Tabs items={["TypeScript", "Python", "Rust", "Go"]}>
   <Tab value="TypeScript">
-    ```typescript
+    ```typescript doctest
     import { SolvelaClient, Wallet, KeypairSigner } from '@solvela/sdk';
 
     // @solvela/sdk caps spend per call, not per session.

--- a/dashboard/content/docs/quickstart.mdx
+++ b/dashboard/content/docs/quickstart.mdx
@@ -55,7 +55,7 @@ First, send a request without any payment header. The gateway will respond with 
 
 <Tabs items={['TypeScript', 'Python', 'Go', 'cURL']}>
   <Tab value="TypeScript">
-    ```typescript
+    ```typescript doctest
     import { SolvelaClient, ChatRequest, ChatMessage, PaymentRequiredError } from '@solvela/sdk';
 
     const client = new SolvelaClient({
@@ -226,7 +226,7 @@ Build and sign a USDC-SPL transfer transaction to the `pay_to` address for the `
 
 <Tabs items={['TypeScript', 'Python', 'Go', 'solvela CLI']}>
   <Tab value="TypeScript">
-    ```typescript
+    ```typescript doctest
     import { SolvelaClient, ChatRequest, ChatMessage, Wallet, KeypairSigner } from '@solvela/sdk';
 
     // Construct the wallet + signer explicitly — the SDK does not read

--- a/scripts/audit-docs/doc_examples/README.md
+++ b/scripts/audit-docs/doc_examples/README.md
@@ -1,0 +1,76 @@
+# Doc-example doctest guard
+
+Type-checks **opt-in** fenced code blocks in the docs against the **in-repo SDK
+sources**, so a PR that changes an SDK's public API breaks the matching doc
+example in the *same* PR.
+
+This closes a long-standing gap: the doc code examples were type-checked **once,
+by hand** (PR #369, 2026-05-21), but nothing guarded them afterward, so they
+could silently drift as the SDKs evolved.
+
+## The marker convention
+
+A code block is checked only when its fence info string carries the `doctest`
+token:
+
+````md
+```typescript doctest
+import { SolvelaClient } from '@solvela/sdk';
+const client = new SolvelaClient({ config: { gatewayUrl: 'https://api.solvela.ai' } });
+```
+````
+
+Opt-in is deliberate. Most fences in the docs are **intentional fragments** —
+placeholders (`yourWalletAdapter`), bare `interface` declarations referencing
+un-imported types, JSON response bodies. Marking *every* fence would flood CI
+with false failures. Only mark a block `doctest` when it is a complete example
+that should compile against the real SDK.
+
+The `doctest` token is ignored by the docs renderer (Fumadocs/Shiki treat
+unknown fence metadata as a no-op), so it has no visual effect on the published
+page.
+
+### Rules for a `doctest` block
+
+- It must be self-contained: every identifier is either imported or declared in
+  the block. (No placeholders like `yourWalletAdapter`.)
+- It is checked as an ES module against the SDK **source** (`sdks/<lang>/`), not
+  a published build — so it reflects the API as it exists in this repo.
+- If an example is meant to be illustrative/partial, **don't** mark it
+  `doctest`.
+
+## Running locally
+
+```bash
+# one-time: install the TS SDK's own deps so its types resolve
+( cd sdks/typescript && npm ci )
+
+python3 scripts/audit-docs/doc_examples/run_ts.py
+```
+
+Exit `0` = all marked blocks type-check (or none exist). Exit `1` = at least one
+failed; errors are reported at the **doc** `file:line`, e.g.:
+
+```
+dashboard/content/docs/quickstart.mdx:59  error TS2305: Module '"@solvela/sdk"' has no exported member 'Foo'.
+```
+
+## Currently covered
+
+- **TypeScript** — blocks importing `@solvela/sdk`, checked against
+  `sdks/typescript/src` (`run_ts.py`).
+
+## Adding a language
+
+`extract.py` is language-agnostic; it already recognizes `python`, `go`, and
+`rust` doctest blocks. To enforce one, add a `run_<lang>.py` that:
+
+1. calls `extract_blocks(DOC_ROOTS, REPO_ROOT, lang="<lang>")`,
+2. writes each block to a temp file and runs that toolchain's type-checker
+   against the in-repo SDK (`mypy`/`pyright` for Python, `go build` for Go,
+   `cargo check` with a path dep for Rust),
+3. maps errors back to `block.file:block.line + <error line>`,
+
+then add a job to `.github/workflows/docs-doctest.yml`. Examples that pull in
+many external deps (`ai`, `viem`, `zod`, …) need those installed before they can
+be enforced; start with SDK-only examples.

--- a/scripts/audit-docs/doc_examples/__init__.py
+++ b/scripts/audit-docs/doc_examples/__init__.py
@@ -1,0 +1,8 @@
+"""Doc-example compile/type-check guard.
+
+Extracts opt-in fenced code blocks from the docs and type-checks them against
+the in-repo SDK sources, so a PR that changes an SDK's public API breaks the
+matching doc example in the *same* PR.
+
+See README.md for the marker convention and how to add languages.
+"""

--- a/scripts/audit-docs/doc_examples/extract.py
+++ b/scripts/audit-docs/doc_examples/extract.py
@@ -1,0 +1,109 @@
+"""Extract opt-in fenced code blocks from Markdown / MDX docs.
+
+A block is a *doctest* when the fence info string carries the ``doctest``
+token, e.g.::
+
+    ```typescript doctest
+    import { SolvelaClient } from '@solvela/sdk';
+    ...
+    ```
+
+Opt-in is deliberate: most fences in the docs are intentional fragments
+(placeholders like ``yourWalletAdapter``, bare ``interface`` declarations,
+JSON response bodies). Only blocks an author marks ``doctest`` are expected
+to be complete and to type-check against the real in-repo SDK sources.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# Languages we treat as the same toolchain bucket.
+LANG_ALIASES = {
+    "ts": "typescript",
+    "typescript": "typescript",
+    "js": "typescript",
+    "javascript": "typescript",
+    "py": "python",
+    "python": "python",
+    "go": "go",
+    "rust": "rust",
+    "rs": "rust",
+}
+
+_FENCE = re.compile(
+    r"^(?P<indent>[ \t]*)```(?P<info>[^\n]*)\n(?P<body>.*?)^(?P=indent)```",
+    re.S | re.M,
+)
+
+
+@dataclass(frozen=True)
+class Block:
+    file: str          # path relative to repo root
+    line: int          # 1-based line of the opening fence
+    lang: str          # normalized language bucket (typescript / python / ...)
+    raw_lang: str      # language token as written
+    meta: str          # full fence info string after the language token
+    code: str          # block body (no fences)
+
+    @property
+    def location(self) -> str:
+        return f"{self.file}:{self.line}"
+
+
+def _info_tokens(info: str) -> tuple[str, list[str]]:
+    parts = info.strip().split()
+    if not parts:
+        return "", []
+    return parts[0], parts[1:]
+
+
+def is_doctest(meta_tokens: list[str]) -> bool:
+    return "doctest" in meta_tokens
+
+
+def extract_blocks(
+    roots: list[Path],
+    repo_root: Path,
+    lang: str | None = None,
+) -> list[Block]:
+    """Return all ``doctest``-marked blocks under ``roots``.
+
+    ``lang`` (normalized, e.g. "typescript") filters to one toolchain bucket.
+    """
+    out: list[Block] = []
+    seen: set[Path] = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in sorted([*root.rglob("*.md"), *root.rglob("*.mdx")]):
+            if path in seen:
+                continue
+            seen.add(path)
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for m in _FENCE.finditer(text):
+                raw_lang, tokens = _info_tokens(m.group("info"))
+                if not is_doctest(tokens):
+                    continue
+                norm = LANG_ALIASES.get(raw_lang.lower())
+                if norm is None:
+                    raise ValueError(
+                        f"{path}: ```{raw_lang} doctest``` — unsupported "
+                        f"doctest language '{raw_lang}'"
+                    )
+                if lang is not None and norm != lang:
+                    continue
+                line = text[: m.start()].count("\n") + 1
+                out.append(
+                    Block(
+                        file=str(path.relative_to(repo_root)),
+                        line=line,
+                        lang=norm,
+                        raw_lang=raw_lang,
+                        meta=m.group("info").strip(),
+                        code=m.group("body"),
+                    )
+                )
+    return out

--- a/scripts/audit-docs/doc_examples/run_ts.py
+++ b/scripts/audit-docs/doc_examples/run_ts.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Type-check ``doctest``-marked TypeScript doc examples against the in-repo SDK.
+
+Each marked ```typescript doctest``` block is written to a temp file inside
+``sdks/typescript/`` (so Node module resolution finds the SDK's own
+node_modules) and compiled with ``tsc --noEmit``. The bare specifier
+``@solvela/sdk`` is mapped to ``sdks/typescript/src/index.ts`` via tsconfig
+``paths`` — so the doc example is checked against the SDK *source*, not a
+possibly-stale published build. A renamed/removed export breaks the example
+here, in the same PR that changed the SDK.
+
+Exit code 0 = all marked TS blocks type-check (or none exist).
+Exit code 1 = at least one block failed (errors are mapped to doc file:line).
+
+Usage:
+    python3 scripts/audit-docs/doc_examples/run_ts.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[2]  # scripts/audit-docs/doc_examples -> repo root
+sys.path.insert(0, str(HERE.parent))
+
+from doc_examples.extract import extract_blocks  # noqa: E402
+
+DOC_ROOTS = [
+    REPO_ROOT / "dashboard" / "content" / "docs",
+    REPO_ROOT / "docs",
+]
+TS_SDK = REPO_ROOT / "sdks" / "typescript"
+TMP_DIR = TS_SDK / ".doctest-tmp"
+
+TSCONFIG = {
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "strict": True,
+        "esModuleInterop": True,
+        "skipLibCheck": True,
+        "noEmit": True,
+        "forceConsistentCasingInFileNames": True,
+        "resolveJsonModule": True,
+        "types": ["node"],
+        "baseUrl": ".",
+        "paths": {
+            "@solvela/sdk": ["../src/index.ts"],
+            "@solvela/sdk/*": ["../src/*"],
+        },
+    },
+    "include": ["*.ts"],
+}
+
+_TSC_ERR = re.compile(
+    r"^(?P<file>block_\d+\.ts)\((?P<line>\d+),(?P<col>\d+)\):\s*(?P<msg>.*)$"
+)
+
+
+def main() -> int:
+    blocks = extract_blocks(DOC_ROOTS, REPO_ROOT, lang="typescript")
+    if not blocks:
+        print("doctest(ts): no ```typescript doctest``` blocks found — nothing to check.")
+        return 0
+
+    if not (TS_SDK / "node_modules").exists():
+        print(
+            "doctest(ts): sdks/typescript/node_modules missing — run `npm ci` "
+            "in sdks/typescript first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if TMP_DIR.exists():
+        shutil.rmtree(TMP_DIR)
+    TMP_DIR.mkdir(parents=True)
+
+    # Map temp filename -> (doc location, fence body line offset).
+    index: dict[str, object] = {}
+    try:
+        for i, b in enumerate(blocks):
+            fname = f"block_{i}.ts"
+            # Force module scope so each block is isolated (no global collisions
+            # between same-named top-level consts across examples).
+            (TMP_DIR / fname).write_text(b.code + "\nexport {};\n", encoding="utf-8")
+            index[fname] = b
+
+        (TMP_DIR / "tsconfig.json").write_text(json.dumps(TSCONFIG, indent=2))
+
+        proc = subprocess.run(
+            ["npx", "tsc", "-p", "tsconfig.json", "--pretty", "false"],
+            cwd=TMP_DIR,
+            capture_output=True,
+            text=True,
+        )
+
+        failures: list[str] = []
+        for raw in (proc.stdout + proc.stderr).splitlines():
+            m = _TSC_ERR.match(raw.strip())
+            if not m:
+                if raw.strip():
+                    failures.append(raw.rstrip())
+                continue
+            b = index[m.group("file")]
+            # body line L (1-based) -> doc line = fence line + L
+            doc_line = b.line + int(m.group("line"))
+            failures.append(f"{b.file}:{doc_line}  {m.group('msg')}")
+
+        if proc.returncode == 0 and not failures:
+            print(f"doctest(ts): OK — {len(blocks)} block(s) type-check against @solvela/sdk source.")
+            return 0
+
+        print(f"doctest(ts): FAILED — {len(blocks)} block(s) checked, errors below:\n")
+        for f in failures:
+            print(f"  {f}")
+        print(
+            "\nThese doc examples no longer type-check against sdks/typescript/src. "
+            "Either fix the example or, if the snippet is intentionally a fragment, "
+            "remove its `doctest` marker."
+        )
+        return 1
+    finally:
+        shutil.rmtree(TMP_DIR, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit-docs/tests/test_doc_examples.py
+++ b/scripts/audit-docs/tests/test_doc_examples.py
@@ -1,0 +1,104 @@
+"""Tests for the doc-example extractor (doc_examples.extract).
+
+Stands up a tiny synthetic docs tree in a tmpdir and asserts which fenced
+blocks the extractor treats as ``doctest`` blocks, that indented fences (as
+used inside MDX ``<Tab>`` components) are handled, and that line numbers map
+back to the source.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from doc_examples.extract import (
+    LANG_ALIASES,
+    extract_blocks,
+    is_doctest,
+)
+
+DOC = """\
+# Title
+
+```typescript doctest
+import { SolvelaClient } from '@solvela/sdk';
+```
+
+A plain, unmarked block (a fragment) must be ignored:
+
+```typescript
+const x = somePlaceholder;
+```
+
+An indented marked block inside a Tab:
+
+<Tab>
+    ```python doctest
+    from solvela import SolvelaClient
+    ```
+</Tab>
+
+A marked block in another language bucket:
+
+```go doctest
+package main
+```
+"""
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    root = tmp_path / "docs"
+    root.mkdir()
+    (root / "page.mdx").write_text(body, encoding="utf-8")
+    return root
+
+
+def test_only_marked_blocks_are_extracted(tmp_path: Path) -> None:
+    root = _write(tmp_path, DOC)
+    blocks = extract_blocks([root], tmp_path)
+    langs = sorted(b.lang for b in blocks)
+    # 3 marked blocks (ts, python, go); the unmarked ts fragment is skipped.
+    assert langs == ["go", "python", "typescript"]
+
+
+def test_language_filter(tmp_path: Path) -> None:
+    root = _write(tmp_path, DOC)
+    ts = extract_blocks([root], tmp_path, lang="typescript")
+    assert len(ts) == 1
+    assert ts[0].code.strip() == "import { SolvelaClient } from '@solvela/sdk';"
+
+
+def test_indented_fence_is_handled(tmp_path: Path) -> None:
+    root = _write(tmp_path, DOC)
+    py = extract_blocks([root], tmp_path, lang="python")
+    assert len(py) == 1
+    # Body keeps its source indentation; content resolves after a strip.
+    assert "from solvela import SolvelaClient" in py[0].code
+
+
+def test_line_numbers_point_at_opening_fence(tmp_path: Path) -> None:
+    root = _write(tmp_path, DOC)
+    ts = extract_blocks([root], tmp_path, lang="typescript")[0]
+    # The first ```typescript doctest fence is on line 3 of DOC.
+    assert ts.line == 3
+    assert ts.file == "docs/page.mdx"
+
+
+def test_unmarked_block_not_doctest() -> None:
+    assert is_doctest(["title=\"x\""]) is False
+    assert is_doctest([]) is False
+    assert is_doctest(["doctest"]) is True
+
+
+def test_unsupported_doctest_language_raises(tmp_path: Path) -> None:
+    root = _write(tmp_path, "```ruby doctest\nputs 1\n```\n")
+    with pytest.raises(ValueError, match="unsupported doctest language"):
+        extract_blocks([root], tmp_path)
+
+
+def test_known_languages_normalize() -> None:
+    assert LANG_ALIASES["ts"] == "typescript"
+    assert LANG_ALIASES["js"] == "typescript"
+    assert LANG_ALIASES["py"] == "python"
+    assert LANG_ALIASES["rs"] == "rust"


### PR DESCRIPTION
## What

Adds a **doctest guard** for documentation code examples. Fenced blocks marked
` ```lang doctest ` are type-checked against the **in-repo SDK sources**, so a PR
that changes an SDK's public API breaks the matching doc example in the *same* PR.

## Why

Doc code examples were type-checked **once, by hand** (#369) but never guarded in
CI — so they could silently drift as the SDKs evolved. This came out of a
retrospective audit of past on-the-fly "(Recommended)" decisions: the
"compile/type-check each example" decision was accepted but only ever applied
manually, leaving a declared-but-unenforced quality gate.

## How

- `scripts/audit-docs/doc_examples/extract.py` — language-agnostic extractor;
  pulls only `doctest`-marked fences (handles MDX-indented fences inside `<Tab>`).
  **Opt-in** by design: most fences are intentional fragments (placeholders, bare
  `interface` decls, JSON bodies) and would flood CI if all were compiled.
- `scripts/audit-docs/doc_examples/run_ts.py` — type-checks marked TS blocks
  against `sdks/typescript/src` via tsconfig `paths` (the SDK *source*, not a
  stale published build). Maps each `tsc` error back to the doc `file:line`.
- `.github/workflows/docs-doctest.yml` — fires on docs **or** TS-SDK-source changes.
- `scripts/audit-docs/tests/test_doc_examples.py` — 7 extractor unit tests.
- Marked the 4 `@solvela/sdk`-only TS examples (quickstart, chat-completions,
  payment-flow). The `doctest` token is render-invisible (Shiki ignores unknown
  fence metadata).

## Scope

First slice = the 4 SDK-only TypeScript examples. The extractor already
recognizes python/go/rust; enforcing those + the dep-heavy TS examples (`ai`,
`viem`, `zod`) are clean follow-ups (a `run_<lang>.py` + a CI job each).

## Test plan

- `python3 scripts/audit-docs/doc_examples/run_ts.py` → OK, 4 blocks type-check.
- Negative test: injected a bad export + bad method → flagged as TS2305/TS2339 at
  the correct doc `file:line`, green again after removal.
- `pytest scripts/audit-docs/tests/` → 108 existing + 7 new pass.
