### PR TITLE
fix(a2a): advertise /a2a endpoint in AgentCard url (A2A conformance)

### DIFF
--- a/crates/gateway/src/a2a/agent_card.rs
+++ b/crates/gateway/src/a2a/agent_card.rs
@@ -23,16 +23,21 @@ pub async fn agent_card(State(state): State<Arc<AppState>>) -> impl IntoResponse
         schemes.push("escrow");
     }
 
-    // The AgentCard `url` is the A2A service endpoint external agents/registries
-    // POST to. Prefer the configured public URL; the host:port fallback is for
-    // local dev only (the default bind host is 0.0.0.0, not publicly routable).
-    let url = match &state.config.server.public_url {
+    // The AgentCard `url` IS the A2A JSON-RPC endpoint a conformant client POSTs
+    // `message/send` directly to (A2A v0.3: `url` MUST support the
+    // `preferredTransport`, which is `JSONRPC`). That handler is mounted at
+    // `/a2a` (see `lib.rs`), so the advertised url is `{base}/a2a` — NOT the
+    // bare host, which serves no JSON-RPC and would 404 a conformant probe.
+    // Prefer the configured public URL; the host:port fallback is for local dev
+    // only (the default bind host is 0.0.0.0, not publicly routable).
+    let base = match &state.config.server.public_url {
         Some(u) => u.trim_end_matches('/').to_string(),
         None => format!(
             "http://{}:{}",
             state.config.server.host, state.config.server.port
         ),
     };
+    let url = format!("{base}/a2a");
 
     Json(json!({
         "name": "Solvela",
@@ -213,8 +218,10 @@ supports_vision = false
         );
     }
 
-    /// When `public_url` is configured, the card's `url` is that value
-    /// (an external agent/registry follows it to reach `/a2a`).
+    /// When `public_url` is configured, the card's `url` is the full A2A
+    /// JSON-RPC endpoint (`{public_url}/a2a`) — the URL a conformant A2A client
+    /// POSTs `message/send` directly to (A2A v0.3: `url` MUST support the
+    /// `preferredTransport`, and ours is `JSONRPC`, served only at `/a2a`).
     #[tokio::test]
     async fn test_agent_card_url_uses_public_url_when_set() {
         let mut config = AppConfig::default();
@@ -224,15 +231,89 @@ supports_vision = false
             "/.well-known/agent-card.json",
         )
         .await;
-        // Trailing slash trimmed.
-        assert_eq!(json["url"], "https://api.solvela.ai");
+        // Trailing slash on the public URL is trimmed, then `/a2a` appended.
+        assert_eq!(json["url"], "https://api.solvela.ai/a2a");
     }
 
-    /// With no `public_url`, the card falls back to the host:port form (dev only).
+    /// With no `public_url`, the card falls back to the host:port form (dev
+    /// only), still pointing at the `/a2a` JSON-RPC endpoint.
     #[tokio::test]
     async fn test_agent_card_url_falls_back_to_host_port() {
         let json = get_card(test_app(), "/.well-known/agent-card.json").await;
-        assert_eq!(json["url"], "http://0.0.0.0:8402");
+        assert_eq!(json["url"], "http://0.0.0.0:8402/a2a");
+    }
+
+    /// Regression for the A2A conformance bug a2aregistry.org's probe caught:
+    /// the AgentCard `url` MUST address a route that actually serves the
+    /// `preferredTransport` (JSONRPC). Previously `url` was the bare public
+    /// host, so a conformant client POSTing `message/send` directly to it hit
+    /// the root and got 404 ("the message/send endpoint does not exist at the
+    /// URL declared in the agent card"). Our prior a2a tests hardcoded
+    /// `.uri("/a2a")`, so they never exercised the advertised URL — this test
+    /// closes that gap by wiring BOTH the agent-card route AND the real
+    /// production `/a2a` handler, then driving traffic to the path the card
+    /// advertises.
+    #[tokio::test]
+    async fn test_advertised_url_path_reaches_real_a2a_endpoint() {
+        // Router carrying the agent card AND the production JSON-RPC route.
+        let app = axum::Router::new()
+            .route(
+                "/.well-known/agent-card.json",
+                axum::routing::get(super::agent_card),
+            )
+            .route(
+                "/a2a",
+                axum::routing::post(crate::a2a::jsonrpc::a2a_endpoint),
+            )
+            .with_state(make_state());
+
+        // 1. Fetch the card and extract the path component of the advertised URL.
+        let json = get_card(app.clone(), "/.well-known/agent-card.json").await;
+        let advertised = json["url"].as_str().expect("url is a string");
+        let path = advertised
+            .strip_prefix("http://0.0.0.0:8402")
+            .expect("dev fallback url should be host:port-prefixed");
+        // The advertised path must be the real JSON-RPC route, not the root.
+        assert_eq!(
+            path, "/a2a",
+            "AgentCard url must advertise the /a2a JSON-RPC endpoint, not the bare host"
+        );
+
+        // 2. POST a minimal `message/send` to the advertised path and assert the
+        //    response is NOT 404 — i.e. the path the card advertises is a real
+        //    route that reaches the handler. (With cache: None the handler
+        //    returns 200 + a JSON-RPC error body; any non-404 proves routing.)
+        let resp = app
+            .oneshot(
+                http::Request::builder()
+                    .method("POST")
+                    .uri(path)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "method": "message/send",
+                            "id": "conformance-1",
+                            "params": {
+                                "message": {
+                                    "role": "user",
+                                    "parts": [{"kind": "text", "text": "ping"}],
+                                    "metadata": {"model": "test-model"}
+                                }
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .expect("valid request"),
+            )
+            .await
+            .expect("request should succeed");
+        assert_ne!(
+            resp.status(),
+            http::StatusCode::NOT_FOUND,
+            "POSTing message/send to the advertised AgentCard url path must not 404 — \
+             that 404 is the exact conformance failure this test guards against"
+        );
     }
 
     /// The card carries every field a strict A2A v0.3 schema validator requires.


### PR DESCRIPTION
## The bug

`crates/gateway/src/a2a/agent_card.rs` set the AgentCard `url` field to the **bare public base**:

- configured: `https://api.solvela.ai`
- dev fallback: `http://{host}:{port}`

But the A2A JSON-RPC endpoint that serves `message/send` is mounted at **`POST /a2a`** (`crates/gateway/src/lib.rs:381`: `.route("/a2a", post(a2a::jsonrpc::a2a_endpoint))`).

## Why this is a conformance bug

Per the **A2A v0.3 JSON schema** (`a2aproject/A2A@v0.3.0`, `specification/json/a2a.json`):

- `AgentCard.url` — *"The preferred endpoint URL for interacting with the agent. This URL **MUST support the transport** specified by 'preferredTransport'."* (example: `https://api.example.com/a2a/v1`)
- `preferredTransport` (we advertise `JSONRPC`) — *"the transport specified here **MUST be available at the main 'url'**."*

A conformant A2A client POSTs `message/send` **directly to `AgentCard.url`** — it does not append a path. With `url = https://api.solvela.ai` the client hit the **root** and got **404**, because no JSON-RPC lives there. The JSON-RPC transport is only at `/a2a`, so the advertised `url` violated the v0.3 MUST.

**a2aregistry.org's conformance probe caught exactly this** — `task_conformance` failed with *"the message/send endpoint does not exist at the URL declared in the agent card."*

## The fix

Advertise the full A2A endpoint as the card `url`:

- configured: `{trimmed public_url}/a2a` → e.g. `https://api.solvela.ai/a2a`
- dev fallback: `http://{host}:{port}/a2a`

`public_url` has exactly one consumer (this handler — verified via `grep -rn public_url crates/gateway/src`: only `config.rs` definition, `main.rs` env-load, and `agent_card.rs`), so the change is localized. `main.rs`/`config.rs` are untouched. The handler comment now states the `url` **IS** the JSON-RPC endpoint clients POST to (the old "follow it to reach /a2a" mental model was the bug).

No money-path semantics change: this is the AP2/A2A **discovery** field only — no USDC math, scheme selection, claim ceiling, signing, or key material is touched. No silent fallback is introduced; the dev fallback arm is the pre-existing explicit branch, now pointing at the real route.

## The CI gap this closes

Our existing a2a tests hardcoded `.uri("/a2a")`, so they exercised the route directly and **never validated the URL the card actually advertises** — which is why CI was green while production was non-conformant.

New regression test `test_advertised_url_path_reaches_real_a2a_endpoint`:
1. Builds a router with **both** the agent-card route **and** the real production `crate::a2a::jsonrpc::a2a_endpoint` route.
2. GETs the card, parses `url`, extracts its path.
3. Asserts the path is `/a2a` (not the bare host).
4. POSTs a minimal JSON-RPC `message/send` to that path and asserts the response is **not 404** — i.e. the advertised path is a real route that reaches the handler. (With `cache: None` the handler returns 200 + a JSON-RPC error body; the test asserts non-404, which is what "the advertised endpoint exists" means.)

The two existing url tests are updated to expect the `/a2a` suffix.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean (exit 0)
- `cargo test -p gateway` — 812 lib + 4 + all 81 a2a tests pass; the only failures are the 12 pre-existing `escrow_queue` `#[sqlx::test]` cases that need a live Postgres (documented as the sole acceptable failures). No new failures.

## Notes

- Touches only `crates/gateway/src/a2a/agent_card.rs`, mirroring the directly-analogous #583.
- `STATUS.md` / `CHANGELOG.md` intentionally not touched — per repo convention those are logged post-deploy with the Fly version (feature PRs #583/#584 did not touch them).
- Money-path review budget: this is a discovery-field change, but per the money-path process the formal 2-round review (rust-reviewer + silent-failure-hunter, then an independent pass) still applies before merge.