### PR TITLE
feat(x402): serve discovery 402 challenge to unpaid probes

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -274,7 +274,14 @@ pub fn build_router(state: Arc<AppState>, rate_limiter: RateLimiter) -> Router {
         .unwrap_or(256);
 
     Router::new()
-        .route("/v1/chat/completions", post(routes::chat::chat_completions))
+        // GET serves the x402 discovery 402 (so registry health-checkers probing
+        // with a GET see the challenge instead of a 405); POST is the real
+        // OpenAI-compatible endpoint (which itself returns the discovery 402 for
+        // an UNPAID empty/malformed body — see `chat_completions`).
+        .route(
+            "/v1/chat/completions",
+            get(routes::chat::chat_completions_discovery_get).post(routes::chat::chat_completions),
+        )
         .route(
             "/v1/images/generations",
             post(routes::images::image_generations),

--- a/crates/gateway/src/routes/chat/cost.rs
+++ b/crates/gateway/src/routes/chat/cost.rs
@@ -678,6 +678,70 @@ pub(crate) fn semantic_hit_full_atomic(
         .filter(|&c| c > 0)
 }
 
+/// Fallback discovery floor when the registry yields no priceable paid model
+/// (e.g. an all-free deployment). 1 atomic unit (1e-6 USDC) advertises a
+/// non-zero, payable amount without quoting a misleading $0 — the discovery
+/// challenge exists to signal "this resource is payable", and a $0 advert would
+/// misrepresent that. Documented nominal, never a binding quote.
+pub(crate) const DISCOVERY_FLOOR_FALLBACK_ATOMIC: u64 = 1;
+
+/// Compute the **discovery floor** — a non-binding, representative atomic-USDC
+/// amount to advertise in the GET / malformed-body discovery 402.
+///
+/// This is NOT a per-request quote. The exact price is request-dependent (it
+/// varies with the model and token usage) and is only known once a valid
+/// `ChatRequest` is parsed (that path returns the real quote, unchanged). The
+/// discovery challenge cannot see a model or tokens, so it advertises an honest
+/// floor — the smallest non-zero total cost any real request could incur across
+/// the model registry.
+///
+/// Derivation (all integer / fail-closed per solvela-fintech):
+///
+/// 1. For each registered model, price a representative minimal request of
+///    `(1 input, 1 output)` token via the registry's `estimate_cost` — which
+///    already applies the 5% platform fee exactly once.
+/// 2. Convert each total to atomic units via the checked decimal→atomic
+///    conversion (rejects NaN/∞/negative/overflow — never saturates to 0).
+/// 3. Take the minimum non-zero result. Zero-priced (free-tier) models are
+///    excluded: a $0 advertisement would misrepresent a payable resource, and
+///    those models are served free on their own path anyway.
+/// 4. If no model yields a positive cost (degenerate all-free registry), fall
+///    back to [`DISCOVERY_FLOOR_FALLBACK_ATOMIC`].
+///
+/// Cost is monotonic in tokens, so no real paid request can settle below this
+/// floor — it is a true lower bound, advertised as such, never a binding quote.
+pub(crate) fn discovery_floor_atomic(registry: &solvela_router::models::ModelRegistry) -> u64 {
+    registry
+        .all()
+        .iter()
+        .filter_map(|m| {
+            // Minimal representative request: 1 input + 1 output token. The 5%
+            // fee is applied inside `estimate_cost`; we never re-apply it.
+            let breakdown = registry.estimate_cost(&m.id, 1, 1).ok()?;
+            // Checked decimal→atomic (fail-closed): a corrupt registry entry
+            // that produced a non-numeric total is skipped, not coerced to 0.
+            let atomic: u64 = usdc_atomic_amount_checked(&breakdown.total)
+                .ok()?
+                .parse()
+                .ok()?;
+            // Exclude free models — a $0 floor would advertise a non-payable
+            // amount on a discovery challenge whose whole purpose is to say
+            // "this resource is payable".
+            (atomic > 0).then_some(atomic)
+        })
+        .min()
+        .unwrap_or_else(|| {
+            // Degenerate: every model failed pricing or is free. Surface it —
+            // a silent fallback would hide a misconfigured/unpriced registry.
+            tracing::warn!(
+                fallback_atomic = DISCOVERY_FLOOR_FALLBACK_ATOMIC,
+                "discovery floor fell back to nominal: no model produced a positive \
+                 priced quote (check model registry pricing)"
+            );
+            DISCOVERY_FLOOR_FALLBACK_ATOMIC
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1470,6 +1534,68 @@ supports_vision = false
 
     fn simple_req() -> ChatRequest {
         make_request("test-model", vec![user_msg("hello")])
+    }
+
+    #[test]
+    fn test_discovery_floor_picks_cheapest_nonzero_model_and_excludes_free() {
+        // Three models: a $0 free model, a cheap model, and an expensive one.
+        // The discovery floor must be the cheapest NON-ZERO 1-input/1-output
+        // estimate (5% fee included by `estimate_cost`), never the free $0
+        // model (a $0 advertisement would misrepresent a payable resource).
+        let toml = r#"
+[models.free]
+provider = "test"
+model_id = "free"
+display_name = "Free"
+input_cost_per_million = 0.0
+output_cost_per_million = 0.0
+context_window = 4096
+supports_streaming = false
+
+[models.cheap]
+provider = "test"
+model_id = "cheap"
+display_name = "Cheap"
+input_cost_per_million = 0.28
+output_cost_per_million = 0.42
+context_window = 4096
+supports_streaming = false
+
+[models.pricey]
+provider = "test"
+model_id = "pricey"
+display_name = "Pricey"
+input_cost_per_million = 2.50
+output_cost_per_million = 10.00
+context_window = 4096
+supports_streaming = false
+"#;
+        let reg = solvela_router::models::ModelRegistry::from_toml(toml).unwrap();
+        let floor = discovery_floor_atomic(&reg);
+
+        // Cheap model at (1,1): (0.28 + 0.42)/1e6 = 0.0000007, ×1.05 =
+        // 0.000000735, formatted to 6 dp = "0.000001" → 1 atomic.
+        // Pricey model at (1,1): (2.50 + 10.0)/1e6 = 0.0000125, ×1.05 =
+        // 0.000013125, formatted to 6 dp = "0.000013" → 13 atomic.
+        // Floor = min over non-zero = 1 (the cheap model), free model excluded.
+        assert_eq!(
+            floor, 1,
+            "discovery floor must be the cheapest non-zero per-request cost"
+        );
+        assert!(floor > 0, "discovery floor must never advertise $0");
+    }
+
+    #[test]
+    fn test_discovery_floor_falls_back_when_all_models_free() {
+        // Degenerate all-free registry: there is no positive cost to advertise,
+        // so the floor falls back to the documented 1-atomic nominal rather
+        // than advertising $0 (non-payable) on a payable-resource challenge.
+        let reg = registry_with_cost(0.0);
+        assert_eq!(
+            discovery_floor_atomic(&reg),
+            DISCOVERY_FLOOR_FALLBACK_ATOMIC,
+            "an all-free registry must fall back to the 1-atomic nominal floor"
+        );
     }
 
     #[test]

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -17,7 +17,6 @@ use std::time::Instant;
 use axum::extract::State;
 use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use axum::response::Response;
-use axum::Json;
 use metrics::{counter, histogram};
 use tracing::{debug, info, warn};
 
@@ -34,9 +33,9 @@ use crate::AppState;
 
 use cost::{
     cap_usage_to_request_limits, completion_token_ceiling, compute_actual_atomic_cost,
-    estimate_input_tokens, estimated_atomic_cost, is_free_estimate, scheme_realized_discount,
-    select_spend_log_arm, spend_cost_atomic, usdc_atomic_amount_checked, usdc_f64_to_atomic_safe,
-    PaymentScheme, SpendLogArm,
+    discovery_floor_atomic, estimate_input_tokens, estimated_atomic_cost, is_free_estimate,
+    scheme_realized_discount, select_spend_log_arm, spend_cost_atomic, usdc_atomic_amount_checked,
+    usdc_f64_to_atomic_safe, PaymentScheme, SpendLogArm,
 };
 use payment::{decode_payment_from_header, extract_payment_info, fire_escrow_claim};
 use provider::{ProviderCallContext, ProviderCallError, ProviderCallResult};
@@ -85,10 +84,54 @@ pub async fn chat_completions(
     // path degrades to the stricter "unknown" bucket rather than 500-ing.
     peer_addr: crate::middleware::rate_limit::PeerAddr,
     headers: HeaderMap,
-    Json(mut req): Json<ChatRequest>,
+    // Take the RAW body (not `Json<ChatRequest>`) so we can intercept a
+    // malformed/empty body BEFORE Axum's extractor rejects it with a bare
+    // 400/422. An x402 registry health-checker probes an UNPAID request with an
+    // empty/minimal body to confirm the resource speaks x402; it must see the
+    // discovery 402, not a parse error. `Bytes` is the LAST argument because it
+    // consumes the request body. The 10MB `RequestBodyLimitLayer` (lib.rs)
+    // still bounds it.
+    body: axum::body::Bytes,
 ) -> Result<Response, GatewayError> {
     let request_start = Instant::now();
     let debug_enabled = is_debug_enabled(&headers);
+
+    // Is a payment credential present? This single check decides how a
+    // bad/empty body is handled (CLAUDE.md rule #8: the route, not middleware,
+    // emits the 402). A `PAYMENT-SIGNATURE` header means a PAYING client, which
+    // must get real validation errors on a bad body. NO header means an UNPAID
+    // request, which is eligible for the discovery 402 on a bad body.
+    let has_payment_header = headers
+        .get("payment-signature")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| !v.is_empty());
+
+    // Deserialize the body into a `ChatRequest`.
+    //
+    //   - Payment header PRESENT → strict parse; on failure return today's 4xx
+    //     (a paying client still gets a real validation error — UNCHANGED).
+    //   - Payment header ABSENT → on parse failure (empty/garbage/missing
+    //     fields) return the DISCOVERY 402, never a 400/422. This is the only
+    //     behavior change, and it is confined to the UNPAID path. On parse
+    //     SUCCESS the request flows through the existing logic, which returns
+    //     the EXACT per-request quote 402 for a paid model (UNCHANGED).
+    //
+    // The discovery path returns here BEFORE any guard, model resolution,
+    // payment verification, settlement, provider call, budget mutation, or
+    // spend logging — it is read-only.
+    let mut req: ChatRequest = match serde_json::from_slice::<ChatRequest>(&body) {
+        Ok(req) => req,
+        Err(e) => {
+            if has_payment_header {
+                // Paying client, bad body → real validation error (as today).
+                return Err(GatewayError::BadRequest(format!(
+                    "invalid request body: {e}"
+                )));
+            }
+            // Unpaid probe with a bad/empty body → advertise the resource.
+            return Err(chat_completions_discovery(&state));
+        }
+    };
 
     // Validate message count before any processing
     if req.messages.len() > MAX_MESSAGES {
@@ -539,43 +582,11 @@ pub async fn chat_completions(
         counter!("solvela_payments_total", "status" => "none").increment(1);
         info!(model = %req.model, "no payment signature, returning 402");
 
-        // Quote the CONFIGURED mint — the same one `SolanaVerifier`/
-        // `EscrowVerifier` enforce — never the compile-time constant, so a
-        // deployment with a non-default mint (e.g. devnet) quotes an asset it
-        // will actually accept.
-        let mut accepts = vec![solvela_x402::types::PaymentAccept {
-            scheme: "exact".to_string(),
-            network: solvela_x402::types::SOLANA_NETWORK.to_string(),
-            amount: atomic_amount.clone(),
-            asset: state.config.solana.usdc_mint.clone(),
-            pay_to: state.config.solana.recipient_wallet.clone(),
-            max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
-            escrow_program_id: None,
-        }];
-
-        // Offer escrow scheme if configured
-        if state.escrow_claimer.is_some() {
-            accepts.push(solvela_x402::types::PaymentAccept {
-                scheme: "escrow".to_string(),
-                network: solvela_x402::types::SOLANA_NETWORK.to_string(),
-                amount: atomic_amount,
-                asset: state.config.solana.usdc_mint.clone(),
-                pay_to: state.config.solana.recipient_wallet.clone(),
-                max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
-                escrow_program_id: state.config.solana.escrow_program_id.clone(),
-            });
-        }
-
-        let payment_required = solvela_x402::types::PaymentRequired {
-            x402_version: solvela_x402::types::X402_VERSION,
-            resource: solvela_x402::types::Resource {
-                url: "/v1/chat/completions".to_string(),
-                method: "POST".to_string(),
-            },
-            accepts,
-            cost_breakdown: cost,
-            error: "Payment required".to_string(),
-        };
+        // Reuse the single 402 challenge builder so the per-request quote and
+        // the discovery challenge are byte-shape-identical (same accepts /
+        // legacy body / canonical PAYMENT-REQUIRED header). The CONFIGURED mint
+        // and recipient are baked in there — never the compile-time constant.
+        let payment_required = build_payment_challenge(&state, atomic_amount, cost);
 
         // Emit the PaymentRequired body at the top level of the 402 response
         // per x402 spec — NOT wrapped in the OpenAI-style error envelope.
@@ -1643,6 +1654,137 @@ pub async fn chat_completions(
             Err(GatewayError::Internal(msg))
         }
     }
+}
+
+/// Build the x402 [`PaymentRequired`] challenge for `/v1/chat/completions`.
+///
+/// The SINGLE source of truth for the 402 `accepts[]` shape, shared by both the
+/// per-request quote path ([`chat_completions`]) and the discovery path
+/// ([`chat_completions_discovery`]). Sharing one builder guarantees the
+/// discovery challenge is byte-shape-identical to the real quote — same
+/// scheme(s), same legacy snake_case body, and (via
+/// `GatewayError::PaymentChallenge`) the same canonical `PAYMENT-REQUIRED`
+/// header.
+///
+/// - `amount` is the atomic-USDC string to advertise (the per-request quote on
+///   the quote path; the non-binding discovery floor on the discovery path).
+/// - `cost_breakdown` is the matching breakdown to embed.
+///
+/// The CONFIGURED mint / recipient are baked in here — never the compile-time
+/// constant — so a deployment with a non-default mint (e.g. devnet) advertises
+/// an asset its verifier will actually accept. The `escrow` scheme is offered
+/// iff an escrow claimer is configured, exactly mirroring the quote path.
+fn build_payment_challenge(
+    state: &AppState,
+    amount: String,
+    cost_breakdown: solvela_protocol::CostBreakdown,
+) -> solvela_x402::types::PaymentRequired {
+    let mut accepts = vec![solvela_x402::types::PaymentAccept {
+        scheme: "exact".to_string(),
+        network: solvela_x402::types::SOLANA_NETWORK.to_string(),
+        amount: amount.clone(),
+        asset: state.config.solana.usdc_mint.clone(),
+        pay_to: state.config.solana.recipient_wallet.clone(),
+        max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
+        escrow_program_id: None,
+    }];
+
+    // Offer escrow scheme if configured
+    if state.escrow_claimer.is_some() {
+        accepts.push(solvela_x402::types::PaymentAccept {
+            scheme: "escrow".to_string(),
+            network: solvela_x402::types::SOLANA_NETWORK.to_string(),
+            amount,
+            asset: state.config.solana.usdc_mint.clone(),
+            pay_to: state.config.solana.recipient_wallet.clone(),
+            max_timeout_seconds: solvela_x402::types::MAX_TIMEOUT_SECONDS,
+            escrow_program_id: state.config.solana.escrow_program_id.clone(),
+        });
+    }
+
+    solvela_x402::types::PaymentRequired {
+        x402_version: solvela_x402::types::X402_VERSION,
+        resource: solvela_x402::types::Resource {
+            url: "/v1/chat/completions".to_string(),
+            method: "POST".to_string(),
+        },
+        accepts,
+        cost_breakdown,
+        error: "Payment required".to_string(),
+    }
+}
+
+/// Build the DISCOVERY 402 challenge — a non-binding advertisement that
+/// `/v1/chat/completions` is a payable x402 resource.
+///
+/// Returned for UNPAID requests that an x402 registry health-checker sends to
+/// probe the protocol: a `GET`, or a `POST` with an empty/unparseable/invalid
+/// body and NO `PAYMENT-SIGNATURE` header. Without this, those probes saw
+/// 405/400/422 (Axum rejects a bad body before the handler runs) and the
+/// service was marked "degraded / unknown protocol".
+///
+/// The advertised amount is the [`discovery_floor_atomic`] — the minimum
+/// non-zero per-request cost across the model registry, an honest LOWER BOUND.
+/// It is explicitly NOT a binding quote: the price is model- and
+/// token-dependent and is only known once a valid request is parsed (that path
+/// returns the exact per-request quote, unchanged). The embedded
+/// `cost_breakdown` surfaces that floor as the `total` (the 5% platform fee is
+/// already folded in), with a `provider_cost`/`platform_fee` split derived by
+/// the canonical integer fee math so the parts sum back to the total and the
+/// fee is never re-applied.
+///
+/// This is a pure builder (no payment verification, no settlement, no provider
+/// call, no budget or spend mutation) — the discovery path is read-only.
+fn chat_completions_discovery(state: &AppState) -> GatewayError {
+    let floor_atomic = discovery_floor_atomic(&state.model_registry);
+    // Atomic → decimal string (6 dp) for the wire `amount`/breakdown. Integer
+    // math only (solvela-fintech): split the atomic value into whole + 6-digit
+    // fractional USDC. This is a display projection of an exact integer, not a
+    // float computation.
+    let amount = floor_atomic.to_string();
+
+    // The discovery floor is a single all-in figure (the registry estimate
+    // already folds in the 5% platform fee exactly once). Present it honestly:
+    // the total is the floor; the provider_cost / platform_fee split is derived
+    // by the canonical integer fee math so the breakdown sums to the total and
+    // never re-applies the fee.
+    //   total = provider * 105/100  ⇒  provider = floor(total * 100 / 105)
+    let total_atomic = floor_atomic;
+    let provider_atomic = (total_atomic as u128 * 100 / 105) as u64;
+    let fee_atomic = total_atomic.saturating_sub(provider_atomic);
+    let to_usdc =
+        |atomic: u64| -> String { format!("{}.{:06}", atomic / 1_000_000, atomic % 1_000_000) };
+    let cost_breakdown = solvela_protocol::CostBreakdown {
+        provider_cost: to_usdc(provider_atomic),
+        platform_fee: to_usdc(fee_atomic),
+        total: to_usdc(total_atomic),
+        currency: "USDC".to_string(),
+        fee_percent: solvela_protocol::PLATFORM_FEE_PERCENT,
+    };
+
+    info!(
+        floor_atomic,
+        "returning x402 discovery challenge (non-binding floor; exact quote requires a valid request)"
+    );
+    counter!("solvela_payments_total", "status" => "discovery").increment(1);
+
+    GatewayError::PaymentChallenge(Box::new(build_payment_challenge(
+        state,
+        amount,
+        cost_breakdown,
+    )))
+}
+
+/// GET /v1/chat/completions — x402 discovery probe.
+///
+/// A GET carries no body and cannot be paid, so it always returns the discovery
+/// 402 challenge (constraint: discovery is for UNPAID requests only). Registry
+/// health-checkers use this to confirm the resource speaks x402 before ever
+/// building a payment.
+pub async fn chat_completions_discovery_get(
+    State(state): State<Arc<AppState>>,
+) -> Result<Response, GatewayError> {
+    Err(chat_completions_discovery(&state))
 }
 
 /// Inputs for one chat-path receipt (settlement-platform P2). Groups the

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -4886,11 +4886,20 @@ async fn test_chat_wrong_resource_url_rejected() {
 }
 
 // ---------------------------------------------------------------------------
-// POST /v1/chat/completions — missing body returns 4xx
+// POST /v1/chat/completions — empty body (no payment) returns the x402
+// discovery 402
+//
+// Behavior change (feat/x402-discovery-402): an UNPAID empty/malformed-body POST
+// used to be rejected with a bare 400/422 (Axum's `Json<ChatRequest>` extractor
+// failed before the handler ran), which made x402 registry health-checkers mark
+// the service "unknown protocol". It now returns the discovery 402 challenge so
+// those probes can confirm the resource speaks x402. The precise challenge shape
+// is pinned in `discovery_challenge_tests`; this test guards the status code at
+// the original probe site.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_chat_empty_body_returns_error() {
+async fn test_chat_empty_body_returns_discovery_402() {
     let app = test_app();
 
     let response = app
@@ -4905,10 +4914,11 @@ async fn test_chat_empty_body_returns_error() {
         .await
         .unwrap();
 
-    // Missing JSON body should be rejected
-    assert!(
-        response.status().is_client_error(),
-        "empty body should return a 4xx error, got {}",
+    // Empty body, no payment header → x402 discovery challenge (NOT a 400/422).
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "an unpaid empty-body POST must return the discovery 402, got {}",
         response.status()
     );
 }
@@ -13814,5 +13824,286 @@ mod faucet_route_tests {
             "disabled must short-circuit BEFORE the rate limiter (no slot consumed)"
         );
         assert_eq!(j2["reason"], serde_json::json!("disabled"));
+    }
+}
+
+// ===========================================================================
+// x402 discovery-challenge tests (feat/x402-discovery-402)
+//
+// An x402 registry health-checker probes a resource with a GET or an
+// empty/minimal POST and expects a 402 challenge so it can mark the service
+// "x402-enabled". Previously the gateway only emitted the 402 AFTER a valid
+// `ChatRequest` deserialized, so those probes saw 405 / 400 / 422 and the
+// service was marked "degraded / unknown protocol".
+//
+// The discovery 402 is a NON-BINDING advertisement: it reuses the exact
+// `GatewayError::PaymentChallenge` builder (so the legacy snake_case body AND
+// the canonical `payment-required` header are byte-shape-identical to the real
+// 402), advertises the same `accepts` (asset = configured mint, payTo =
+// configured recipient), and quotes a discovery FLOOR (not a per-request
+// quote). The discovery path is for UNPAID requests only and must never reach
+// payment verification, settlement, the provider, budget mutation, or spend
+// logging.
+// ===========================================================================
+mod discovery_challenge_tests {
+    use super::*;
+
+    /// Assert a 402 response carries a parseable x402 challenge advertising the
+    /// configured asset/payTo and the canonical `payment-required` header.
+    /// Returns the parsed legacy body so callers can inspect the amount.
+    async fn assert_discovery_402(response: axum::http::Response<Body>) -> serde_json::Value {
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYMENT_REQUIRED,
+            "discovery probe must return a 402 challenge"
+        );
+
+        // Canonical x402 v2 header must be present (byte-shape parity with the
+        // real 402 — registry checkers read this header BEFORE body parse).
+        assert!(
+            response
+                .headers()
+                .contains_key(CANONICAL_PAYMENT_REQUIRED_HEADER),
+            "discovery 402 must carry the canonical payment-required header"
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let challenge: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // x402-spec body shape (issue #217: top-level PaymentRequired).
+        assert_eq!(challenge["x402_version"], 2);
+        let accepts = challenge["accepts"].as_array().expect("accepts array");
+        assert!(!accepts.is_empty(), "accepts must be non-empty");
+
+        let exact = &accepts[0];
+        assert_eq!(exact["scheme"], "exact");
+        // Asset MUST be the CONFIGURED mint (here the mainnet default), never
+        // empty / a placeholder.
+        assert_eq!(exact["asset"], USDC_MINT);
+        assert_eq!(exact["pay_to"], TEST_RECIPIENT_WALLET);
+        assert_eq!(challenge["cost_breakdown"]["currency"], "USDC");
+        assert_eq!(challenge["cost_breakdown"]["fee_percent"], 5);
+
+        challenge
+    }
+
+    /// GET /v1/chat/completions (no payment) -> 402 discovery challenge.
+    /// Previously 405 (route was POST-only).
+    #[tokio::test]
+    async fn test_get_returns_discovery_402() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/chat/completions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_discovery_402(response).await;
+    }
+
+    /// POST empty body, no payment -> 402 discovery challenge.
+    /// Previously 400 (JSON parse error).
+    #[tokio::test]
+    async fn test_post_empty_body_returns_discovery_402() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_discovery_402(response).await;
+    }
+
+    /// POST `{}` (missing `model` + `messages`), no payment -> 402 discovery.
+    /// Previously 422 (missing field `model`).
+    #[tokio::test]
+    async fn test_post_empty_object_returns_discovery_402() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_discovery_402(response).await;
+    }
+
+    /// POST `{"messages":[]}` (missing `model`), no payment -> 402 discovery.
+    /// Previously 422.
+    #[tokio::test]
+    async fn test_post_messages_only_returns_discovery_402() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"messages":[]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_discovery_402(response).await;
+    }
+
+    /// POST unparseable garbage, no payment -> 402 discovery (not 400).
+    #[tokio::test]
+    async fn test_post_garbage_body_returns_discovery_402() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from("not json at all <<<"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_discovery_402(response).await;
+    }
+
+    /// POST a VALID body with no payment -> 402 with the EXACT per-request
+    /// quote (existing behavior preserved). The quoted amount must be the real
+    /// computed cost for gpt-4o (> 1 atomic, distinguishable from the discovery
+    /// floor of 1 atomic from the cheapest model).
+    #[tokio::test]
+    async fn test_valid_body_returns_exact_quote_not_discovery_floor() {
+        let app = test_app();
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "messages": [{"role": "user", "content": "Summarize the French Revolution in detail."}],
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let challenge = assert_discovery_402(response).await;
+        let amount: u64 = challenge["accepts"][0]["amount"]
+            .as_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        // gpt-4o quote for a real prompt is far above the 1-atomic discovery
+        // floor (cheapest deepseek model at 1+1 tokens), proving the valid-body
+        // path returns the per-request quote, not the discovery advertisement.
+        assert!(
+            amount > 1,
+            "valid-body 402 must quote the real per-request cost, got {amount}"
+        );
+    }
+
+    /// POST a BAD body WITH a payment-signature header present -> still 400/422.
+    /// A paying client must keep getting real validation errors; only the
+    /// UNPAID probe path is rerouted to discovery.
+    #[tokio::test]
+    async fn test_bad_body_with_payment_header_still_4xx() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header(
+                        "payment-signature",
+                        valid_payment_header("/v1/chat/completions"),
+                    )
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        assert!(
+            status == StatusCode::BAD_REQUEST || status == StatusCode::UNPROCESSABLE_ENTITY,
+            "a paying client sending a bad body must get a 4xx validation error, got {status}"
+        );
+        assert_ne!(
+            status,
+            StatusCode::PAYMENT_REQUIRED,
+            "a present payment header must never be rerouted to the discovery 402"
+        );
+    }
+
+    /// The discovery path must NEVER reach settlement or the provider. We build
+    /// an app with a mock provider AND a settle-recording verifier, then send a
+    /// GET and an empty POST (no payment). Both must 402, the settle flag must
+    /// stay false, and the mock provider's response body must never appear.
+    #[tokio::test]
+    async fn test_discovery_never_settles_or_calls_provider() {
+        let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (app, _state) =
+            test_app_with_mock_provider_and_exact_verifier(Arc::new(SettleRecordingVerifier {
+                settled: Arc::clone(&settled),
+            }));
+
+        // GET probe.
+        let get_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/chat/completions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(get_resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let get_body = get_resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(
+            !String::from_utf8_lossy(&get_body).contains("[mock response]"),
+            "discovery GET must not reach the provider"
+        );
+
+        // Empty-POST probe.
+        let post_resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(post_resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let post_body = post_resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(
+            !String::from_utf8_lossy(&post_body).contains("[mock response]"),
+            "discovery POST must not reach the provider"
+        );
+
+        assert!(
+            !settled.load(std::sync::atomic::Ordering::SeqCst),
+            "discovery path must NEVER reach on-chain settlement"
+        );
     }
 }


### PR DESCRIPTION
## What

Make `/v1/chat/completions` advertise its x402 payment challenge to **unpaid probers** so x402 registry health-checkers can discover it. Previously a GET or empty/minimal POST hit 405/400/422 (the 402 only fired after a fully valid body deserialized), so registries marked the service **"degraded / unknown protocol."**

| Request | Before | After |
|---|---|---|
| `GET /v1/chat/completions` | 405 | **402 discovery challenge** |
| unpaid POST, empty/invalid body | 400/422 | **402 discovery challenge** |
| valid POST, no payment | 402 exact quote | 402 exact quote (unchanged) |
| POST + `PAYMENT-SIGNATURE` | verify/settle | verify/settle (unchanged) |
| bad body **with** payment header | 4xx | 4xx (paying clients keep validation errors) |

## Design
- Discovery 402 **reuses the shared challenge builder** → byte-shape identical to the real 402 (legacy snake_case body + canonical base64 `PAYMENT-REQUIRED` header), advertising the same `accepts` (scheme(s), Solana CAIP-2, configured USDC mint, `payTo`).
- Advertised amount is a **non-binding floor** = cheapest priced model's per-request cost (atomic USDC, fail-closed conversion, 5% fee applied once; `warn!` if the registry yields no priced model). The exact quote is still returned on a valid POST.
- The discovery path is read-only and **structurally cannot reach verify/settle/provider/spend** (early-return before any of it; test-pinned).

## Money-path review
Implemented by the money-path engineer (tests-first, `solvela-x402` + `solvela-fintech` skills). Round-1 review: `ecc:rust-reviewer` + `ecc:silent-failure-hunter`.
- Their one shared **HIGH** (discovery `amount` format) was a **false positive** — both assumed the real wire `amount` is decimal; verified against live prod it's an **atomic integer** (`"68815"`), which the discovery path (`"1"`) correctly mirrors. Applying the proposed "fix" would have *introduced* a 1,000,000× error.
- The settlement-isolation invariant (no unpaid request can settle/serve) was confirmed clean by both + a dedicated test.
- The one actionable finding (no signal on the degenerate all-unpriced-registry fallback) is fixed with a `warn!`.

## Tests
9 discovery integration tests + 2 floor unit tests (GET/empty/`{}`/garbage → 402; valid → exact quote; bad-body-with-payment → 4xx; discovery never settles/calls provider; floor picks cheapest non-free / falls back). `gateway` lib 811 + integration (discovery) green; fmt + clippy clean. (The 12 `escrow_queue` `#[sqlx::test]` failures are the pre-existing DB-less ones.)

## Deploy
Same path as prior — needs a Fly deploy to go live (will follow on merge), then the registry health-checks pass.