### PR TITLE
fix(a2a): quote completion cap via completion_token_ceiling, not hardcoded 1000 (#504)

### DIFF
--- a/crates/gateway/src/a2a/handler.rs
+++ b/crates/gateway/src/a2a/handler.rs
@@ -20,7 +20,9 @@ use crate::a2a::task_store::{self, new_task_id, TaskRecord};
 use crate::a2a::types::*;
 use crate::providers::fallback::chat_with_model_fallback;
 use crate::receipts;
-use crate::routes::chat::cost::{estimate_input_tokens, usdc_atomic_amount_checked, PaymentScheme};
+use crate::routes::chat::cost::{
+    completion_token_ceiling, estimate_input_tokens, usdc_atomic_amount_checked, PaymentScheme,
+};
 use crate::usage::SpendLogEntry;
 use crate::AppState;
 
@@ -78,17 +80,18 @@ async fn handle_new_request(
 
     let resolved_model = resolve_model(model_hint, &user_text, state)?;
 
-    // Look up model in registry for pricing
-    // Verify model exists in registry before computing cost
-    let _model_info =
-        state
-            .model_registry
-            .get(&resolved_model)
-            .ok_or_else(|| JsonRpcErrorData {
-                code: ERR_MODEL_NOT_FOUND,
-                message: format!("Model not found: {resolved_model}"),
-                data: None,
-            })?;
+    // Look up model in registry for pricing. The registration carries the
+    // model's declared `max_output_tokens`, which feeds the completion-token
+    // ceiling below — quoting/billing must reflect what the model can actually
+    // return, not a fixed 1000-token assumption (#504).
+    let model_info = state
+        .model_registry
+        .get(&resolved_model)
+        .ok_or_else(|| JsonRpcErrorData {
+            code: ERR_MODEL_NOT_FOUND,
+            message: format!("Model not found: {resolved_model}"),
+            data: None,
+        })?;
 
     // Build a temporary ChatRequest for token estimation
     let chat_req = ChatRequest {
@@ -109,7 +112,15 @@ async fn handle_new_request(
     };
 
     let input_tokens = estimate_input_tokens(&chat_req);
-    let max_tokens = 1000u32;
+    // Quote against the true completion-token ceiling, NOT a hardcoded 1000
+    // (#504). `chat_req.max_tokens` is `None` on this intake path, so the
+    // ceiling falls back to `min(model.max_output_tokens, 8192)` — the largest
+    // completion the gateway could end up billing for. This value is stored on
+    // the TaskRecord and re-applied as the provider cap at settlement
+    // (`handle_payment_submitted`), so quote == provider cap == settlement by
+    // construction (the same single-source-of-truth invariant the chat path
+    // holds via `completion_token_ceiling`; see #500/#503).
+    let max_tokens = completion_token_ceiling(chat_req.max_tokens, model_info);
 
     let cost = state
         .model_registry
@@ -374,10 +385,18 @@ async fn handle_payment_submitted(
             data: None,
         })?;
 
-    // Re-apply the max_tokens cap that was used to compute the quoted cost
-    // in step 2 (handle_new_request). Records persisted before the H1 fix
-    // have `max_tokens = None`; for those we fall back to the historical
-    // 1000-token default so the cap is never silently absent.
+    // Re-apply the max_tokens cap that was used to compute the quoted cost in
+    // step 2 (handle_new_request). New records store the `completion_token_ceiling`
+    // computed at quote time (#504), so quote == provider cap == settlement.
+    //
+    // LEGACY FALLBACK (do not change): VERY old records — persisted before the
+    // `max_tokens` field existed on `TaskRecord` — deserialize with
+    // `max_tokens = None`. Those tasks were quoted at the historical hardcoded
+    // 1000, and the agent paid against that 1000-token quote, so they MUST
+    // settle at 1000 to match what was actually paid for. Raising the legacy
+    // fallback to the new ceiling would let a provider return more than the
+    // pre-paid 1000 tokens for those old tasks, with the gateway absorbing the
+    // delta — settle at the figure the agent was quoted, never silently absent.
     let enforced_max_tokens = record.max_tokens.unwrap_or(1000);
 
     let messages = vec![ChatMessage {
@@ -1027,11 +1046,21 @@ fn record_a2a_settlement(
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
     };
-    let (Some(provider_cost_atomic), Some(platform_fee_atomic), Some(total_atomic)) = (
-        atomic(&breakdown.provider_cost),
-        atomic(&breakdown.platform_fee),
-        atomic(&breakdown.total),
-    ) else {
+    // `total` is authoritative (it is what settled on-chain). DERIVE the fee
+    // component from it so the three receipt atomics always reconcile:
+    //   total = provider * 105/100  ⇒  fee = total - provider
+    // The registry estimate rounds `provider_cost`, `platform_fee`, and `total`
+    // INDEPENDENTLY as float strings (`format!("{:.6}")` in
+    // `ModelRegistry::estimate_cost`), so parsing `platform_fee` from its own
+    // string can disagree with `total - provider` by 1 atomic unit (1 micro-USDC).
+    // Letting the ±1 integer-USDC rounding skew land in the fee component is the
+    // accepted treatment everywhere else (see `chat_completions_discovery` /
+    // `emit_chat_receipt` in routes/chat/mod.rs). We keep `provider_cost_atomic`
+    // (the real upstream cost) and `total_atomic` (what settled) from the
+    // breakdown, and never parse `platform_fee` independently.
+    let (Some(provider_cost_atomic), Some(total_atomic)) =
+        (atomic(&breakdown.provider_cost), atomic(&breakdown.total))
+    else {
         metrics::counter!(
             "solvela_a2a_settlement_record_skipped_total",
             "reason" => "corrupt_breakdown"
@@ -1040,10 +1069,32 @@ fn record_a2a_settlement(
         warn!(
             task_id,
             provider_cost = %breakdown.provider_cost,
-            platform_fee = %breakdown.platform_fee,
             total = %breakdown.total,
             "A2A settled but cost breakdown failed the checked atomic conversion — \
              spend row and receipt skipped"
+        );
+        return None;
+    };
+    // Checked subtraction: `total ≈ provider * 1.05`, so `total ≥ provider`
+    // always holds for a well-formed breakdown. If a corrupt breakdown ever
+    // reports `provider_cost > total`, fail closed the SAME way as a bad atomic
+    // conversion (skip + counter) rather than underflow into a negative/wrapped
+    // fee. Never produce a fee from saturating-to-zero either — a silent zero
+    // would misreport the split.
+    let Some(platform_fee_atomic) = total_atomic.checked_sub(provider_cost_atomic) else {
+        metrics::counter!(
+            "solvela_a2a_settlement_record_skipped_total",
+            "reason" => "corrupt_breakdown"
+        )
+        .increment(1);
+        warn!(
+            task_id,
+            provider_cost = %breakdown.provider_cost,
+            total = %breakdown.total,
+            provider_cost_atomic,
+            total_atomic,
+            "A2A settled but breakdown provider_cost exceeds total (cannot derive a \
+             non-negative platform fee) — spend row and receipt skipped"
         );
         return None;
     };
@@ -3085,5 +3136,181 @@ supports_vision = false
             err2.contains("requires Redis"),
             "update_task_state should surface the Redis-absent error, got: {err2}"
         );
+    }
+
+    /// Like [`test_state_with_redis`] but with a caller-supplied model registry
+    /// TOML, so a test can pin a model's `max_output_tokens` and observe how it
+    /// drives the A2A completion-token ceiling (#504).
+    fn test_state_with_redis_models(models_toml: &str) -> Arc<AppState> {
+        use crate::cache::{CacheConfig, ResponseCache};
+
+        let redis_client =
+            redis::Client::open("redis://127.0.0.1:6379").expect("local Redis must be reachable");
+        let cache = ResponseCache::from_client(redis_client, CacheConfig::default())
+            .expect("ResponseCache::from_client should not connect");
+
+        Arc::new(AppState {
+            config: AppConfig::default(),
+            model_registry: ModelRegistry::from_toml(models_toml).expect("valid test model TOML"),
+            service_registry: RwLock::new(ServiceRegistry::empty()),
+            providers: ProviderRegistry::from_env(reqwest::Client::new()),
+            facilitator: Facilitator::new(vec![]),
+            usage: UsageTracker::noop(),
+            cache: Some(cache),
+            semantic_cache: None,
+            provider_health: ProviderHealthTracker::new(CircuitBreakerConfig::default()),
+            escrow_claimer: None,
+            fee_payer_pool: None,
+            nonce_pool: None,
+            db_pool: None,
+            faucet: None,
+            session_secret: b"test-secret".to_vec(),
+            http_client: reqwest::Client::new(),
+            replay_set: AppState::new_replay_set(),
+            slot_cache: new_slot_cache(),
+            escrow_metrics: None,
+            admin_token: None,
+            api_key_hmac_secret: None,
+            auth_provider: None,
+            prometheus_handle: None,
+            dev_bypass_payment: false,
+            free_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::free_default(),
+            ),
+            receipts_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::receipts_default(),
+            ),
+            faucet_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::faucet_default(),
+            ),
+            deposit_tx_rate_limiter: crate::middleware::rate_limit::RateLimiter::new(
+                crate::middleware::rate_limit::RateLimitConfig::deposit_tx_default(),
+            ),
+            free_global_cap: crate::middleware::rate_limit::FreeTierGlobalCap::new(
+                crate::middleware::rate_limit::FREE_TIER_GLOBAL_RPM_DEFAULT,
+            ),
+        })
+    }
+
+    /// A model registry with one `test-model` whose `max_output_tokens` is the
+    /// given value. Pricing matches the other test registries (1.0 in / 2.0 out
+    /// per million) so cost comparisons across ceilings are apples-to-apples.
+    fn registry_toml_with_max_output(max_output_tokens: u32) -> String {
+        format!(
+            r#"
+[models.test-model]
+provider = "test"
+model_id = "test-model"
+display_name = "Test"
+input_cost_per_million = 1.0
+output_cost_per_million = 2.0
+context_window = 4096
+max_output_tokens = {max_output_tokens}
+supports_streaming = false
+supports_tools = false
+supports_vision = false
+"#
+        )
+    }
+
+    /// Read the quoted total (USDC decimal string) out of the input-required
+    /// task value returned by `handle_new_request`.
+    fn quoted_total(task_value: &Value) -> String {
+        task_value["status"]["message"]["metadata"][x402_meta::REQUIRED_KEY]["cost_breakdown"]
+            ["total"]
+            .as_str()
+            .expect("cost_breakdown.total must be a string")
+            .to_string()
+    }
+
+    /// #504 regression: the A2A new-request quote MUST price against
+    /// `completion_token_ceiling`, NOT a hardcoded 1000 tokens.
+    ///
+    /// Two registries with the SAME pricing but different `max_output_tokens`
+    /// (1000 vs 8000) are quoted for the same prompt. Pricing is linear in the
+    /// completion ceiling, so the 8000-ceiling model must quote strictly more
+    /// than the 1000-ceiling model — impossible if the handler still hardcoded
+    /// 1000. We also assert the lower-ceiling model still caps DOWN to 1000.
+    #[tokio::test]
+    async fn new_request_quote_uses_completion_ceiling_not_hardcoded_1000() {
+        let params = user_msg_with_text("Hello world", Some("test-model"));
+
+        // Ceiling = min(None, Some(1000), 8192) = 1000 — matches the old literal.
+        let state_1000 = test_state_with_redis_models(&registry_toml_with_max_output(1000));
+        let task_1000 = handle_new_request(&state_1000, &params)
+            .await
+            .expect("happy path must succeed with Redis");
+        let total_1000 = quoted_total(&task_1000);
+
+        // Ceiling = min(None, Some(8000), 8192) = 8000 — the #504 case: the model
+        // allows far more output than the old hardcoded default.
+        let state_8000 = test_state_with_redis_models(&registry_toml_with_max_output(8000));
+        let task_8000 = handle_new_request(&state_8000, &params)
+            .await
+            .expect("happy path must succeed with Redis");
+        let total_8000 = quoted_total(&task_8000);
+
+        // Compare as atomic integers (no float gotchas).
+        let atomic = |s: &str| -> u64 {
+            usdc_atomic_amount_checked(s)
+                .expect("quote must be a valid USDC decimal")
+                .parse()
+                .expect("atomic must parse")
+        };
+        assert!(
+            atomic(&total_8000) > atomic(&total_1000),
+            "an 8000-token-ceiling model ({total_8000}) must quote strictly more \
+             than a 1000-token-ceiling model ({total_1000}); the A2A quote must use \
+             completion_token_ceiling, not a hardcoded 1000"
+        );
+
+        // Cleanup both seeded task keys.
+        for (state, task) in [(&state_1000, &task_1000), (&state_8000, &task_8000)] {
+            if let Some(cache) = &state.cache {
+                let id = task["id"].as_str().expect("task id");
+                let _ = cache.del_raw(&format!("a2a_task:{id}")).await;
+            }
+        }
+    }
+
+    /// #504: the ceiling computed at quote time is stored on the TaskRecord, so
+    /// the settlement path (`handle_payment_submitted`) re-applies the SAME cap.
+    /// This pins quote == stored cap == settlement cap for the #504 case (a model
+    /// whose ceiling exceeds the old hardcoded 1000), and that the stored value
+    /// is exactly `completion_token_ceiling(None, model_info)`.
+    #[tokio::test]
+    async fn new_request_stores_completion_ceiling_for_settlement() {
+        let state = test_state_with_redis_models(&registry_toml_with_max_output(8000));
+        let params = user_msg_with_text("Hello world", Some("test-model"));
+
+        let task = handle_new_request(&state, &params)
+            .await
+            .expect("happy path must succeed with Redis");
+        let task_id = task["id"].as_str().expect("task id").to_string();
+
+        // The ceiling the settlement path will re-apply is exactly what was used
+        // to quote: completion_token_ceiling(None, model) = min(8000, 8192) = 8000.
+        let model_info = state
+            .model_registry
+            .get("test-model")
+            .expect("test-model registered");
+        let expected_ceiling = completion_token_ceiling(None, model_info);
+        assert_eq!(expected_ceiling, 8000, "ceiling sanity for the #504 case");
+
+        let record = task_store::load_task(&state, &task_id)
+            .await
+            .expect("load_task must not error")
+            .expect("task must be stored");
+        assert_eq!(
+            record.max_tokens,
+            Some(expected_ceiling),
+            "the stored cap must equal completion_token_ceiling (quote == settlement); \
+             a hardcoded 1000 would store Some(1000) here"
+        );
+
+        // Cleanup the seeded task key.
+        if let Some(cache) = &state.cache {
+            let _ = cache.del_raw(&format!("a2a_task:{task_id}")).await;
+        }
     }
 }

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -1848,18 +1848,46 @@ fn emit_chat_receipt(
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
     };
-    let (Some(provider_cost_atomic), Some(platform_fee_atomic), Some(total_atomic)) = (
+    // `total` is authoritative (it is what was billed). DERIVE the fee component
+    // from it so the three receipt atomics always reconcile:
+    //   total = provider * 105/100  ⇒  fee = total - provider
+    // The registry estimate rounds `provider_cost`, `platform_fee`, and `total`
+    // INDEPENDENTLY as float strings (`format!("{:.6}")` in
+    // `ModelRegistry::estimate_cost`), so parsing `platform_fee` from its own
+    // string can disagree with `total - provider` by 1 atomic unit (1 micro-USDC).
+    // Letting the ±1 integer-USDC rounding skew land in the fee component is the
+    // accepted treatment everywhere else (see `chat_completions_discovery` above).
+    // We keep `provider_cost_atomic` (the real upstream cost) and `total_atomic`
+    // (what was billed) from the breakdown, and never parse `platform_fee`
+    // independently.
+    let (Some(provider_cost_atomic), Some(total_atomic)) = (
         atomic(&inputs.breakdown.provider_cost),
-        atomic(&inputs.breakdown.platform_fee),
         atomic(&inputs.breakdown.total),
     ) else {
         counter!("solvela_receipt_skipped_total", "reason" => "corrupt_breakdown").increment(1);
         warn!(
             model = %inputs.model,
             provider_cost = %inputs.breakdown.provider_cost,
-            platform_fee = %inputs.breakdown.platform_fee,
             total = %inputs.breakdown.total,
             "skipping receipt: cost breakdown failed the checked atomic conversion — header not emitted"
+        );
+        return;
+    };
+    // Checked subtraction: `total ≈ provider * 1.05`, so `total ≥ provider`
+    // always holds for a well-formed breakdown. If a corrupt breakdown ever
+    // reports `provider_cost > total`, fail closed the SAME way as a bad atomic
+    // conversion (skip + counter) rather than underflow into a negative/wrapped
+    // fee — never produce a fee from saturating-to-zero either.
+    let Some(platform_fee_atomic) = total_atomic.checked_sub(provider_cost_atomic) else {
+        counter!("solvela_receipt_skipped_total", "reason" => "corrupt_breakdown").increment(1);
+        warn!(
+            model = %inputs.model,
+            provider_cost = %inputs.breakdown.provider_cost,
+            total = %inputs.breakdown.total,
+            provider_cost_atomic,
+            total_atomic,
+            "skipping receipt: breakdown provider_cost exceeds total (cannot derive a \
+             non-negative platform fee) — header not emitted"
         );
         return;
     };

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -845,6 +845,75 @@ fn usageless_provider_registry() -> ProviderRegistry {
     ProviderRegistry::from_providers(providers)
 }
 
+/// A mock LLM provider that returns CALLER-CHOSEN token usage, so a chat-path
+/// test can drive the non-streaming receipt to a `(prompt, completion)` pair
+/// whose registry breakdown rounds with a ±1 micro-USDC skew between
+/// `provider_cost + platform_fee` and `total` (the independent-`{:.6}`-rounding
+/// bug fixed in `emit_chat_receipt`). See
+/// `paid_non_streaming_chat_receipt_fee_derived_from_total_under_rounding_skew`.
+struct FixedUsageProvider {
+    provider_name: String,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+}
+
+impl FixedUsageProvider {
+    fn new(name: &str, prompt_tokens: u32, completion_tokens: u32) -> Self {
+        Self {
+            provider_name: name.to_string(),
+            prompt_tokens,
+            completion_tokens,
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for FixedUsageProvider {
+    fn name(&self) -> &str {
+        &self.provider_name
+    }
+
+    fn supported_models(&self) -> Vec<ModelRegistration> {
+        vec![]
+    }
+
+    async fn chat_completion(
+        &self,
+        req: solvela_protocol::ChatRequest,
+    ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+        let mut resp = MockProvider::mock_response(&req.model);
+        resp.usage = Some(Usage {
+            prompt_tokens: self.prompt_tokens,
+            completion_tokens: self.completion_tokens,
+            total_tokens: self.prompt_tokens + self.completion_tokens,
+        });
+        Ok(resp)
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _req: solvela_protocol::ChatRequest,
+    ) -> Result<ChatStream, Box<dyn std::error::Error + Send + Sync>> {
+        Err("FixedUsageProvider does not stream".into())
+    }
+}
+
+/// A `ProviderRegistry` whose providers all report the given fixed token usage.
+fn fixed_usage_provider_registry(prompt_tokens: u32, completion_tokens: u32) -> ProviderRegistry {
+    let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+    for name in ["openai", "anthropic", "deepseek", "google"] {
+        providers.insert(
+            name.to_string(),
+            Arc::new(FixedUsageProvider::new(
+                name,
+                prompt_tokens,
+                completion_tokens,
+            )) as Arc<dyn LLMProvider>,
+        );
+    }
+    ProviderRegistry::from_providers(providers)
+}
+
 /// Build a mock `ProviderRegistry` that has providers for all models in TEST_MODELS_TOML.
 fn mock_provider_registry() -> ProviderRegistry {
     let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
@@ -11973,6 +12042,99 @@ async fn paid_non_streaming_chat_emits_receipt_header_and_get_round_trip() {
     );
 }
 
+/// REGRESSION: the chat receipt's `platform_fee_atomic` MUST be DERIVED from the
+/// authoritative `total` (`fee = total - provider`), not parsed independently
+/// from the breakdown's own `platform_fee` string.
+///
+/// `ModelRegistry::estimate_cost` rounds `provider_cost`, `platform_fee`, and
+/// `total` INDEPENDENTLY as `format!("{:.6}")` float strings, so for some token
+/// combinations `round(provider) + round(fee) != round(total)` by 1 micro-USDC.
+/// gpt-4o (2.50 in / 10.00 out per million) at 3 prompt / 8192 completion tokens
+/// is exactly such a case:
+///   provider_cost = 0.0819275  → "0.081927" → 81927 atomic
+///   platform_fee  = 0.004096375 → "0.004096" →  4096 atomic  (independent parse)
+///   total         = 0.086023875 → "0.086024" → 86024 atomic  (authoritative)
+/// The old code's `81927 + 4096 = 86023 != 86024` skew under-reported the fee
+/// component on the receipt; deriving `fee = total - provider = 86024 - 81927 =
+/// 4097` makes the three atomics reconcile, and the 1-micro rounding skew lands
+/// in the fee (the accepted treatment, matching the chat discovery path and the
+/// A2A settlement path).
+///
+/// Driven through the REAL paid route: a provider that reports usage of
+/// (3 prompt, 8192 completion) for gpt-4o (no `max_output_tokens`, so the 8192
+/// completion is capped to min(req.max_tokens=8192, 8192) = 8192 and survives),
+/// then the receipt is fetched and its atomic decomposition pinned.
+#[tokio::test]
+async fn paid_non_streaming_chat_receipt_fee_derived_from_total_under_rounding_skew() {
+    let Some(pool) = try_receipts_db_pool().await else {
+        return;
+    };
+    // Provider reports (3 prompt, 8192 completion) — the skewing combination.
+    let (app, _state) = test_app_with_db_pool(
+        fixed_usage_provider_registry(3, 8192),
+        Arc::new(AlwaysPassVerifier),
+        pool,
+    );
+
+    // `max_tokens: 8192` so the completion cap is min(8192, max_output_tokens=None,
+    // 8192) = 8192 and the provider's 8192 completion tokens survive capping —
+    // billing the full skewing breakdown.
+    let body = serde_json::json!({
+        "model": "openai/gpt-4o",
+        "messages": [{"role": "user", "content": "Hi"}],
+        "max_tokens": 8192,
+    });
+    let response = paid_chat_response(&app, &body).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let path = receipt_header_path(&response);
+
+    let receipt = poll_receipt_until_ok(&app, &path).await;
+
+    // Cross-check the authoritative total against the registry single source of
+    // truth, so the literal pins below can never silently drift if pricing moves.
+    let expected_total = registry_quote_atomic("openai/gpt-4o", 3, 8192);
+    assert_eq!(
+        expected_total, 86_024,
+        "sanity: the gpt-4o 3/8192 registry total is the documented skewing case"
+    );
+
+    let provider_cost = receipt["cost_breakdown"]["provider_cost_atomic"]
+        .as_u64()
+        .expect("provider_cost_atomic");
+    let platform_fee = receipt["cost_breakdown"]["platform_fee_atomic"]
+        .as_u64()
+        .expect("platform_fee_atomic");
+    let total = receipt["cost_breakdown"]["total_atomic"]
+        .as_u64()
+        .expect("total_atomic");
+
+    // Exact atomic pins for the skewing case.
+    assert_eq!(
+        provider_cost, 81_927,
+        "provider_cost from the breakdown string"
+    );
+    assert_eq!(total, 86_024, "total is authoritative (what was billed)");
+    assert_eq!(
+        platform_fee, 4_097,
+        "platform_fee MUST be derived as total - provider (86024 - 81927 = 4097); \
+         the old independent parse produced 4096 and failed to reconcile"
+    );
+    // The invariant the fix guarantees: the components reconcile to the total
+    // (5% fee, applied once). Independent parsing would make this 86023 == 86024.
+    assert_eq!(
+        provider_cost + platform_fee,
+        total,
+        "provider_cost + platform_fee must equal total (fee derived from total)"
+    );
+    // The billed amount is unchanged by this fix — still the authoritative total.
+    assert_eq!(
+        receipt["amount_paid_atomic"].as_u64(),
+        Some(total),
+        "amount_paid must remain the billed total — the fix only redistributes \
+         the 1-micro rounding skew into the fee component, never the bill"
+    );
+}
+
 /// A paid STREAMING chat completion (the #541 bug class) must also produce a
 /// receipt. The header must be decided BEFORE the SSE body starts (it is on
 /// the response head), and the stored amounts are the ESTIMATE — the same
@@ -13006,13 +13168,37 @@ async fn a2a_paid_request_writes_receipt_and_metadata_path() {
         Some(total),
         "A2A receipt records the settled total as the amount paid"
     );
+    // This flow quotes gpt-4o (2.50 in / 10.00 out per million) for "What is
+    // Solana?" — 3 input tokens, completion ceiling 8192 (gpt-4o declares no
+    // max_output_tokens → min(8192) after #504). That is exactly the breakdown
+    // that rounds with a 1-micro skew between independently-parsed components and
+    // the authoritative total:
+    //   provider 0.0819275 → 81927 ; total 0.086023875 → 86024
+    // The fee MUST be derived as total - provider (86024 - 81927 = 4097); the old
+    // independent parse produced 4096 and `81927 + 4096 = 86023 != 86024`. Pin the
+    // exact atomics so a revert to independent parsing fails on the fee value, not
+    // just the generic sum below.
+    let provider_cost = receipt["cost_breakdown"]["provider_cost_atomic"]
+        .as_u64()
+        .expect("provider_cost_atomic");
+    let platform_fee = receipt["cost_breakdown"]["platform_fee_atomic"]
+        .as_u64()
+        .expect("platform_fee_atomic");
     assert_eq!(
-        receipt["cost_breakdown"]["provider_cost_atomic"]
-            .as_u64()
-            .unwrap()
-            + receipt["cost_breakdown"]["platform_fee_atomic"]
-                .as_u64()
-                .unwrap(),
+        provider_cost, 81_927,
+        "provider_cost from the breakdown string"
+    );
+    assert_eq!(
+        total, 86_024,
+        "authoritative settled total (the skewing case)"
+    );
+    assert_eq!(
+        platform_fee, 4_097,
+        "platform_fee MUST be derived as total - provider (86024 - 81927 = 4097); \
+         the old independent parse produced 4096 and failed to reconcile"
+    );
+    assert_eq!(
+        provider_cost + platform_fee,
         total,
         "provider_cost + platform_fee must equal total (5% fee, applied once)"
     );


### PR DESCRIPTION
## Summary

Fixes #504. `handle_new_request` quoted A2A cost with a literal `max_tokens = 1000`, so an A2A agent was only ever quoted/billed for **≤1000 completion tokens** even on models whose `max_output_tokens` (or the 8192 default cap) is larger — the gateway absorbed any overrun. The quote now uses `completion_token_ceiling(None, model_info)`, the **same single source of truth** as the chat path, and stores it on `TaskRecord.max_tokens` so settlement re-applies the identical cap (quote == settlement, no overshoot).

The legacy `record.max_tokens.unwrap_or(1000)` fallback is retained for records persisted before the field existed (those were quoted at 1000 and must settle at 1000).

## Receipt fee additivity (a pre-existing bug this unmasked)

Raising the quote exposed a latent consistency bug: `ModelRegistry::estimate_cost` rounds `provider_cost`, `platform_fee`, and `total` **independently** as float strings, so `provider_cost_atomic + platform_fee_atomic` could differ from `total_atomic` by 1 atomic unit (1 micro-USDC). The receipt now derives `platform_fee_atomic = total_atomic.checked_sub(provider_cost_atomic)` in both `record_a2a_settlement` and `emit_chat_receipt` (total stays authoritative — the canonical idiom already at `routes/chat/mod.rs`), so the three audit components always reconcile.

- **No billed/quoted/settled amount changes** — pure redistribution of the already-computed total; `amount_paid_atomic`, the spend-ledger amount, and the 402 quote strings are untouched.
- **Fails closed** on the impossible `provider > total` (skip the record + existing `corrupt_breakdown` counter + warn), never `saturating_sub` to fee=0.

## Tests

- `new_request_quote_uses_completion_ceiling_not_hardcoded_1000` — two registries (max_output 1000 vs 8000), same prompt: the 8000-ceiling quote is strictly larger (impossible if still hardcoded 1000).
- `new_request_stores_completion_ceiling_for_settlement` — stored `record.max_tokens` == the ceiling (pins quote == settlement).
- `paid_non_streaming_chat_receipt_fee_derived_from_total_under_rounding_skew` (chat) and exact-atomic pins on `a2a_paid_request_writes_receipt_and_metadata_path` — both reconcile under the gpt-4o skew case (provider 81927 + fee 4097 = total 86024); negative controls confirmed.
- `cargo fmt --check`, `clippy -D warnings`, `a2a` lib (83), `cost` lib (89), and integration `a2a_` (16) all clean. Rebased onto current `main`.

## Review

Two **independent** money-path reviews (rust-reviewer + silent-failure-hunter):
- rust-reviewer: **APPROVE**, no Critical/High — confirmed no double-applied fee, no billed-amount change, quote==settlement by construction.
- silent-failure-hunter: the fee-derivation is a clean fail-closed redistribution. Its CRITICAL/HIGH findings are **pre-existing** (the non-atomic `log_spend`→receipt-write split, already tracked by #448/#556) and **not introduced** here.

## Follow-up

The 402 `cost_breakdown` **strings** from `estimate_cost` remain independently rounded (non-additive by ≤1 micro-USDC); fixing that at the source (atomic-unit math per the fintech rule) is filed separately so it gets its own scoped review rather than riding under this change.