### PR TITLE
feat(gateway): serve static /.well-known/ verification files via config

### DIFF
--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -124,6 +124,11 @@ pub struct ServerConfig {
     /// deployment that publishes its card.
     #[serde(default)]
     pub public_url: Option<String>,
+    /// Static files served verbatim under `/.well-known/` (filename → contents),
+    /// e.g. domain-ownership verification tokens for x402 registries. Populated
+    /// from `SOLVELA_WELLKNOWN_FILES` (a JSON object). Empty by default.
+    #[serde(default)]
+    pub wellknown_files: std::collections::HashMap<String, String>,
 }
 
 /// Solana network settings.
@@ -332,6 +337,7 @@ impl Default for AppConfig {
                 host: default_host(),
                 port: default_port(),
                 public_url: None,
+                wellknown_files: std::collections::HashMap::new(),
             },
             solana: SolanaConfig {
                 rpc_url: "https://api.devnet.solana.com".to_string(),

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -365,6 +365,19 @@ pub fn build_router(state: Arc<AppState>, rate_limiter: RateLimiter) -> Router {
             get(a2a::agent_card::agent_card),
         )
         .route("/.well-known/agent.json", get(a2a::agent_card::agent_card))
+        // Static well-known files (x402-registry domain verification, etc.),
+        // served verbatim from `server.wellknown_files`; 404 when unconfigured.
+        .route(
+            "/.well-known/402index-verify.txt",
+            get(
+                |axum::extract::State(state): axum::extract::State<std::sync::Arc<AppState>>| async move {
+                    match state.config.server.wellknown_files.get("402index-verify.txt") {
+                        Some(contents) => contents.clone().into_response(),
+                        None => axum::http::StatusCode::NOT_FOUND.into_response(),
+                    }
+                },
+            ),
+        )
         .route("/a2a", post(a2a::jsonrpc::a2a_endpoint))
         .route("/metrics", get(routes::metrics::get_metrics))
         .layer(axum::middleware::from_fn(

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -200,6 +200,17 @@ async fn main() -> anyhow::Result<()> {
             app_config.server.port
         );
     }
+    // Static `/.well-known/` files (e.g. x402-registry domain-verification
+    // tokens) as a JSON object {filename: contents}. Parsed once at startup; a
+    // malformed value is ignored with a warning rather than failing boot.
+    if let Ok(val) = env_with_fallback("SOLVELA_WELLKNOWN_FILES", "RCR_WELLKNOWN_FILES") {
+        match serde_json::from_str::<std::collections::HashMap<String, String>>(&val) {
+            Ok(map) => app_config.server.wellknown_files = map,
+            Err(e) => {
+                warn!(error = %e, "SOLVELA_WELLKNOWN_FILES is not a valid JSON object — ignoring")
+            }
+        }
+    }
 
     // The configured USDC mint is quoted in every 402 challenge and enforced
     // by every payment verifier, but `EscrowVerifier` only Pubkey-parses its


### PR DESCRIPTION
Adds `server.wellknown_files` (filename→contents, from `SOLVELA_WELLKNOWN_FILES` JSON env) and serves `GET /.well-known/402index-verify.txt` from it (404 when unconfigured).

Enables file-based domain-ownership verification for x402 registries — `api.solvela.ai` is the gateway itself, so there's no static host to drop a `.well-known` file on. Token/contents live in env (rotatable/removable, not in source).

Non-money-path: a read-only static-file route; no payment/USDC/settlement logic. fmt + clippy clean (incl. `main.rs`). Verified live post-deploy (file serves the hash → registry domain-verify call).