### PR TITLE
ci(auto-approve): widen money-path regex to all key-handling paths

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -73,9 +73,10 @@ jobs:
             const ALLOW = ['sky64', 'dependabot[bot]'];
 
             // Money-path surfaces: code that signs / verifies / settles payments,
-            // computes cost, or touches escrow / USDC. A PR touching ANY of these
-            // is NOT auto-approved — it requires a human review even on green CI,
-            // because here CI is not a sufficient gate (funds move).
+            // computes cost, touches escrow / USDC, or handles secret key material
+            // (wallets / keypairs / signers). A PR touching ANY of these is NOT
+            // auto-approved — it requires a human review even on green CI, because
+            // here CI is not a sufficient gate (funds move, or keys are at risk).
             const MONEY_PATH = [
               /^crates\/x402\//,
               /^crates\/escrow-tx\//,
@@ -86,7 +87,10 @@ jobs:
               /^crates\/gateway\/src\/escrow\//,
               /^crates\/gateway\/src\/a2a\//,
               /^crates\/gateway\/src\/usage\.rs$/,
-              /(^|\/)signer\.(rs|ts|py|go)$/, // SDK signing modules (any language)
+              /(^|\/)signer\.(rs|ts|py|go)$/, // per-language SDK signing modules
+              /^sdks\/signer-core\//,         // shared cross-language signer pkg (sign/scheme-filter/stub-guard fall through signer.* above)
+              /(^|\/)(wallet|keypair)[\w-]*\.(rs|ts|py|go)$/, // wallet/keypair modules that load/create/hold secret keys (e.g. sdks/mcp/src/wallet.ts, missed on #577)
+              /(^|\/)adapters\/local\.ts$/,   // dev/test local wallet adapter — decodes raw secret-key bytes
               /^sdks\/.*\/escrow/,            // SDK escrow paths
             ];
 


### PR DESCRIPTION
## What

Widen the `MONEY_PATH` exclusion in `auto-approve.yml` so any PR touching
secret-key / signing code is forced to human review (never auto-approved on
green CI alone).

## Why

The exclusion matched `signer.{rs,ts,py,go}` but had **no wallet/keypair
pattern**, so `sdks/mcp/src/wallet.ts` — which generates, loads, and
validates an ed25519 secret keypair and writes `wallet.json` — was
auto-approved on #577 with no human review. CI is not a sufficient gate for
code that handles key material.

While closing that, two adjacent same-class gaps surfaced and are closed in
the same pass (the regex is supposed to be *exhaustive* per
`solvela-supply-chain-governance` §4):

- **`sdks/signer-core/`** — the actual shared cross-language signer. Its
  `sign.ts` / `scheme-filter.ts` / `stub-guard.ts` fall through the
  `signer.*` *filename* rule (only `escrow.ts` happened to match). Now
  excluded wholesale — a dependabot bump to its `package.json` is exactly the
  money-path supply-chain event we want reviewed.
- **`adapters/local.ts`** — the dev/test adapter that decodes raw secret-key
  bytes.

## New patterns

```js
/^sdks\/signer-core\//,                          // shared signer pkg
/(^|\/)(wallet|keypair)[\w-]*\.(rs|ts|py|go)$/,  // wallet/keypair key modules
/(^|\/)adapters\/local\.ts$/,                    // raw-key dev adapter
```

## Verification

`MONEY_PATH` evaluated (as written) against the full tracked file set,
including the #577 additions:

- **Matches** (24-assertion check): `sdks/mcp/src/wallet.ts` (the miss),
  every per-language `wallet.{ts,go,py,rs}`, the CLI wallet command,
  `wallet-adapter.ts`, `adapters/local.ts`, `signer-core/{sign,scheme-filter,stub-guard}.ts`,
  `signer-core/package.json`, and all pre-existing money-path entries still hold.
- **Rejects:** `dashboard/.../wallet/page.tsx` (read-only UI),
  `scripts/wallet-balances.sh`, and non-key SDK source (`config.ts`,
  `types.ts`, `tools.ts`, `generated/models.ts`).
- Only "extra" matches are `wallet_test.go` and the `wallet-adapter.ts`
  interface — both the safe (over-cautious → human review) direction.

`auto-approve.yml` still parses as valid YAML.

APPROVE-only behavior, fork exclusion, `ALLOW` list, and REQUIRED-checks gate
are all unchanged.
