### PR TITLE
fix(a2a): return Err (ERR_INTERNAL) not "task not found" when Redis absent (#532)

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -255,7 +255,11 @@ async fn handle_payment_submitted(
     // part can never enter this path. See `reject_image_data_parts`.
     reject_image_data_parts(&params.message.parts)?;
 
-    // Load task record
+    // Load task record. `load_task` distinguishes infra failure from a genuine
+    // miss (issue #532): an absent/unreachable Redis returns `Err` → ERR_INTERNAL
+    // ("retry, this is on us"), while only a true expiry/never-existed returns
+    // `Ok(None)` → ERR_TASK_NOT_FOUND. An agent that already signed a payment must
+    // not be told its task is gone when Redis is merely down.
     let record = task_store::load_task(state, task_id)
         .await
         .map_err(|e| JsonRpcErrorData {
@@ -438,11 +442,12 @@ async fn handle_payment_submitted(
     //   the money already moved, so a retry must not settle again.
     //
     // No-Redis behaviour: the A2A task store REQUIRES Redis (`load_task`
-    // returns `Ok(None)` without it → this request already 404'd at task load
-    // above), so reaching here implies Redis is present. Acquisition failing
-    // closed (Err → reject) therefore never strands a legitimately-loadable
-    // task, and there is deliberately no in-memory lock fallback (it could not
-    // serialise across gateway instances — the exact race we are closing).
+    // returns `Err` without it → this request already failed with ERR_INTERNAL
+    // at task load above, issue #532), so reaching here implies Redis is present.
+    // Acquisition failing closed (Err → reject) therefore never strands a
+    // legitimately-loadable task, and there is deliberately no in-memory lock
+    // fallback (it could not serialise across gateway instances — the exact race
+    // we are closing).
     match &state.cache {
         Some(cache) => match cache
             .acquire_settle_lock(task_id, crate::cache::A2A_SETTLE_LOCK_TTL_SECS)
@@ -498,12 +503,12 @@ async fn handle_payment_submitted(
             }
         },
         // F2 (#566): fail CLOSED, never fall through. The A2A task store REQUIRES
-        // Redis (`load_task` returns `Ok(None)` without it), so this arm is
-        // unreachable in practice — reaching here means the "task store requires
-        // Redis" invariant broke. Settling with NO lock would re-open the exact
-        // exactly-once race the lock exists to close (and across instances, an
-        // in-memory lock could not serialise it), so we reject rather than
-        // proceed unlocked. Tracked on the infra-degradation counter (not the
+        // Redis (`load_task` returns `Err` without it → ERR_INTERNAL at task load,
+        // issue #532), so this arm is unreachable in practice — reaching here means
+        // the "task store requires Redis" invariant broke. Settling with NO lock
+        // would re-open the exact exactly-once race the lock exists to close (and
+        // across instances, an in-memory lock could not serialise it), so we reject
+        // rather than proceed unlocked. Tracked on the infra-degradation counter (not the
         // "concurrent" one) so a missing-Redis misconfiguration is alertable.
         None => {
             metrics::counter!(
@@ -1719,38 +1724,6 @@ supports_vision = false
     }
 
     #[tokio::test]
-    async fn test_payment_submitted_unknown_task_returns_error() {
-        let state = test_state();
-        let headers = HeaderMap::new();
-        let params = MessageSendParams {
-            message: Message {
-                role: MessageRole::User,
-                parts: vec![Part::Text {
-                    text: "pay".to_string(),
-                }],
-                metadata: Some({
-                    let mut m = serde_json::Map::new();
-                    m.insert(
-                        x402_meta::STATUS_KEY.to_string(),
-                        json!(x402_meta::PAYMENT_SUBMITTED),
-                    );
-                    m
-                }),
-            },
-            task_id: Some("nonexistent_task_id".to_string()),
-        };
-
-        let result =
-            handle_payment_submitted(&state, &headers, "nonexistent_task_id", &params).await;
-        assert!(result.is_err(), "should error for unknown task");
-        assert_eq!(
-            result.unwrap_err().code, // safe: just asserted is_err
-            ERR_TASK_NOT_FOUND,
-            "error code should be task not found"
-        );
-    }
-
-    #[tokio::test]
     async fn test_handle_message_send_routes_new_request() {
         let state = test_state();
         let headers = HeaderMap::new();
@@ -1776,32 +1749,6 @@ supports_vision = false
             ERR_INTERNAL,
             "should return ERR_INTERNAL when task store is unavailable"
         );
-    }
-
-    #[tokio::test]
-    async fn test_handle_message_send_routes_payment_submitted() {
-        let state = test_state();
-        let headers = HeaderMap::new();
-        // With a non-existent taskId, should error with task-not-found
-        let request = JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            method: "message/send".to_string(),
-            id: json!("req-2"),
-            params: json!({
-                "message": {
-                    "role": "user",
-                    "parts": [{"kind": "text", "text": "pay"}],
-                    "metadata": {
-                        "x402.payment.status": "payment-submitted"
-                    }
-                },
-                "taskId": "nonexistent_task"
-            }),
-        };
-
-        let result = handle_message_send(state, &headers, &request).await;
-        assert!(result.is_err(), "should error for unknown task");
-        assert_eq!(result.unwrap_err().code, ERR_TASK_NOT_FOUND); // safe: just asserted is_err
     }
 
     #[test]
@@ -1986,6 +1933,72 @@ supports_vision = false
             },
             task_id: None,
         }
+    }
+
+    /// Submitting a payment against a task id that genuinely does NOT exist in a
+    /// PRESENT Redis returns ERR_TASK_NOT_FOUND. This is the true "not found"
+    /// case — distinct from a no-Redis outage, which returns ERR_INTERNAL (issue
+    /// #532; the no-Redis load path is covered by
+    /// `load_task_without_redis_errors_not_none`). A random `new_task_id()` is
+    /// never saved, so its key is absent and `load_task` returns `Ok(None)`.
+    #[tokio::test]
+    async fn test_payment_submitted_unknown_task_returns_error() {
+        let state = test_state_with_redis();
+        let headers = HeaderMap::new();
+        let task_id = new_task_id(); // random, never saved → genuine miss
+        let params = MessageSendParams {
+            message: Message {
+                role: MessageRole::User,
+                parts: vec![Part::Text {
+                    text: "pay".to_string(),
+                }],
+                metadata: Some({
+                    let mut m = serde_json::Map::new();
+                    m.insert(
+                        x402_meta::STATUS_KEY.to_string(),
+                        json!(x402_meta::PAYMENT_SUBMITTED),
+                    );
+                    m
+                }),
+            },
+            task_id: Some(task_id.clone()),
+        };
+
+        let result = handle_payment_submitted(&state, &headers, &task_id, &params).await;
+        assert!(result.is_err(), "should error for unknown task");
+        assert_eq!(
+            result.unwrap_err().code, // safe: just asserted is_err
+            ERR_TASK_NOT_FOUND,
+            "a genuine absent task (Redis present) must map to task-not-found"
+        );
+    }
+
+    /// `message/send` carrying a `taskId` routes to the payment-submitted path;
+    /// with a genuinely-absent task (Redis present) it returns task-not-found.
+    #[tokio::test]
+    async fn test_handle_message_send_routes_payment_submitted() {
+        let state = test_state_with_redis();
+        let headers = HeaderMap::new();
+        let task_id = new_task_id(); // random, never saved → genuine miss
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "message/send".to_string(),
+            id: json!("req-2"),
+            params: json!({
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "pay"}],
+                    "metadata": {
+                        "x402.payment.status": "payment-submitted"
+                    }
+                },
+                "taskId": task_id,
+            }),
+        };
+
+        let result = handle_message_send(state, &headers, &request).await;
+        assert!(result.is_err(), "should error for unknown task");
+        assert_eq!(result.unwrap_err().code, ERR_TASK_NOT_FOUND); // safe: just asserted is_err
     }
 
     /// New-request happy path: with Redis configured, save_task succeeds and
@@ -3035,5 +3048,33 @@ supports_vision = false
         if let Some(cache) = &state.cache {
             let _ = cache.del_raw(&format!("a2a_task:{task_id}")).await;
         }
+    }
+
+    /// Regression (#532): with no Redis configured, `load_task` must return
+    /// `Err` (an infrastructure failure), NOT `Ok(None)` — which the handler
+    /// maps to ERR_TASK_NOT_FOUND ("task not found or expired"). An agent that
+    /// already signed a payment and submits it while Redis is down must be told
+    /// to retry (ERR_INTERNAL), never that its task vanished. `save_task`
+    /// already fails closed; this proves `load_task` is now consistent, and
+    /// that `update_task_state` (which reads through `load_task`) inherits it.
+    #[tokio::test]
+    async fn load_task_without_redis_errors_not_none() {
+        let state = test_state(); // cache: None
+
+        let err = task_store::load_task(&state, "a2a_irrelevant_id")
+            .await
+            .expect_err("no-Redis load_task must be Err, not Ok(None)");
+        assert!(
+            err.contains("requires Redis"),
+            "error should name the missing Redis dependency, got: {err}"
+        );
+
+        let err2 = task_store::update_task_state(&state, "a2a_irrelevant_id", TaskState::Completed)
+            .await
+            .expect_err("no-Redis update_task_state must propagate the load_task Err");
+        assert!(
+            err2.contains("requires Redis"),
+            "update_task_state should surface the Redis-absent error, got: {err2}"
+        );
     }
 }

--- a/crates/gateway/src/a2a/task_store.rs
+++ b/crates/gateway/src/a2a/task_store.rs
@@ -62,11 +62,27 @@ pub async fn save_task(state: &Arc<AppState>, record: &TaskRecord) -> Result<(),
 ///
 /// Returns:
 /// - `Ok(Some(record))` — found
-/// - `Ok(None)` — not found (task expired or never existed)
-/// - `Err(msg)` — Redis error
+/// - `Ok(None)` — not recoverable with Redis present: the task expired, never
+///   existed, or its stored record was corrupt and has been purged (see below)
+/// - `Err(msg)` — Redis absent, or a Redis read error
+///
+/// When no Redis is configured this returns `Err`, NOT `Ok(None)`: the A2A task
+/// store REQUIRES Redis (`save_task` already errors without it), so an absent
+/// cache is an infrastructure failure, not a missing task. Conflating the two
+/// mapped a Redis outage to `ERR_TASK_NOT_FOUND` ("task not found or expired") —
+/// a misleading terminal-looking error for an agent that already signed a
+/// payment, which it cannot distinguish from genuine expiry and may not retry.
+/// The handler maps this `Err` to `ERR_INTERNAL`, the correct retry signal
+/// (issue #532). This mirrors `save_task`, which already fails closed.
+///
+/// A *corrupt* stored record (Redis present, value un-deserializable) is treated
+/// as `Ok(None)`, not `Err`: unlike a transient Redis outage, the record is
+/// unrecoverable, so we purge it and report it as a genuine miss rather than a
+/// retryable error (a retry would only re-find nothing). This is deliberately
+/// distinct from the no-Redis case above.
 pub async fn load_task(state: &Arc<AppState>, task_id: &str) -> Result<Option<TaskRecord>, String> {
     let Some(ref cache) = state.cache else {
-        return Ok(None);
+        return Err("A2A task store requires Redis — no Redis configured".to_string());
     };
     let key = format!("a2a_task:{task_id}");
 
@@ -75,7 +91,16 @@ pub async fn load_task(state: &Arc<AppState>, task_id: &str) -> Result<Option<Ta
             Ok(record) => Ok(Some(record)),
             Err(e) => {
                 tracing::warn!(task_id, error = %e, "A2A task store: corrupt record, deleting");
-                let _ = cache.del_raw(&key).await;
+                // Don't swallow the purge failure: if the delete fails the corrupt
+                // record persists and every subsequent load re-hits this arm, so the
+                // failed cleanup must be observable rather than silently dropped.
+                if let Err(del_err) = cache.del_raw(&key).await {
+                    tracing::warn!(
+                        task_id,
+                        error = %del_err,
+                        "A2A task store: failed to delete corrupt record (it will be re-encountered)"
+                    );
+                }
                 Ok(None)
             }
         },

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -13371,14 +13371,14 @@ async fn a2a_provider_failure_after_settle_writes_ledger_and_holds_lock() {
 }
 
 // (c) F2 — no-Redis fail-closed: NOT integration-testable. The A2A task store
-// REQUIRES Redis (`task_store::load_task` returns `Ok(None)` when `cache` is
-// `None`), so a payment-submitted request without Redis already 404s at task
-// load, BEFORE the settlement-lock block — the `None` arm there is unreachable
-// by construction in the current flow and exists purely as defense-in-depth
-// against a future refactor that decouples task loading from the lock cache.
-// There is therefore no honest end-to-end trigger; the arm's fail-closed
-// behaviour is verified by inspection (it returns ERR_PAYMENT_FAILED, never
-// `false`). See the F2 comment on the `None` arm in `a2a/handler.rs`.
+// REQUIRES Redis (`task_store::load_task` returns `Err` when `cache` is `None`,
+// issue #532), so a payment-submitted request without Redis already fails with
+// ERR_INTERNAL at task load, BEFORE the settlement-lock block — the `None` arm
+// there is unreachable by construction in the current flow and exists purely as
+// defense-in-depth against a future refactor that decouples task loading from
+// the lock cache. There is therefore no honest end-to-end trigger; the arm's
+// fail-closed behaviour is verified by inspection (it returns ERR_PAYMENT_FAILED,
+// never `false`). See the F2 comment on the `None` arm in `a2a/handler.rs`.
 
 // ===========================================================================
 // Gas-drip faucet — POST /v1/faucet/gas (through the real route)


### PR DESCRIPTION
## Summary

Fixes #532. `task_store::load_task` returned `Ok(None)` when no Redis cache was configured, which the A2A handler maps to `ERR_TASK_NOT_FOUND` ("task not found or expired"). An agent that already signed a payment and submitted it while Redis was down therefore got a misleading **terminal-looking** error it couldn't distinguish from genuine expiry — and might not retry. (Prod currently runs Redis-less, so this path is live.)

`save_task` already fails closed without Redis; this makes `load_task` consistent.

## Change

- `load_task` now returns `Err` when `state.cache` is absent → the handler maps it to `ERR_INTERNAL` ("retry, this is on us"). Genuine misses (Redis **present**, key absent) still return `Ok(None)` → `ERR_TASK_NOT_FOUND`.
- A **corrupt** stored record (Redis present, value un-deserializable) stays `Ok(None)` — it's unrecoverable, distinct from a transient outage — but the doc now states this explicitly, and the previously-swallowed `del_raw` purge error is now logged (review follow-up).
- Updated the now-stale "`load_task` returns `Ok(None)`" comments in the settlement-lock block (`handler.rs`) and the F2 integration-test note.

## Tests

- New `load_task_without_redis_errors_not_none`: `load_task` **and** `update_task_state` both surface the no-Redis `Err`.
- The two "unknown task" handler tests now use the present-Redis fixture (`test_state_with_redis()`) with a random unsaved `new_task_id()`, so they exercise the **genuine** not-found path (which now requires Redis) and were relocated into the Redis-dependent test section.
- `cargo fmt --check`, `cargo clippy -p gateway --all-targets --all-features -- -D warnings`, and `cargo test -p gateway --lib a2a` (82 passed) all clean. Rebased onto current `main`.

## Review

Money-path 2-pass review (rust-reviewer + silent-failure-hunter): the change is a clean removal of the silent infra-vs-missing conflation, with no new swallowed errors and no money-moving decision reachable on degraded Redis. Their MEDIUM notes (a garbled comment + the swallowed `del_raw` error + doc consistency on the corrupt-record case) are folded into this PR.