### PR TITLE
feat(dashboard): BYO-wallet escrow funding with verify-what-you-sign

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -80,8 +80,9 @@ jobs:
           cache: npm
           cache-dependency-path: dashboard/package-lock.json
       - run: npm ci
-      # Dashboard has no Solana dependencies, so the bigint-buffer CVE
-      # exception that the SDK workflows carry doesn't apply here.
-      # `--audit-level=high` is the right floor for a frontend with no
-      # crypto-adjacent transitives.
+      # The dashboard now carries Solana deps (@solana/kit + Wallet Standard,
+      # for the escrow-funding flow), but @solana/kit is the modern web3.js 2.0
+      # line and pulls NO bigint-buffer, so the bigint-buffer CVE exception the
+      # SDK workflows carry still doesn't apply here. `--audit-level=high`
+      # remains a clean, appropriate floor for this frontend.
       - run: npm audit --production --audit-level=high

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -53,7 +53,10 @@ deployments set these in Vercel.
 
 | Variable | Where read | Description |
 |---|---|---|
-| `NEXT_PUBLIC_GATEWAY_URL` | `src/lib/api.ts` | Solvela gateway base URL. Defaults to `http://localhost:8402` for local dev. |
+| `NEXT_PUBLIC_GATEWAY_URL` | `src/lib/api.ts`, `src/app/dashboard/wallet/page.tsx` | Solvela gateway base URL. Defaults to `http://localhost:8402` for local dev. Also used browser-side by the escrow-funding flow, so in production the dashboard origin must be in the gateway's `SOLVELA_CORS_ORIGINS`. |
+| `NEXT_PUBLIC_SOLANA_CHAIN` | `src/lib/wallet/wallet-standard.tsx` | Wallet-Standard cluster the escrow-funding flow signs/broadcasts against (`solana:mainnet` \| `solana:devnet` \| `solana:testnet`). Defaults to `solana:mainnet`; set `solana:devnet` to test against a devnet gateway. |
+| `NEXT_PUBLIC_ESCROW_PROGRAM_ID` | `src/lib/escrow/verify.ts` | Pinned escrow program the verify-what-you-sign gate checks the deposit against — a hostile/compromised gateway can't substitute its own program. Defaults to the mainnet program `9neD…`; set the devnet program id when targeting devnet. |
+| `NEXT_PUBLIC_USDC_MINT` | `src/lib/escrow/verify.ts` | Pinned USDC mint the verify gate checks the deposit against (blocks a fake-token substitution). Defaults to mainnet USDC `EPjF…`; set devnet USDC `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` for devnet. |
 | `NEXT_PUBLIC_SITE_URL` | `src/lib/theme-config.ts` | Canonical site URL for OG / Twitter card metadata. Falls back through `VERCEL_PROJECT_PRODUCTION_URL` → `VERCEL_URL` → `http://localhost:3000`. |
 | `GATEWAY_ADMIN_KEY` | `src/lib/api.ts` | Server-only admin bearer token used for privileged gateway calls (Overview, Models, and Metrics pages). Never exposed to the browser. |
 | `SOLVELA_SOLANA_RECIPIENT_WALLET` | `src/app/dashboard/wallet/page.tsx` | Public recipient wallet shown on the Wallet page. Legacy `RCR_SOLANA_RECIPIENT_WALLET` is also accepted as a fallback. |

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,7 +8,12 @@
       "name": "dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@solana/kit": "^6.10.0",
+        "@solana/wallet-standard-chains": "^1.1.1",
+        "@solana/wallet-standard-features": "^1.3.0",
         "@types/mdx": "^2.0.14",
+        "@wallet-standard/app": "^1.1.1",
+        "@wallet-standard/base": "^1.1.1",
         "clsx": "^2.1.1",
         "fumadocs-core": "^16.9.3",
         "fumadocs-mdx": "^15.0.11",
@@ -106,13 +111,13 @@
       "dev": true
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -121,29 +126,31 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -160,13 +167,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -176,13 +184,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -192,36 +201,39 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -231,18 +243,19 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -250,34 +263,37 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -287,31 +303,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -319,13 +337,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -509,6 +528,422 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1238,14 +1673,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -1457,10 +1892,11 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "devOptional": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -1502,9 +1938,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1519,9 +1955,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1536,9 +1972,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1553,9 +1989,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1570,9 +2006,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1587,9 +2023,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1604,9 +2040,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1621,9 +2057,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1638,9 +2074,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1655,9 +2091,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1672,9 +2108,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1689,9 +2125,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1706,9 +2142,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1725,9 +2161,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1742,9 +2178,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1762,7 +2198,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
@@ -1870,6 +2306,1043 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@solana/accounts": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.10.0.tgz",
+      "integrity": "sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.10.0.tgz",
+      "integrity": "sha512-vEoCGBTxG0HCERAn84KXkrJjl+pDaNzOpZ0qbgcPS98fYxP5yzbKB8SNOY2bzrbkRUmmw5Q3hqTRERemUN2Gcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.10.0.tgz",
+      "integrity": "sha512-lKSAdVo+P/6Lp4vs6shstXmFOpvxrABwn4o1462tb7sKkNapk6o9pPFVPGw4DUgPS3WqWRs1j2tmpuVjhQRntg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.10.0.tgz",
+      "integrity": "sha512-lLVuxod4ChWp9i7OvpgIykYG8Q9OGPVXKnHM9VlzDDLylsx7Y1FoQL00sHa7PqFkJVmkBufaA6dcGbQ7FU+lAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/fixed-points": "6.10.0",
+        "@solana/options": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.10.0.tgz",
+      "integrity": "sha512-nfAl9OMGo4HanIMxGsQoVB7BxMoqBCYEUxl8oEAZZ09pDxnaXQZkTRXEwPPccag37XfW1ciPd1vWPKwB2b0HHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.10.0.tgz",
+      "integrity": "sha512-CNasJW3bq5u+632Zt5aJ8rOjAjv2HyenpV8o9kAIqdmV4CBpjCCoBnKn8LkuR/sbeREZxJYfhKTXO/9ruAkw7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.10.0.tgz",
+      "integrity": "sha512-CcM+wX4zOiA9zkh8A7t1787A0Ehgmu5+6Z2tKoHew6cNw/dkaUTPa8JnNHbvfsLC8dfHC1BhAEJl86sKmRsfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.10.0.tgz",
+      "integrity": "sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.10.0.tgz",
+      "integrity": "sha512-KBLAxCtAXr357JNhCyIDQXWbuSj5vN6w+28FSfcYY6OOSiphmXLAV3V58jgV0C6iNbIzFJFi6yatFyDTdeJsNg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.10.0.tgz",
+      "integrity": "sha512-iCNed27wk6PKSS3QUtHovRfMWF/jbVWogs2vB4tukKUCsqG4rDfDInIwZ6ur/nY6XTrgi2gMMdZq9GAUlWsbfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fixed-points": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.10.0.tgz",
+      "integrity": "sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.10.0.tgz",
+      "integrity": "sha512-P8cevu4mAqHTXC37h1TVoOh8zhWB2tlOI/R9vWjYPpcLwcyWf8p2qq4LEGHl5kY+1C+4PNX39HsmCocXOPCDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.10.0.tgz",
+      "integrity": "sha512-YG7mo4zykzdc6ZTV0BuN6pveK9qeBySzlYYerq578A4eQu3xcypMAYRGAvhMZtWTanjjmD6CKtM0M7kVp0TNxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.10.0.tgz",
+      "integrity": "sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.10.0.tgz",
+      "integrity": "sha512-26IRfdm/hTUCmM7MeEeX0ULSbCM6OzkZTkfkrPircqmRM7xyNqP4hq7u0P7wjb9dl7NfgyG6K7cdvUxrj2e3mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/promises": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.10.0.tgz",
+      "integrity": "sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/offchain-messages": "6.10.0",
+        "@solana/plugin-core": "6.10.0",
+        "@solana/plugin-interfaces": "6.10.0",
+        "@solana/program-client-core": "6.10.0",
+        "@solana/programs": "6.10.0",
+        "@solana/rpc": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/rpc-parsed-types": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-subscriptions": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/signers": "6.10.0",
+        "@solana/subscribable": "6.10.0",
+        "@solana/sysvars": "6.10.0",
+        "@solana/transaction-confirmation": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.10.0.tgz",
+      "integrity": "sha512-9ykyBBvnkInH7fCacjJi7zu2PJyd+OCt+VTjIISv070fHzKIMFqZqJJ/dJ0SRH2aHwfB3n86iVsmtBtuxi4KKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.10.0.tgz",
+      "integrity": "sha512-RiEgAueeMkFMC1suOXBIcmCZgtXRxy24yk0DldPB37bB4zwOF1SAaRjNRPjIkGK8RhCYrEpPosnzLyavw9ueRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.10.0.tgz",
+      "integrity": "sha512-RO9UT3UYD8/Cu2uM6ZXbKvLeMnVD42+g9JRds7Pfs4AhiOyg4R4TJrQUAppTgavPTO3PBRlWtWOC05ZH/yAIbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.10.0.tgz",
+      "integrity": "sha512-JE70YTQOfFACVFGvoJon4Scc/eHUWjMu8Ovo35CcV2kHTAHYMCd4UkBd2gmlhK0vRMMomsQi1ZLPlAlTq0OoUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.10.0.tgz",
+      "integrity": "sha512-vr0/l9wcM4orwGr8cjkFWaJ9A4HvzuAv00jMFNMg0Spd0GZqnwnpW+D/fXa1lIJnTRaF3EeEjLh4VjKU037T0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/signers": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.10.0.tgz",
+      "integrity": "sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/plugin-interfaces": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/signers": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.10.0.tgz",
+      "integrity": "sha512-qn/HeLP5KGUJXVub3fyGe69/rWaLX4jzwm6V/1pNxJDbdF+MBdgn18hP6F+VmhfdNmwK0lue3J/1HQ1UTMuQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.10.0.tgz",
+      "integrity": "sha512-oJSIn+VBBMWDo8oqw7RV3tI6Jih+Ieup6FcQLYLDUriaeo7+8l1Zdezl8zh7SIfeU4lOfAbRg6mR0huaS/Lltg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.10.0.tgz",
+      "integrity": "sha512-EwxsqoD+NXV+m+iobnWNtATD93gTgaNsOiQOzYB1/2e+8S6fl6obdNPB55yfXgtl4jt6GV6/ae4xuPhLv76vvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/fast-stable-stringify": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-transport-http": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.10.0.tgz",
+      "integrity": "sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-parsed-types": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.10.0.tgz",
+      "integrity": "sha512-5275mvSV1mxhwvrMVa+K7BU/nAetpHfcb+8Ql9rtA8RRf6DyiimFQFZUukE4Ez6XJihEpCHNy98yhkgai9wytQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.10.0.tgz",
+      "integrity": "sha512-yQdbWw5mZEWrwsunHR9NHkuhMXIB9sPOObwm18D53v5tAJnxTB0IcHvO647XqFDLTK/yQ4AdDtlYD1vsY07AMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.10.0.tgz",
+      "integrity": "sha512-NDZrKyZrJk4HaMFhTE/lAiMB824cWAodKqDHyKi0UteHU9pyRmil3BN1jt7e+j08mwMWwfklSgyrTaq52g6DIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.10.0.tgz",
+      "integrity": "sha512-6mfuHp/K7unFKCOTCCBC9ziEGnxe2tyJ74EbR51QUnBeCUdYD7Hhdpxic1WRSJ3UeNW/mG4OzFM6z8Wi64Eh9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/fast-stable-stringify": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-subscriptions-api": "6.10.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.10.0.tgz",
+      "integrity": "sha512-CRPQoTtT1cOwOQUsqS7jgo7wYdAj7jB5ab/UmMPWVpecf2FNMhWhgvxP2s82M7VkDGTGl13qaQ0WySmi7Egrlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.10.0.tgz",
+      "integrity": "sha512-KkqP1186HELPlJftA88SNAT2znR8knCVzsUipXVzY4zfW8sN3LOa0ePMzh9VZ/V+J+raTt55laR87ovAO0n+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/subscribable": "6.10.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.10.0.tgz",
+      "integrity": "sha512-nWMwGaG4ulzeX2sskY5TywXF3cwEd8FDmUpLe2JBWxE8XDAOGOKcsYPYFcBgb8ee9KqfPT2PTNdcz9jOhJf34w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.10.0.tgz",
+      "integrity": "sha512-2nFUrVTiE720pJOY4XKx3HuYmishw0of/4oScu76YGm6O8wsmvFvPNAkrEinmieWXQkfpBfRvLZmpl8PaAy+ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.10.0.tgz",
+      "integrity": "sha512-JrdNuYi0nBbD3X8JUtgX1dQJwIwz/WJvmigDdELysXfGB2bTJpfjqGDLhCLOz2sRl66FASIEqgG/LVa2C9VXcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "undici-types": "^8.4.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.5.0.tgz",
+      "integrity": "sha512-+FxhD+5RUdCZHlVPt+pd0DaYYHBPsgoHovxhMnFq9R1SOejHGE4ma0swzuRoKhOisEzsjFWdFedyD0JQmftrHg==",
+      "license": "MIT"
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.10.0.tgz",
+      "integrity": "sha512-zaSecTfCPvz/vcoAmKD6XoRstGHTr1EKJBD8T9UcpEFFB6CtF6DxerDB+wrzkamuT6msmnR2DWXMrYOGDAsgIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/fixed-points": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.10.0.tgz",
+      "integrity": "sha512-+vtCc+mT1FpGxrA5oL2aaMxSHiMJ2hH5PcDIfjo2XJkHz2klZiCZyT5F9+zpltc9vdi1QTElQq59Sfplmtd33A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/offchain-messages": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.10.0.tgz",
+      "integrity": "sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/promises": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.10.0.tgz",
+      "integrity": "sha512-cG13p1+onxz+20iWjwWQr1Z1jQwPm0fnjoW75fqZq7p4rVCie3L2sXvaJsYPjWKrUvpOzOIEHnqZGkG05rCpjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.10.0.tgz",
+      "integrity": "sha512-ULvtg65qfenh4T/GYcIlKSUv5EqDcng9UN0dxbHU4kuZdR2e0B8HN2xDC4WhcFQVeFJSbTZmaYFkeTY/Y4gfGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc": "6.10.0",
+        "@solana/rpc-subscriptions": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.10.0.tgz",
+      "integrity": "sha512-s7v8G3BTxGlKYIj3eWCG0g1296v+1LBt16mVnlRH5FuyaJ5AdhlhtRho5HUDpdwE8EXun+y1c48V6uhcZ8wdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.10.0.tgz",
+      "integrity": "sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/wallet-standard-chains": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.1.tgz",
+      "integrity": "sha512-Us3TgL4eMVoVWhuC4UrePlYnpWN+lwteCBlhZDUhFZBJ5UMGh94mYPXno3Ho7+iHPYRtuCi/ePvPcYBqCGuBOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@solana/wallet-standard-features": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.3.0.tgz",
+      "integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3118,6 +4591,39 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@wallet-standard/app": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.1.tgz",
+      "integrity": "sha512-WDGwoByhP5gwHH01r5EaLgQdLVkACPCdOMQhmhn8rsm10h/siSgTorShzBxrn0ExSPof+Lu+C3TfgqBrPa1xoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@wallet-standard/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@wallet-standard/features": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+      "integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3437,10 +4943,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -3480,6 +4987,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3582,6 +5090,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -3670,6 +5190,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/compute-scroll-into-view": {
@@ -4075,10 +5604,11 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.348",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.348.tgz",
-      "integrity": "sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==",
-      "dev": true
+      "version": "1.5.373",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
+      "integrity": "sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -4336,11 +5866,53 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5270,463 +6842,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fumadocs-mdx/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/fumadocs-mdx/node_modules/picomatch": {
@@ -6807,6 +7922,7 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -7239,6 +8355,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -8543,10 +9660,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "dev": true
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -9379,13 +10500,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -9394,28 +10516,22 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
-      "devOptional": true
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -10356,7 +11472,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10591,6 +11707,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -10671,16 +11788,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -10696,7 +11814,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -11042,6 +12160,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -11063,7 +12202,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,7 +10,12 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@solana/kit": "^6.10.0",
+    "@solana/wallet-standard-chains": "^1.1.1",
+    "@solana/wallet-standard-features": "^1.3.0",
     "@types/mdx": "^2.0.14",
+    "@wallet-standard/app": "^1.1.1",
+    "@wallet-standard/base": "^1.1.1",
     "clsx": "^2.1.1",
     "fumadocs-core": "^16.9.3",
     "fumadocs-mdx": "^15.0.11",

--- a/dashboard/src/__tests__/escrow-amount.test.ts
+++ b/dashboard/src/__tests__/escrow-amount.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  usdcDecimalToAtomic,
+  atomicToUsdcDisplay,
+} from "@/lib/escrow/amount";
+
+// USDC is 6-decimal atomic micro-USDC; all math is integer / BigInt, fail-closed.
+// The gateway rejects non-canonical amount strings, so usdcDecimalToAtomic must
+// emit a canonical integer string (no leading zeros).
+
+describe("usdcDecimalToAtomic", () => {
+  it("converts a whole number to atomic micro-USDC", () => {
+    expect(usdcDecimalToAtomic("1")).toBe("1000000");
+  });
+
+  it("converts the canonical golden-vector fraction 0.002625 to 2625", () => {
+    expect(usdcDecimalToAtomic("0.002625")).toBe("2625");
+  });
+
+  it("converts a half dollar to 500000", () => {
+    expect(usdcDecimalToAtomic("0.5")).toBe("500000");
+  });
+
+  it("converts the smallest unit 0.000001 to 1", () => {
+    expect(usdcDecimalToAtomic("0.000001")).toBe("1");
+  });
+
+  it("pads a short fraction to exactly 6 digits", () => {
+    expect(usdcDecimalToAtomic("1.5")).toBe("1500000");
+    expect(usdcDecimalToAtomic("12.34")).toBe("12340000");
+  });
+
+  it("accepts a value at exactly 6 fractional digits", () => {
+    expect(usdcDecimalToAtomic("1.234567")).toBe("1234567");
+  });
+
+  it("accepts a trailing-dot integer", () => {
+    expect(usdcDecimalToAtomic("7.")).toBe("7000000");
+  });
+
+  it("accepts a leading-dot fraction", () => {
+    expect(usdcDecimalToAtomic(".5")).toBe("500000");
+  });
+
+  it("round-trips through atomicToUsdcDisplay", () => {
+    for (const dec of ["1", "0.002625", "0.5", "0.000001", "1234.567890"]) {
+      const atomic = usdcDecimalToAtomic(dec);
+      const back = atomicToUsdcDisplay(atomic);
+      // Re-canonicalize the input decimal the same way display would format it.
+      expect(usdcDecimalToAtomic(back)).toBe(atomic);
+    }
+  });
+
+  it("accepts a large value just below the u64 ceiling", () => {
+    // u64 max = 18446744073709551615 atomic = 18446744073709.551615 USDC.
+    expect(usdcDecimalToAtomic("18446744073709.551615")).toBe(
+      "18446744073709551615",
+    );
+  });
+
+  // ── fail-closed rejections ────────────────────────────────────────────────
+
+  it("rejects empty string", () => {
+    expect(() => usdcDecimalToAtomic("")).toThrow();
+  });
+
+  it("rejects a negative amount", () => {
+    expect(() => usdcDecimalToAtomic("-1")).toThrow();
+    expect(() => usdcDecimalToAtomic("-0.5")).toThrow();
+  });
+
+  it("rejects an explicit + sign", () => {
+    expect(() => usdcDecimalToAtomic("+1")).toThrow();
+  });
+
+  it("rejects surrounding whitespace", () => {
+    expect(() => usdcDecimalToAtomic(" 1")).toThrow();
+    expect(() => usdcDecimalToAtomic("1 ")).toThrow();
+  });
+
+  it("rejects more than 6 fractional digits", () => {
+    expect(() => usdcDecimalToAtomic("1.2345678")).toThrow();
+    expect(() => usdcDecimalToAtomic("0.0000001")).toThrow();
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(() => usdcDecimalToAtomic("abc")).toThrow();
+    expect(() => usdcDecimalToAtomic("1.2.3")).toThrow();
+    expect(() => usdcDecimalToAtomic("1e6")).toThrow();
+    expect(() => usdcDecimalToAtomic("0x10")).toThrow();
+    expect(() => usdcDecimalToAtomic("NaN")).toThrow();
+    expect(() => usdcDecimalToAtomic("Infinity")).toThrow();
+  });
+
+  it("rejects zero (gateway requires amount > 0)", () => {
+    expect(() => usdcDecimalToAtomic("0")).toThrow();
+    expect(() => usdcDecimalToAtomic("0.0")).toThrow();
+    expect(() => usdcDecimalToAtomic("0.000000")).toThrow();
+    expect(() => usdcDecimalToAtomic(".0")).toThrow();
+  });
+
+  it("rejects a value that overflows u64", () => {
+    // u64 max + 1 atomic.
+    expect(() => usdcDecimalToAtomic("18446744073709.551616")).toThrow();
+    expect(() => usdcDecimalToAtomic("99999999999999")).toThrow();
+  });
+
+  it("rejects a bare dot", () => {
+    expect(() => usdcDecimalToAtomic(".")).toThrow();
+  });
+});
+
+describe("atomicToUsdcDisplay", () => {
+  it("formats the golden-vector amount", () => {
+    expect(atomicToUsdcDisplay("2625")).toBe("0.002625");
+  });
+
+  it("formats a whole-dollar amount", () => {
+    expect(atomicToUsdcDisplay("1000000")).toBe("1");
+  });
+
+  it("formats the smallest unit", () => {
+    expect(atomicToUsdcDisplay("1")).toBe("0.000001");
+    expect(atomicToUsdcDisplay(BigInt(1))).toBe("0.000001");
+  });
+
+  it("trims trailing fractional zeros but keeps significant ones", () => {
+    expect(atomicToUsdcDisplay("1500000")).toBe("1.5");
+    expect(atomicToUsdcDisplay("1234567")).toBe("1.234567");
+    expect(atomicToUsdcDisplay("12340000")).toBe("12.34");
+  });
+
+  it("accepts a bigint input", () => {
+    expect(atomicToUsdcDisplay(BigInt(2625))).toBe("0.002625");
+  });
+
+  it("formats zero", () => {
+    expect(atomicToUsdcDisplay("0")).toBe("0");
+    expect(atomicToUsdcDisplay(BigInt(0))).toBe("0");
+  });
+
+  it("rejects a malformed atomic string", () => {
+    expect(() => atomicToUsdcDisplay("abc")).toThrow();
+    expect(() => atomicToUsdcDisplay("-1")).toThrow();
+    expect(() => atomicToUsdcDisplay("1.5")).toThrow();
+  });
+});

--- a/dashboard/src/__tests__/escrow-deposit-client.test.ts
+++ b/dashboard/src/__tests__/escrow-deposit-client.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  requestDepositTx,
+  EscrowDepositError,
+} from "@/lib/escrow/deposit-client";
+import type { DepositTxResponse } from "@/lib/escrow/types";
+
+const GATEWAY = "http://localhost:8402";
+
+const VALID_BODY = {
+  agent_wallet: "2iXtA8oeZqUU5pofxK971TCEvFGfems2AcDRaZHKD2pQ",
+  service_id: "BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=",
+  amount: "2625",
+};
+
+const OK_RESPONSE: DepositTxResponse = {
+  message: "AQAG...==",
+  decoded_intent: {
+    program_id: "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU",
+    usdc_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    provider: "RecipientWallet111111111111111111111111111111",
+    escrow_pda: "8itRK9Q7QErNubyjhuTjs85FHAfmQ7FzKjPRp6FBsaf1",
+    vault_ata: "B3Gfznfz8k5ePdQgAqRkWCvL5U5Pg1jL8SbEoGKt7BXX",
+    amount: "2625",
+    service_id: "BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=",
+    expiry_slot: 1000750,
+    recent_blockhash: "CZ8YUVdk7znjrUmnb5n7kgySk9yRAsQDYmyCxzfSky9t",
+  },
+  network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+};
+
+function mockFetch(
+  status: number,
+  body: unknown,
+  opts: { json?: boolean } = { json: true },
+): typeof fetch {
+  return vi.fn(async () =>
+    new Response(opts.json !== false ? JSON.stringify(body) : String(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  ) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("requestDepositTx", () => {
+  it("POSTs to /v1/escrow/deposit-tx and returns the parsed response on 200", async () => {
+    const fetchMock = mockFetch(200, OK_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await requestDepositTx(GATEWAY, VALID_BODY);
+
+    expect(result).toEqual(OK_RESPONSE);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe(`${GATEWAY}/v1/escrow/deposit-tx`);
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual(VALID_BODY);
+    expect(
+      new Headers(init.headers).get("content-type"),
+    ).toBe("application/json");
+  });
+
+  it("does not double up a trailing slash in the gateway URL", async () => {
+    const fetchMock = mockFetch(200, OK_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await requestDepositTx(`${GATEWAY}/`, VALID_BODY);
+
+    const [url] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe(`${GATEWAY}/v1/escrow/deposit-tx`);
+  });
+
+  it("maps a 404 escrow-not-configured ({error:string}) envelope", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(404, { error: "escrow not configured" }),
+    );
+
+    await expect(requestDepositTx(GATEWAY, VALID_BODY)).rejects.toMatchObject({
+      status: 404,
+      message: expect.stringContaining("escrow not configured"),
+    });
+  });
+
+  it("maps a 400 bad-request ({error:{message}}) envelope", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(400, {
+        error: { type: "bad_request", message: "amount must be greater than zero" },
+      }),
+    );
+
+    const err = await requestDepositTx(GATEWAY, VALID_BODY).catch((e) => e);
+    expect(err).toBeInstanceOf(EscrowDepositError);
+    expect(err.status).toBe(400);
+    expect(err.message).toContain("amount must be greater than zero");
+  });
+
+  it("maps a 429 rate-limited envelope", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(429, {
+        error: { type: "rate_limit_exceeded", message: "Too many requests. Please slow down." },
+      }),
+    );
+
+    const err = await requestDepositTx(GATEWAY, VALID_BODY).catch((e) => e);
+    expect(err).toBeInstanceOf(EscrowDepositError);
+    expect(err.status).toBe(429);
+    expect(err.message.toLowerCase()).toContain("too many requests");
+  });
+
+  it("maps a 503 RPC-unavailable envelope", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(503, {
+        error: {
+          type: "service_unavailable",
+          message: "could not reach the Solana cluster to build the deposit",
+        },
+      }),
+    );
+
+    const err = await requestDepositTx(GATEWAY, VALID_BODY).catch((e) => e);
+    expect(err).toBeInstanceOf(EscrowDepositError);
+    expect(err.status).toBe(503);
+    expect(err.message).toContain("Solana cluster");
+  });
+
+  it("maps a 500 with a fallback message when the body is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(500, "Internal Server Error", { json: false }),
+    );
+
+    const err = await requestDepositTx(GATEWAY, VALID_BODY).catch((e) => e);
+    expect(err).toBeInstanceOf(EscrowDepositError);
+    expect(err.status).toBe(500);
+    expect(err.message).toContain("500");
+  });
+
+  it("wraps a network failure as EscrowDepositError with status 0", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("Failed to fetch");
+      }) as unknown as typeof fetch,
+    );
+
+    const err = await requestDepositTx(GATEWAY, VALID_BODY).catch((e) => e);
+    expect(err).toBeInstanceOf(EscrowDepositError);
+    expect(err.status).toBe(0);
+  });
+
+  it("throws if the 200 body is missing required fields (untrusted response)", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, { network: "solana:x" }));
+
+    const err = await requestDepositTx(GATEWAY, VALID_BODY).catch((e) => e);
+    expect(err).toBeInstanceOf(EscrowDepositError);
+  });
+
+  it("rejects a 200 body whose expiry_slot is not a safe integer (u64 > 2^53)", async () => {
+    // A Solana u64 expiry beyond Number.MAX_SAFE_INTEGER cannot round-trip
+    // through a JS number; trusting it would compare a rounded value downstream.
+    // assertDepositTxResponse must fail closed.
+    const body = {
+      ...OK_RESPONSE,
+      decoded_intent: {
+        ...OK_RESPONSE.decoded_intent,
+        expiry_slot: Number.MAX_SAFE_INTEGER + 1,
+      },
+    };
+    vi.stubGlobal("fetch", mockFetch(200, body));
+
+    const err = await requestDepositTx(GATEWAY, VALID_BODY).catch((e) => e);
+    expect(err).toBeInstanceOf(EscrowDepositError);
+    expect(err.message.toLowerCase()).toContain("expiry_slot");
+  });
+});

--- a/dashboard/src/__tests__/escrow-verify.test.ts
+++ b/dashboard/src/__tests__/escrow-verify.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect } from "vitest";
+import {
+  address,
+  getAddressEncoder,
+  getBase64Encoder,
+  getBase64Decoder,
+  getCompiledTransactionMessageDecoder,
+} from "@solana/kit";
+
+import { verifyDepositMessage } from "@/lib/escrow/verify";
+import type { DecodedIntent } from "@/lib/escrow/types";
+
+// ── Golden-vector ground truth (the canonical signed-tx vector) ──────────────
+// GOLDEN_VECTOR_B64 lives in sdks/typescript/src/escrow.ts and is
+// `compact-u16(1) || sig(64) || message`. The deposit-tx endpoint returns ONLY
+// the message (base64). We compute the positive-test message fixture here from
+// the golden vector — never hardcode a guess.
+const GOLDEN_VECTOR_B64 =
+  "Ad449R7ht12UKokgbDUYh29Ey/wDEwPioT/QtJOPKwSO4RHIaFRqS0DH+bPpEo2vCK78jbRLpP/6FV/5TY+qLw8BAAYKGX9rI+FshTLGq8g4+s1ep4m+DHaykgM0A5v6iz02jWFyvMLyv5o/k5XBGVxL9QMaEsQP6v01aK7nXazb0N/wMBS12eVticTdq8DzgM47jC/J8D1uNnFG6ZNqwpSU6GOelSnAbR4dY/56biCP6roeTxLQ8Q4TL7a2ArnBn2RW9HJ+jAiHYL/eHd3PMsF/IJuCQu5SqvEx+s2I0OosbQsG8sb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKmMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgo61GtoIM8r3akxjdsa2N5CEHZ8QBYuAbfwPDOL78eGrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urqwEJCQAEBQECAwYHCDjyI8aJUuHytkEKAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcuRQ8AAAAAAA==";
+
+const b64enc = getBase64Encoder();
+const b64dec = getBase64Decoder();
+const addrEnc = getAddressEncoder();
+
+/** Base58 pubkey string → its raw 32 bytes (matches verify.ts derivation). */
+function pubkeyBytes(addr: string): Uint8Array {
+  return new Uint8Array(addrEnc.encode(address(addr)));
+}
+
+/** Strip the `compact-u16(1) || sig(64)` prefix → message bytes only. */
+function goldenMessageBytes(): Uint8Array {
+  const full = new Uint8Array(b64enc.encode(GOLDEN_VECTOR_B64));
+  return full.subarray(65);
+}
+
+function goldenMessageB64(): string {
+  return b64dec.decode(goldenMessageBytes());
+}
+
+// Connected-wallet + request fixtures matching the golden vector.
+const AGENT = "2iXtA8oeZqUU5pofxK971TCEvFGfems2AcDRaZHKD2pQ";
+const PROGRAM = "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+const MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const PROVIDER = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const ESCROW_PDA = "8itRK9Q7QErNubyjhuTjs85FHAfmQ7FzKjPRp6FBsaf1";
+const VAULT_ATA = "B3Gfznfz8k5ePdQgAqRkWCvL5U5Pg1jL8SbEoGKt7BXX";
+const SERVICE_ID_B64 = "BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc="; // [7;32]
+const AMOUNT = "2625";
+const EXPIRY = 1000750;
+const BLOCKHASH = "CZ8YUVdk7znjrUmnb5n7kgySk9yRAsQDYmyCxzfSky9t";
+
+function goldenIntent(): DecodedIntent {
+  return {
+    program_id: PROGRAM,
+    usdc_mint: MINT,
+    provider: PROVIDER,
+    escrow_pda: ESCROW_PDA,
+    vault_ata: VAULT_ATA,
+    amount: AMOUNT,
+    service_id: SERVICE_ID_B64,
+    expiry_slot: EXPIRY,
+    recent_blockhash: BLOCKHASH,
+  };
+}
+
+function goldenExpected() {
+  return { agentWallet: AGENT, amountAtomic: AMOUNT, serviceIdB64: SERVICE_ID_B64 };
+}
+
+/**
+ * Decode the golden message, apply a byte/struct mutation, and re-encode to
+ * base64. Lets negative tests tamper with the actual signed bytes the wallet
+ * would sign.
+ */
+function mutatedMessageB64(mutate: (data: Uint8Array) => Uint8Array): string {
+  // We mutate the *instruction data* region in place. The message layout keeps
+  // the 56-byte ix data contiguous at the tail; decode to find it, mutate the
+  // raw bytes, re-encode.
+  const bytes = new Uint8Array(goldenMessageBytes());
+  return b64dec.decode(mutate(bytes));
+}
+
+/**
+ * Decode a compiled message and narrow it to the legacy shape (which carries
+ * `instructions`). The kit decoder returns a versioned union; legacy messages
+ * always have an `instructions` array here.
+ */
+function decodeLegacy(bytes: Uint8Array) {
+  const dec = getCompiledTransactionMessageDecoder().decode(bytes);
+  if (dec.version !== "legacy") throw new Error("not a legacy message");
+  return dec;
+}
+
+// Find the byte offset of the 56-byte instruction data inside the message so we
+// can flip individual bytes. The ix.data is the last 56 bytes before any
+// trailing structure; we locate it by decoding and matching.
+function ixDataOffset(bytes: Uint8Array): number {
+  const dec = decodeLegacy(bytes);
+  const ixData = dec.instructions[0].data ?? new Uint8Array(0);
+  // Search for the 56-byte ix data sequence in the message bytes.
+  outer: for (let i = bytes.length - ixData.length; i >= 0; i--) {
+    for (let j = 0; j < ixData.length; j++) {
+      if (bytes[i + j] !== ixData[j]) continue outer;
+    }
+    return i;
+  }
+  throw new Error("could not locate ix data in message bytes");
+}
+
+describe("verifyDepositMessage — positive", () => {
+  it("accepts the golden-vector message with a matching intent + connected wallet", async () => {
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: goldenIntent(),
+      expected: goldenExpected(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.deposit.agentWallet).toBe(AGENT);
+      expect(result.deposit.amountAtomic).toBe(BigInt(2625));
+      expect(result.deposit.amountUsdc).toBe("0.002625");
+      expect(result.deposit.escrowPda).toBe(ESCROW_PDA);
+      expect(result.deposit.vaultAta).toBe(VAULT_ATA);
+      expect(result.deposit.provider).toBe(PROVIDER);
+      expect(result.deposit.usdcMint).toBe(MINT);
+      expect(result.deposit.programId).toBe(PROGRAM);
+      expect(result.deposit.expirySlot).toBe(EXPIRY);
+      expect(result.deposit.recentBlockhash).toBe(BLOCKHASH);
+    }
+  });
+});
+
+describe("verifyDepositMessage — malformed input (truly bad base64)", () => {
+  it("rejects non-base64 garbage without throwing", async () => {
+    const result = await verifyDepositMessage({
+      messageB64: "!!!not base64!!!",
+      decodedIntent: goldenIntent(),
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a base64 string that does not decode to a legacy message", async () => {
+    const result = await verifyDepositMessage({
+      messageB64: b64dec.decode(new Uint8Array([1, 2, 3, 4])),
+      decodedIntent: goldenIntent(),
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("verifyDepositMessage — tamper negatives (ok:false, never throw)", () => {
+  it("rejects when decoded_intent.amount disagrees with the message", async () => {
+    const intent = goldenIntent();
+    intent.amount = "9999"; // message still says 2625
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      // expected.amountAtomic stays at the (tampered) intent value so we isolate
+      // the message-vs-intent mismatch.
+      decodedIntent: intent,
+      expected: { ...goldenExpected(), amountAtomic: "9999" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("amount");
+  });
+
+  it("rejects when user-expected amount disagrees with the message", async () => {
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: goldenIntent(),
+      // The intent matches the message (2625) but the USER asked for a different
+      // amount — the wallet must not sign the wrong number.
+      expected: { ...goldenExpected(), amountAtomic: "5000" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("amount");
+  });
+
+  it("rejects when the connected wallet differs (re-derived PDA mismatch)", async () => {
+    // A different connected pubkey re-derives a DIFFERENT escrow PDA, so the
+    // message's escrow account no longer belongs to this user. This is the core
+    // fund-safety check.
+    const otherWallet = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: goldenIntent(),
+      expected: { ...goldenExpected(), agentWallet: otherWallet },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a tampered decoded_intent.escrow_pda", async () => {
+    const intent = goldenIntent();
+    intent.escrow_pda = VAULT_ATA; // plausible-looking but wrong PDA
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: intent,
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("escrow");
+  });
+
+  it("rejects a tampered decoded_intent.vault_ata", async () => {
+    const intent = goldenIntent();
+    intent.vault_ata = ESCROW_PDA; // wrong vault
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: intent,
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("vault");
+  });
+
+  it("rejects a blockhash mismatch (intent vs message lifetimeToken)", async () => {
+    const intent = goldenIntent();
+    intent.recent_blockhash = "11111111111111111111111111111111";
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: intent,
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("blockhash");
+  });
+
+  it("rejects a service_id mismatch", async () => {
+    const otherSid = b64dec.decode(new Uint8Array(32).fill(8));
+    const intent = goldenIntent();
+    intent.service_id = otherSid;
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: intent,
+      expected: { ...goldenExpected(), serviceIdB64: otherSid },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("service");
+  });
+
+  it("rejects a non-deposit discriminator (first ix byte flipped)", async () => {
+    const tampered = mutatedMessageB64((bytes) => {
+      const off = ixDataOffset(bytes);
+      bytes[off] = bytes[off] ^ 0xff; // corrupt discriminator byte 0
+      return bytes;
+    });
+    const result = await verifyDepositMessage({
+      messageB64: tampered,
+      decodedIntent: goldenIntent(),
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("deposit");
+  });
+
+  it("rejects a message with the in-band amount bytes tampered", async () => {
+    // Flip a byte in the u64 amount region [8..16] of the ix data. The decoded
+    // amount changes, disagreeing with both intent and expected.
+    const tampered = mutatedMessageB64((bytes) => {
+      const off = ixDataOffset(bytes);
+      bytes[off + 8] = bytes[off + 8] ^ 0xff;
+      return bytes;
+    });
+    const result = await verifyDepositMessage({
+      messageB64: tampered,
+      decodedIntent: goldenIntent(),
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("amount");
+  });
+
+  it("rejects an expiry mismatch (intent expiry ≠ in-band expiry)", async () => {
+    const intent = goldenIntent();
+    intent.expiry_slot = EXPIRY + 1; // intent claims a different expiry
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: intent,
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("expiry");
+  });
+
+  it("rejects a 2-instruction message", async () => {
+    // Duplicate the single instruction so the message carries two — a deposit
+    // message must contain EXACTLY one instruction.
+    const tampered = mutatedMessageB64((bytes) => {
+      const dec = decodeLegacy(bytes);
+      const ix = dec.instructions[0];
+      // The compiled instructions vector ends the message. It is prefixed by a
+      // compact-u16 count (1) just before the single instruction. Rebuild the
+      // message tail with two copies and count=2.
+      const off = ixDataOffset(bytes);
+      const accountIndices = ix.accountIndices ?? [];
+      const ixData = ix.data ?? new Uint8Array(0);
+      // The instruction structure right before ix.data: [programIdIndex(1)]
+      // [accounts compact-len(1)][accountIndices(9)][data compact-len(1)][data(56)]
+      // Reconstruct the full single-instruction blob: start = off - (1+1+9+1).
+      const ixStart = off - (1 + 1 + accountIndices.length + 1);
+      const instrBlob = bytes.subarray(ixStart, off + ixData.length);
+      // Everything before the instructions count compact-u16 (1 byte = 0x01).
+      const head = bytes.subarray(0, ixStart - 1);
+      const out = new Uint8Array(head.length + 1 + instrBlob.length * 2);
+      out.set(head, 0);
+      out[head.length] = 0x02; // instruction count = 2
+      out.set(instrBlob, head.length + 1);
+      out.set(instrBlob, head.length + 1 + instrBlob.length);
+      return out;
+    });
+    const result = await verifyDepositMessage({
+      messageB64: tampered,
+      decodedIntent: goldenIntent(),
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("instruction");
+  });
+});
+
+describe("verifyDepositMessage — pinned program/mint + header (V-2/V-3/V-4)", () => {
+  // A valid base58 pubkey that is NOT the pinned escrow program / mint.
+  const OTHER_PROGRAM = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+  const OTHER_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"; // devnet USDC
+
+  it("rejects an intent program_id that differs from the pinned escrow program", async () => {
+    // The message slot 9 still names the real program, but a hostile gateway
+    // swapped the intent's program_id. Pinning rejects on the intent field even
+    // though the message ↔ message checks would pass.
+    const intent = goldenIntent();
+    intent.program_id = OTHER_PROGRAM;
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: intent,
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("program");
+  });
+
+  it("rejects an intent usdc_mint that differs from the pinned mint", async () => {
+    const intent = goldenIntent();
+    intent.usdc_mint = OTHER_MINT;
+    const result = await verifyDepositMessage({
+      messageB64: goldenMessageB64(),
+      decodedIntent: intent,
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("mint");
+  });
+
+  it("rejects a message whose static account 9 (program) is overwritten", async () => {
+    // Overwrite the 32 bytes at static-account index 9 with a different valid
+    // pubkey: offset = 3 (header) + 1 (count) + 9*32. staticAccounts[9] then
+    // fails the pin even though the intent still names the real program.
+    const off9 = 3 + 1 + 9 * 32;
+    const replacement = pubkeyBytes(OTHER_PROGRAM);
+    const tampered = mutatedMessageB64((bytes) => {
+      bytes.set(replacement, off9);
+      return bytes;
+    });
+    const result = await verifyDepositMessage({
+      messageB64: tampered,
+      decodedIntent: goldenIntent(),
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.toLowerCase()).toContain("program");
+  });
+
+  it("rejects a message with a tampered legacy header (readonly-non-signer count)", async () => {
+    // Flip message byte[2] (numReadonlyNonSignerAccounts) from 6 to 4.
+    const tampered = mutatedMessageB64((bytes) => {
+      bytes[2] = 4;
+      return bytes;
+    });
+    const result = await verifyDepositMessage({
+      messageB64: tampered,
+      decodedIntent: goldenIntent(),
+      expected: goldenExpected(),
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/dashboard/src/app/dashboard/wallet/page.tsx
+++ b/dashboard/src/app/dashboard/wallet/page.tsx
@@ -5,8 +5,13 @@ import { TerminalCard } from "@/components/ui/terminal-card";
 import { WALLET_TXS, DASHBOARD_STATS } from "@/lib/mock-data";
 import { fetchAdminStats, fetchEscrowConfig } from "@/lib/api";
 import { formatUSDC, formatNumber } from "@/lib/utils";
+import { EscrowFunding } from "@/components/wallet/escrow-funding";
 
 const WALLET_SETUP_DOCS_URL = "/docs/quickstart#configure-recipient-wallet";
+
+// Browser-reachable gateway URL for the client-side escrow-funding flow.
+const GATEWAY_URL =
+  process.env.NEXT_PUBLIC_GATEWAY_URL ?? "http://localhost:8402";
 
 export default async function WalletPage() {
   const recipientWallet =
@@ -84,6 +89,12 @@ export default async function WalletPage() {
               </a>
             </div>
         </TerminalCard>
+
+        {/* BYO-wallet escrow funding (connect → verify → sign → submit) */}
+        <EscrowFunding
+          gatewayUrl={GATEWAY_URL}
+          escrowConfigured={Boolean(escrowConfig?.escrow_program_id)}
+        />
 
         {/* Escrow config */}
         {escrowConfig && (

--- a/dashboard/src/components/wallet/escrow-funding.tsx
+++ b/dashboard/src/components/wallet/escrow-funding.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+// ---------------------------------------------------------------------------
+// BYO-wallet escrow funding (dashboard PR 2).
+//
+// Connect any Wallet-Standard wallet, request an UNSIGNED escrow-deposit
+// message from the gateway (`POST /v1/escrow/deposit-tx`, #597), VERIFY what
+// you're about to sign (decode + independently re-derive the destination), then
+// sign + broadcast. The gateway holds no key on this path; the user's wallet is
+// the sole signer and fee payer.
+//
+// Money-path safety: the deposit is NEVER signed until `verifyDepositMessage`
+// confirms the message decodes to exactly one `deposit` instruction whose escrow
+// PDA, re-derived from the *connected* pubkey, matches the message and the
+// gateway's stated intent. A failed verification hard-stops before any signature
+// is requested.
+// ---------------------------------------------------------------------------
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  Wallet as WalletIcon,
+  ShieldCheck,
+  Check,
+  AlertTriangle,
+  ExternalLink,
+  RefreshCw,
+  Loader,
+  X,
+} from "lucide-react";
+
+import { getBase64Decoder, getBase64Encoder } from "@solana/kit";
+
+import { TerminalCard } from "@/components/ui/terminal-card";
+import {
+  SolanaWalletProvider,
+  useSolanaWallet,
+  type SolanaChain,
+} from "@/lib/wallet/wallet-standard";
+import { usdcDecimalToAtomic } from "@/lib/escrow/amount";
+import { requestDepositTx } from "@/lib/escrow/deposit-client";
+import { verifyDepositMessage, type VerifiedDeposit } from "@/lib/escrow/verify";
+
+export interface EscrowFundingProps {
+  /** Browser-reachable gateway base URL (NEXT_PUBLIC_GATEWAY_URL). */
+  gatewayUrl: string;
+  /** Whether the gateway has an escrow program configured. */
+  escrowConfigured: boolean;
+}
+
+const PRIMARY_BTN =
+  "inline-flex items-center justify-center gap-2 rounded border border-[color:var(--accent-salmon)] bg-[color:var(--accent-salmon)] px-4 py-2 text-sm font-medium text-[#1a1410] hover:bg-[color:var(--accent-salmon-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-salmon)]";
+
+const SECONDARY_BTN =
+  "inline-flex items-center justify-center gap-2 rounded border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-bg-surface disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-salmon)]";
+
+const INPUT_CLS =
+  "w-full rounded border border-border px-3 py-2 text-sm text-text-primary placeholder-text-tertiary bg-bg-inset focus:border-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-salmon)] transition-colors font-mono";
+
+function shorten(addr: string, head = 6, tail = 6): string {
+  return addr.length > head + tail + 1
+    ? `${addr.slice(0, head)}…${addr.slice(-tail)}`
+    : addr;
+}
+
+/** A fresh random 32-byte service_id seeding the escrow PDA. */
+function randomServiceId(): { bytes: Uint8Array; b64: string } {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return { bytes, b64: getBase64Decoder().decode(bytes) };
+}
+
+/** Solscan cluster query suffix for the configured chain. */
+function explorerCluster(chain: SolanaChain): string {
+  if (chain === "solana:mainnet") return "";
+  if (chain === "solana:devnet") return "?cluster=devnet";
+  if (chain === "solana:testnet") return "?cluster=testnet";
+  return "";
+}
+
+function errMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// ---------------------------------------------------------------------------
+// Connect-wallet sub-panel
+// ---------------------------------------------------------------------------
+
+function ConnectPanel() {
+  const { wallets, connected, connecting, connect, disconnect } =
+    useSolanaWallet();
+
+  if (connected) {
+    return (
+      <div className="flex items-center gap-3">
+        {connected.wallet.icon && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={connected.wallet.icon}
+            alt=""
+            className="h-6 w-6 rounded"
+            aria-hidden
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-primary">
+            {connected.wallet.name}
+          </p>
+          <code className="text-xs font-mono text-text-tertiary">
+            {shorten(connected.account.address, 8, 8)}
+          </code>
+        </div>
+        <button
+          type="button"
+          onClick={() => void disconnect()}
+          className={SECONDARY_BTN}
+        >
+          <X size={13} /> Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  if (wallets.length === 0) {
+    return (
+      <div className="text-sm text-text-secondary">
+        No Solana wallet detected. Install{" "}
+        <a
+          href="https://phantom.app/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[color:var(--accent-salmon)] hover:underline"
+        >
+          Phantom
+        </a>
+        ,{" "}
+        <a
+          href="https://solflare.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[color:var(--accent-salmon)] hover:underline"
+        >
+          Solflare
+        </a>
+        , or{" "}
+        <a
+          href="https://backpack.app/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[color:var(--accent-salmon)] hover:underline"
+        >
+          Backpack
+        </a>{" "}
+        and reload.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {wallets.map((w) => (
+        <button
+          key={w.name}
+          type="button"
+          disabled={connecting}
+          onClick={() => void connect(w)}
+          className={SECONDARY_BTN}
+        >
+          {w.icon ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={w.icon} alt="" className="h-4 w-4 rounded" aria-hidden />
+          ) : (
+            <WalletIcon size={14} />
+          )}
+          {w.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Verify-what-you-sign review panel
+// ---------------------------------------------------------------------------
+
+function IntentRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[11px] text-text-tertiary font-mono uppercase tracking-wide mb-1">
+        {label}
+      </dt>
+      <dd>
+        <code className="text-xs font-mono text-text-secondary break-all">
+          {value}
+        </code>
+      </dd>
+    </div>
+  );
+}
+
+function ReviewPanel({
+  deposit,
+  chain,
+  onConfirm,
+  onCancel,
+  signing,
+}: {
+  deposit: VerifiedDeposit;
+  chain: SolanaChain;
+  onConfirm: () => void;
+  onCancel: () => void;
+  signing: boolean;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 rounded border border-border bg-bg-surface px-3 py-2.5">
+        <ShieldCheck
+          size={14}
+          className="mt-0.5 flex-shrink-0 text-[color:var(--accent-salmon)]"
+        />
+        <p className="text-xs text-text-secondary">
+          Verified locally: this transaction is a single escrow{" "}
+          <span className="font-medium text-text-primary">deposit</span> whose
+          destination was re-derived from your connected wallet. Review the
+          decoded intent before signing.
+        </p>
+      </div>
+
+      <p className="metric-xl">{deposit.amountUsdc} USDC</p>
+      <p className="-mt-1 text-xs text-text-tertiary font-mono">
+        {deposit.amountAtomic.toString()} atomic micro-USDC · {chain}
+      </p>
+
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-4">
+        <IntentRow label="Escrow PDA (destination)" value={deposit.escrowPda} />
+        <IntentRow label="Vault ATA" value={deposit.vaultAta} />
+        <IntentRow label="Escrow program" value={deposit.programId} />
+        <IntentRow label="USDC mint" value={deposit.usdcMint} />
+        <IntentRow label="Provider" value={deposit.provider} />
+        <IntentRow
+          label="Expiry slot"
+          value={deposit.expirySlot.toLocaleString()}
+        />
+      </dl>
+
+      <div className="flex items-center gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={signing}
+          className={PRIMARY_BTN}
+        >
+          {signing ? (
+            <>
+              <Loader size={14} className="animate-spin" /> Signing…
+            </>
+          ) : (
+            <>
+              <ShieldCheck size={14} /> Confirm &amp; sign deposit
+            </>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={signing}
+          className={SECONDARY_BTN}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main funding flow
+// ---------------------------------------------------------------------------
+
+type Status = "idle" | "building" | "review" | "signing" | "success" | "error";
+
+function FundingFlow({ gatewayUrl, escrowConfigured }: EscrowFundingProps) {
+  const { connected, chain, signAndSend } = useSolanaWallet();
+
+  const [amount, setAmount] = useState("");
+  const [amountError, setAmountError] = useState<string | null>(null);
+  const [service, setService] = useState(() => randomServiceId());
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [review, setReview] = useState<{
+    deposit: VerifiedDeposit;
+    messageB64: string;
+  } | null>(null);
+  const [signature, setSignature] = useState<string | null>(null);
+
+  const busy = status === "building" || status === "signing";
+
+  const reset = useCallback(() => {
+    setStatus("idle");
+    setError(null);
+    setReview(null);
+    setSignature(null);
+    setAmount("");
+    setAmountError(null);
+    setService(randomServiceId());
+  }, []);
+
+  const handleBuild = useCallback(async () => {
+    setError(null);
+    setAmountError(null);
+
+    let amountAtomic: string;
+    try {
+      amountAtomic = usdcDecimalToAtomic(amount);
+    } catch (e) {
+      setAmountError(errMessage(e));
+      return;
+    }
+    if (!connected) {
+      setError("Connect a wallet first.");
+      return;
+    }
+
+    setStatus("building");
+    try {
+      const resp = await requestDepositTx(gatewayUrl, {
+        agent_wallet: connected.account.address,
+        service_id: service.b64,
+        amount: amountAtomic,
+      });
+
+      const verdict = await verifyDepositMessage({
+        messageB64: resp.message,
+        decodedIntent: resp.decoded_intent,
+        expected: {
+          agentWallet: connected.account.address,
+          amountAtomic,
+          serviceIdB64: service.b64,
+        },
+      });
+
+      if (!verdict.ok) {
+        setStatus("error");
+        setError(`Verification failed — refusing to sign. ${verdict.reason}`);
+        return;
+      }
+
+      setReview({ deposit: verdict.deposit, messageB64: resp.message });
+      setStatus("review");
+    } catch (e) {
+      setStatus("error");
+      setError(errMessage(e));
+    }
+  }, [amount, connected, gatewayUrl, service.b64]);
+
+  const handleSign = useCallback(async () => {
+    if (!review) return;
+    setStatus("signing");
+    setError(null);
+    try {
+      // Sign exactly the bytes that were verified: re-decoding the same base64
+      // string is deterministic, so these bytes are identical to those
+      // `verifyDepositMessage` inspected.
+      const messageBytes = new Uint8Array(
+        getBase64Encoder().encode(review.messageB64),
+      );
+      const sig = await signAndSend(messageBytes);
+      setSignature(sig);
+      setStatus("success");
+    } catch (e) {
+      setStatus("error");
+      setError(errMessage(e));
+    }
+  }, [review, signAndSend]);
+
+  if (!escrowConfigured) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <AlertTriangle size={13} className="flex-shrink-0 text-warning" />
+        <span>
+          Escrow is not configured on this gateway, so funding is unavailable.
+        </span>
+      </div>
+    );
+  }
+
+  if (status === "success" && signature) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 text-sm text-text-primary">
+          <span className="flex h-7 w-7 items-center justify-center rounded-full border border-success/40 text-success">
+            <Check size={14} />
+          </span>
+          Deposit submitted.
+        </div>
+        {review && (
+          <p className="text-sm text-text-secondary">
+            Funded escrow{" "}
+            <code className="font-mono text-xs text-text-primary break-all">
+              {review.deposit.escrowPda}
+            </code>{" "}
+            with {review.deposit.amountUsdc} USDC.
+          </p>
+        )}
+        <a
+          href={`https://solscan.io/tx/${signature}${explorerCluster(chain)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-sm text-[color:var(--accent-salmon)] hover:underline font-mono"
+        >
+          {shorten(signature, 10, 10)} <ExternalLink size={12} />
+        </a>
+        <div>
+          <button type="button" onClick={reset} className={SECONDARY_BTN}>
+            <RefreshCw size={13} /> Fund another
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if ((status === "review" || status === "signing") && review) {
+    return (
+      <ReviewPanel
+        deposit={review.deposit}
+        chain={chain}
+        signing={status === "signing"}
+        onConfirm={() => void handleSign()}
+        onCancel={reset}
+      />
+    );
+  }
+
+  // idle / building / error → the entry form.
+  return (
+    <div className="space-y-4">
+      <div>
+        <label
+          htmlFor="deposit-amount"
+          className="block text-[11px] text-text-tertiary font-mono uppercase tracking-wide mb-1.5"
+        >
+          Amount (USDC)
+        </label>
+        <input
+          id="deposit-amount"
+          inputMode="decimal"
+          autoComplete="off"
+          placeholder="5.00"
+          value={amount}
+          disabled={busy}
+          onChange={(e) => {
+            setAmount(e.target.value);
+            setAmountError(null);
+          }}
+          className={INPUT_CLS}
+        />
+        {amountError && (
+          <p className="mt-1.5 text-xs text-error">{amountError}</p>
+        )}
+        <p className="mt-1.5 text-xs text-text-tertiary font-mono break-all">
+          escrow service_id: {shorten(service.b64, 10, 8)}
+          <button
+            type="button"
+            onClick={() => setService(randomServiceId())}
+            disabled={busy}
+            className="ml-2 inline-flex items-center gap-1 text-text-tertiary hover:text-text-primary transition-colors disabled:opacity-50"
+            title="Generate a new escrow id"
+          >
+            <RefreshCw size={10} /> new
+          </button>
+        </p>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded border border-error/40 bg-error/5 px-3 py-2.5 text-xs text-text-secondary">
+          <AlertTriangle size={13} className="mt-0.5 flex-shrink-0 text-error" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => void handleBuild()}
+        disabled={busy || !connected || amount.trim() === ""}
+        className={PRIMARY_BTN}
+      >
+        {status === "building" ? (
+          <>
+            <Loader size={14} className="animate-spin" /> Building…
+          </>
+        ) : (
+          <>
+            <ShieldCheck size={14} /> Review deposit
+          </>
+        )}
+      </button>
+      {!connected && (
+        <p className="text-xs text-text-tertiary">
+          Connect a wallet above to fund an escrow.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public component (wires the wallet provider)
+// ---------------------------------------------------------------------------
+
+export function EscrowFunding(props: EscrowFundingProps) {
+  const subtitle = useMemo(
+    () =>
+      props.escrowConfigured
+        ? "Connect a wallet you control and fund an escrow — verified before you sign."
+        : "Escrow funding is unavailable on this gateway.",
+    [props.escrowConfigured],
+  );
+
+  return (
+    <SolanaWalletProvider>
+      <TerminalCard
+        title="Fund an escrow with your wallet"
+        accentDot
+        meta={
+          <span className="text-text-tertiary truncate text-xxs">
+            Wallet Standard · non-custodial
+          </span>
+        }
+      >
+        <div className="space-y-5">
+          <p className="text-xs text-text-tertiary">{subtitle}</p>
+          <ConnectPanel />
+          <div className="h-px bg-border" />
+          <FundingFlow {...props} />
+        </div>
+      </TerminalCard>
+    </SolanaWalletProvider>
+  );
+}

--- a/dashboard/src/components/wallet/escrow-funding.tsx
+++ b/dashboard/src/components/wallet/escrow-funding.tsx
@@ -86,7 +86,7 @@ function errMessage(e: unknown): string {
 // ---------------------------------------------------------------------------
 
 function ConnectPanel() {
-  const { wallets, connected, connecting, connect, disconnect } =
+  const { wallets, connected, connecting, connectError, connect, disconnect } =
     useSolanaWallet();
 
   if (connected) {
@@ -174,6 +174,9 @@ function ConnectPanel() {
           {w.name}
         </button>
       ))}
+      {connectError && (
+        <p className="w-full text-xs text-error">{connectError}</p>
+      )}
     </div>
   );
 }
@@ -360,6 +363,10 @@ function FundingFlow({ gatewayUrl, escrowConfigured }: EscrowFundingProps) {
       // Sign exactly the bytes that were verified: re-decoding the same base64
       // string is deterministic, so these bytes are identical to those
       // `verifyDepositMessage` inspected.
+      // NOTE on @solana/kit naming: a base64 *Encoder*'s `.encode(string)`
+      // returns the raw bytes the base64 represents — i.e. this line DECODES
+      // base64 → bytes. (Conversely getBase64Decoder().decode(bytes) → string.)
+      // Do not "fix" this to getBase64Decoder; the direction here is correct.
       const messageBytes = new Uint8Array(
         getBase64Encoder().encode(review.messageB64),
       );

--- a/dashboard/src/lib/escrow/amount.ts
+++ b/dashboard/src/lib/escrow/amount.ts
@@ -1,0 +1,109 @@
+// USDC atomic-unit conversion for the escrow-funding money path.
+//
+// USDC has 6 decimals; the atomic unit ("micro-USDC") is 1e-6 USDC. ALL math
+// here is integer / BigInt — never f64 — per the Solvela money-path rules
+// ([solvela-fintech] §1). Every conversion is fail-closed: any malformed,
+// negative, zero, over-precise, or overflowing input throws rather than
+// silently coercing to 0 or a wrong value (a silent 0 would build a deposit the
+// user never intended, or under-fund the escrow).
+//
+// The gateway (`POST /v1/escrow/deposit-tx`) requires `amount` to be a CANONICAL
+// integer string (`> 0`, no leading zeros / sign / whitespace) and rejects
+// anything else, so `usdcDecimalToAtomic` emits exactly that canonical form.
+
+/** USDC fractional precision (decimals). */
+const USDC_DECIMALS = 6;
+
+/** Zero as a BigInt (avoids `0n` literal so the code typechecks on ES2017). */
+const ZERO = BigInt(0);
+
+/** Maximum value of a Solana u64 — the on-chain amount field width. */
+const U64_MAX = (BigInt(1) << BigInt(64)) - BigInt(1);
+
+/**
+ * Convert a decimal-USDC string (as a user types it) to a canonical atomic
+ * micro-USDC integer string.
+ *
+ * Accepts only a plain decimal: an optional integer part, an optional single
+ * `.`, and up to 6 fractional digits. No sign, no whitespace, no exponent, no
+ * hex, no thousands separators.
+ *
+ * Throws on: empty / non-numeric / negative / signed / whitespace-padded /
+ * `> 6` fractional digits / zero / overflow beyond u64. Returns a canonical
+ * integer string with no leading zeros.
+ */
+export function usdcDecimalToAtomic(input: string): string {
+  if (typeof input !== "string" || input.length === 0) {
+    throw new Error("amount is required");
+  }
+
+  // Strict grammar: digits, optional single dot, up to 6 fractional digits.
+  // Disallows sign, whitespace, exponent, hex, NaN/Infinity, "1.2.3", bare "."
+  // (requires at least one digit on one side of the dot). Anchored, so any
+  // surrounding whitespace fails closed.
+  const match = /^(\d*)(?:\.(\d{0,6}))?$/.exec(input);
+  if (!match) {
+    throw new Error(
+      `invalid USDC amount: "${input}" (use a plain decimal with at most ${USDC_DECIMALS} fractional digits)`,
+    );
+  }
+
+  const intPart = match[1] ?? "";
+  const fracPart = match[2] ?? "";
+
+  // The regex permits "" (empty), "." (no digits at all), and ".5"/"5." — but a
+  // value with no digit anywhere is not a number. Require at least one digit.
+  if (intPart.length === 0 && fracPart.length === 0) {
+    throw new Error(`invalid USDC amount: "${input}"`);
+  }
+
+  // Pad the fraction to exactly 6 digits, then concatenate as an integer.
+  // String concatenation (not float multiply) keeps this exact.
+  const paddedFrac = fracPart.padEnd(USDC_DECIMALS, "0");
+  const atomic = BigInt(`${intPart === "" ? "0" : intPart}${paddedFrac}`);
+
+  if (atomic <= ZERO) {
+    throw new Error("amount must be greater than zero");
+  }
+  if (atomic > U64_MAX) {
+    throw new Error("amount exceeds the maximum supported value");
+  }
+
+  // BigInt#toString is already canonical (no leading zeros).
+  return atomic.toString();
+}
+
+/**
+ * Convert an atomic micro-USDC amount to a human display decimal-USDC string
+ * (e.g. `"2625"` → `"0.002625"`, `"1000000"` → `"1"`). Trailing fractional
+ * zeros are trimmed. Integer / BigInt only.
+ *
+ * Throws on a malformed atomic input (non-integer, negative, non-numeric).
+ */
+export function atomicToUsdcDisplay(atomic: string | bigint): string {
+  let value: bigint;
+  if (typeof atomic === "bigint") {
+    value = atomic;
+  } else {
+    if (!/^\d+$/.test(atomic)) {
+      throw new Error(`invalid atomic amount: "${atomic}"`);
+    }
+    value = BigInt(atomic);
+  }
+
+  if (value < ZERO) {
+    throw new Error("atomic amount must be non-negative");
+  }
+
+  const scale = BigInt(10) ** BigInt(USDC_DECIMALS);
+  const whole = value / scale;
+  const frac = value % scale;
+
+  if (frac === ZERO) {
+    return whole.toString();
+  }
+
+  // Zero-pad the fraction to 6 digits, then trim trailing zeros for display.
+  const fracStr = frac.toString().padStart(USDC_DECIMALS, "0").replace(/0+$/, "");
+  return `${whole.toString()}.${fracStr}`;
+}

--- a/dashboard/src/lib/escrow/deposit-client.ts
+++ b/dashboard/src/lib/escrow/deposit-client.ts
@@ -1,0 +1,141 @@
+// Browser → gateway client for `POST /v1/escrow/deposit-tx`.
+//
+// Calls the gateway directly from the dashboard client component. The gateway
+// holds NO private key on this path — it returns an UNSIGNED message that the
+// connected wallet signs. The response here is UNTRUSTED: callers MUST run it
+// through `verifyDepositMessage` (verify.ts) before requesting a signature.
+//
+// Error envelopes differ across gateway code paths, so this maps BOTH shapes the
+// gateway emits:
+//   - `{ "error": { "type": "...", "message": "..." } }`  (GatewayError + 429)
+//   - `{ "error": "escrow not configured" }`              (bare-string 404)
+// into a single typed `EscrowDepositError` carrying the HTTP status.
+
+import type { DepositTxRequestBody, DepositTxResponse } from "@/lib/escrow/types";
+
+/**
+ * Typed error for the deposit-tx request. `status` is the HTTP status (or `0`
+ * for a network-level failure before any response).
+ */
+export class EscrowDepositError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "EscrowDepositError";
+    this.status = status;
+  }
+}
+
+/** Join a gateway base URL with the endpoint path without doubling the slash. */
+function endpointUrl(gatewayUrl: string): string {
+  return `${gatewayUrl.replace(/\/+$/, "")}/v1/escrow/deposit-tx`;
+}
+
+/** Extract a human message from either gateway error-envelope shape. */
+function messageFromErrorBody(body: unknown, status: number): string {
+  if (body && typeof body === "object" && "error" in body) {
+    const err = (body as { error: unknown }).error;
+    if (typeof err === "string" && err.length > 0) {
+      return err;
+    }
+    if (err && typeof err === "object" && "message" in err) {
+      const msg = (err as { message: unknown }).message;
+      if (typeof msg === "string" && msg.length > 0) {
+        return msg;
+      }
+    }
+  }
+  return `escrow deposit request failed (HTTP ${status})`;
+}
+
+/**
+ * Shape-check an untrusted 200 body before handing it to callers. This is NOT
+ * the fund-safety gate (that is `verifyDepositMessage`); it only guarantees the
+ * fields exist and are strings/numbers so downstream verification does not
+ * dereference `undefined`. A missing field means the gateway returned something
+ * we do not understand — fail closed.
+ */
+function assertDepositTxResponse(body: unknown): asserts body is DepositTxResponse {
+  if (!body || typeof body !== "object") {
+    throw new EscrowDepositError(200, "gateway returned a non-object response");
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.message !== "string" || typeof b.network !== "string") {
+    throw new EscrowDepositError(200, "gateway response missing message/network");
+  }
+  const di = b.decoded_intent;
+  if (!di || typeof di !== "object") {
+    throw new EscrowDepositError(200, "gateway response missing decoded_intent");
+  }
+  const d = di as Record<string, unknown>;
+  const strFields = [
+    "program_id",
+    "usdc_mint",
+    "provider",
+    "escrow_pda",
+    "vault_ata",
+    "amount",
+    "service_id",
+    "recent_blockhash",
+  ];
+  for (const f of strFields) {
+    if (typeof d[f] !== "string") {
+      throw new EscrowDepositError(200, `gateway decoded_intent missing field: ${f}`);
+    }
+  }
+  // expiry_slot is a Solana u64 on the wire. A JS `number` cannot faithfully
+  // hold a u64 > 2^53, so a non-safe-integer value would silently round and then
+  // be compared against a rounded re-derivation in verify.ts. Reject rather than
+  // trust a lossy value (fail-closed — never sign against a rounded expiry).
+  if (typeof d.expiry_slot !== "number" || !Number.isSafeInteger(d.expiry_slot)) {
+    throw new EscrowDepositError(200, "gateway decoded_intent missing field: expiry_slot");
+  }
+}
+
+/**
+ * Request an unsigned escrow-deposit message from the gateway.
+ *
+ * @param gatewayUrl base gateway URL (e.g. `NEXT_PUBLIC_GATEWAY_URL`).
+ * @param body the deposit request (atomic-unit amount string — see amount.ts).
+ * @throws {EscrowDepositError} on any non-2xx response or network failure.
+ */
+export async function requestDepositTx(
+  gatewayUrl: string,
+  body: DepositTxRequestBody,
+): Promise<DepositTxResponse> {
+  let res: Response;
+  try {
+    res = await fetch(endpointUrl(gatewayUrl), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    // Network-level failure (DNS, CORS, offline) — no HTTP status available.
+    throw new EscrowDepositError(
+      0,
+      err instanceof Error ? err.message : "network error reaching the gateway",
+    );
+  }
+
+  if (!res.ok) {
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch {
+      // Body was not JSON — fall back to a status-only message.
+      parsed = undefined;
+    }
+    throw new EscrowDepositError(res.status, messageFromErrorBody(parsed, res.status));
+  }
+
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch {
+    throw new EscrowDepositError(res.status, "gateway returned a non-JSON success body");
+  }
+  assertDepositTxResponse(data);
+  return data;
+}

--- a/dashboard/src/lib/escrow/deposit-client.ts
+++ b/dashboard/src/lib/escrow/deposit-client.ts
@@ -110,6 +110,10 @@ export async function requestDepositTx(
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
+      // Defense-in-depth: never silently follow a cross-origin redirect with the
+      // request body. A misconfigured/hostile gateway redirect can't bypass the
+      // verify gate, but we don't forward the POST off-origin either.
+      redirect: "error",
     });
   } catch (err) {
     // Network-level failure (DNS, CORS, offline) — no HTTP status available.

--- a/dashboard/src/lib/escrow/types.ts
+++ b/dashboard/src/lib/escrow/types.ts
@@ -1,0 +1,63 @@
+// Shared wire types for the BYO-wallet escrow-funding money path.
+//
+// These mirror the gateway's `POST /v1/escrow/deposit-tx` contract (gateway
+// `crates/gateway/src/routes/escrow.rs`, shipped as #597). The `amount` field
+// on the wire is ALWAYS an atomic-unit integer string of micro-USDC (6 decimals),
+// never a decimal-USDC string — see `amount.ts` for the conversion.
+//
+// Treat every value the gateway returns as UNTRUSTED until `verify.ts` has
+// independently re-derived the deposit accounts and byte-matched the message
+// against the connected wallet ("verify-what-you-sign").
+
+/**
+ * Request body for `POST /v1/escrow/deposit-tx`.
+ *
+ * - `agent_wallet`: base58 pubkey of the external signer (the connected wallet);
+ *   becomes the fee payer / signer / escrow owner.
+ * - `service_id`: base64 of the 32-byte service id seeding the escrow PDA.
+ * - `amount`: atomic micro-USDC as a canonical integer string (e.g. `"2625"`),
+ *   `> 0`. The gateway rejects non-canonical strings (leading zeros, sign,
+ *   whitespace), so always pass the output of `usdcDecimalToAtomic`.
+ * - `expiry_slot`: optional absolute expiry slot; omitted lets the gateway pick
+ *   a default inside its window.
+ */
+export interface DepositTxRequestBody {
+  agent_wallet: string;
+  service_id: string;
+  amount: string;
+  expiry_slot?: number;
+}
+
+/**
+ * The deterministic inputs the gateway claims the unsigned message was built
+ * from. UNTRUSTED until verified: `verify.ts` re-derives every account here from
+ * the connected wallet and confirms it matches both this intent AND the decoded
+ * message bytes before any signature is requested.
+ */
+export interface DecodedIntent {
+  program_id: string;
+  usdc_mint: string;
+  provider: string;
+  escrow_pda: string;
+  vault_ata: string;
+  /** Atomic micro-USDC integer string (echoes the validated request amount). */
+  amount: string;
+  /** Base64 of the 32-byte service_id (echoes the validated request). */
+  service_id: string;
+  expiry_slot: number;
+  /** Base58 recent blockhash embedded in the message. */
+  recent_blockhash: string;
+}
+
+/**
+ * Response body for `POST /v1/escrow/deposit-tx`.
+ *
+ * `message` is base64 of the UNSIGNED legacy message bytes ONLY (not a full
+ * signed transaction): the signer signs these bytes and assembles
+ * `compact-u16(1) || signature(64) || message` itself.
+ */
+export interface DepositTxResponse {
+  message: string;
+  decoded_intent: DecodedIntent;
+  network: string;
+}

--- a/dashboard/src/lib/escrow/verify.ts
+++ b/dashboard/src/lib/escrow/verify.ts
@@ -1,0 +1,390 @@
+// THE FUND-SAFETY GATE: "verify-what-you-sign" for escrow deposits.
+//
+// The gateway returns an UNSIGNED message and a `decoded_intent`. Both are
+// UNTRUSTED. Before the wallet signs, this module independently:
+//   1. decodes the message bytes the wallet will actually sign,
+//   2. parses the in-band instruction (discriminator, amount, service_id,
+//      expiry) and the static account list,
+//   3. RE-DERIVES the escrow PDA + ATAs from the *connected user's* pubkey, and
+//   4. asserts the message, the intent, AND the re-derivation all agree, and
+//      that the user-requested amount/service_id match too.
+//
+// The point of the re-derivation is fund safety: re-deriving the escrow PDA from
+// the connected wallet and matching it to the message proves the deposit funds
+// an escrow the user controls — not an attacker's. Any mismatch → reject.
+//
+// Browser-native ONLY: @solana/kit + Web APIs. No node:crypto, no Buffer.
+// On a tamper we return `{ ok:false, reason }`; we throw ONLY on truly malformed
+// base64 that cannot be decoded at all.
+
+import {
+  address,
+  type Address,
+  getProgramDerivedAddress,
+  getAddressEncoder,
+  getCompiledTransactionMessageDecoder,
+  getBase64Encoder,
+  getU64Decoder,
+} from "@solana/kit";
+
+import type { DecodedIntent } from "@/lib/escrow/types";
+import { atomicToUsdcDisplay } from "@/lib/escrow/amount";
+
+// Well-known program addresses (from [solvela-x402]).
+const TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const ATA_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+
+// Client-owned canonical addresses (build-time). Defaults are mainnet; override
+// per deployment (e.g. devnet) via NEXT_PUBLIC_*. The gateway-supplied
+// program_id/usdc_mint are UNTRUSTED — pinning here is what makes the PDA/ATA
+// re-derivation meaningful: a hostile gateway cannot substitute its own program
+// or a fake mint. Fail-closed: any mismatch rejects.
+const EXPECTED_ESCROW_PROGRAM =
+  process.env.NEXT_PUBLIC_ESCROW_PROGRAM_ID ?? "9neDHouXgEgHZDde5SpmqqEZ9Uv35hFcjtFEPxomtHLU";
+const EXPECTED_USDC_MINT =
+  process.env.NEXT_PUBLIC_USDC_MINT ?? "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+// Canonical instruction-account index order (writability-sorted positions).
+const EXPECTED_ACCOUNT_INDICES = [0, 4, 5, 1, 2, 3, 6, 7, 8] as const;
+
+// Canonical static-account count and instruction-data length.
+const STATIC_ACCOUNT_COUNT = 10;
+const IX_DATA_LEN = 56;
+
+const addressEncoder = getAddressEncoder();
+const base64Encoder = getBase64Encoder();
+const u64Decoder = getU64Decoder();
+
+/** Inputs to the verification gate. */
+export interface VerifyInput {
+  messageB64: string;
+  decodedIntent: DecodedIntent;
+  /** Connected pubkey + user-requested amount + the service_id we sent. */
+  expected: { agentWallet: string; amountAtomic: string; serviceIdB64: string };
+}
+
+/** A fully-verified, safe-to-sign deposit summary. */
+export interface VerifiedDeposit {
+  agentWallet: string;
+  amountAtomic: bigint;
+  amountUsdc: string;
+  escrowPda: string;
+  vaultAta: string;
+  provider: string;
+  usdcMint: string;
+  programId: string;
+  expirySlot: number;
+  recentBlockhash: string;
+}
+
+export type VerifyResult =
+  | { ok: true; deposit: VerifiedDeposit }
+  | { ok: false; reason: string };
+
+function fail(reason: string): VerifyResult {
+  return { ok: false, reason };
+}
+
+/**
+ * Address (base58 string) → its raw 32 bytes. `address()` validates AND brands
+ * the input, so a malformed pubkey throws here (callers wrap derivation in
+ * try/catch and fail closed).
+ */
+function addressBytes(addr: string): Uint8Array {
+  return new Uint8Array(addressEncoder.encode(address(addr)));
+}
+
+/**
+ * SHA-256 over `data` using browser WebCrypto. Copies into a fresh
+ * `ArrayBuffer`-backed view so the `BufferSource` type is exact (a subarray may
+ * be `SharedArrayBuffer`-backed, which `digest` rejects on the type level).
+ */
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  const copy = new Uint8Array(data.length);
+  copy.set(data);
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", copy);
+  return new Uint8Array(digest);
+}
+
+/** The 8-byte Anchor discriminator for `deposit` = sha256("global:deposit")[..8]. */
+async function depositDiscriminator(): Promise<Uint8Array> {
+  const full = await sha256(new TextEncoder().encode("global:deposit"));
+  return full.subarray(0, 8);
+}
+
+/** Escrow PDA = PDA(program, ["escrow", agent(32), service_id(32)]). */
+async function deriveEscrowPda(
+  programId: string,
+  agentWallet: string,
+  serviceId: Uint8Array,
+): Promise<Address> {
+  const [pda] = await getProgramDerivedAddress({
+    programAddress: address(programId),
+    seeds: [new TextEncoder().encode("escrow"), addressBytes(agentWallet), serviceId],
+  });
+  return pda;
+}
+
+/** ATA(owner, mint) = PDA(ATA_PROGRAM, [owner(32), TOKEN_PROGRAM(32), mint(32)]). */
+async function deriveAta(owner: string, mint: string): Promise<Address> {
+  const [ata] = await getProgramDerivedAddress({
+    programAddress: address(ATA_PROGRAM),
+    seeds: [addressBytes(owner), addressBytes(TOKEN_PROGRAM), addressBytes(mint)],
+  });
+  return ata;
+}
+
+/** Constant-time-ish byte compare (length-checked, full scan). */
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+function arraysEqual(a: readonly number[], b: readonly number[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/**
+ * Verify what the wallet is about to sign. Returns `{ ok:true, deposit }` only
+ * when EVERY check below holds; otherwise `{ ok:false, reason }`. Throws only on
+ * base64 that cannot be decoded to bytes at all.
+ */
+export async function verifyDepositMessage(input: VerifyInput): Promise<VerifyResult> {
+  const { messageB64, decodedIntent, expected } = input;
+
+  // ── 1. Decode the message bytes. ──────────────────────────────────────────
+  // Base64 that decodes is structural data; a decode failure is the only
+  // "throw" case the spec permits, but we still wrap it as ok:false so callers
+  // get a uniform result type for any untrusted-input failure.
+  let messageBytes: Uint8Array;
+  try {
+    messageBytes = new Uint8Array(base64Encoder.encode(messageB64));
+  } catch {
+    return fail("message is not valid base64");
+  }
+  if (messageBytes.length === 0) {
+    return fail("message is empty");
+  }
+
+  let decoded;
+  try {
+    decoded = getCompiledTransactionMessageDecoder().decode(messageBytes);
+  } catch {
+    return fail("message could not be decoded as a Solana transaction message");
+  }
+
+  // ── 2. Structural shape. ──────────────────────────────────────────────────
+  if (decoded.version !== "legacy") {
+    return fail("message is not a legacy transaction message");
+  }
+  if (decoded.header.numSignerAccounts !== 1) {
+    return fail("message must have exactly one signer");
+  }
+  // Pin the full canonical legacy header [1, 0, 6] (1 signer, 0 readonly
+  // signers, 6 readonly non-signers). The single-signer check above is not
+  // enough: a tampered header that re-partitions writable/readonly accounts
+  // could flip a readonly program/mint into a writable position. Assert the
+  // remaining two header fields explicitly. (kit field names per
+  // @solana/transaction-messages compile/legacy/header.d.ts.)
+  if (decoded.header.numReadonlySignerAccounts !== 0) {
+    return fail("message must have zero read-only signers");
+  }
+  if (decoded.header.numReadonlyNonSignerAccounts !== 6) {
+    return fail("message must have exactly six read-only non-signer accounts");
+  }
+  const staticAccounts = decoded.staticAccounts;
+  if (staticAccounts.length !== STATIC_ACCOUNT_COUNT) {
+    return fail(
+      `message must reference exactly ${STATIC_ACCOUNT_COUNT} accounts, found ${staticAccounts.length}`,
+    );
+  }
+
+  // ── 3. Exactly one instruction, the escrow program at slot 9. ─────────────
+  if (decoded.instructions.length !== 1) {
+    return fail(
+      `message must contain exactly one instruction, found ${decoded.instructions.length}`,
+    );
+  }
+  const ix = decoded.instructions[0];
+  if (ix.programAddressIndex !== 9) {
+    return fail("instruction does not target the escrow program slot");
+  }
+  // Pin the program to the CLIENT-OWNED constant, not the gateway's intent. A
+  // hostile gateway could name its own program here (whose `deposit` drains the
+  // user's ATA); without this pin every downstream consistency check would still
+  // pass. Assert both the on-chain message slot AND the intent equal the pin.
+  if (staticAccounts[9] !== EXPECTED_ESCROW_PROGRAM) {
+    return fail("program id in the message is not the expected escrow program");
+  }
+  if (decodedIntent.program_id !== EXPECTED_ESCROW_PROGRAM) {
+    return fail("program id in the intent is not the expected escrow program");
+  }
+
+  // ── 4. Canonical account-index order. ─────────────────────────────────────
+  const accountIndices = ix.accountIndices ?? [];
+  if (!arraysEqual([...accountIndices], [...EXPECTED_ACCOUNT_INDICES])) {
+    return fail("instruction account order is not the canonical deposit order");
+  }
+
+  // ── 5. Instruction data: length + deposit discriminator. ──────────────────
+  const data = ix.data ?? new Uint8Array(0);
+  if (data.length !== IX_DATA_LEN) {
+    return fail(`instruction data must be ${IX_DATA_LEN} bytes, found ${data.length}`);
+  }
+  const expectedDisc = await depositDiscriminator();
+  if (!bytesEqual(data.subarray(0, 8), expectedDisc)) {
+    return fail("not a deposit instruction");
+  }
+
+  // ── 6. Parse in-band fields and cross-check intent + user-expected. ───────
+  const amount = u64Decoder.decode(data.subarray(8, 16));
+  const serviceIdBytes = data.subarray(16, 48);
+  const expiry = u64Decoder.decode(data.subarray(48, 56));
+  // The gateway echoes service_id base64-encoded; compare in that form.
+  const serviceIdB64 = bytesToBase64(serviceIdBytes);
+
+  // amount: message ↔ intent ↔ user-expected (all integer/BigInt).
+  let intentAmount: bigint;
+  let expectedAmount: bigint;
+  try {
+    intentAmount = BigInt(decodedIntent.amount);
+    expectedAmount = BigInt(expected.amountAtomic);
+  } catch {
+    return fail("amount is not a valid integer");
+  }
+  if (amount !== intentAmount) {
+    return fail("amount in the message does not match the intent");
+  }
+  if (amount !== expectedAmount) {
+    return fail("amount in the message does not match the requested amount");
+  }
+
+  // service_id: message ↔ intent ↔ user-expected (base64 compare).
+  if (serviceIdB64 !== decodedIntent.service_id) {
+    return fail("service_id in the message does not match the intent");
+  }
+  if (serviceIdB64 !== expected.serviceIdB64) {
+    return fail("service_id in the message does not match the requested service_id");
+  }
+
+  // expiry: message ↔ intent.
+  if (expiry !== BigInt(decodedIntent.expiry_slot)) {
+    return fail("expiry slot in the message does not match the intent");
+  }
+
+  // ── 7. Re-derive from the CONNECTED wallet and match message + intent. ────
+  // This is the fund-safety core: the escrow PDA must derive from the user's
+  // own pubkey, or the deposit would fund an escrow they do not control.
+  let escrowPda: string;
+  let agentAta: string;
+  let vaultAta: string;
+  try {
+    // Derive from the PINNED program + mint (proven equal to the intent above),
+    // NOT from gateway-supplied fields. This is what binds the re-derivation to a
+    // program the client trusts rather than one the gateway named.
+    escrowPda = await deriveEscrowPda(EXPECTED_ESCROW_PROGRAM, expected.agentWallet, serviceIdBytes);
+    agentAta = await deriveAta(expected.agentWallet, EXPECTED_USDC_MINT);
+    vaultAta = await deriveAta(escrowPda, EXPECTED_USDC_MINT);
+  } catch {
+    return fail("failed to re-derive escrow accounts from the connected wallet");
+  }
+
+  // fee payer / signer is the connected wallet.
+  if (staticAccounts[0] !== expected.agentWallet) {
+    return fail("the transaction is not signed by the connected wallet");
+  }
+
+  // escrow PDA: re-derived === intent === message slot 1.
+  if (escrowPda !== decodedIntent.escrow_pda) {
+    return fail("re-derived escrow account does not match the intent");
+  }
+  if (escrowPda !== staticAccounts[1]) {
+    return fail("escrow account in the message does not match the re-derived value");
+  }
+
+  // agent ATA: re-derived === message slot 2.
+  if (agentAta !== staticAccounts[2]) {
+    return fail("agent token account in the message does not match the re-derived value");
+  }
+
+  // vault ATA: re-derived === intent === message slot 3.
+  if (vaultAta !== decodedIntent.vault_ata) {
+    return fail("re-derived vault account does not match the intent");
+  }
+  if (vaultAta !== staticAccounts[3]) {
+    return fail("vault account in the message does not match the re-derived value");
+  }
+
+  // provider / mint / programs at their canonical slots.
+  if (staticAccounts[4] !== decodedIntent.provider) {
+    return fail("provider in the message does not match the intent");
+  }
+  // Pin the mint to the CLIENT-OWNED constant, not the gateway's intent. A fake
+  // mint substituted by a hostile gateway would re-derive a self-consistent (but
+  // wrong) ATA pair and pass every internal cross-check. Assert both the on-chain
+  // message slot AND the intent equal the pin.
+  if (staticAccounts[5] !== EXPECTED_USDC_MINT) {
+    return fail("USDC mint in the message is not the expected mint");
+  }
+  if (decodedIntent.usdc_mint !== EXPECTED_USDC_MINT) {
+    return fail("USDC mint in the intent is not the expected mint");
+  }
+  if (staticAccounts[6] !== TOKEN_PROGRAM) {
+    return fail("token program in the message is not canonical");
+  }
+  if (staticAccounts[7] !== ATA_PROGRAM) {
+    return fail("associated-token program in the message is not canonical");
+  }
+  if (staticAccounts[8] !== SYSTEM_PROGRAM) {
+    return fail("system program in the message is not canonical");
+  }
+
+  // ── 8. Blockhash (lifetimeToken) === intent.recent_blockhash. ─────────────
+  // V-1 DECLINED (anchor blockhash to an independent `expected` value): the
+  // client has no INDEPENDENT blockhash source — the UI only sees the gateway's
+  // response, so comparing `expected.recentBlockhash` would compare the gateway's
+  // value to itself (vacuous). On-chain liveness already rejects a stale
+  // blockhash at broadcast. This internal-consistency check (message ↔ intent) is
+  // all that is meaningful here.
+  const lifetimeToken = decoded.lifetimeToken;
+  if (lifetimeToken !== decodedIntent.recent_blockhash) {
+    return fail("recent blockhash in the message does not match the intent");
+  }
+
+  // All checks passed — safe to sign.
+  return {
+    ok: true,
+    deposit: {
+      agentWallet: expected.agentWallet,
+      amountAtomic: amount,
+      amountUsdc: atomicToUsdcDisplay(amount),
+      escrowPda,
+      vaultAta,
+      provider: decodedIntent.provider,
+      // Report the PINNED program/mint (proven equal to the intent above), so the
+      // summary the user signs against reflects the client-trusted addresses.
+      usdcMint: EXPECTED_USDC_MINT,
+      programId: EXPECTED_ESCROW_PROGRAM,
+      expirySlot: Number(expiry),
+      recentBlockhash: lifetimeToken,
+    },
+  };
+}
+
+// Encode raw bytes to standard-alphabet base64 (browser-native, no Buffer).
+// Used to compare the in-band 32-byte service_id against the gateway's
+// base64-echoed `decoded_intent.service_id` and the user-supplied `serviceIdB64`.
+// V-6 DECLINED (URL-safe base64 normalization): the gateway emits STANDARD-
+// alphabet base64 (golden-vector-pinned; the Rust handler uses `STANDARD.encode`),
+// so this standard-alphabet contract is exact. A variant mismatch could only
+// cause a false-reject, never a verification bypass — so no normalization.
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}

--- a/dashboard/src/lib/wallet/wallet-standard.tsx
+++ b/dashboard/src/lib/wallet/wallet-standard.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+// ---------------------------------------------------------------------------
+// Solana Wallet Standard connect provider (interop-first, no proprietary
+// connector). Discovers any installed Wallet-Standard wallet (Phantom,
+// Solflare, Backpack, embedded wallets from Privy/Dynamic, …) via the
+// `@wallet-standard/app` registry, lets the user connect one, and exposes a
+// byte-faithful `signAndSend`.
+//
+// Design rule (money-path adjacent): we feed the wallet the EXACT unsigned
+// message bytes the gateway returned and that the user has already verified
+// (see `lib/escrow/verify`). We do NOT re-compile or re-order the message — the
+// wallet signs precisely the bytes that were verified. The message is wrapped
+// into the legacy wire transaction `compact-u16(1) || 64 zero bytes || message`;
+// the wallet fills the single fee-payer signature slot (account index 0 = the
+// connected wallet) and broadcasts.
+// ---------------------------------------------------------------------------
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { getWallets } from "@wallet-standard/app";
+import type { Wallet, WalletAccount } from "@wallet-standard/base";
+import {
+  StandardConnect,
+  StandardDisconnect,
+  StandardEvents,
+  type StandardConnectFeature,
+  type StandardDisconnectFeature,
+  type StandardEventsFeature,
+} from "@wallet-standard/features";
+import {
+  SolanaSignAndSendTransaction,
+  type SolanaSignAndSendTransactionFeature,
+} from "@solana/wallet-standard-features";
+import { getBase58Decoder } from "@solana/kit";
+
+/** A Wallet-Standard cluster identifier, e.g. `solana:mainnet` / `solana:devnet`. */
+export type SolanaChain = `solana:${string}`;
+
+/**
+ * Target cluster for signing/broadcast. The gateway's deposit-tx `network`
+ * field is a hardcoded mainnet genesis constant and is NOT a reliable cluster
+ * signal, so the dashboard picks its own cluster from env (defaulting to
+ * mainnet). For local testing against a devnet gateway, set
+ * `NEXT_PUBLIC_SOLANA_CHAIN=solana:devnet`.
+ */
+export const SOLANA_CHAIN: SolanaChain =
+  (process.env.NEXT_PUBLIC_SOLANA_CHAIN as SolanaChain | undefined) ??
+  "solana:mainnet";
+
+/** A wallet we can actually use: it can connect AND sign+send Solana txs. */
+function isUsableWallet(wallet: Wallet): boolean {
+  return (
+    StandardConnect in wallet.features &&
+    SolanaSignAndSendTransaction in wallet.features
+  );
+}
+
+function connectFeature(wallet: Wallet) {
+  return (wallet.features as StandardConnectFeature)[StandardConnect];
+}
+function disconnectFeature(wallet: Wallet) {
+  return (wallet.features as Partial<StandardDisconnectFeature>)[
+    StandardDisconnect
+  ];
+}
+function eventsFeature(wallet: Wallet) {
+  return (wallet.features as Partial<StandardEventsFeature>)[StandardEvents];
+}
+function signAndSendFeature(wallet: Wallet) {
+  return (wallet.features as SolanaSignAndSendTransactionFeature)[
+    SolanaSignAndSendTransaction
+  ];
+}
+
+export interface ConnectedWallet {
+  wallet: Wallet;
+  account: WalletAccount;
+}
+
+export interface SolanaWalletContextValue {
+  /** Installed, usable wallets discovered via the Wallet-Standard registry. */
+  wallets: Wallet[];
+  /** The connected wallet + account, or null. */
+  connected: ConnectedWallet | null;
+  connecting: boolean;
+  /** The cluster used for signing/broadcast. */
+  chain: SolanaChain;
+  connect: (wallet: Wallet) => Promise<void>;
+  disconnect: () => Promise<void>;
+  /**
+   * Sign + broadcast the given UNSIGNED legacy-message bytes verbatim. Returns
+   * the base58 transaction signature. Throws if not connected or the wallet
+   * rejects/fails.
+   */
+  signAndSend: (messageBytes: Uint8Array) => Promise<string>;
+}
+
+const SolanaWalletContext = createContext<SolanaWalletContextValue | null>(null);
+
+export function SolanaWalletProvider({ children }: { children: ReactNode }) {
+  const [wallets, setWallets] = useState<Wallet[]>([]);
+  const [connected, setConnected] = useState<ConnectedWallet | null>(null);
+  const [connecting, setConnecting] = useState(false);
+
+  // Discover wallets on the client only (the registry touches `window`). Keep
+  // the list in sync with register/unregister events.
+  useEffect(() => {
+    const registry = getWallets();
+    const refresh = () =>
+      setWallets(registry.get().filter(isUsableWallet).slice());
+    refresh();
+    const offRegister = registry.on("register", refresh);
+    const offUnregister = registry.on("unregister", refresh);
+    return () => {
+      offRegister();
+      offUnregister();
+    };
+  }, []);
+
+  const connect = useCallback(async (wallet: Wallet) => {
+    setConnecting(true);
+    try {
+      const { accounts } = await connectFeature(wallet).connect();
+      const account =
+        accounts.find((a) => a.chains.includes(SOLANA_CHAIN)) ?? accounts[0];
+      if (!account) {
+        throw new Error("Wallet returned no accounts");
+      }
+      setConnected({ wallet, account });
+    } finally {
+      setConnecting(false);
+    }
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    const current = connected;
+    setConnected(null);
+    if (current) {
+      await disconnectFeature(current.wallet)?.disconnect();
+    }
+  }, [connected]);
+
+  // Track wallet-side account changes / disconnects for the connected wallet.
+  useEffect(() => {
+    if (!connected) return;
+    const events = eventsFeature(connected.wallet);
+    if (!events) return;
+    const off = events.on("change", (props) => {
+      if (props.accounts) {
+        const next =
+          props.accounts.find((a) => a.chains.includes(SOLANA_CHAIN)) ??
+          props.accounts[0] ??
+          null;
+        setConnected(next ? { wallet: connected.wallet, account: next } : null);
+      }
+    });
+    return off;
+  }, [connected]);
+
+  const signAndSend = useCallback(
+    async (messageBytes: Uint8Array): Promise<string> => {
+      if (!connected) {
+        throw new Error("No wallet connected");
+      }
+      // Wrap the verified message verbatim into an unsigned legacy wire tx:
+      // compact-u16(1) signature || 64 zero signature bytes || message. The
+      // message bytes are NOT modified, so the wallet signs exactly what the
+      // user verified.
+      const tx = new Uint8Array(1 + 64 + messageBytes.length);
+      tx[0] = 1;
+      tx.set(messageBytes, 65);
+
+      const [output] = await signAndSendFeature(
+        connected.wallet,
+      ).signAndSendTransaction({
+        account: connected.account,
+        transaction: tx,
+        chain: SOLANA_CHAIN,
+      });
+      return getBase58Decoder().decode(output.signature);
+    },
+    [connected],
+  );
+
+  const value = useMemo<SolanaWalletContextValue>(
+    () => ({
+      wallets,
+      connected,
+      connecting,
+      chain: SOLANA_CHAIN,
+      connect,
+      disconnect,
+      signAndSend,
+    }),
+    [wallets, connected, connecting, connect, disconnect, signAndSend],
+  );
+
+  return (
+    <SolanaWalletContext.Provider value={value}>
+      {children}
+    </SolanaWalletContext.Provider>
+  );
+}
+
+export function useSolanaWallet(): SolanaWalletContextValue {
+  const ctx = useContext(SolanaWalletContext);
+  if (!ctx) {
+    throw new Error(
+      "useSolanaWallet must be used within a <SolanaWalletProvider>",
+    );
+  }
+  return ctx;
+}

--- a/dashboard/src/lib/wallet/wallet-standard.tsx
+++ b/dashboard/src/lib/wallet/wallet-standard.tsx
@@ -92,6 +92,8 @@ export interface SolanaWalletContextValue {
   /** The connected wallet + account, or null. */
   connected: ConnectedWallet | null;
   connecting: boolean;
+  /** Last connect failure (e.g. the user declined), or null. */
+  connectError: string | null;
   /** The cluster used for signing/broadcast. */
   chain: SolanaChain;
   connect: (wallet: Wallet) => Promise<void>;
@@ -110,6 +112,7 @@ export function SolanaWalletProvider({ children }: { children: ReactNode }) {
   const [wallets, setWallets] = useState<Wallet[]>([]);
   const [connected, setConnected] = useState<ConnectedWallet | null>(null);
   const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   // Discover wallets on the client only (the registry touches `window`). Keep
   // the list in sync with register/unregister events.
@@ -128,6 +131,7 @@ export function SolanaWalletProvider({ children }: { children: ReactNode }) {
 
   const connect = useCallback(async (wallet: Wallet) => {
     setConnecting(true);
+    setConnectError(null);
     try {
       const { accounts } = await connectFeature(wallet).connect();
       const account =
@@ -136,6 +140,11 @@ export function SolanaWalletProvider({ children }: { children: ReactNode }) {
         throw new Error("Wallet returned no accounts");
       }
       setConnected({ wallet, account });
+    } catch (e) {
+      // Surface the failure (e.g. the user declined the connection in their
+      // wallet) instead of letting the rejection vanish into a `void connect()`
+      // — otherwise the UI just silently returns to the wallet list.
+      setConnectError(e instanceof Error ? e.message : "Failed to connect wallet");
     } finally {
       setConnecting(false);
     }
@@ -160,7 +169,12 @@ export function SolanaWalletProvider({ children }: { children: ReactNode }) {
           props.accounts.find((a) => a.chains.includes(SOLANA_CHAIN)) ??
           props.accounts[0] ??
           null;
-        setConnected(next ? { wallet: connected.wallet, account: next } : null);
+        // Functional updater: read the wallet from current state, never the
+        // closed-over `connected`, so a rapid wallet switch can't pin a stale
+        // wallet to a new account.
+        setConnected((prev) =>
+          prev && next ? { wallet: prev.wallet, account: next } : null,
+        );
       }
     });
     return off;
@@ -196,12 +210,13 @@ export function SolanaWalletProvider({ children }: { children: ReactNode }) {
       wallets,
       connected,
       connecting,
+      connectError,
       chain: SOLANA_CHAIN,
       connect,
       disconnect,
       signAndSend,
     }),
-    [wallets, connected, connecting, connect, disconnect, signAndSend],
+    [wallets, connected, connecting, connectError, connect, disconnect, signAndSend],
   );
 
   return (


### PR DESCRIPTION
## What

PR 2 of the BYO-wallet funding slice. Adds a **connect-wallet escrow funding** flow to the dashboard Wallet page: connect any Solana Wallet-Standard wallet (Phantom / Solflare / Backpack / embedded wallets), request an **unsigned** escrow-deposit message from the gateway (#597 `POST /v1/escrow/deposit-tx`), **independently verify what you're about to sign**, then sign + broadcast. The gateway holds no private key on this path — the user's own wallet is the sole signer and fee payer.

Consumes the merged-but-not-yet-deployed #597 endpoint.

## Verify-what-you-sign (the fund-safety gate)

`src/lib/escrow/verify.ts` treats the gateway response (message + `decoded_intent`) as **untrusted**. Before the wallet signs, it:

1. Decodes the legacy message bytes the wallet will actually sign (`@solana/kit`).
2. Asserts the full structural shape — legacy, header `[1,0,6]`, exactly 10 accounts, exactly **one** `deposit` instruction (`sha256("global:deposit")` discriminator) at the escrow-program slot with the canonical account-index order — rejecting any surprise `Approve`/`SetAuthority`/`Close`/extra instruction.
3. **Re-derives** the escrow PDA + vault ATA from the **connected wallet's** pubkey — proving the deposit funds an escrow the user controls, not an attacker's.
4. **Pins** the escrow program + USDC mint to client-owned build-time constants (`NEXT_PUBLIC_ESCROW_PROGRAM_ID` / `NEXT_PUBLIC_USDC_MINT`, mainnet defaults) so a hostile/compromised gateway can't substitute its own program (which could drain the user's ATA) or a fake token.
5. Cross-checks every amount / expiry / service_id / blockhash against **both** the decoded message and the user's request.

The wallet signs the **exact bytes** that were verified — no message re-compile that could reorder accounts.

## Design choices

- **Wallet Standard + `@solana/kit`**, not legacy web3.js v1 + a proprietary connector — interop-first (any Wallet-Standard wallet, incl. embedded), per the BYO-wallet design doc.
- Browser-native verify: kit codecs + WebCrypto `sha256` (no `node:crypto`/`Buffer`).
- `usdcDecimalToAtomic`: integer/BigInt-only, fail-closed, canonical output (solvela-fintech rules).
- Cluster comes from the dashboard's own env (`NEXT_PUBLIC_SOLANA_CHAIN`), not the endpoint's `network` echo (a hardcoded mainnet-genesis constant).

## Money-path review (two rounds)

1. TDD build of the verify / amount / deposit-client modules — re-derived escrow PDA / agent ATA / vault ATA proven **byte-identical** to `crates/escrow-tx` `GOLDEN_VECTOR_B64`.
2. An independent silent-failure review of the verifier → added the program/mint pinning (V-2/V-3), the full-header check (V-4), and an expiry safe-integer guard (V-5). Two findings were **declined with documented rationale**: anchoring the blockhash to a non-existent independent client source (vacuous), and URL-safe-base64 normalization for a gateway that emits standard base64 (false-reject-only).

## Tests / CI

- **154** dashboard tests pass (49 new escrow tests: golden-vector positive + tamper negatives — substituted program/mint, header tamper, wrong connected wallet, amount/service_id/expiry/blockhash mismatch, non-deposit discriminator, 2-instruction message, unsafe-integer expiry).
- `next build` green (the Wallet page prerenders); `npm audit --production --audit-level=high` green.
- Incidentally patched two **pre-existing** dev-tooling highs flagged by a fresh advisory DB (esbuild 0.28.0→0.28.1, vite 8.0.10→8.0.16) so the audit job lands fully green; updated the now-stale "no Solana dependencies" comment in `dashboard.yml`.

## Notes for reviewer / deploy

- #597 is merged but **not yet deployed**, so local dev/test points at a local gateway via `NEXT_PUBLIC_GATEWAY_URL` (+ `NEXT_PUBLIC_SOLANA_CHAIN` / `NEXT_PUBLIC_ESCROW_PROGRAM_ID` / `NEXT_PUBLIC_USDC_MINT` for devnet).
- In production the dashboard origin must be added to the gateway's `SOLVELA_CORS_ORIGINS` (the browser calls the gateway directly to preserve per-user-IP rate limiting).
- Full click-through E2E (connect → sign → on-chain deposit) needs a browser wallet extension + a running gateway with escrow configured, so it isn't exercised in CI; the SSR render, the verify/amount/client logic, and golden-vector parity are covered by the build + 154 tests.
- Money-path PR — excluded from auto-approve; needs manual review.