### PR TITLE
fix(gateway): record proxy spend at settlement time so a settled payment is never unledgered (#556)

### DIFF
--- a/crates/gateway/src/routes/proxy.rs
+++ b/crates/gateway/src/routes/proxy.rs
@@ -219,9 +219,10 @@ impl PaymentTarget {
 /// 2. Reject internal services (400) and unhealthy services (503)
 /// 3. If no PAYMENT-SIGNATURE header → return 402 with cost breakdown
 /// 4. If payment present → decode, validate, replay-protect, verify via Facilitator
-/// 5. Forward request body to service endpoint with 60s timeout
-/// 6. Return upstream response (2xx passthrough, 5xx → 502, timeout → 504)
-/// 7. Fire-and-forget spend log
+/// 5. Fire-and-forget spend log + receipt at SETTLEMENT time (the money moved
+///    on-chain; the ledger row must not be contingent on the upstream — #556)
+/// 6. Forward request body to service endpoint with 60s timeout
+/// 7. Return upstream response (2xx passthrough, 5xx → 502, timeout → 504)
 pub async fn proxy_service(
     State(state): State<Arc<AppState>>,
     Path(service_id): Path<String>,
@@ -689,17 +690,19 @@ pub async fn proxy_service(
     // Build the spend entry once (fire-and-forget: log_spend spawns its own
     // writes, never awaited on the hot path).
     //
-    // WHEN it is logged differs by path:
-    // - Vendor services log NOW, at settlement time: the 5% receivable is owed
-    //   on SETTLED volume (the vendor was just paid on-chain), so deferring
-    //   the record past the upstream call would silently drop receivables for
-    //   settled requests whose upstream then times out or is unreachable.
-    // - Non-vendor services keep the legacy post-upstream write below,
-    //   byte-for-byte today's behavior.
+    // WHEN it is logged: NOW, at settlement time, for BOTH vendor and non-vendor
+    // (plain) services (#556). The money has just moved on-chain — the agent
+    // settled to the vendor wallet or the gateway recipient — so the ledger row
+    // must NOT be contingent on the upstream call succeeding. The legacy code
+    // deferred the PLAIN-service write past `send().await`, which silently
+    // dropped the spend_logs row for any settled request whose upstream then
+    // timed out, was unreachable, or failed the SSRF re-check / client build /
+    // body read: money moved, no record. Vendor receivables already logged at
+    // settlement time; collapsing the branch makes plain services match.
+    //
     // P2 receipt: built from the same settlement facts as the spend entry and
-    // written at the same point(s) — vendor services NOW (the vendor was just
-    // paid on-chain), plain services post-upstream below — so every paid
-    // request that writes a spend row also writes a receipt row.
+    // written at the SAME point — every paid request that writes a spend row
+    // also writes a receipt row, at settlement, for both paths.
     let receipt_record = payment_target.receipt_record(
         &service_id,
         &payload.accepted.scheme,
@@ -731,17 +734,26 @@ pub async fn proxy_service(
         estimated_cost_usdc: None,
         vendor: payment_target.into_vendor_settlement(),
     };
+    // Record spend + receipt UNCONDITIONALLY at settlement time, for both
+    // vendor and plain services (#556). `log_spend` is fire-and-forget (it
+    // spawns its own writes) and `record_receipt` dispatches its insert the
+    // same way — neither blocks the hot path, and a spend/receipt write failure
+    // never fails the request (settlement already happened on-chain; the failure
+    // stays observable via log_spend's existing warn/counter, Architectural
+    // Rule #9). These rows now make charge-without-delivery cases visible — the
+    // upstream-fails arms below 502/504 but the agent was still charged; that
+    // delivery-after-charge gap is tracked as open issue #486 (out of scope
+    // here: #556 only guarantees the ledger records the settled charge).
+    //
     // `receipt_header_path` is `Some` once a retrievable receipt exists (DB
     // configured AND the row write was dispatched); it is attached to every
-    // response built after that point. With no DATABASE_URL it stays `None`
-    // and no header is ever emitted (never promise an unfetchable receipt).
-    let (deferred_spend_entry, mut receipt_header_path) = if spend_entry.vendor.is_some() {
-        state.usage.log_spend(spend_entry);
-        let path = receipts::record_receipt(state.db_pool.as_ref(), receipt_record);
-        (None, path)
-    } else {
-        (Some((spend_entry, receipt_record)), None)
-    };
+    // response built after this point — including the upstream-fails arms, so a
+    // failed-upstream 502/504 now also carries a fetchable receipt (a correct
+    // improvement that matches the vendor path). With no DATABASE_URL it stays
+    // `None` and no header is ever emitted (never promise an unfetchable
+    // receipt).
+    state.usage.log_spend(spend_entry);
+    let receipt_header_path = receipts::record_receipt(state.db_pool.as_ref(), receipt_record);
 
     // Step 5: SSRF check — resolve DNS once, validate all addresses are public,
     // then pin the validated IP into a per-request reqwest client. This eliminates
@@ -815,7 +827,7 @@ pub async fn proxy_service(
         upstream_req = upstream_req.header("x-solvela-request-id", rid.as_str());
     }
 
-    // Step 6: Send request and handle response
+    // Step 7: Send request and handle response
     let upstream_response = match upstream_req.send().await {
         Ok(resp) => resp,
         Err(e) if e.is_timeout() => {
@@ -824,11 +836,11 @@ pub async fn proxy_service(
                 error = %e,
                 "upstream service timed out"
             );
-            // Vendor services already settled AND recorded their receipt at
-            // settlement time above, so the paid (504) response still carries
-            // it. Plain services have not written spend or receipt yet —
-            // `receipt_header_path` is `None` and no header is emitted
-            // (mirrors the legacy spend-log behavior on this arm).
+            // Both vendor AND plain services already recorded spend + receipt
+            // at settlement time above (#556), so this paid (504) response
+            // carries the receipt header when a DB is configured — the agent
+            // was charged on-chain and the ledger/receipt reflect it even
+            // though the upstream timed out (charge-without-delivery: #486).
             let mut response = (
                 StatusCode::GATEWAY_TIMEOUT,
                 axum::Json(json!({
@@ -845,7 +857,9 @@ pub async fn proxy_service(
                 error = %e,
                 "failed to reach upstream service"
             );
-            // Same receipt-header semantics as the timeout arm above.
+            // Same receipt-header semantics as the timeout arm above (#556):
+            // spend + receipt were recorded at settlement, so this 502 carries
+            // the receipt header when a DB is configured.
             let mut response = (
                 StatusCode::BAD_GATEWAY,
                 axum::Json(json!({
@@ -860,13 +874,9 @@ pub async fn proxy_service(
 
     let upstream_status = upstream_response.status();
 
-    // Step 7: Fire-and-forget spend log + receipt (both internally use
-    // tokio::spawn). Non-vendor services only — vendor services already
-    // logged at settlement time above (one row per request either way).
-    if let Some((entry, record)) = deferred_spend_entry {
-        state.usage.log_spend(entry);
-        receipt_header_path = receipts::record_receipt(state.db_pool.as_ref(), record);
-    }
+    // Spend + receipt are already recorded at settlement time above (#556),
+    // for both vendor and plain services — no post-upstream write here. The
+    // ledger row is never contingent on the upstream outcome.
 
     // Handle upstream response based on status
     if upstream_status.is_server_error() {

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -7931,6 +7931,148 @@ async fn test_proxy_normal_wallet_not_rejected_and_settles() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Issue #556 — non-vendor (plain) proxy services must record spend at
+// SETTLEMENT TIME, not deferred past the upstream call.
+//
+// The money already moved on-chain at settlement, so the spend_logs row must
+// not be contingent on the upstream succeeding. The legacy code stashed the
+// plain-service spend entry into `deferred_spend_entry` and only wrote it AFTER
+// `send().await`, so any early exit between settlement and that write (upstream
+// timeout / unreachable / SSRF re-check / client-build / body-read failure)
+// dropped the ledger row: money moved, no record. These tests prove the row is
+// written at settlement time through the REAL route — the captured synchronous
+// `info!("spend logged")` event fires inside `log_spend` with no DB attached.
+// ---------------------------------------------------------------------------
+
+/// #556 RED→GREEN: a settled paid request to a NON-VENDOR (plain) marketplace
+/// service whose upstream then FAILS (the test endpoint `search.example.com`
+/// is unresolvable — the upstream `send()` errors out) must STILL record its
+/// spend entry. The money settled on-chain; the ledger row must exist.
+///
+/// On the legacy deferred-write code this asserts ZERO spend events (the drop
+/// this issue fixes) — i.e. it FAILS RED. After the settlement-time write it
+/// records exactly one.
+#[tokio::test]
+async fn plain_proxy_request_records_spend_at_settlement_even_when_upstream_fails() {
+    use tracing::instrument::WithSubscriber;
+
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        mock_provider_registry(),
+        Arc::new(SettleRecordingVerifier {
+            settled: Arc::clone(&settled),
+        }),
+    );
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    // `web-search` is a NON-vendor service (no vendor_wallet) whose endpoint
+    // `https://search.example.com/...` fails the SSRF/DNS step naturally, so the
+    // upstream fetch never succeeds — the exact drop window #556 closes.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/web-search/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/services/web-search/proxy"),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+    // Settlement was reached (request passed all gates and the facilitator
+    // settled on-chain) — so the money moved.
+    assert!(
+        settled.load(std::sync::atomic::Ordering::SeqCst),
+        "the plain-service request must reach settlement (money moved on-chain)"
+    );
+    assert_ne!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "payment must have been accepted (not a 402)"
+    );
+
+    // The ledger row must exist BECAUSE settlement happened — independent of the
+    // upstream outcome. On the legacy deferred-write path this is 0 (the bug).
+    let events = spend_logged_events(&capture);
+    assert_eq!(
+        events.len(),
+        1,
+        "a settled plain-service request MUST record exactly one spend entry at \
+         settlement time even when the upstream fails (got {}): money moved \
+         on-chain, the ledger row must not be contingent on the upstream",
+        events.len()
+    );
+}
+
+/// #556 no-double-write guard: the same settled, upstream-failing plain-service
+/// request must record spend EXACTLY ONCE — not once at settlement and again on
+/// a (now-removed) deferred path. Pins the collapse of the vendor/non-vendor
+/// branch to a single unconditional write.
+#[tokio::test]
+async fn plain_proxy_settled_request_logs_spend_exactly_once() {
+    use tracing::instrument::WithSubscriber;
+
+    let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+        mock_provider_registry(),
+        Arc::new(SettleRecordingVerifier {
+            settled: Arc::clone(&settled),
+        }),
+    );
+
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/services/web-search/proxy")
+                .header("content-type", "application/json")
+                .header(
+                    "payment-signature",
+                    valid_payment_header("/v1/services/web-search/proxy"),
+                )
+                .body(Body::from(r#"{"query":"test"}"#))
+                .unwrap(),
+        )
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+    assert!(
+        settled.load(std::sync::atomic::Ordering::SeqCst),
+        "the plain-service request must reach settlement"
+    );
+    assert_ne!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+    let events = spend_logged_events(&capture);
+    assert_eq!(
+        events.len(),
+        1,
+        "a settled plain-service request must log spend EXACTLY once \
+         (no double-write across the collapsed branch), got {}",
+        events.len()
+    );
+}
+
 /// #499 POSITIVE-reject pin (proxy path): a wallet provisioned
 /// `require_tenant = TRUE` MUST be rejected with 403 `GatewayError::Forbidden`
 /// BEFORE any settlement on the service-marketplace proxy path.


### PR DESCRIPTION
## Summary

Fixes #556. On the proxied-service payment path (`crates/gateway/src/routes/proxy.rs`), the **non-vendor** (`vendor: None`) `spend_logs` write was *deferred* until after the upstream call. Any early exit between successful on-chain settlement and that deferred write dropped the ledger row — **money moved, no record**.

The drop window was wider than the issue described: beyond the three `?`-propagating calls (SSRF re-check, reqwest client builder, request-body read), the two `Ok(response)` early-exit arms — **upstream timeout and unreachable** — also dropped the row, and those are the *dominant* real-world drop (an upstream being down/slow is far more common than a DNS race).

## Change

The vendor path (#555) already logs at settlement time. This collapses the vendor/non-vendor branch into a **single unconditional `log_spend` + `record_receipt` at settlement time** and **deletes the deferred-write block**, so both targets record at settlement and no post-settlement early exit can drop the row. Same class as #541 (chat streaming variant). One file of handler change + tests; vendor path behavior, SSRF validation, the claim/settlement amount, and `usage.rs` are untouched.

## Semantics (matches the reviewed vendor path since #555)

A non-vendor proxied request that settles on-chain but whose upstream then fails now produces a `spend_logs` row for the collected amount and increments the wallet's budget counters — truthful, since the agent was charged on-chain. **No double-count**: the proxy path holds no reservation (`estimated_cost_usdc: None`), so there is exactly one increment. Side effect: failed-upstream 502/504 responses on plain services now also carry a fetchable receipt header (when a DB is configured), matching vendor. The now-visible charge-without-delivery cases are the separately-tracked #486.

**Fire-and-forget preserved**: the moved writes still never block or fail the request; a DB write failure stays observable via the existing warn/error + counters (Architectural Rule #9).

## Tests (real route, no seeded fixtures)

- `plain_proxy_request_records_spend_at_settlement_even_when_upstream_fails` — **RED on old code** (0 spend events), **GREEN now** (1).
- `plain_proxy_settled_request_logs_spend_exactly_once` — no-double-write guard.

Both drive the real `/v1/services/{id}/proxy` route against a naturally-failing upstream via the existing `CaptureWriter`/`spend_logged_events` harness. **No new test seam** was added: an injectable-upstream client or a test-only SSRF allowlist was *deliberately rejected* to avoid weakening the SSRF control. The happy-path (2xx) no-double-write is guaranteed structurally (single call site; deferred block deleted) and would only be reachable with that rejected seam.

`cargo fmt --check`, `clippy -D warnings`, integration `proxy` (17), and lib `routes::proxy` (47) all clean. Rebased onto current `main`.

## Review

Full skilled-agent pipeline: money-path engineer (research → plan → TDD implement), then **two independent reviews** — `rust-reviewer` (**APPROVE**, no Critical/High; confirmed no double-write, vendor path unchanged, ownership clean) and `silent-failure-hunter` (clean closure of the drop, no new swallowing, fire-and-forget observability intact). Their remaining notes are pre-existing (receipt-header-not-advertised on `Err` arms / #486) or a test-redundancy/coverage observation that the rejected-seam decision addresses.