### PR TITLE
fix(faucet): per-IP rate limit on the gas faucet endpoint (F6)

### DIFF
--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -144,6 +144,9 @@ supports_vision = false
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -1375,6 +1375,9 @@ supports_vision = false
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -1883,6 +1886,9 @@ supports_vision = false
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -1946,6 +1952,9 @@ supports_vision = false
             ),
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
@@ -2439,6 +2448,9 @@ supports_vision = false
             ),
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,

--- a/crates/gateway/src/a2a/jsonrpc.rs
+++ b/crates/gateway/src/a2a/jsonrpc.rs
@@ -130,6 +130,9 @@ supports_vision = false
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -145,6 +145,19 @@ pub struct AppState {
     /// (GHSA-6ggq-cvwx-4f67); absent `ConnectInfo` falls back to the shared
     /// stricter "unknown" bucket.
     pub receipts_rate_limiter: RateLimiter,
+    /// Per-client (IP) rate limiter for the public, unauthenticated
+    /// `POST /v1/faucet/gas` gas-drip route (security review finding F6).
+    ///
+    /// Same in-handler pattern as
+    /// [`receipts_rate_limiter`](Self::receipts_rate_limiter): the faucet is
+    /// unauthenticated and the per-wallet DB primary key only stops repeat drips
+    /// to one wallet, NOT mass enumeration (mint fresh wallets, pre-fund each
+    /// past the USDC floor, drain the daily cap in a one-IP burst). This cap
+    /// bounds drip attempts per peer IP, STRICTER than the generic outer limiter
+    /// ([`RateLimitConfig::faucet_default`]). Keyed on the TCP peer IP, never a
+    /// client-supplied header (GHSA-6ggq-cvwx-4f67); absent `ConnectInfo` falls
+    /// back to the shared stricter "unknown" bucket.
+    pub faucet_rate_limiter: RateLimiter,
 }
 
 impl AppState {

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -818,6 +818,13 @@ async fn main() -> anyhow::Result<()> {
         // so the cap only needs to bound scan/enumeration throughput; tune
         // `RateLimitConfig::receipts_default` in code if that ever changes.
         receipts_rate_limiter: RateLimiter::new(RateLimitConfig::receipts_default()),
+        // Public faucet POST: fixed stricter per-IP cap (3/24h). Like the
+        // receipts limiter above, deliberately NOT env-tunable — the per-wallet
+        // DB key already stops per-wallet repeats, so this cap only needs to
+        // bound single-IP enumeration bursts (mint fresh wallets to drain the
+        // daily cap). Tune `RateLimitConfig::faucet_default` in code if that
+        // ever changes.
+        faucet_rate_limiter: RateLimiter::new(RateLimitConfig::faucet_default()),
     });
 
     // ── Shutdown signal for background tasks ────────────────────────────────

--- a/crates/gateway/src/middleware/api_key.rs
+++ b/crates/gateway/src/middleware/api_key.rs
@@ -234,6 +234,9 @@ supports_vision = false
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/middleware/rate_limit.rs
+++ b/crates/gateway/src/middleware/rate_limit.rs
@@ -109,6 +109,31 @@ impl RateLimitConfig {
             unknown_max_requests: 5,
         }
     }
+
+    /// Default per-IP rate-limit budget for the public, unauthenticated
+    /// `POST /v1/faucet/gas` gas-drip route (security review finding F6).
+    ///
+    /// The faucet is unauthenticated and the per-wallet DB primary key only
+    /// stops repeat drips to ONE wallet — it does NOT stop mass enumeration: an
+    /// attacker can mint unlimited fresh wallets, pre-fund each past the cheap
+    /// USDC floor, and drain the entire daily cap in a single-IP burst. The
+    /// daily cap is the only throttle without this per-IP cap. The legitimate
+    /// caller (the MCP wallet auto-create flow) hits the faucet at most once per
+    /// wallet per device lifetime, so a TIGHT cap is safe: 3 drips per IP per
+    /// 24h is generous for a real device (initial wallet + a couple of retries)
+    /// and hostile to a single-IP enumeration burst. The `unknown` bucket (no
+    /// `ConnectInfo`) is stricter still (1), matching the receipts/free policy.
+    ///
+    /// Like [`receipts_default`](Self::receipts_default) this is deliberately
+    /// NOT env-tunable — the cap only needs to bound enumeration throughput;
+    /// tune it here in code if the legitimate-caller pattern ever changes.
+    pub fn faucet_default() -> Self {
+        Self {
+            max_requests: 3,
+            window: Duration::from_secs(24 * 60 * 60),
+            unknown_max_requests: 1,
+        }
+    }
 }
 
 /// Per-client rate limit state.
@@ -682,6 +707,23 @@ mod tests {
         assert_eq!(receipts.max_requests, 20);
         assert_eq!(receipts.unknown_max_requests, 5);
         assert_eq!(receipts.window, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_faucet_default_is_stricter_than_paid() {
+        let faucet = RateLimitConfig::faucet_default();
+        let paid = RateLimitConfig::default();
+        assert!(
+            faucet.max_requests < paid.max_requests,
+            "faucet per-IP limit ({}) must be stricter than the generic outer limit ({})",
+            faucet.max_requests,
+            paid.max_requests
+        );
+        assert_eq!(faucet.max_requests, 3);
+        assert_eq!(faucet.unknown_max_requests, 1);
+        // 24h window: the legitimate caller hits the faucet once per wallet per
+        // device lifetime, so the throttle is over a day, not a minute.
+        assert_eq!(faucet.window, Duration::from_secs(24 * 60 * 60));
     }
 
     #[test]

--- a/crates/gateway/src/routes/faucet.rs
+++ b/crates/gateway/src/routes/faucet.rs
@@ -56,6 +56,7 @@ use zeroize::Zeroizing;
 use solvela_x402::solana::{sign_system_transfer, SystemTransferError};
 use solvela_x402::solana_types::Pubkey;
 
+use crate::middleware::rate_limit::{connect_info_client_id, rate_limited_response, PeerAddr};
 use crate::AppState;
 
 /// Request body for `POST /v1/faucet/gas`.
@@ -605,14 +606,46 @@ impl GasSource for RpcGasSource {
 /// callers can distinguish "declined" from "tried and failed").
 pub async fn gas_faucet(
     State(state): State<Arc<AppState>>,
+    // Infallible peer-address extractor (same as the receipts/free-tier path):
+    // `None` when `ConnectInfo` is absent, degrading to the stricter "unknown"
+    // bucket rather than 500-ing. Extracted before the body so the rate limit can
+    // gate on the real TCP peer IP.
+    peer_addr: PeerAddr,
     Json(req): Json<FaucetRequest>,
 ) -> impl IntoResponse {
-    let outcome = match &state.faucet {
+    let faucet = match &state.faucet {
         // Gate 1: enabled. An absent faucet (disabled, no source key, or no DB)
-        // short-circuits — no chain or DB work.
-        None => DripOutcome::Disabled,
-        Some(faucet) => faucet.drip(req.wallet.trim()).await,
+        // short-circuits FIRST — it is the cheapest possible reject (a single
+        // `Option` check on already-loaded state, no lock/DB/RPC), and a disabled
+        // faucet has no abuse surface to protect (no drip work ever runs). So we
+        // answer "disabled" before even touching the rate limiter.
+        None => {
+            let outcome = DripOutcome::Disabled;
+            metrics::counter!("solvela_gas_drips_total", "result" => outcome.metric_label())
+                .increment(1);
+            return (StatusCode::OK, Json(decline("disabled"))).into_response();
+        }
+        Some(faucet) => faucet,
     };
+
+    // F6 anti-enumeration: the faucet is unauthenticated and the per-wallet DB
+    // key only stops repeat drips to ONE wallet, not mass enumeration (mint
+    // fresh wallets, pre-fund each past the cheap USDC floor, drain the daily
+    // cap in a single-IP burst). Enforce a per-IP cap BEFORE any drip work
+    // (DB reservation / RPC balance reads / chain send) so an abusive caller is
+    // rejected at the cheapest point. Keyed on the TCP peer IP, never a
+    // client-supplied header (X-Forwarded-For et al. are forgeable —
+    // GHSA-6ggq-cvwx-4f67); absent `ConnectInfo` falls back to the shared
+    // stricter "unknown" bucket. Mirrors the receipts/free-tier in-handler
+    // limiter.
+    let client_id = connect_info_client_id(peer_addr.0);
+    if state.faucet_rate_limiter.check(&client_id).await.is_err() {
+        metrics::counter!("solvela_gas_faucet_rate_limited_total").increment(1);
+        warn!(client_id = %client_id, "gas faucet rate limit exceeded");
+        return rate_limited_response(state.faucet_rate_limiter.config());
+    }
+
+    let outcome = faucet.drip(req.wallet.trim()).await;
 
     // Metrics: one labelled counter per outcome + a lamports counter on funded.
     metrics::counter!("solvela_gas_drips_total", "result" => outcome.metric_label()).increment(1);
@@ -646,12 +679,15 @@ pub async fn gas_faucet(
         DripOutcome::AlreadyHasSol => (StatusCode::OK, decline("already_has_sol")),
         DripOutcome::DailyCap => (StatusCode::OK, decline("daily_cap")),
         DripOutcome::BadWallet => (StatusCode::BAD_REQUEST, decline("invalid_wallet")),
+        // `drip()` never yields `Disabled` (the disabled case returns early at
+        // the top of the handler, before the rate limiter and before any drip
+        // work); the arm is kept only to keep the match exhaustive.
         DripOutcome::Disabled => (StatusCode::OK, decline("disabled")),
         // A send failure is the one "we tried and it broke" case → 502.
         DripOutcome::SendFailed => (StatusCode::BAD_GATEWAY, decline("send_failed")),
     };
 
-    (status, Json(body))
+    (status, Json(body)).into_response()
 }
 
 /// Build a `funded: false` response with a reason.

--- a/crates/gateway/src/routes/health.rs
+++ b/crates/gateway/src/routes/health.rs
@@ -169,6 +169,9 @@ supports_vision = false
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -251,6 +254,9 @@ supports_vision = false
             ),
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,

--- a/crates/gateway/src/routes/orgs/api_keys.rs
+++ b/crates/gateway/src/routes/orgs/api_keys.rs
@@ -258,6 +258,9 @@ mod tests {
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/routes/orgs/mod.rs
+++ b/crates/gateway/src/routes/orgs/mod.rs
@@ -408,6 +408,9 @@ supports_vision = true
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -580,6 +583,9 @@ mod tests {
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),
@@ -634,6 +640,9 @@ mod tests {
             ),
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
@@ -692,6 +701,9 @@ mod tests {
             ),
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,

--- a/crates/gateway/src/routes/orgs/teams.rs
+++ b/crates/gateway/src/routes/orgs/teams.rs
@@ -436,6 +436,9 @@ mod tests {
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
             ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
             ),

--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -1220,6 +1220,7 @@ mod tests {
             dev_bypass_payment: false,
             free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(crate::middleware::rate_limit::RateLimitConfig::free_default()),
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(crate::middleware::rate_limit::RateLimitConfig::receipts_default()),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(crate::middleware::rate_limit::RateLimitConfig::faucet_default()),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT),
         });
 
@@ -1372,6 +1373,9 @@ mod tests {
             ),
             receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
                 crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
             ),
             free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
                 crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -495,6 +495,19 @@ fn generous_receipts_limiter() -> RateLimiter {
     })
 }
 
+/// Faucet-POST limiter for test apps: effectively unlimited so unrelated tests
+/// that exercise `POST /v1/faucet/gas` (or just construct an `AppState`) are
+/// never tripped by the production per-IP cap. The strict cap itself is
+/// exercised by the `app_with_faucet_and_limit` fixture in the
+/// `faucet_route_tests` module below.
+fn generous_faucet_limiter() -> RateLimiter {
+    RateLimiter::new(RateLimitConfig {
+        max_requests: 10_000,
+        window: std::time::Duration::from_secs(60),
+        unknown_max_requests: 10_000,
+    })
+}
+
 /// Build a test app with the test model config (no real provider API keys).
 ///
 /// Uses `AlwaysPassVerifier` so that properly-structured PaymentPayload headers
@@ -553,6 +566,7 @@ fn test_app_with_state() -> (axum::Router, Arc<AppState>) {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
@@ -608,6 +622,7 @@ fn test_app_with_usdc_mint_and_providers(mint: &str, providers: ProviderRegistry
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -906,6 +921,7 @@ fn test_app_with_provider_registry_and_exact_verifier(
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
@@ -990,6 +1006,7 @@ fn app_with_semantic_cache(sem: Arc<gateway::cache::semantic::SemanticCache>) ->
         dev_bypass_payment: true,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -1303,6 +1320,7 @@ fn app_with_semantic_cache_and_escrow(
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -1381,6 +1399,7 @@ fn app_with_semantic_cache_escrow_and_db_pool(
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -2043,6 +2062,7 @@ fn test_app_with_provider_registry_and_escrow_verifier(
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -2125,6 +2145,7 @@ fn test_app_with_escrow_and_usdc_mint(mint: &str) -> axum::Router {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -2594,6 +2615,7 @@ async fn test_chat_enforced_wallet_unprovisioned_tenant_returns_400_e2e() {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
@@ -4978,6 +5000,7 @@ fn test_app_with_nonce_pool() -> axum::Router {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     gateway::build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -7013,6 +7036,7 @@ fn test_app_with_escrow_metrics() -> axum::Router {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -7180,6 +7204,7 @@ async fn test_escrow_health_reflects_incremented_metrics() {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
 
@@ -7417,6 +7442,7 @@ async fn test_escrow_health_status_down_without_claimer() {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
 
@@ -7808,6 +7834,7 @@ async fn test_proxy_require_tenant_wallet_rejected_before_settlement() {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
@@ -9329,6 +9356,7 @@ async fn test_admin_stats_returns_404_when_admin_token_not_configured() {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let app = build_router(
@@ -9983,6 +10011,7 @@ fn test_app_with_free_limit(free_max: u32) -> axum::Router {
         // accidentally tripped by the global cap; the aggregate-cap tests build
         // their own app via `test_app_with_global_cap`.
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -10346,6 +10375,7 @@ async fn dev_bypass_still_works() {
         // Aggregate cap also set to 0 — if the dev-bypass branch were ever
         // (incorrectly) routed through the free gates, this PAID model would 429.
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(0),
     });
     let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
@@ -10420,6 +10450,7 @@ fn test_app_with_global_cap(global_cap: u32) -> axum::Router {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(free_cfg),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(global_cap),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
@@ -10548,6 +10579,7 @@ async fn free_per_ip_and_global_cap_are_independent() {
         free_rate_limiter: RateLimiter::new(free_cfg),
         // Global cap deliberately LOOSER than the per-IP limit.
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(100),
     });
     let app = build_router(state, RateLimiter::new(RateLimitConfig::default()));
@@ -11418,6 +11450,7 @@ fn test_app_with_db_pool(
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
@@ -11968,6 +12001,7 @@ fn test_app_with_receipts_limit(max: u32) -> axum::Router {
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
         receipts_rate_limiter: RateLimiter::new(receipts_cfg),
+        faucet_rate_limiter: generous_faucet_limiter(),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))
 }
@@ -12055,7 +12089,6 @@ async fn receipts_get_rate_limited_per_ip_with_canonical_429() {
         "an unrelated IP must not be affected by another IP's exhausted bucket"
     );
 }
-
 /// A settled paid request to a VENDOR-wallet marketplace service must record a
 /// receipt carrying the vendor settlement + fee receivable — written at
 /// SETTLEMENT time (the vendor was just paid on-chain), so it must exist even
@@ -12345,6 +12378,7 @@ fn a2a_app_with_redis_db_and_providers(
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
@@ -12745,6 +12779,7 @@ fn a2a_app_with_verifier_and_db(
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: generous_receipts_limiter(),
+        faucet_rate_limiter: generous_faucet_limiter(),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     let router = build_router(
@@ -13432,6 +13467,7 @@ mod faucet_route_tests {
             dev_bypass_payment: false,
             free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
             receipts_rate_limiter: generous_receipts_limiter(),
+            faucet_rate_limiter: generous_faucet_limiter(),
             free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
         });
         build_router(
@@ -13564,5 +13600,219 @@ mod faucet_route_tests {
         assert_eq!(json["reason"], serde_json::json!("send_failed"));
         // Reservation rolled back so a retry is possible.
         assert!(!ledger.reserved.lock().unwrap().contains_key(FAUCET_WALLET));
+    }
+
+    // ── F6: per-IP faucet rate limit (security review) ───────────────────────
+
+    /// `app_with_faucet` variant with a custom faucet limiter so the per-IP cap
+    /// can be exercised through the real `POST /v1/faucet/gas` route. Identical
+    /// to `app_with_faucet` except `faucet_rate_limiter` is the supplied one.
+    fn app_with_faucet_and_limit(
+        faucet: Option<Arc<Faucet>>,
+        faucet_rate_limiter: RateLimiter,
+    ) -> axum::Router {
+        let model_registry = ModelRegistry::from_toml(TEST_MODELS_TOML).unwrap();
+        let service_registry = ServiceRegistry::from_toml(TEST_SERVICES_TOML)
+            .unwrap()
+            .with_gateway_recipient(TEST_RECIPIENT_WALLET)
+            .unwrap();
+        let facilitator =
+            solvela_x402::facilitator::Facilitator::new(vec![Arc::new(AlwaysPassVerifier)]);
+        let mut config = AppConfig::default();
+        config.solana.recipient_wallet = TEST_RECIPIENT_WALLET.to_string();
+
+        let new_state = Arc::new(AppState {
+            config,
+            model_registry,
+            service_registry: RwLock::new(service_registry),
+            providers: ProviderRegistry::from_env(reqwest::Client::new()),
+            facilitator,
+            usage: gateway::usage::UsageTracker::noop(),
+            cache: None,
+            semantic_cache: None,
+            provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+            escrow_claimer: None,
+            fee_payer_pool: None,
+            nonce_pool: None,
+            db_pool: None,
+            faucet,
+            session_secret: b"test-secret".to_vec(),
+            http_client: reqwest::Client::new(),
+            replay_set: AppState::new_replay_set(),
+            slot_cache: gateway::routes::escrow::new_slot_cache(),
+            escrow_metrics: None,
+            admin_token: Some(gateway::secret::AdminToken::new(
+                TEST_ADMIN_TOKEN.to_string(),
+            )),
+            api_key_hmac_secret: None,
+            prometheus_handle: Some(test_prometheus_handle()),
+            dev_bypass_payment: false,
+            free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
+            receipts_rate_limiter: generous_receipts_limiter(),
+            faucet_rate_limiter,
+            free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
+        });
+        build_router(
+            Arc::clone(&new_state),
+            RateLimiter::new(RateLimitConfig::default()),
+        )
+    }
+
+    /// A strict faucet limiter of `max` per 24h window, with the SAME cap on the
+    /// "unknown" bucket so the per-IP behavior is deterministic in `oneshot`.
+    fn strict_faucet_limiter(max: u32) -> RateLimiter {
+        RateLimiter::new(RateLimitConfig {
+            max_requests: max,
+            window: std::time::Duration::from_secs(24 * 60 * 60),
+            unknown_max_requests: max,
+        })
+    }
+
+    /// `POST /v1/faucet/gas` with a fixed `ConnectInfo` peer IP so the faucet
+    /// limiter keys on a NAMED bucket (not the shared "unknown" one). Mirrors
+    /// `receipts_get_request`'s ConnectInfo injection.
+    async fn post_faucet_from_ip(
+        app: axum::Router,
+        wallet: &str,
+        ip: &str,
+    ) -> (StatusCode, axum::http::HeaderMap, serde_json::Value) {
+        let body = format!(r#"{{"wallet":"{wallet}"}}"#);
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("/v1/faucet/gas")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let addr: std::net::SocketAddr = format!("{ip}:40000").parse().unwrap();
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(addr));
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        (status, headers, json)
+    }
+
+    /// F6: the (N+1)th drip attempt from ONE IP gets the canonical 429 — and a
+    /// FRESH wallet on every attempt must NOT escape the per-IP cap (this is the
+    /// enumeration burst the finding defends against: the per-wallet DB key only
+    /// stops per-wallet repeats, not mass fresh-wallet enumeration from one IP).
+    /// The cap is consumed BEFORE any drip work and the 429 carries the FAUCET
+    /// limit in the standard `rate_limit_exceeded` envelope.
+    #[tokio::test]
+    async fn route_rate_limited_per_ip_with_canonical_429() {
+        let source = Arc::new(MockSource::new(1_000_000, 0, true)); // always funds
+        let ledger = Arc::new(MockLedger::default());
+        let app = app_with_faucet_and_limit(
+            Some(wired_faucet(source.clone(), ledger)),
+            strict_faucet_limiter(3),
+        );
+        let ip = "198.51.100.7";
+
+        // Three drips from one IP, each a DISTINCT fresh wallet, all funded.
+        let wallets = [
+            "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+            "So11111111111111111111111111111111111111112",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        ];
+        for (i, w) in wallets.iter().enumerate() {
+            let (status, _h, json) = post_faucet_from_ip(app.clone(), w, ip).await;
+            assert_eq!(status, StatusCode::OK, "drip {i} must fund under the cap");
+            assert_eq!(json["funded"], serde_json::json!(true), "drip {i} funded");
+        }
+        // Three sends happened — the per-wallet key did NOT stop the burst.
+        assert_eq!(source.sends.load(Ordering::SeqCst), 3);
+
+        // 4th attempt (another fresh wallet) exceeds the per-IP cap → 429 BEFORE
+        // any drip work (send count stays at 3).
+        let (status, headers, json) = post_faucet_from_ip(
+            app.clone(),
+            "GDDMwNyyx8uB6zrqwBFHjLLG3TBYk2F8Az4yrQC5RzMp",
+            ip,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "a fresh wallet must NOT escape the per-IP faucet cap"
+        );
+        assert_eq!(
+            source.sends.load(Ordering::SeqCst),
+            3,
+            "the rate-limited request must be rejected BEFORE any drip/send work"
+        );
+        assert_eq!(
+            headers.get("x-ratelimit-limit").unwrap(),
+            "3",
+            "429 must carry the FAUCET limit (3), not the outer global limit (60)"
+        );
+        assert_eq!(headers.get("x-ratelimit-remaining").unwrap(), "0");
+        assert!(
+            headers.get("retry-after").is_some(),
+            "429 must carry retry-after"
+        );
+        assert_eq!(
+            json["error"]["type"],
+            serde_json::json!("rate_limit_exceeded")
+        );
+    }
+
+    /// F6: different IPs get independent faucet buckets — one IP exhausting its
+    /// cap must not affect another IP.
+    #[tokio::test]
+    async fn route_rate_limit_is_per_ip_independent() {
+        let source = Arc::new(MockSource::new(1_000_000, 0, true));
+        let ledger = Arc::new(MockLedger::default());
+        let app = app_with_faucet_and_limit(
+            Some(wired_faucet(source.clone(), ledger)),
+            strict_faucet_limiter(1),
+        );
+
+        // IP A: first drip funds, second is rate-limited.
+        let (s1, _h1, _j1) = post_faucet_from_ip(app.clone(), FAUCET_WALLET, "198.51.100.10").await;
+        assert_eq!(s1, StatusCode::OK, "IP-A first drip funds");
+        let (s2, _h2, _j2) = post_faucet_from_ip(app.clone(), FAUCET_WALLET, "198.51.100.10").await;
+        assert_eq!(
+            s2,
+            StatusCode::TOO_MANY_REQUESTS,
+            "IP-A second drip is rate-limited (cap of 1)"
+        );
+
+        // IP B (a different peer) still has its full allowance.
+        let (s3, _h3, _j3) = post_faucet_from_ip(app.clone(), FAUCET_WALLET, "198.51.100.11").await;
+        assert_eq!(
+            s3,
+            StatusCode::OK,
+            "an unrelated IP must not be affected by another IP's exhausted faucet bucket"
+        );
+    }
+
+    /// F6 ordering: a DISABLED faucet returns the `disabled` decline early —
+    /// cheapest-first, ahead of the rate limiter — so it does NOT consume a
+    /// rate-limit slot. Proven by exhausting the per-IP cap with disabled
+    /// responses and confirming the (cap+1)th from the same IP STILL returns
+    /// `disabled` (a 200), never a 429.
+    #[tokio::test]
+    async fn route_disabled_returns_early_without_consuming_rate_limit() {
+        // Disabled faucet (None) + a strict cap of 1 on the per-IP bucket.
+        let app = app_with_faucet_and_limit(None, strict_faucet_limiter(1));
+        let ip = "198.51.100.30";
+
+        // First disabled response.
+        let (s1, _h1, j1) = post_faucet_from_ip(app.clone(), FAUCET_WALLET, ip).await;
+        assert_eq!(s1, StatusCode::OK);
+        assert_eq!(j1["reason"], serde_json::json!("disabled"));
+
+        // Second from the SAME IP: if the disabled path had consumed a rate-limit
+        // slot, this would 429. It must still be `disabled` (the disabled check
+        // is ahead of the limiter), proving the cheapest-first ordering.
+        let (s2, _h2, j2) = post_faucet_from_ip(app.clone(), FAUCET_WALLET, ip).await;
+        assert_eq!(
+            s2,
+            StatusCode::OK,
+            "disabled must short-circuit BEFORE the rate limiter (no slot consumed)"
+        );
+        assert_eq!(j2["reason"], serde_json::json!("disabled"));
     }
 }

--- a/crates/gateway/tests/openapi_contract.rs
+++ b/crates/gateway/tests/openapi_contract.rs
@@ -279,6 +279,7 @@ fn contract_app_with_db(
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: RateLimiter::new(RateLimitConfig::receipts_default()),
+        faucet_rate_limiter: RateLimiter::new(RateLimitConfig::faucet_default()),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(state, RateLimiter::new(RateLimitConfig::default()))

--- a/crates/gateway/tests/orgs_routes.rs
+++ b/crates/gateway/tests/orgs_routes.rs
@@ -92,6 +92,9 @@ fn router_with_pool(pool: PgPool) -> Router {
         receipts_rate_limiter: gateway::middleware::rate_limit::RateLimiter::new(
             gateway::middleware::rate_limit::RateLimitConfig::receipts_default(),
         ),
+        faucet_rate_limiter: gateway::middleware::rate_limit::RateLimiter::new(
+            gateway::middleware::rate_limit::RateLimitConfig::faucet_default(),
+        ),
         free_global_cap: gateway::middleware::rate_limit::FreeTierGlobalCap::new(
             gateway::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
         ),

--- a/crates/gateway/tests/stats_http_redis.rs
+++ b/crates/gateway/tests/stats_http_redis.rs
@@ -100,6 +100,7 @@ fn stats_router(usage: UsageTracker, db_pool: Option<PgPool>) -> axum::Router {
         dev_bypass_payment: false,
         free_rate_limiter: RateLimiter::new(RateLimitConfig::free_default()),
         receipts_rate_limiter: RateLimiter::new(RateLimitConfig::receipts_default()),
+        faucet_rate_limiter: RateLimiter::new(RateLimitConfig::faucet_default()),
         free_global_cap: FreeTierGlobalCap::new(FREE_TIER_GLOBAL_RPM_DEFAULT),
     });
     build_router(


### PR DESCRIPTION
## What
Adds a per-IP rate limit to the unauthenticated gas-faucet endpoint
`POST /v1/faucet/gas`. Implements **F6** from the gas-drip faucet security
review (`docs/pr-reviews/2026-06-14-gas-drip-faucet-review.md`).

## Why
The faucet is unauthenticated and the per-wallet DB primary key only stops
repeat drips to **one** wallet — not mass enumeration. An attacker could mint
unlimited fresh wallets, pre-fund each past the cheap USDC floor, and drain the
entire daily cap in a single-IP burst. The daily cap was the only throttle.
This was the dominant abuse vector in the review and is a **prerequisite for
enabling the faucet in prod**.

## How
Mirrors the existing `receipts_rate_limiter` pattern (closest analog: a public,
anti-enumeration-gated route with a fixed in-code cap):
- `faucet_rate_limiter` on `AppState`; `RateLimitConfig::faucet_default()` =
  **3 req / IP / 24h** (`unknown` bucket = 1). The legit MCP caller hits the
  faucet at most once per wallet per device lifetime.
- Keyed on the **real TCP peer IP** via `ConnectInfo` — never a client-supplied
  header (`X-Forwarded-For` is forgeable, GHSA-6ggq-cvwx-4f67); absent
  `ConnectInfo` degrades to the stricter shared `unknown` bucket.
- Enforced **after** the cheap disabled-check and **before** any drip work
  (DB reservation / RPC reads / chain send); 429 via the canonical
  `rate_limited_response`; new `solvela_gas_faucet_rate_limited_total` metric.

## Tests
Route-level (`oneshot` + `build_router`): (N+1)th request per IP → 429 (proven
with a fresh wallet each time, so the per-IP cap — not the per-wallet key — is
what stops the burst); per-IP independence; disabled returns early without
consuming a slot. Plus a unit test pinning the cap < the generic outer limit.

`cargo fmt`/`clippy -D warnings` clean; `cargo test -p gateway` green (808 lib +
4 main + 250 integration; the only failures are the pre-existing no-Postgres
`escrow_queue` `#[sqlx::test]` cases, unaffected here).

## Notes
No payment/escrow/settlement/wire-format code touched. Faucet still ships
**disabled by default**. Remaining review follow-ups (Tier-3 hardening + a live
devnet drip test) tracked in the review doc.
