### PR TITLE
chore(x402scan): OpenAPI contact/guidance + bump crates to 0.4.0 for republish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-protocol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,4 +91,4 @@ dotenvy = "0.15"
 solvela-x402 = { path = "crates/x402", version = "0.2" }           # renamed from `x402` — that name is taken on crates.io
 solvela-escrow-tx = { path = "crates/escrow-tx", version = "0.2" } # no-deps escrow deposit-tx builder, shared with the Rust SDK
 solvela-router = { path = "crates/router", version = "0.2" }
-solvela-protocol = { path = "crates/protocol", version = "0.3" }
+solvela-protocol = { path = "crates/protocol", version = "0.4" }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solvela-protocol"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Shared wire-format types for the Solvela ecosystem (x402 payment protocol + OpenAI-compatible chat types)"
 license = "Apache-2.0"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4,7 +4,9 @@
     "title": "Solvela Gateway",
     "description": "Solana-native AI agent payment gateway. OpenAI-compatible LLM chat completions paid per request in USDC-SPL over the x402 protocol — no API key, no account, just a wallet. A rule-based smart router selects a model per request, an exact-match response cache returns prior answers at zero upstream cost, and a trustless on-chain escrow scheme is available for prepaid sessions.",
     "version": "0.1.0",
-    "license": { "name": "BUSL-1.1", "identifier": "BUSL-1.1" }
+    "license": { "name": "BUSL-1.1", "identifier": "BUSL-1.1" },
+    "contact": { "email": "partnerships@solvela.ai", "url": "https://solvela.ai" },
+    "x-guidance": "Pay per request in USDC-SPL on Solana via x402 — no API key or account, just a wallet. POST /v1/chat/completions with no PAYMENT-SIGNATURE header to receive a 402 challenge quoting the USDC cost; sign the quoted `exact` (or `escrow`) payment and resubmit the same request with the signed payload in the PAYMENT-SIGNATURE header. Model catalog at GET /v1/models; x402 discovery at /openapi.json and /.well-known/x402."
   },
   "servers": [
     { "url": "https://api.solvela.ai", "description": "Production" },

--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ahash",
  "base64",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "futures",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-cli-args"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bs58",
  "clap",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-client-proxy"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "clap",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "solvela-protocol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.91"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ keywords = ["solana", "x402", "usdc", "payments", "llm"]
 [workspace.dependencies]
 # Protocol — local path dep so wire-format drift between gateway and this SDK
 # fails CI in the same PR. Version pin matches the monorepo's crates/protocol.
-solvela-protocol = { path = "../../crates/protocol", version = "0.3" }
+solvela-protocol = { path = "../../crates/protocol", version = "0.4" }
 
 # Escrow deposit-tx builder — shared no-deps crate from the monorepo. Local path
 # dep so the on-chain-verified deposit byte layout stays in lockstep with the

--- a/sdks/rust/crates/solvela-client-cli-args/Cargo.toml
+++ b/sdks/rust/crates/solvela-client-cli-args/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 clap = { workspace = true }
-solvela-client = { path = "../solvela-client", version = "0.3" }
+solvela-client = { path = "../solvela-client", version = "0.4" }
 dirs = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }

--- a/sdks/rust/crates/solvela-client-cli/Cargo.toml
+++ b/sdks/rust/crates/solvela-client-cli/Cargo.toml
@@ -17,8 +17,8 @@ name = "solvela-client"
 path = "src/main.rs"
 
 [dependencies]
-solvela-client = { path = "../solvela-client", version = "0.3" }
-solvela-client-cli-args = { path = "../solvela-client-cli-args", version = "0.3" }
+solvela-client = { path = "../solvela-client", version = "0.4" }
+solvela-client-cli-args = { path = "../solvela-client-cli-args", version = "0.4" }
 solvela-protocol = { workspace = true }
 reqwest = { workspace = true }
 clap = { workspace = true }

--- a/sdks/rust/crates/solvela-client-proxy/Cargo.toml
+++ b/sdks/rust/crates/solvela-client-proxy/Cargo.toml
@@ -21,8 +21,8 @@ name = "solvela-client-proxy"
 path = "src/main.rs"
 
 [dependencies]
-solvela-client = { path = "../solvela-client", version = "0.3" }
-solvela-client-cli-args = { path = "../solvela-client-cli-args", version = "0.3" }
+solvela-client = { path = "../solvela-client", version = "0.4" }
+solvela-client-cli-args = { path = "../solvela-client-cli-args", version = "0.4" }
 solvela-protocol = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }


### PR DESCRIPTION
Two low-priority x402scan follow-ups after #605/#606.

## Task 1 — OpenAPI nits (`docs/openapi.json`)
Adds `info.contact` (partnerships@solvela.ai / https://solvela.ai) and `info.x-guidance` (agent-readable usage string), clearing the agentcash audit's two `[info]` warnings. The served `/openapi.json` updates automatically (`include_str!`); `openapi_contract` drift guard green (15/15).

## Task 2 — SDK republish version prep
#606 changed the published `PaymentRequired` wire type (dropped `deny_unknown_fields`, added the `extensions` field) **without** a version bump, so the published crates are content-behind. This bumps them so a republish makes the published SDK tolerant + extensions-aware:

- `solvela-protocol` **0.3.0 → 0.4.0** — additive public API (canonical module #533 + `extensions` field #606) + parse-tolerance loosening. Minor (not patch) under 0.x because a new public field is source-breaking for struct-literal constructors.
- `solvela-client` + `solvela-client-cli-args` + `solvela-client-proxy` + `solvela-client-cli` **0.3.0 → 0.4.0** — production code unchanged; bumped to depend on protocol ^0.4. Inter-crate version reqs + both `Cargo.lock`s updated.
- `solvela-escrow-tx` **left out of scope** — its source is ahead of published 0.2.0 (unrelated #597 API), but the SDK depends on `^0.2` which still resolves; track separately.

### ⚠️ Publish NOT performed — needs human sign-off
`cargo publish` is irreversible, needs the crates.io token, and is **not** run by CI or this PR. After merge, run from the committed tree (no `--allow-dirty`):

```
# 1. Protocol first (main workspace root)
cargo publish --locked -p solvela-protocol
# 2. Wait ~30-90s for index propagation; confirm 0.4.0 live via crates.io API
# 3. SDK workspace (sdks/rust) — dry-run now passes once protocol is live:
cargo publish --dry-run --locked -p solvela-client   # then publish
cargo publish --locked -p solvela-client
cargo publish --locked -p solvela-client-cli-args
cargo publish --locked -p solvela-client-proxy
cargo publish --locked -p solvela-client-cli
# 4. Verify all five report max_version 0.4.0
```
Order matters (deps first); each later `--locked` publish verifies its `^0.4` dep against the live index, hence the propagation waits. `solvela-protocol` dry-run already PASSED locally; the SDK crates can't dry-run until protocol is live (cross-workspace ordering — expected, not a defect).

## Context
Zero external consumers (all crates.io reverse-deps first-party, 0 forks), so this is low-urgency hygiene. Prepared by the `payment-sdk-publisher` agent under the local harness; the x402scan browser "Add Server" listing remains a manual step (needs an interactive browser + Solana wallet).