### PR TITLE
feat(a2a): serve AgentCard at v0.3 /.well-known/agent-card.json + public_url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ SOLVELA_ENV=development
 # ── Server ────────────────────────────────────────────────────────────────────
 SOLVELA_HOST=0.0.0.0
 SOLVELA_PORT=8402
+# Public base URL advertised in the A2A AgentCard `url` (the endpoint external
+# agents/registries follow to reach /a2a). REQUIRED in any deployment that
+# publishes its AgentCard — without it the card falls back to http://HOST:PORT,
+# which is the internal bind address (0.0.0.0), not a routable address.
+# SOLVELA_PUBLIC_URL=https://api.solvela.ai
 # Deprecated: RCR_SERVER_HOST, RCR_SERVER_PORT
 
 # ── Solana ────────────────────────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Next.js 16 + Tailwind + Recharts. Pages: Overview, Usage, Models, Wallet, Settin
 
 ## A2A Request Flow (POST /a2a, method: message/send)
 
-1. Agent discovers Solvela via `GET /.well-known/agent.json` (AgentCard with AP2 + x402 extensions)
+1. Agent discovers Solvela via `GET /.well-known/agent-card.json` (A2A v0.3 canonical path; `/.well-known/agent.json` is a backward-compat alias). The AgentCard carries AP2 + x402 extensions and a `url` field set from `SOLVELA_PUBLIC_URL` (falls back to `http://host:port`)
 2. Agent sends `message/send` JSON-RPC with text prompt → gateway computes cost → returns Task (`input-required`) with `x402.payment.required` metadata
 3. Agent signs Solana USDC-SPL transaction → sends `message/send` with `taskId` + `x402.payment.payload` metadata
 4. Gateway verifies payment (reuses facilitator), proxies to LLM provider → returns Task (`completed`) with artifacts + receipt

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ All prices are provider cost in USDC. A 5% platform fee is applied on top. See `
 | `GET` | `/v1/escrow/config` | Escrow program configuration |
 | `GET` | `/v1/escrow/health` | Escrow claim metrics (admin) |
 | `GET` | `/v1/admin/stats` | Aggregate gateway statistics (admin) |
-| `GET` | `/.well-known/agent.json` | A2A AgentCard for agent discovery |
+| `GET` | `/.well-known/agent-card.json` | A2A AgentCard for agent discovery (v0.3 canonical path; `/.well-known/agent.json` kept as a backward-compat alias) |
 | `GET` | `/pricing` | Per-model USDC cost breakdown |
 | `GET` | `/health` | Gateway health check |
 | `GET` | `/metrics` | Prometheus metrics (admin) |

--- a/crates/gateway/src/a2a/AGENTS.md
+++ b/crates/gateway/src/a2a/AGENTS.md
@@ -11,7 +11,7 @@ A2A (Agent-to-Agent) protocol adapter. Translates A2A JSON-RPC `message/send` ca
 |------|-------------|
 | `mod.rs` | Module root; re-exports public types and the top-level handler |
 | `types.rs` | A2A wire types: `Task`, `Message`, `Artifact`, `TaskState`, x402/AP2 metadata |
-| `agent_card.rs` | Builds the `AgentCard` returned at `GET /.well-known/agent.json` (includes AP2 + x402 extensions) |
+| `agent_card.rs` | Builds the `AgentCard` returned at `GET /.well-known/agent-card.json` (A2A v0.3 canonical path; `/.well-known/agent.json` is a backward-compat alias). Includes AP2 + x402 extensions; `url` from `SOLVELA_PUBLIC_URL` |
 | `jsonrpc.rs` | JSON-RPC 2.0 request/response envelope + error mapping |
 | `handler.rs` | Main `message/send` handler — cost calc → 402 / payment verify → LLM proxy → Task response |
 | `task_store.rs` | In-memory task store keyed by task id — tracks state transitions across request chains |
@@ -23,7 +23,7 @@ _(none)_
 
 ### Working In This Directory
 - A2A flow:
-  1. Agent calls `GET /.well-known/agent.json` → gets `AgentCard`.
+  1. Agent calls `GET /.well-known/agent-card.json` (or the `agent.json` alias) → gets `AgentCard`.
   2. Agent sends `message/send` (no payment) → gateway returns a Task in `input-required` state with `x402.payment.required` metadata.
   3. Agent signs SPL USDC transfer → sends `message/send` with `taskId` + `x402.payment.payload` metadata.
   4. Gateway verifies payment (reuses the facilitator), proxies to LLM, returns Task in `completed` state with artifacts + receipt.

--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -1,6 +1,8 @@
 //! AgentCard endpoint — AP2 discovery for AI agents.
 //!
-//! Serves at `GET /.well-known/agent.json` per the A2A discovery convention.
+//! Served at the A2A v0.3 canonical path `GET /.well-known/agent-card.json`
+//! (RFC 8615), with `GET /.well-known/agent.json` kept as a backward-compatible
+//! alias for pre-v0.3 clients. Both routes resolve to the same handler.
 //! Advertises AP2 merchant role and x402 Solana settlement support.
 
 use std::sync::Arc;
@@ -13,17 +15,29 @@ use serde_json::json;
 use crate::a2a::types::{AP2_EXTENSION_URI, X402_EXTENSION_URI};
 use crate::AppState;
 
-/// `GET /.well-known/agent.json` — Return the A2A AgentCard.
+/// `GET /.well-known/agent-card.json` (and the `/.well-known/agent.json` alias)
+/// — Return the A2A AgentCard.
 pub async fn agent_card(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let mut schemes = vec!["exact"];
     if state.escrow_claimer.is_some() {
         schemes.push("escrow");
     }
 
+    // The AgentCard `url` is the A2A service endpoint external agents/registries
+    // POST to. Prefer the configured public URL; the host:port fallback is for
+    // local dev only (the default bind host is 0.0.0.0, not publicly routable).
+    let url = match &state.config.server.public_url {
+        Some(u) => u.trim_end_matches('/').to_string(),
+        None => format!(
+            "http://{}:{}",
+            state.config.server.host, state.config.server.port
+        ),
+    };
+
     Json(json!({
         "name": "Solvela",
         "description": "Solana-native AI agent payment gateway — pay for LLM API calls with USDC-SPL via x402",
-        "url": format!("http://{}:{}", state.config.server.host, state.config.server.port),
+        "url": url,
         "version": "0.1.0",
         "capabilities": {
             "streaming": true,
@@ -136,13 +150,76 @@ supports_vision = false
     }
 
     fn test_app() -> axum::Router {
-        let state = make_state();
+        app_with_state(make_state())
+    }
+
+    /// Mirror production routing: the canonical A2A v0.3 path plus the
+    /// backward-compat alias, both bound to the same handler.
+    fn app_with_state(state: Arc<AppState>) -> axum::Router {
         axum::Router::new()
+            .route(
+                "/.well-known/agent-card.json",
+                axum::routing::get(super::agent_card),
+            )
             .route(
                 "/.well-known/agent.json",
                 axum::routing::get(super::agent_card),
             )
             .with_state(state)
+    }
+
+    async fn get_card(app: axum::Router, uri: &str) -> serde_json::Value {
+        let resp = app
+            .oneshot(
+                http::Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        // Generous cap: the card grows as skills/extensions are added; a tight
+        // cap would silently truncate and fail with a misleading JSON error.
+        let body = axum::body::to_bytes(resp.into_body(), 65_536)
+            .await
+            .expect("read body");
+        serde_json::from_slice(&body).expect("valid JSON")
+    }
+
+    /// The canonical v0.3 path serves the card, byte-identical to the alias.
+    #[tokio::test]
+    async fn test_agent_card_canonical_path_matches_alias() {
+        let canonical = get_card(test_app(), "/.well-known/agent-card.json").await;
+        let alias = get_card(test_app(), "/.well-known/agent.json").await;
+        assert_eq!(canonical["name"], "Solvela");
+        assert_eq!(
+            canonical, alias,
+            "canonical agent-card.json and agent.json alias must return identical cards"
+        );
+    }
+
+    /// When `public_url` is configured, the card's `url` is that value
+    /// (an external agent/registry follows it to reach `/a2a`).
+    #[tokio::test]
+    async fn test_agent_card_url_uses_public_url_when_set() {
+        let mut config = AppConfig::default();
+        config.server.public_url = Some("https://api.solvela.ai/".to_string());
+        let json = get_card(
+            app_with_state(make_state_with_config(config)),
+            "/.well-known/agent-card.json",
+        )
+        .await;
+        // Trailing slash trimmed.
+        assert_eq!(json["url"], "https://api.solvela.ai");
+    }
+
+    /// With no `public_url`, the card falls back to the host:port form (dev only).
+    #[tokio::test]
+    async fn test_agent_card_url_falls_back_to_host_port() {
+        let json = get_card(test_app(), "/.well-known/agent-card.json").await;
+        assert_eq!(json["url"], "http://0.0.0.0:8402");
     }
 
     #[tokio::test]

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -27,6 +27,15 @@ pub struct ServerConfig {
     /// Port to listen on (default: 8402).
     #[serde(default = "default_port")]
     pub port: u16,
+    /// Public base URL the gateway is reachable at (e.g. `https://api.solvela.ai`).
+    ///
+    /// Used as the `url` field of the A2A AgentCard, which external agents and
+    /// registries follow to reach `/a2a`. When unset, the card falls back to
+    /// `http://{host}:{port}` — correct for local dev but NOT a public address
+    /// (the default bind host is `0.0.0.0`). Set via `SOLVELA_PUBLIC_URL` in any
+    /// deployment that publishes its card.
+    #[serde(default)]
+    pub public_url: Option<String>,
 }
 
 /// Solana network settings.
@@ -234,6 +243,7 @@ impl Default for AppConfig {
             server: ServerConfig {
                 host: default_host(),
                 port: default_port(),
+                public_url: None,
             },
             solana: SolanaConfig {
                 rpc_url: "https://api.devnet.solana.com".to_string(),

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -332,6 +332,11 @@ pub fn build_router(state: Arc<AppState>, rate_limiter: RateLimiter) -> Router {
             get(routes::orgs::get_team_stats),
         )
         .route("/v1/orgs/{id}/stats", get(routes::orgs::get_org_stats))
+        // A2A v0.3 canonical AgentCard path (RFC 8615) + pre-v0.3 alias.
+        .route(
+            "/.well-known/agent-card.json",
+            get(a2a::agent_card::agent_card),
+        )
         .route("/.well-known/agent.json", get(a2a::agent_card::agent_card))
         .route("/a2a", post(a2a::jsonrpc::a2a_endpoint))
         .route("/metrics", get(routes::metrics::get_metrics))

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -129,6 +129,36 @@ async fn main() -> anyhow::Result<()> {
             app_config.server.port = port;
         }
     }
+    // Public base URL advertised in the A2A AgentCard `url` field. Ignore an
+    // empty/whitespace override (same guard as USDC_MINT above) so a blank env
+    // var doesn't replace a valid TOML value with an unroutable empty string,
+    // and reject a value without an http(s) scheme rather than publish a
+    // malformed url an agent/registry can't follow.
+    if let Ok(val) = env_with_fallback("SOLVELA_PUBLIC_URL", "RCR_PUBLIC_URL") {
+        let trimmed = val.trim();
+        if trimmed.is_empty() {
+            warn!("SOLVELA_PUBLIC_URL is set but empty — ignoring; AgentCard url falls back to host:port");
+        } else if !(trimmed.starts_with("http://") || trimmed.starts_with("https://")) {
+            warn!(
+                value = %trimmed,
+                "SOLVELA_PUBLIC_URL must start with http:// or https:// — ignoring; AgentCard url falls back to host:port"
+            );
+        } else {
+            app_config.server.public_url = Some(trimmed.to_string());
+        }
+    }
+    // If no public URL is set and we're bound to the wildcard host, the
+    // AgentCard will advertise an unroutable url (http://0.0.0.0:PORT) that
+    // external agents/registries cannot reach. Warn loudly — a published card
+    // pointing at 0.0.0.0 is the silent failure mode for any deployment.
+    if app_config.server.public_url.is_none() && app_config.server.host == "0.0.0.0" {
+        warn!(
+            "SOLVELA_PUBLIC_URL is unset and host is 0.0.0.0 — the A2A AgentCard \
+             will advertise an unroutable url (http://0.0.0.0:{}); set \
+             SOLVELA_PUBLIC_URL in any deployment that publishes its card",
+            app_config.server.port
+        );
+    }
 
     // The configured USDC mint is quoted in every 402 challenge and enforced
     // by every payment verifier, but `EscrowVerifier` only Pubkey-parses its

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -9410,6 +9410,44 @@ async fn test_a2a_agent_card_returns_capabilities() {
     assert!(extensions.len() >= 2, "should have AP2 + x402 extensions");
 }
 
+/// The A2A v0.3 canonical path is served by the real router and returns the
+/// same card as the backward-compat `/.well-known/agent.json` alias.
+#[tokio::test]
+async fn test_a2a_agent_card_canonical_path() {
+    let canonical = test_app()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/.well-known/agent-card.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(canonical.status(), StatusCode::OK);
+    let canonical_body = canonical.into_body().collect().await.unwrap().to_bytes();
+    let canonical_json: serde_json::Value = serde_json::from_slice(&canonical_body).unwrap();
+
+    let alias = test_app()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/.well-known/agent.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let alias_body = alias.into_body().collect().await.unwrap().to_bytes();
+    let alias_json: serde_json::Value = serde_json::from_slice(&alias_body).unwrap();
+
+    assert_eq!(canonical_json["name"], "Solvela");
+    assert_eq!(
+        canonical_json, alias_json,
+        "canonical path and alias must return identical AgentCards"
+    );
+}
+
 #[tokio::test]
 async fn test_a2a_unknown_method_returns_method_not_found() {
     let app = test_app();

--- a/docs/CODEMAPS/INDEX.md
+++ b/docs/CODEMAPS/INDEX.md
@@ -74,7 +74,7 @@ solvela/
 9. Return JSON or SSE stream
 
 ### A2A Protocol (POST /a2a)
-1. Agent discovers gateway via GET /.well-known/agent.json
+1. Agent discovers gateway via GET /.well-known/agent-card.json (alias: /.well-known/agent.json)
 2. Send message/send JSON-RPC → Gateway returns Task (input-required) + cost
 3. Agent signs USDC-SPL transaction → sends with payment payload
 4. Gateway verifies payment → proxies to LLM → returns Task (completed)

--- a/docs/CODEMAPS/architecture.md
+++ b/docs/CODEMAPS/architecture.md
@@ -76,7 +76,7 @@ Has PAYMENT-SIGNATURE?
 ## Request Flow: POST /a2a (Agent-to-Agent Protocol)
 
 ```
-GET /.well-known/agent.json
+GET /.well-known/agent-card.json   (alias: /.well-known/agent.json)
     ↓ (returns AgentCard with AP2 + x402 extensions)
 Agent sends message/send JSON-RPC
     ↓

--- a/docs/CODEMAPS/backend.md
+++ b/docs/CODEMAPS/backend.md
@@ -11,7 +11,7 @@
 Routes as registered in `crates/gateway/src/lib.rs::build_router`.
 
 ```
-GET  /.well-known/agent.json
+GET  /.well-known/agent-card.json   (alias: /.well-known/agent.json)
 GET  /health
 POST /a2a
 
@@ -63,9 +63,9 @@ GET  /v1/orgs/{id}/audit-logs
 
 ## Public Routes
 
-### GET /.well-known/agent.json
+### GET /.well-known/agent-card.json (alias: /.well-known/agent.json)
 **Handler:** `a2a/agent_card.rs`  
-**Response:** AgentCard with AP2 + x402 extensions.
+**Response:** AgentCard with AP2 + x402 extensions. A2A v0.3 canonical path; the `agent.json` path is served as a backward-compat alias.
 ```json
 {
   "name": "Solvela Gateway",

--- a/docs/product/regulatory-position.md
+++ b/docs/product/regulatory-position.md
@@ -212,7 +212,7 @@ These boundaries are architectural decisions made to avoid regulatory exposure:
 
 Solvela implements compatibility with Google's **Agent-to-Agent (A2A)** protocol and the **Agentic Payments (AP2)** specification, but only the parts that do not involve fiat:
 
-- **Implemented**: Agent discovery via `AgentCard` (`.well-known/agent.json`), x402 payment settlement flow within the A2A `message/send` lifecycle.
+- **Implemented**: Agent discovery via `AgentCard` (`.well-known/agent-card.json`, with the legacy `.well-known/agent.json` path served as an alias), x402 payment settlement flow within the A2A `message/send` lifecycle.
 - **Explicitly excluded**: The AP2 specification includes a Managed Payment Provider (MPP) flow for card-based payments. Implementing MPP would require acting as a payment facilitator, which triggers MSB registration and state licensing. We do not implement MPP.
 
 ## Summary of Money Flow


### PR DESCRIPTION
## What

Serve the A2A AgentCard at the **v0.3 canonical path** `/.well-known/agent-card.json` (RFC 8615) as an alias to the existing `/.well-known/agent.json`, which is kept for pre-v0.3 clients. Both routes share one handler.

Add a `SOLVELA_PUBLIC_URL` config (`server.public_url`) used for the AgentCard `url` field — the A2A service endpoint external agents/registries follow to reach `/a2a`.

## Why

The A2A spec moved the canonical AgentCard path to `/.well-known/agent-card.json` in v0.3; registries like `a2aregistry.org` auto-fetch that path, so we're currently undiscoverable there. Separately, the card's `url` was built from `host:port`, which in prod resolves to the internal bind address `http://0.0.0.0:8402` — an unroutable endpoint. Listing the card without a real public URL would publish a dead address, so the path alias and the public-URL fix ship together.

## Changes

- **Route alias** (`lib.rs`): `/.well-known/agent-card.json` → same handler as `agent.json`.
- **`server.public_url`** (`config.rs`, `main.rs`): set via `SOLVELA_PUBLIC_URL`; AgentCard `url` prefers it, else falls back to `http://host:port` (dev only).
- **Misconfig guards** (`main.rs`): reject an empty or schemeless `SOLVELA_PUBLIC_URL` (warn + fall back); warn at startup when the card would advertise an unroutable `0.0.0.0` url.
- **Docs**: README, CLAUDE.md, `a2a/AGENTS.md`, CODEMAPS, regulatory-position, `.env.example`.

## Money-path note

No change to payment **scheme/mint advertisement** or any USDC amount/claim logic — only the discovery `url` field and routing. The pinned mint/scheme tests are unchanged and still pass. Reviewed via the `solvela-x402` skill + a 2-agent pass (rust-reviewer + silent-failure-hunter); the two surfaced operational findings (no startup signal for an unroutable card; unvalidated `SOLVELA_PUBLIC_URL`) are addressed by the misconfig guards above.

## Tests

- Unit: canonical/alias byte-parity; `public_url` set vs `host:port` fallback.
- Integration: canonical path served by the real router, identical to alias.
- Full suite green: 786 lib + 239 integration pass. (The 12 `escrow_queue` `#[sqlx::test]` failures are pre-existing — they require `DATABASE_URL`/Postgres, not present in this env, and touch no code here.)

## Deploy

Set `SOLVELA_PUBLIC_URL=https://<prod gateway domain>` as a Fly secret before/at release so the published card points at the real endpoint.

## Out of scope (follow-up)

Full A2A v0.3 card-schema compliance (`protocolVersion`, transport fields). The card is valid and registry-fetchable today; a strict v0.3 validator may want `protocolVersion`.