### PR TITLE
feat(mcp): auto-resolve/create a non-custodial wallet on first run

### DIFF
--- a/sdks/mcp/README.md
+++ b/sdks/mcp/README.md
@@ -19,9 +19,27 @@ solvela mcp install --host=claude-desktop
 solvela mcp install --host=openclaw
 ```
 
-The installer writes the correct config for your host and prints a reminder to
-set `SOLANA_WALLET_KEY` in your shell environment (it is intentionally never
-written to disk by default):
+The installer writes the correct config for your host. **You do not need to
+generate a keypair or set any wallet env var to get started** — on first run the
+server resolves a non-custodial wallet automatically:
+
+1. If `SOLANA_WALLET_KEY` is set in the environment, that key is used (and no
+   file is read or created).
+2. Otherwise it reads `~/.solvela/wallet.json` if present (the same file the
+   `solvela` CLI uses — they share one wallet).
+3. If neither exists, it **generates a new ed25519 wallet and writes
+   `~/.solvela/wallet.json`** (mode `0600`, dir `0700`), then prints the new
+   address to stderr.
+
+After the first run, fund the printed address with **USDC-SPL on Solana plus a
+little SOL (~0.01) for network fees** to start paying for calls.
+
+> **Back up `~/.solvela/wallet.json` — it controls your funds.** Anyone who can
+> read that file can drain the wallet. The private key never leaves your
+> machine; only signed transactions reach the gateway.
+
+To use an existing keypair instead of the auto-created one, set it explicitly
+(it is intentionally never written to disk by the installer):
 
 ```bash
 export SOLANA_WALLET_KEY=<your-base58-keypair>
@@ -164,9 +182,9 @@ All configuration is via environment variables:
 | `SOLVELA_MAX_ESCROW_SESSION` | `20.0` | Cumulative session deposit cap in USDC (applies only when escrow mode is enabled) |
 | `SOLVELA_ESCROW_PROGRAM_ID` | required (when escrow enabled) | Base58 address of the Solvela escrow program on Solana |
 | `SOLVELA_RECIPIENT_WALLET` | required (when escrow enabled) | Base58 wallet address that receives escrow payments |
-| `SOLANA_WALLET_KEY` | required (when signing enabled) | Base58-encoded Solana keypair secret key |
+| `SOLANA_WALLET_KEY` | auto-resolved | Base58-encoded Solana keypair secret key. **Optional** — when unset (and signing is enabled) the server reads or auto-creates `~/.solvela/wallet.json`. Set it to override the on-disk wallet. |
 | `SOLANA_RPC_URL` | required (when signing enabled) | Solana RPC endpoint (e.g. `https://api.mainnet-beta.solana.com`) |
-| `SOLANA_WALLET_ADDRESS` | not configured | Wallet pubkey shown in `wallet_status` and `spending` |
+| `SOLANA_WALLET_ADDRESS` | derived from key | Display-only override. The address shown in `wallet_status` / `spending` is **derived from the resolved key**; if this env var is set and differs, the server logs a warning and uses the derived address. |
 
 ### Escrow Mode
 
@@ -224,7 +242,11 @@ rm ~/.solvela/mcp-session.json
 - **`auto`** (default) — The SDK prefers escrow deposits when the gateway advertises them, falling back to direct TransferChecked. Recommended for production.
 - **`escrow`** — Only use escrow payment schemes. Fails if the gateway does not advertise escrow.
 - **`direct`** — Only use direct USDC TransferChecked payment schemes. Ignores escrow offers.
-- **`off`** — Do not sign payments. Useful when the gateway runs with `dev_bypass_payment` enabled (development only). `SOLANA_WALLET_KEY` and `SOLANA_RPC_URL` are not required in this mode.
+- **`off`** — Do not sign payments. Useful when the gateway runs with `dev_bypass_payment` enabled (development only). `SOLANA_WALLET_KEY` and `SOLANA_RPC_URL` are not required in this mode, and **no wallet file is read or created**.
+
+In every mode except `off`, the wallet is resolved on startup using the
+precedence `SOLANA_WALLET_KEY` env → `~/.solvela/wallet.json` → auto-create. The
+displayed wallet address is always derived from the resolved key.
 
 ## Available Tools
 
@@ -281,7 +303,7 @@ Deposit USDC into a trustless escrow PDA on Solana for a future Solvela call. Th
 
 **Only visible when `SOLVELA_ESCROW_MODE=enabled`.**
 
-Requires `SOLANA_WALLET_KEY` and `SOLANA_RPC_URL` regardless of `SOLVELA_SIGNING_MODE`.
+Requires a signing wallet and `SOLANA_RPC_URL` regardless of `SOLVELA_SIGNING_MODE` (escrow always signs on-chain). The wallet is resolved the same way as for chat — `SOLANA_WALLET_KEY` env, then `~/.solvela/wallet.json`, auto-created if absent — even when `SOLVELA_SIGNING_MODE=off`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -383,9 +405,19 @@ Use a single MCP server instance per session file.
 
 ### Key storage model
 
-`SOLANA_WALLET_KEY` is a **hot-wallet secret**. Anyone who can read it can drain your USDC. Treat it with the same care as an SSH private key.
+Your wallet's private key is a **hot-wallet secret**. Anyone who can read it can
+drain your USDC. Treat it with the same care as an SSH private key.
 
-**The installer does NOT write `SOLANA_WALLET_KEY` to any config file by default.** The generated config intentionally omits the key. You must supply it through one of the secure paths below.
+**Default (auto-wallet):** when `SOLANA_WALLET_KEY` is not set, the server stores
+the key in `~/.solvela/wallet.json` (file mode `0600`, dir mode `0700`),
+auto-creating it on first run. This is the same file the `solvela` CLI uses, so
+the CLI and the MCP server share one wallet. The file is written atomically and
+is **never overwritten** once it exists. On load it is validated (the key must
+be exactly 64 bytes and its derived address must match the stored `address`); a
+corrupt or tampered file is rejected rather than used. **Back up
+`~/.solvela/wallet.json` and keep it `0600`.**
+
+**The installer does NOT write `SOLANA_WALLET_KEY` to any config file by default.** The generated config intentionally omits the key. To use an explicit key instead of the auto-created file, supply it through one of the secure paths below.
 
 **`--include-key` flag (dev/CI only):** Passing this flag writes a plaintext placeholder into the config file. The installer emits a prominent stderr warning. Only use this in isolated dev environments or ephemeral CI runners where the config file is never committed or shared. The placeholder must be replaced with your actual key before the MCP server will work.
 
@@ -409,10 +441,10 @@ Or store it in a `0600` file and source it from your profile.
 
 ### General rules
 
-- Never commit `SOLANA_WALLET_KEY` to version control. Add `*.env`, `.solvela/env`, and any file containing the key to `.gitignore`.
-- The MCP server never logs, echoes, or returns the key in tool responses. Stack traces and error messages are also sanitized.
+- Never commit `SOLANA_WALLET_KEY` or `~/.solvela/wallet.json` to version control. Add `*.env`, `.solvela/`, and any file containing the key to `.gitignore`.
+- The MCP server never logs, echoes, or returns the key in tool responses or startup notices (which print the **address only**). Stack traces and error messages are also sanitized.
 - The SDK zeroes secret key bytes in memory after signing.
-- Private key material flows only from environment variable into the signer — it is never passed through tool arguments (which are model-controlled).
+- Private key material flows only from the resolved wallet (env var or `~/.solvela/wallet.json`) into the signer — it is never passed through tool arguments (which are model-controlled).
 
 ## Testing
 

--- a/sdks/mcp/package.json
+++ b/sdks/mcp/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "node --test tests/server.test.ts tests/contract.test.ts tests/session.test.ts tests/escrow.test.ts",
+    "test": "node --test tests/server.test.ts tests/contract.test.ts tests/session.test.ts tests/escrow.test.ts tests/wallet.test.ts",
     "prebuild": "node ../signer-core/scripts/ensure-built.mjs",
     "pretest": "node ../signer-core/scripts/ensure-built.mjs"
   },

--- a/sdks/mcp/src/index.ts
+++ b/sdks/mcp/src/index.ts
@@ -18,9 +18,14 @@
  *   SOLVELA_ESCROW_MODE         Set to "enabled" to expose the deposit_escrow tool
  *   SOLVELA_MAX_ESCROW_DEPOSIT  Per-call deposit cap in USDC (default: 5.0)
  *   SOLVELA_MAX_ESCROW_SESSION  Cumulative session deposit cap in USDC (default: 20.0)
- *   SOLANA_WALLET_KEY           Base58 secret key (required unless SOLVELA_SIGNING_MODE=off)
+ *   SOLANA_WALLET_KEY           Base58 secret key. OPTIONAL: when unset (and
+ *                               SOLVELA_SIGNING_MODE != off) the server resolves
+ *                               ~/.solvela/wallet.json, auto-creating a
+ *                               non-custodial wallet on first run.
  *   SOLANA_RPC_URL              Solana RPC endpoint (required unless SOLVELA_SIGNING_MODE=off)
- *   SOLANA_WALLET_ADDRESS       Wallet pubkey shown in wallet_status / spending
+ *   SOLANA_WALLET_ADDRESS       Optional override for display only. The address
+ *                               shown is DERIVED from the resolved key; a
+ *                               mismatch logs a warning and the derived value wins.
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -40,6 +45,8 @@ import { parseStrictUsdc } from './parse-amount.js';
 import { createPaymentHeader, decodePaymentHeader, isStubTransaction } from '@solvela/signer-core';
 import type { PaymentRequired, PaymentAccept } from '@solvela/signer-core';
 import { Connection, PublicKey } from '@solana/web3.js';
+
+import { resolveWallet } from './wallet.js';
 
 // ---------------------------------------------------------------------------
 // Bootstrap client from environment
@@ -133,6 +140,12 @@ if (maxEscrowSessionStr !== undefined) {
 
 // T-1K-B: Wire session store for persistence.
 const sessionStore = createSessionStore();
+
+// Resolved wallet address (source of truth, derived from the resolved key).
+// Populated in main() by resolveWallet() before the transport connects, so
+// every tool handler (which runs post-connect) sees a stable value. Stays
+// undefined in `off` mode when no key is configured.
+let resolvedWalletAddress: string | undefined;
 
 const client = new GatewayClient({
   apiUrl: process.env['SOLVELA_API_URL'] ?? process.env['RCR_API_URL'], // compat
@@ -245,7 +258,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'wallet_status': {
         const health = await client.health();
-        const walletAddress = process.env['SOLANA_WALLET_ADDRESS'] ?? 'not configured';
+        // Show the address DERIVED from the resolved key (source of truth), not
+        // the SOLANA_WALLET_ADDRESS env var (display-only, may be stale/mismatched).
+        const walletAddress = resolvedWalletAddress ?? 'not configured';
         const spend = client.spendSummary();
 
         const lines = [
@@ -638,14 +653,59 @@ function formatUsage(response: { model: string; usage?: { prompt_tokens: number;
 // ---------------------------------------------------------------------------
 
 async function main() {
-  // T1-D / T1-E: Startup validation — fail fast when signing is enabled without required keys.
+  // Auto-wallet: resolve (and, on first run, auto-create) a non-custodial
+  // wallet so a new user never has to generate a keypair or set an env var.
+  // Precedence: SOLANA_WALLET_KEY env > ~/.solvela/wallet.json > auto-generate.
+  // In `off` mode no wallet is required and none is created. The resolved key
+  // is published to process.env['SOLANA_WALLET_KEY'] so the existing signer
+  // read-path (signer-core via client.chat / deposit_escrow) plugs in
+  // identically — only signed txs ever leave the host.
   if (signingMode !== 'off') {
-    if (!process.env['SOLANA_WALLET_KEY']) {
+    let resolved;
+    try {
+      resolved = await resolveWallet({ signingMode });
+    } catch (err) {
+      // Fail closed — never sign with a half-resolved or tampered wallet.
       process.stderr.write(
-        'Fatal: SOLANA_WALLET_KEY is required when signing is enabled. Set SOLVELA_SIGNING_MODE=off to run without signing.\n',
+        `Fatal: could not resolve a Solana wallet: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       process.exit(1);
+      return; // unreachable; satisfies the type narrower below
     }
+
+    if (resolved.privateKey === undefined || resolved.address === undefined) {
+      // Defensive: signing mode != off must always yield a usable wallet.
+      process.stderr.write(
+        'Fatal: wallet resolution returned no key while signing is enabled.\n',
+      );
+      process.exit(1);
+      return;
+    }
+
+    // If the user pinned SOLANA_WALLET_ADDRESS and it disagrees with the
+    // key-derived address, warn (possible misconfig) but proceed with derived.
+    const envAddress = process.env['SOLANA_WALLET_ADDRESS'];
+    if (envAddress !== undefined && envAddress !== '' && envAddress !== resolved.address) {
+      process.stderr.write(
+        `[solvela-mcp] WARN: SOLANA_WALLET_ADDRESS=${envAddress} does not match the ` +
+        `address derived from the resolved key (${resolved.address}). Using the derived address.\n`,
+      );
+    }
+
+    // Publish the resolved key + address to the env the existing read-path uses
+    // (signer-core reads SOLANA_WALLET_KEY; spendSummary reads SOLANA_WALLET_ADDRESS).
+    // The derived address overwrites any stale/mismatched env value so every
+    // display path is consistent with the key that actually signs.
+    process.env['SOLANA_WALLET_KEY'] = resolved.privateKey;
+    process.env['SOLANA_WALLET_ADDRESS'] = resolved.address;
+    resolvedWalletAddress = resolved.address;
+
+    // Startup notice → stderr only (stdout must stay clean for stdio transport).
+    // Address only; the private key is NEVER logged.
+    if (resolved.notice) {
+      process.stderr.write(`${resolved.notice}\n`);
+    }
+
     if (!process.env['SOLANA_RPC_URL']) {
       process.stderr.write(
         'Fatal: SOLANA_RPC_URL is required when signing is enabled. Set SOLVELA_SIGNING_MODE=off to run without signing.\n',
@@ -686,13 +746,36 @@ async function main() {
       );
       process.exit(1);
     }
-    // SOLANA_WALLET_KEY and SOLANA_RPC_URL are also required when escrow is enabled,
-    // even if SOLVELA_SIGNING_MODE=off (escrow always needs real signing).
+    // Escrow always needs a real signing wallet, even when SOLVELA_SIGNING_MODE=off
+    // (the deposit_escrow path signs + broadcasts on-chain). If the signing-mode
+    // block above already resolved a wallet, SOLANA_WALLET_KEY and
+    // resolvedWalletAddress are set; otherwise (off mode + escrow) resolve one
+    // now, forcing file resolution/auto-create with mode 'auto'.
     if (!process.env['SOLANA_WALLET_KEY']) {
-      process.stderr.write(
-        'Fatal: SOLANA_WALLET_KEY required when SOLVELA_ESCROW_MODE=enabled.\n',
-      );
-      process.exit(1);
+      let resolved;
+      try {
+        resolved = await resolveWallet({ signingMode: 'auto' });
+      } catch (err) {
+        process.stderr.write(
+          `Fatal: SOLVELA_ESCROW_MODE=enabled but could not resolve a wallet: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exit(1);
+        return;
+      }
+      if (resolved.privateKey === undefined || resolved.address === undefined) {
+        process.stderr.write(
+          'Fatal: wallet resolution returned no key while SOLVELA_ESCROW_MODE=enabled.\n',
+        );
+        process.exit(1);
+        return;
+      }
+      process.env['SOLANA_WALLET_KEY'] = resolved.privateKey;
+      process.env['SOLANA_WALLET_ADDRESS'] = resolved.address;
+      resolvedWalletAddress = resolved.address;
+      if (resolved.notice) {
+        process.stderr.write(`${resolved.notice}\n`);
+      }
     }
     if (!process.env['SOLANA_RPC_URL']) {
       process.stderr.write(

--- a/sdks/mcp/src/wallet.ts
+++ b/sdks/mcp/src/wallet.ts
@@ -1,0 +1,377 @@
+/**
+ * Non-custodial wallet resolution + auto-creation for the Solvela MCP server.
+ *
+ * The MCP server used to hard-exit when `SOLANA_WALLET_KEY` was unset. This
+ * module resolves — and, on first run, auto-creates — a client-side wallet so a
+ * new user never has to generate a keypair or set an env var. The security model
+ * is unchanged: the private key stays on the machine and only ever reaches the
+ * signer via the same `SOLANA_WALLET_KEY`-shaped base58 string; only signed
+ * transactions leave the host.
+ *
+ * Resolution precedence (highest first):
+ *   1. `SOLANA_WALLET_KEY` env (base58 64-byte secret) — explicit, wins. When
+ *      set, NO file is read or created.
+ *   2. `<baseDir>/wallet.json` field `private_key` — this file is SHARED with
+ *      the Rust CLI (`crates/cli/src/commands/wallet.rs`). Read if present.
+ *   3. Neither → auto-generate an ed25519 keypair and write `<baseDir>/wallet.json`.
+ *
+ * On-disk schema (byte-compatible with the Rust CLI's `wallet init`):
+ *   { "private_key": "<base58 of 64 bytes: seed[0..32] || pubkey[32..64]>",
+ *     "address":     "<base58 of the 32-byte pubkey>",
+ *     "created_at":  "<RFC3339 timestamp>" }
+ *
+ * The 64-byte base58 form is exactly what `SOLANA_WALLET_KEY` and the signer
+ * (`Keypair.fromSecretKey(bs58.decode(...))` in signer-core) already expect, so
+ * a resolved key plugs into the signing path identically.
+ *
+ * SECURITY:
+ *  - The private key is a secret. It is NEVER logged, printed, or embedded in a
+ *    notice/error — only the public address is surfaced.
+ *  - The wallet file is written 0600; the parent dir is 0700.
+ *  - Auto-create is atomic and exclusive (write a unique temp, fchmod 0600 on the
+ *    FD before close, then rename), and NEVER overwrites an existing wallet.json.
+ *  - On load, the file is validated: the decoded `private_key` must be exactly
+ *    64 bytes and the pubkey derived from it must equal the stored `address`.
+ *    A corrupt/tampered file fails closed (throws) — it is never silently used.
+ */
+
+import { generateKeyPairSync, randomBytes } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { Keypair } from '@solana/web3.js';
+import bs58 from 'bs58';
+
+/** Signing modes accepted by the MCP server (mirrors `SOLVELA_SIGNING_MODE`). */
+export type SigningMode = 'auto' | 'escrow' | 'direct' | 'off';
+
+export interface ResolveWalletOptions {
+  /**
+   * Base directory that holds `wallet.json`. Defaults to `~/.solvela`.
+   * Overridable so tests can inject a tmpdir and never touch the real home dir.
+   */
+  baseDir?: string;
+  /**
+   * Current signing mode. In `off` mode no wallet is required and no file is
+   * created (an explicit `SOLANA_WALLET_KEY` is still honored for display).
+   */
+  signingMode: SigningMode;
+}
+
+/** Where the resolved wallet came from. */
+export type WalletSource = 'env' | 'file' | 'none';
+
+export interface ResolvedWallet {
+  /**
+   * Base58 64-byte secret key, in the exact form `SOLANA_WALLET_KEY` expects.
+   * `undefined` only when `source === 'none'` (off mode, no env key).
+   * SECURITY: never log this value.
+   */
+  privateKey?: string;
+  /** Base58 public address derived from the key. `undefined` only for `source === 'none'`. */
+  address?: string;
+  /** Resolution source. */
+  source: WalletSource;
+  /** True iff this call generated and wrote a brand-new wallet file. */
+  created: boolean;
+  /**
+   * A human-readable, secret-free startup notice for stderr (never stdout —
+   * stdout must stay clean for the stdio transport). Contains the address only.
+   * `undefined` when there is nothing to say (e.g. env source with no notice).
+   */
+  notice?: string;
+}
+
+/** Number of bytes in a Solana secret key (`seed[0..32] || pubkey[32..64]`). */
+const SECRET_KEY_BYTES = 64;
+
+function defaultBaseDir(): string {
+  return path.join(os.homedir(), '.solvela');
+}
+
+function walletFilePath(baseDir: string): string {
+  return path.join(baseDir, 'wallet.json');
+}
+
+/**
+ * Derive the Solana address from a base58 64-byte secret key, using the SAME
+ * primitive the signer uses (`Keypair.fromSecretKey`). This both yields the
+ * source-of-truth address and validates that the key is a well-formed,
+ * self-consistent ed25519 secret key — `Keypair.fromSecretKey` rejects a key
+ * whose pubkey half does not match the seed half.
+ *
+ * @throws Error with a redacted message (never echoes the key) on any decode or
+ *         consistency failure.
+ */
+function deriveAddress(privateKeyB58: string): string {
+  let decoded: Uint8Array;
+  try {
+    decoded = bs58.decode(privateKeyB58);
+  } catch {
+    // Do NOT include the key bytes/string in the message.
+    throw new Error('private key is not valid base58');
+  }
+  if (decoded.length !== SECRET_KEY_BYTES) {
+    throw new Error(
+      `private key must decode to exactly ${SECRET_KEY_BYTES} bytes (got ${decoded.length})`,
+    );
+  }
+  try {
+    // Keypair.fromSecretKey verifies the seed→pubkey relationship and throws on
+    // a tampered key. We never log the resulting secret.
+    return Keypair.fromSecretKey(decoded).publicKey.toBase58();
+  } catch (err) {
+    // err.message from web3.js does not contain the key; still wrap defensively.
+    throw new Error(
+      `private key is not a valid ed25519 secret key: ${err instanceof Error ? err.message : 'unknown error'}`,
+    );
+  }
+}
+
+/**
+ * Resolve (and, on first run, auto-create) the wallet.
+ *
+ * @throws Error on an invalid `SOLANA_WALLET_KEY`, a corrupt/tampered wallet
+ *         file, or an I/O failure. Fails closed — never silently substitutes a
+ *         different key or quotes a zero/empty wallet.
+ */
+export async function resolveWallet(opts: ResolveWalletOptions): Promise<ResolvedWallet> {
+  const baseDir = opts.baseDir ?? defaultBaseDir();
+  const filePath = walletFilePath(baseDir);
+
+  // 1. Explicit env key wins. Do NOT read or create any file.
+  const envKey = process.env['SOLANA_WALLET_KEY'];
+  if (envKey !== undefined && envKey !== '') {
+    let address: string;
+    try {
+      address = deriveAddress(envKey);
+    } catch (err) {
+      // Fail closed — never fall through to the file when an explicit key is set.
+      throw new Error(
+        `SOLANA_WALLET_KEY is set but invalid: ${err instanceof Error ? err.message : 'unknown error'}`,
+      );
+    }
+    return {
+      privateKey: envKey,
+      address,
+      source: 'env',
+      created: false,
+      // From env: a single quiet line, no key. Address only.
+      notice: `[solvela-mcp] Using wallet from SOLANA_WALLET_KEY → ${address}`,
+    };
+  }
+
+  // 2/3. File-backed resolution only happens when signing is actually needed.
+  // In `off` mode require no wallet and create no file.
+  if (opts.signingMode === 'off') {
+    return { source: 'none', created: false };
+  }
+
+  // 2. Existing file → load + validate.
+  if (await fileExists(filePath)) {
+    const { privateKey, address } = await loadWalletFile(filePath);
+    return {
+      privateKey,
+      address,
+      source: 'file',
+      created: false,
+      notice: `[solvela-mcp] Loaded Solvela wallet → ${address}`,
+    };
+  }
+
+  // 3. Neither → auto-generate + write.
+  const { privateKey, address } = generateWallet();
+  // createIfAbsent returns the actual on-disk wallet: if a concurrent run won
+  // the race and wrote first, we adopt THAT wallet rather than clobbering it.
+  const persisted = await createIfAbsent(baseDir, filePath, privateKey, address);
+
+  if (persisted.created) {
+    return {
+      privateKey: persisted.privateKey,
+      address: persisted.address,
+      source: 'file',
+      created: true,
+      notice:
+        `[solvela-mcp] Created a new Solvela wallet → ${persisted.address}. ` +
+        `Fund it with USDC-SPL on Solana — plus a little SOL (~0.01) for network fees — ` +
+        `to start paying for calls. Back it up: ${filePath} controls your funds.`,
+    };
+  }
+  // Lost the create race — adopt the winner's file.
+  return {
+    privateKey: persisted.privateKey,
+    address: persisted.address,
+    source: 'file',
+    created: false,
+    notice: `[solvela-mcp] Loaded Solvela wallet → ${persisted.address}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface WalletFields {
+  privateKey: string;
+  address: string;
+}
+
+/**
+ * Load and validate a wallet.json. Fails closed on any inconsistency.
+ *
+ * Validation (per spec): the decoded `private_key` is exactly 64 bytes AND the
+ * pubkey derived from `seed[0..32]` base58-encodes to the stored `address`. A
+ * mismatch (corruption / tampering) throws rather than silently using the file.
+ */
+async function loadWalletFile(filePath: string): Promise<WalletFields> {
+  const raw = await fs.readFile(filePath, 'utf-8');
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`wallet file ${filePath} is not valid JSON`);
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error(`wallet file ${filePath} is not a JSON object`);
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  const privateKey = obj['private_key'];
+  if (typeof privateKey !== 'string' || privateKey === '') {
+    throw new Error(`wallet file ${filePath} is missing a string 'private_key' field`);
+  }
+  const storedAddress = obj['address'];
+  if (typeof storedAddress !== 'string' || storedAddress === '') {
+    throw new Error(`wallet file ${filePath} is missing a string 'address' field`);
+  }
+
+  // deriveAddress enforces the 64-byte length + ed25519 self-consistency and
+  // gives us the canonical pubkey to compare against the stored address.
+  const derived = deriveAddress(privateKey);
+  if (derived !== storedAddress) {
+    // Tampered / corrupt: the stored address does not match the key. Fail
+    // closed — never sign with a key whose advertised address is wrong.
+    throw new Error(
+      `wallet file ${filePath} address does not match its private key ` +
+        `(stored=${storedAddress}, derived=${derived}). Refusing to use a tampered wallet.`,
+    );
+  }
+
+  return { privateKey, address: derived };
+}
+
+/** Generate a fresh ed25519 keypair in the Solana base58 64-byte secret-key form. */
+function generateWallet(): WalletFields {
+  // node:crypto ed25519 — no extra dependency, FIPS-grade CSPRNG. We extract the
+  // raw 32-byte seed (tail of the PKCS8 DER) and raw 32-byte pubkey (tail of the
+  // SPKI DER), then assemble the Solana `seed || pubkey` secret-key layout.
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const spki = publicKey.export({ type: 'spki', format: 'der' });
+  const pkcs8 = privateKey.export({ type: 'pkcs8', format: 'der' });
+  const rawPub = spki.subarray(spki.length - 32);
+  const rawSeed = pkcs8.subarray(pkcs8.length - 32);
+
+  const secret = Buffer.concat([rawSeed, rawPub]);
+  const privateKeyB58 = bs58.encode(secret);
+  // Derive via the signer's own primitive so the persisted address is exactly
+  // what the signer will produce, and the key is validated before it is written.
+  const address = deriveAddress(privateKeyB58);
+  return { privateKey: privateKeyB58, address };
+}
+
+interface PersistResult {
+  privateKey: string;
+  address: string;
+  /** True iff THIS call wrote the file; false iff a concurrent run won the race. */
+  created: boolean;
+}
+
+/**
+ * Atomically and exclusively persist a freshly-generated wallet, never
+ * overwriting an existing wallet.json.
+ *
+ * Steps:
+ *  1. Ensure `<baseDir>` exists with mode 0700 (chmod after mkdir — mkdir's mode
+ *     is not applied to a pre-existing directory on Linux).
+ *  2. Open a UNIQUELY-named temp file in the same dir with `wx` (O_EXCL) so a
+ *     concurrent run cannot clobber or race our temp.
+ *  3. fchmod 0600 on the FD, write, fsync, close — the file is never visible on
+ *     disk with wider permissions.
+ *  4. `link` the temp to the destination (atomic, fails with EEXIST if another
+ *     run already created wallet.json), then unlink the temp. If the link
+ *     fails because the destination already exists, adopt that existing wallet
+ *     (re-read it) — we never clobber it.
+ */
+async function createIfAbsent(
+  baseDir: string,
+  filePath: string,
+  privateKeyB58: string,
+  address: string,
+): Promise<PersistResult> {
+  await fs.mkdir(baseDir, { recursive: true, mode: 0o700 });
+  if (process.platform !== 'win32') {
+    // mkdir({mode}) does not apply the mode to a pre-existing dir on Linux.
+    await fs.chmod(baseDir, 0o700).catch(() => {});
+  }
+
+  const json = JSON.stringify(
+    {
+      private_key: privateKeyB58,
+      address,
+      created_at: new Date().toISOString(),
+    },
+    null,
+    2,
+  );
+
+  // Unique temp name in the SAME directory (same filesystem → atomic link/rename).
+  const tmpPath = path.join(baseDir, `.wallet.json.tmp-${process.pid}-${randomBytes(6).toString('hex')}`);
+
+  // Open EXCLUSIVE ('wx' = O_CREAT | O_EXCL | O_WRONLY) at mode 0600.
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(tmpPath, 'wx', 0o600);
+    // Defense-in-depth: fchmod 0600 on the FD before writing, in case the umask
+    // widened the create mode.
+    if (process.platform !== 'win32') {
+      await handle.chmod(0o600);
+    }
+    await handle.writeFile(json, 'utf-8');
+    await handle.sync();
+  } finally {
+    await handle?.close();
+  }
+
+  try {
+    // link() is atomic and fails with EEXIST if wallet.json already exists —
+    // this is the no-overwrite guarantee, race-safe across concurrent runs.
+    await fs.link(tmpPath, filePath);
+    await fs.unlink(tmpPath).catch(() => {});
+    if (process.platform !== 'win32') {
+      // Belt-and-braces: re-assert 0600 on the destination.
+      await fs.chmod(filePath, 0o600).catch(() => {});
+    }
+    return { privateKey: privateKeyB58, address, created: true };
+  } catch (err) {
+    // Clean up our temp regardless of why link failed.
+    await fs.unlink(tmpPath).catch(() => {});
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      // Another run won the race (or the file appeared between our existence
+      // check and here). Adopt the existing wallet — never clobber it.
+      const existing = await loadWalletFile(filePath);
+      return { privateKey: existing.privateKey, address: existing.address, created: false };
+    }
+    throw err;
+  }
+}

--- a/sdks/mcp/tests/wallet.test.ts
+++ b/sdks/mcp/tests/wallet.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Tests for wallet resolution + auto-creation (src/wallet.ts).
+ *
+ * Covers the new `resolveWallet()` precedence chain:
+ *   1. SOLANA_WALLET_KEY env  (explicit, wins; no file read or created)
+ *   2. ~/.solvela/wallet.json `private_key`  (shared with the Rust CLI)
+ *   3. neither → auto-generate ed25519 + write ~/.solvela/wallet.json
+ *
+ * SECURITY: every test uses an injected tmpdir base — it MUST never touch the
+ * real ~/.solvela. The private key is a secret; assertions verify it is never
+ * present in any log/notice string and that file perms are 0600 / dir 0700.
+ *
+ * Harness: Node's built-in test runner (node --test), matching the rest of the
+ * MCP test suite — NOT Vitest. TS is type-stripped by Node 22.
+ */
+
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { Keypair } from '@solana/web3.js';
+import bs58 from 'bs58';
+
+import { resolveWallet } from '../src/wallet.ts';
+
+// ---------------------------------------------------------------------------
+// Known golden keypair vector (fixed seed 0x01..0x20).
+// Verified to round-trip through @solana/web3.js Keypair.fromSecretKey:
+//   private_key = base58(seed[0..32] || pubkey[32..64])
+//   address     = base58(pubkey)
+// Reproduce: node script in the auto-wallet implementation notes.
+// ---------------------------------------------------------------------------
+const GOLDEN = {
+  private_key:
+    '2Ana1pUpv2ZbMVkwF5FXapYeBEjdxDatLn7nvJkhgTSdZd8hbDHTd21as7EAsg7ypityqfsw2pMQKJcVDVcAEsd',
+  address: '9C6hybhQ6Aycep9jaUnP6uL9ZYvDjUp1aSkFWPUFJtpj',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeTempBase(): Promise<string> {
+  // The base dir stands in for ~/.solvela — resolveWallet writes wallet.json here.
+  return fs.mkdtemp(path.join(os.tmpdir(), 'solvela-wallet-test-'));
+}
+
+async function cleanupDir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+function walletPath(base: string): string {
+  return path.join(base, 'wallet.json');
+}
+
+async function writeWalletFile(base: string, contents: unknown): Promise<void> {
+  await fs.mkdir(base, { recursive: true });
+  await fs.writeFile(walletPath(base), JSON.stringify(contents, null, 2), 'utf-8');
+}
+
+/** Pubkey derived from the stored private key, via the SAME primitive the signer uses. */
+function derivedAddress(privateKeyB58: string): string {
+  return Keypair.fromSecretKey(bs58.decode(privateKeyB58)).publicKey.toBase58();
+}
+
+before(() => {
+  delete process.env['SOLANA_WALLET_KEY'];
+  delete process.env['SOLANA_WALLET_ADDRESS'];
+  delete process.env['SOLVELA_SIGNING_MODE'];
+});
+
+// Each test owns its env; clear the wallet key between tests so leakage from one
+// test can never satisfy another's precedence assertions.
+beforeEach(() => {
+  delete process.env['SOLANA_WALLET_KEY'];
+});
+
+afterEach(() => {
+  delete process.env['SOLANA_WALLET_KEY'];
+});
+
+// ---------------------------------------------------------------------------
+// 1. Parity golden — CLI-schema file loads, and round-trips back out.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — golden parity with the Rust CLI schema', () => {
+  it('loads a wallet.json written in the CLI schema → correct address + usable signer', async () => {
+    const base = await makeTempBase();
+    try {
+      await writeWalletFile(base, {
+        private_key: GOLDEN.private_key,
+        address: GOLDEN.address,
+        created_at: '2026-01-01T00:00:00Z',
+      });
+
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+
+      assert.equal(resolved.address, GOLDEN.address, 'address must match stored vector');
+      assert.equal(resolved.privateKey, GOLDEN.private_key, 'private key must be returned verbatim');
+      assert.equal(resolved.source, 'file');
+      assert.equal(resolved.created, false);
+
+      // The resolved key must plug into the signer's decoding identically.
+      const signerAddress = derivedAddress(resolved.privateKey);
+      assert.equal(signerAddress, GOLDEN.address, 'signer-derived pubkey must equal stored address');
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('a file written by resolveWallet round-trips: re-load yields the same key + address', async () => {
+    const base = await makeTempBase();
+    try {
+      const first = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      assert.equal(first.created, true, 'first run must auto-create');
+
+      const second = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      assert.equal(second.source, 'file', 'second run must load the file');
+      assert.equal(second.created, false, 'second run must NOT re-create');
+      assert.equal(second.privateKey, first.privateKey, 'private key must survive round-trip');
+      assert.equal(second.address, first.address, 'address must survive round-trip');
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('the on-disk schema matches the CLI: private_key = base58(seed || pubkey), address = base58(pubkey)', async () => {
+    const base = await makeTempBase();
+    try {
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+
+      const raw = JSON.parse(await fs.readFile(walletPath(base), 'utf-8')) as {
+        private_key: string;
+        address: string;
+        created_at: string;
+      };
+
+      // 64-byte secret-key convention.
+      const secret = bs58.decode(raw.private_key);
+      assert.equal(secret.length, 64, 'private_key must decode to exactly 64 bytes');
+
+      // address must be base58(pubkey == bytes[32..64]).
+      assert.equal(bs58.encode(secret.subarray(32)), raw.address, 'address must be base58 of pubkey half');
+      // And the pubkey half must be the ed25519 pubkey of the seed half — verified
+      // through the signer's Keypair.fromSecretKey (rejects an inconsistent key).
+      assert.equal(derivedAddress(raw.private_key), raw.address, 'pubkey must derive from seed half');
+
+      // created_at must be a parseable RFC3339 timestamp.
+      assert.ok(!Number.isNaN(Date.parse(raw.created_at)), 'created_at must be a valid timestamp');
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Env precedence — SOLANA_WALLET_KEY wins; no file read or created.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — SOLANA_WALLET_KEY env precedence', () => {
+  it('uses the env key and never reads or creates a file', async () => {
+    const base = await makeTempBase();
+    try {
+      process.env['SOLANA_WALLET_KEY'] = GOLDEN.private_key;
+
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+
+      assert.equal(resolved.source, 'env');
+      assert.equal(resolved.created, false);
+      assert.equal(resolved.address, GOLDEN.address, 'address must be derived from the env key');
+      assert.equal(resolved.privateKey, GOLDEN.private_key);
+
+      // No file should have been created.
+      await assert.rejects(
+        fs.access(walletPath(base)),
+        'no wallet.json may be created when SOLANA_WALLET_KEY is set',
+      );
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('env wins even when a file is also present (file is not read)', async () => {
+    const base = await makeTempBase();
+    try {
+      // A DIFFERENT key on disk. If the file were read, the address would differ.
+      const fileKp = Keypair.generate();
+      await writeWalletFile(base, {
+        private_key: bs58.encode(fileKp.secretKey),
+        address: fileKp.publicKey.toBase58(),
+        created_at: '2026-01-01T00:00:00Z',
+      });
+
+      process.env['SOLANA_WALLET_KEY'] = GOLDEN.private_key;
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+
+      assert.equal(resolved.source, 'env');
+      assert.equal(resolved.address, GOLDEN.address, 'must use env key, not the on-disk key');
+      assert.notEqual(resolved.address, fileKp.publicKey.toBase58());
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('rejects an invalid SOLANA_WALLET_KEY rather than silently falling back to a file', async () => {
+    const base = await makeTempBase();
+    try {
+      await writeWalletFile(base, {
+        private_key: GOLDEN.private_key,
+        address: GOLDEN.address,
+        created_at: '2026-01-01T00:00:00Z',
+      });
+      process.env['SOLANA_WALLET_KEY'] = 'not-a-valid-base58-key!!!';
+
+      await assert.rejects(
+        resolveWallet({ baseDir: base, signingMode: 'auto' }),
+        /SOLANA_WALLET_KEY/,
+        'an invalid env key must throw, not fall through to the file',
+      );
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. File fallback — no env, file present → loaded.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — file fallback', () => {
+  it('loads the existing wallet.json when no env key is set', async () => {
+    const base = await makeTempBase();
+    try {
+      await writeWalletFile(base, {
+        private_key: GOLDEN.private_key,
+        address: GOLDEN.address,
+        created_at: '2026-01-01T00:00:00Z',
+      });
+
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      assert.equal(resolved.source, 'file');
+      assert.equal(resolved.created, false);
+      assert.equal(resolved.address, GOLDEN.address);
+      assert.equal(resolved.privateKey, GOLDEN.private_key);
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Auto-create — no env, no file → file created with correct schema.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — auto-create on first run', () => {
+  it('creates wallet.json with a valid keypair and derived address', async () => {
+    const base = await makeTempBase();
+    try {
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+
+      assert.equal(resolved.source, 'file');
+      assert.equal(resolved.created, true, 'first run must report created=true');
+
+      // File exists and parses.
+      const raw = JSON.parse(await fs.readFile(walletPath(base), 'utf-8')) as {
+        private_key: string;
+        address: string;
+        created_at: string;
+      };
+
+      // Schema fields present.
+      assert.ok(raw.private_key && raw.address && raw.created_at, 'all schema fields present');
+
+      // Keypair is valid and self-consistent.
+      const secret = bs58.decode(raw.private_key);
+      assert.equal(secret.length, 64);
+      assert.equal(derivedAddress(raw.private_key), raw.address, 'address derives from key');
+
+      // resolveWallet's returned values match the file.
+      assert.equal(resolved.address, raw.address);
+      assert.equal(resolved.privateKey, raw.private_key);
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('creates the base dir if it does not exist', async () => {
+    const parent = await makeTempBase();
+    try {
+      const base = path.join(parent, 'nested', '.solvela');
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      assert.equal(resolved.created, true);
+      await fs.access(walletPath(base)); // throws if missing
+    } finally {
+      await cleanupDir(parent);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Permissions — file 0600, dir 0700.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — file/dir permissions', () => {
+  it('created wallet.json is mode 0600 and the dir is 0700', async (t) => {
+    if (process.platform === 'win32') {
+      t.skip('POSIX permission semantics do not apply on Windows');
+      return;
+    }
+    const base = await makeTempBase();
+    try {
+      await resolveWallet({ baseDir: base, signingMode: 'auto' });
+
+      const fileStat = await fs.stat(walletPath(base));
+      assert.equal(fileStat.mode & 0o777, 0o600, 'wallet.json must be 0600');
+
+      const dirStat = await fs.stat(base);
+      assert.equal(dirStat.mode & 0o777, 0o700, '.solvela dir must be 0700');
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. No-overwrite — a second run does not clobber the existing file.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — never overwrites an existing wallet', () => {
+  it('a second resolveWallet keeps the original key bytes', async () => {
+    const base = await makeTempBase();
+    try {
+      const first = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      const bytesBefore = await fs.readFile(walletPath(base), 'utf-8');
+
+      const second = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      const bytesAfter = await fs.readFile(walletPath(base), 'utf-8');
+
+      assert.equal(second.created, false);
+      assert.equal(second.privateKey, first.privateKey);
+      assert.equal(bytesAfter, bytesBefore, 'file contents must be byte-identical after a second run');
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Validation — corrupt/tampered file throws, never silently used.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — validation of an on-disk file (fail closed)', () => {
+  it('throws on a wrong-length private_key', async () => {
+    const base = await makeTempBase();
+    try {
+      // 32-byte key (seed only) — not the 64-byte secret-key form.
+      const shortKey = bs58.encode(Buffer.alloc(32, 7));
+      await writeWalletFile(base, {
+        private_key: shortKey,
+        address: GOLDEN.address,
+        created_at: '2026-01-01T00:00:00Z',
+      });
+
+      await assert.rejects(
+        resolveWallet({ baseDir: base, signingMode: 'auto' }),
+        /64 bytes|length/i,
+        'a non-64-byte key must be rejected, not used',
+      );
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('throws when the stored address does not match the key (tampered file)', async () => {
+    const base = await makeTempBase();
+    try {
+      // Valid 64-byte key, but the stored address belongs to a DIFFERENT key.
+      const otherAddress = Keypair.generate().publicKey.toBase58();
+      await writeWalletFile(base, {
+        private_key: GOLDEN.private_key,
+        address: otherAddress,
+        created_at: '2026-01-01T00:00:00Z',
+      });
+
+      await assert.rejects(
+        resolveWallet({ baseDir: base, signingMode: 'auto' }),
+        /address|mismatch/i,
+        'a key/address mismatch must be rejected, not silently used',
+      );
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('throws on a missing private_key field', async () => {
+    const base = await makeTempBase();
+    try {
+      await writeWalletFile(base, { address: GOLDEN.address, created_at: '2026-01-01T00:00:00Z' });
+      await assert.rejects(
+        resolveWallet({ baseDir: base, signingMode: 'auto' }),
+        /private_key/,
+      );
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('throws on a non-JSON / corrupt file', async () => {
+    const base = await makeTempBase();
+    try {
+      await fs.mkdir(base, { recursive: true });
+      await fs.writeFile(walletPath(base), 'not json at all', 'utf-8');
+      await assert.rejects(resolveWallet({ baseDir: base, signingMode: 'auto' }));
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Signing off — no wallet required, no file created.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — signingMode=off', () => {
+  it('requires no wallet and creates no file', async () => {
+    const base = await makeTempBase();
+    try {
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'off' });
+
+      assert.equal(resolved.source, 'none');
+      assert.equal(resolved.created, false);
+      assert.equal(resolved.privateKey, undefined, 'no key in off mode');
+      assert.equal(resolved.address, undefined, 'no address in off mode');
+
+      await assert.rejects(
+        fs.access(walletPath(base)),
+        'off mode must not create a wallet file',
+      );
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('off mode still honors an explicit env key without creating a file', async () => {
+    // off mode does not sign, but if the user explicitly set a key we surface
+    // its address; we still must not create a file.
+    const base = await makeTempBase();
+    try {
+      process.env['SOLANA_WALLET_KEY'] = GOLDEN.private_key;
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'off' });
+      assert.equal(resolved.source, 'env');
+      assert.equal(resolved.address, GOLDEN.address);
+      await assert.rejects(fs.access(walletPath(base)));
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Redaction — notice/log strings contain the address, NEVER the private key.
+// ---------------------------------------------------------------------------
+
+describe('resolveWallet — secret redaction in notices', () => {
+  it('the created-wallet notice contains the address but never the private key', async () => {
+    const base = await makeTempBase();
+    try {
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      assert.ok(resolved.notice, 'a startup notice should be produced on create');
+      assert.ok(resolved.notice!.includes(resolved.address!), 'notice should include the address');
+      assert.ok(
+        !resolved.notice!.includes(resolved.privateKey!),
+        'notice must NEVER include the private key',
+      );
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('the loaded-wallet notice contains the address but never the private key', async () => {
+    const base = await makeTempBase();
+    try {
+      await writeWalletFile(base, {
+        private_key: GOLDEN.private_key,
+        address: GOLDEN.address,
+        created_at: '2026-01-01T00:00:00Z',
+      });
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      assert.ok(resolved.notice, 'a notice should be produced on load');
+      assert.ok(resolved.notice!.includes(GOLDEN.address));
+      assert.ok(!resolved.notice!.includes(GOLDEN.private_key), 'notice must not leak the key');
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+
+  it('the from-env path does not emit the private key in its notice', async () => {
+    const base = await makeTempBase();
+    try {
+      process.env['SOLANA_WALLET_KEY'] = GOLDEN.private_key;
+      const resolved = await resolveWallet({ baseDir: base, signingMode: 'auto' });
+      if (resolved.notice) {
+        assert.ok(!resolved.notice.includes(GOLDEN.private_key), 'env notice must not leak the key');
+      }
+    } finally {
+      await cleanupDir(base);
+    }
+  });
+});


### PR DESCRIPTION
## Why
Today the MCP server **hard-exits** if `SOLANA_WALLET_KEY` is unset, so a new user has to generate a keypair, export it, and set env vars before a single paid call. That's the post-install cliff. This makes onboarding **install → fund → use** — matching the ease of competitors (BlockRun) while keeping Solvela's non-custodial model unchanged: the key never leaves the machine, only signed txs do.

**This is PR 1 of 2.** A follow-up adds a gateway gas faucet so the agent pays its own gas from a dust drip and the user funds **USDC only**. Until then the funding copy here honestly says "USDC + a little SOL."

## What
New `sdks/mcp/src/wallet.ts` → `resolveWallet()`:
- **Precedence:** `SOLANA_WALLET_KEY` env → `~/.solvela/wallet.json` → auto-generate.
- The wallet file is **byte-for-byte the Rust CLI's `wallet init` schema** (`{private_key, address, created_at}`), so the CLI and MCP share one wallet (verified by a parity test + a live CLI↔MCP round-trip).
- In `SOLVELA_SIGNING_MODE=off`, no wallet is required or created.

`index.ts`: removed both `Fatal: SOLANA_WALLET_KEY required` exits; `wallet_status` now shows the **key-derived** address; warns if a pinned `SOLANA_WALLET_ADDRESS` disagrees.

## Security invariants (signer/money-path)
- Address derived + key validated via the signer's own `Keypair.fromSecretKey` (rejects a tampered seed↔pubkey).
- **Atomic + `O_EXCL`** create at **0600** under a **0700** dir; `link`-based **no-overwrite** that is race-safe across concurrent runs (loser adopts the winner's wallet, never clobbers).
- **Fail closed**: invalid env key throws (no silent file fallback); a corrupt/tampered file (wrong length or address≠key) throws rather than signing with it.
- **Key never logged** — every notice/error is address-only.

## Tests
20 new tests (parity with the CLI schema, env precedence, auto-create, 0600/0700 perms, no-overwrite, validation, off-mode, redaction). **Full suite 106/106 pass; `tsc` build clean.** Built through the `solvela-sdk-signer-audit` + `solvela-x402` skills, tests-first. No signing/wire format touched — golden-vector parity unaffected.