### PR TITLE
feat(providers): cross-provider prompt-cache token metering

### DIFF
--- a/crates/gateway/src/cache/mod.rs
+++ b/crates/gateway/src/cache/mod.rs
@@ -504,6 +504,29 @@ pub(super) mod test_metrics {
             .filter_map(|l| l.rsplit_once(' ').and_then(|(_, v)| v.parse::<u64>().ok()))
             .sum()
     }
+
+    /// Like [`counter_value`], but sums only the label-series of `name` whose
+    /// exposition line's label block CONTAINS `label_substr`.
+    ///
+    /// The single process-wide recorder means `counter_value` (which sums the
+    /// WHOLE family across labels) is contaminated when sibling tests run
+    /// concurrently and increment the same metric family under different
+    /// labels. Tests that emit labeled counters give themselves a UNIQUE label
+    /// value (e.g. a unique `model="..."`) and read with this filter so their
+    /// before/after delta is attributable only to themselves — independent of
+    /// whatever other tests do to the same family in parallel.
+    pub(crate) fn counter_value_filtered(
+        handle: &metrics_exporter_prometheus::PrometheusHandle,
+        name: &str,
+        label_substr: &str,
+    ) -> u64 {
+        let body = handle.render();
+        body.lines()
+            .filter(|l| l.starts_with(&format!("{name}{{")))
+            .filter(|l| l.contains(label_substr))
+            .filter_map(|l| l.rsplit_once(' ').and_then(|(_, v)| v.parse::<u64>().ok()))
+            .sum()
+    }
 }
 
 #[cfg(test)]

--- a/crates/gateway/src/providers/anthropic.rs
+++ b/crates/gateway/src/providers/anthropic.rs
@@ -532,9 +532,21 @@ fn spawn_anthropic_sse_parser(response: reqwest::Response, model: String) -> Cha
                                         // (we only read `message.usage`) and does NOT
                                         // affect streaming billing, which is a
                                         // request-side estimate, never response usage.
-                                        if let Some(usage) = &msg.message.usage {
-                                            usage.cache_usage().emit(PROVIDER_LABEL, &model);
-                                        }
+                                        //
+                                        // Emit the denominator UNCONDITIONALLY for
+                                        // every successfully parsed message_start —
+                                        // even when `usage` is absent — so the
+                                        // `requests_total` flatline-detection signal
+                                        // counts every streamed response, matching the
+                                        // non-streaming path. An absent usage block
+                                        // emits CacheUsage::default() (0 read / 0
+                                        // write).
+                                        msg.message
+                                            .usage
+                                            .as_ref()
+                                            .map(AnthropicStreamUsage::cache_usage)
+                                            .unwrap_or_default()
+                                            .emit(PROVIDER_LABEL, &model);
                                         message_id = msg.message.id.clone();
                                         let chunk = ChatChunk {
                                             id: msg.message.id,
@@ -1559,6 +1571,77 @@ mod tests {
             write_after - write_before,
             10,
             "streaming write counter must increment by message_start cache_creation_input_tokens"
+        );
+    }
+
+    /// Streaming denominator gap (Finding 2): a `message_start` that parses
+    /// successfully but carries NO `usage` block must STILL increment the
+    /// `requests_total` denominator (emitting `CacheUsage::default()`), matching
+    /// the non-streaming path which emits unconditionally. Without the
+    /// denominator, a streaming-only flatline of cache reads would be invisible
+    /// (the flatline-detection signal that guards against a silent Anthropic
+    /// cache-field rename). Falsifiable: with the old `if let Some(usage)`
+    /// gating, the denominator delta would be 0 here.
+    #[tokio::test]
+    async fn streaming_message_start_without_usage_still_increments_denominator() {
+        use futures::StreamExt;
+
+        let handle = install_test_recorder();
+        let model = "anthropic/metering-stream-no-usage-unique";
+        let key = format!("model=\"{model}\"");
+        let read_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let write_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_write_tokens_total", &key);
+        let req_before = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        // A real message_start with NO `usage` object (caching off / older shape),
+        // followed by a content delta and message_stop.
+        let sse = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_no_usage\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-6\",\"content\":[],\"stop_reason\":null}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n",
+        );
+
+        let http_resp = axum::http::Response::builder()
+            .status(200)
+            .header("content-type", "text/event-stream")
+            .body(sse.as_bytes().to_vec())
+            .expect("response build must succeed");
+        let response = reqwest::Response::from(http_resp);
+
+        let mut stream = spawn_anthropic_sse_parser(response, model.to_string());
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.expect("chunk must be Ok"));
+        }
+
+        // Chunk shape unchanged: role chunk + content chunk.
+        assert_eq!(chunks.len(), 2, "expected role chunk + one content chunk");
+
+        let read_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let write_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_write_tokens_total", &key);
+        let req_after = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        assert_eq!(
+            req_after - req_before,
+            1,
+            "denominator must increment once even when message_start carries no usage block"
+        );
+        assert_eq!(
+            read_after - read_before,
+            0,
+            "no usage block ⇒ zero cache reads"
+        );
+        assert_eq!(
+            write_after - write_before,
+            0,
+            "no usage block ⇒ zero cache writes"
         );
     }
 }

--- a/crates/gateway/src/providers/anthropic.rs
+++ b/crates/gateway/src/providers/anthropic.rs
@@ -7,7 +7,11 @@ use solvela_protocol::{
     MessageContent, ModelRegistration, ParseImageError, ParsedImage, Role, Usage,
 };
 
+use super::cache_usage::CacheUsage;
 use super::{ChatStream, LLMProvider, ProviderError};
+
+/// Provider label used for cache-token metering counters.
+const PROVIDER_LABEL: &str = "anthropic";
 
 /// Anthropic provider adapter.
 ///
@@ -158,6 +162,51 @@ struct AnthropicUsage {
     #[serde(default)]
     cache_read_input_tokens: u32,
     output_tokens: u32,
+}
+
+impl AnthropicUsage {
+    /// Project the cache fields into the internal metering struct.
+    ///
+    /// OBSERVABILITY ONLY — this does not affect billing. Billing reconstructs
+    /// the agent's `prompt_tokens` separately in `from_anthropic_response`
+    /// (folding both cache fields back into `prompt_tokens`); this is a parallel
+    /// read of the same `#[serde(default)]` fields purely to drive counters.
+    /// `cache_read_input_tokens` → read; `cache_creation_input_tokens` → write.
+    fn cache_usage(&self) -> CacheUsage {
+        CacheUsage {
+            cache_read_tokens: self.cache_read_input_tokens,
+            cache_write_tokens: self.cache_creation_input_tokens,
+        }
+    }
+}
+
+/// Streaming `message_start.message.usage` cache fields.
+///
+/// On a streaming response the per-token prompt-cache counts arrive once, in
+/// the `message_start` event's `message.usage` object (verified against the
+/// Anthropic streaming docs 2026-06-17: the object carries `input_tokens`,
+/// `cache_creation_input_tokens`, `cache_read_input_tokens`, `output_tokens`;
+/// the two cache fields are ABSENT when caching did not trigger, hence
+/// `#[serde(default)]`). We capture only the two cache fields here for metering.
+///
+/// OBSERVABILITY ONLY: streaming BILLING is unaffected — the streaming path
+/// bills off a request-side estimate, never response usage (`ChatChunk` carries
+/// no usage block). This struct never reaches billing or the public wire types.
+#[derive(Debug, Default, Deserialize)]
+struct AnthropicStreamUsage {
+    #[serde(default)]
+    cache_creation_input_tokens: u32,
+    #[serde(default)]
+    cache_read_input_tokens: u32,
+}
+
+impl AnthropicStreamUsage {
+    fn cache_usage(&self) -> CacheUsage {
+        CacheUsage {
+            cache_read_tokens: self.cache_read_input_tokens,
+            cache_write_tokens: self.cache_creation_input_tokens,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -340,6 +389,14 @@ fn from_anthropic_response(resp: AnthropicResponse, original_model: &str) -> Cha
         other => other.to_string(),
     });
 
+    // OBSERVABILITY ONLY: emit prompt-cache token counters. This reads the same
+    // `#[serde(default)]` cache fields the billing reconstruction below uses,
+    // but only to drive Prometheus counters — it does not change `prompt_tokens`
+    // or anything the agent is charged.
+    resp.usage
+        .cache_usage()
+        .emit(PROVIDER_LABEL, original_model);
+
     ChatResponse {
         id: resp.id,
         object: "chat.completion".to_string(),
@@ -397,6 +454,12 @@ struct AnthropicMessageStart {
 struct AnthropicMessageStartBody {
     id: String,
     model: String,
+    /// Prompt-cache token counts for this stream, reported once in
+    /// `message_start`. Optional + `#[serde(default)]` so a response that omits
+    /// `usage` (older shape / no caching) parses cleanly to no metering. Used
+    /// for OBSERVABILITY ONLY (streaming billing is request-side estimated).
+    #[serde(default)]
+    usage: Option<AnthropicStreamUsage>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -462,6 +525,16 @@ fn spawn_anthropic_sse_parser(response: reqwest::Response, model: String) -> Cha
                             "message_start" => {
                                 match serde_json::from_str::<AnthropicMessageStart>(&data) {
                                     Ok(msg) => {
+                                        // OBSERVABILITY ONLY: streaming cache-token
+                                        // metering. The prompt-cache counts arrive
+                                        // once, here in message_start. Emitting does
+                                        // NOT change the streamed `ChatChunk` shape
+                                        // (we only read `message.usage`) and does NOT
+                                        // affect streaming billing, which is a
+                                        // request-side estimate, never response usage.
+                                        if let Some(usage) = &msg.message.usage {
+                                            usage.cache_usage().emit(PROVIDER_LABEL, &model);
+                                        }
                                         message_id = msg.message.id.clone();
                                         let chunk = ChatChunk {
                                             id: msg.message.id,
@@ -1295,5 +1368,197 @@ mod tests {
         );
         assert_eq!(chat_resp.choices[0].finish_reason, Some("stop".to_string()));
         assert_eq!(chat_resp.usage.as_ref().unwrap().total_tokens, 18);
+    }
+
+    // -----------------------------------------------------------------------
+    // PR-2 cross-provider cache-token metering (OBSERVABILITY ONLY).
+    // -----------------------------------------------------------------------
+
+    use crate::cache::test_metrics::{counter_value_filtered, install_test_recorder};
+
+    /// `AnthropicUsage::cache_usage()` maps the read field to read and the
+    /// write field to write. A usage WITHOUT cache fields yields
+    /// `CacheUsage::default()` (0/0) — never a parse error.
+    #[test]
+    fn anthropic_usage_projects_cache_usage() {
+        let usage = AnthropicUsage {
+            input_tokens: 200,
+            cache_creation_input_tokens: 500,
+            cache_read_input_tokens: 1800,
+            output_tokens: 50,
+        };
+        let cu = usage.cache_usage();
+        assert_eq!(cu.cache_read_tokens, 1800);
+        assert_eq!(cu.cache_write_tokens, 500);
+
+        // Caching-off shape (no cache fields present) → 0/0, not an error.
+        let raw = r#"{"input_tokens":2000,"output_tokens":50}"#;
+        let usage_no_cache: AnthropicUsage = serde_json::from_str(raw).unwrap();
+        assert_eq!(usage_no_cache.cache_usage(), CacheUsage::default());
+    }
+
+    /// `from_anthropic_response` emits the read, write, and denominator counters
+    /// by the parsed amounts — AND leaves `prompt_tokens` identical to the
+    /// billing-reconstruction value (metering is additive, not a billing
+    /// change). Falsifiable: if `emit` were not called, the counter deltas
+    /// would be 0; if metering altered billing, `prompt_tokens` would differ
+    /// from the PR-1 reconstruction (200 + 500 + 1800 = 2500).
+    #[test]
+    fn from_anthropic_response_emits_counters_without_touching_billing() {
+        let handle = install_test_recorder();
+        // Unique model label isolates this test's series from concurrent tests
+        // touching the same counter families (single process-wide recorder).
+        let model = "anthropic/metering-nonstream-unique";
+        let key = format!("model=\"{model}\"");
+        let read_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let write_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_write_tokens_total", &key);
+        let req_before = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        let anthropic_resp = AnthropicResponse {
+            id: "msg_metering".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            content: vec![AnthropicContentBlock {
+                content_type: "text".to_string(),
+                text: Some("ok".to_string()),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: AnthropicUsage {
+                input_tokens: 200,
+                cache_creation_input_tokens: 500,
+                cache_read_input_tokens: 1800,
+                output_tokens: 50,
+            },
+        };
+        let chat_resp = from_anthropic_response(anthropic_resp, model);
+
+        // Billing is UNCHANGED: full prompt reconstruction (200 + 500 + 1800).
+        assert_eq!(
+            chat_resp.usage.as_ref().unwrap().prompt_tokens,
+            2500,
+            "metering must not change the agent's billed prompt_tokens"
+        );
+
+        let read_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let write_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_write_tokens_total", &key);
+        let req_after = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+        assert_eq!(read_after - read_before, 1800, "read counter delta");
+        assert_eq!(write_after - write_before, 500, "write counter delta");
+        assert_eq!(req_after - req_before, 1, "denominator delta");
+    }
+
+    /// The streaming `message_start.message.usage` cache fields deserialize into
+    /// an `AnthropicStreamUsage` and project to the right `CacheUsage`. Uses a
+    /// real `message_start` data payload captured from the Anthropic streaming
+    /// docs shape.
+    #[test]
+    fn message_start_usage_parses_cache_fields() {
+        let data = r#"{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-opus-4-8","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":2679,"cache_creation_input_tokens":120,"cache_read_input_tokens":2400,"output_tokens":3}}}"#;
+        let parsed: AnthropicMessageStart =
+            serde_json::from_str(data).expect("message_start with usage must parse");
+        let usage = parsed
+            .message
+            .usage
+            .as_ref()
+            .expect("usage must be present");
+        let cu = usage.cache_usage();
+        assert_eq!(cu.cache_read_tokens, 2400);
+        assert_eq!(cu.cache_write_tokens, 120);
+    }
+
+    /// A `message_start` WITHOUT a `usage` object (older shape / caching off)
+    /// still parses — `usage` is `None` (no metering), never a parse error.
+    /// This guards the streaming backward-compat path.
+    #[test]
+    fn message_start_without_usage_parses_to_none() {
+        let data = r#"{"type":"message_start","message":{"id":"msg_02","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","stop_reason":null,"stop_sequence":null}}"#;
+        let parsed: AnthropicMessageStart =
+            serde_json::from_str(data).expect("message_start without usage must still parse");
+        assert!(
+            parsed.message.usage.is_none(),
+            "absent usage must deserialize to None, not error"
+        );
+        assert_eq!(parsed.message.id, "msg_02");
+        assert_eq!(parsed.message.model, "claude-opus-4-8");
+    }
+
+    /// End-to-end streaming metering: feed a real Anthropic SSE byte stream
+    /// (message_start with cache usage → content_block_delta → message_stop)
+    /// through `spawn_anthropic_sse_parser` and assert (a) the read/write
+    /// counters incremented by the message_start cache amounts and (b) the
+    /// streamed `ChatChunk` shape is unchanged (role chunk then a content
+    /// chunk), proving metering did not alter the stream the client receives.
+    #[tokio::test]
+    async fn streaming_metering_emits_counters_and_preserves_chunk_shape() {
+        use futures::StreamExt;
+
+        let handle = install_test_recorder();
+        // Unique model label isolates this test's counter series.
+        let model = "anthropic/metering-stream-unique";
+        let key = format!("model=\"{model}\"");
+        let read_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let write_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_write_tokens_total", &key);
+
+        // A minimal but real Anthropic SSE event sequence: message_start
+        // carrying cache usage, one content delta, then message_stop.
+        let sse = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-6\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":50,\"cache_creation_input_tokens\":10,\"cache_read_input_tokens\":900,\"output_tokens\":1}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n",
+        );
+
+        // Build a `reqwest::Response` in-process from the raw SSE body — no
+        // network, no mock server, no extra dependency. `reqwest::Response`
+        // implements `From<http::Response<B>>`, and axum re-exports the same
+        // `http` crate. `bytes_stream()` then yields the whole body so the
+        // parser exercises the real byte-buffer split + event dispatch path.
+        let http_resp = axum::http::Response::builder()
+            .status(200)
+            .header("content-type", "text/event-stream")
+            .body(sse.as_bytes().to_vec())
+            .expect("response build must succeed");
+        let response = reqwest::Response::from(http_resp);
+
+        let mut stream = spawn_anthropic_sse_parser(response, model.to_string());
+
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.expect("chunk must be Ok"));
+        }
+
+        // Chunk shape unchanged: first chunk is the role marker, then a content
+        // chunk carrying "hi". Metering reads message.usage but emits no extra
+        // chunk and mutates no field.
+        assert_eq!(chunks.len(), 2, "expected role chunk + one content chunk");
+        assert_eq!(chunks[0].choices[0].delta.role, Some(Role::Assistant));
+        assert_eq!(chunks[0].choices[0].delta.content, None);
+        assert_eq!(
+            chunks[1].choices[0].delta.content.as_deref(),
+            Some("hi"),
+            "content chunk must be forwarded unchanged"
+        );
+
+        let read_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let write_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_write_tokens_total", &key);
+        assert_eq!(
+            read_after - read_before,
+            900,
+            "streaming read counter must increment by message_start cache_read_input_tokens"
+        );
+        assert_eq!(
+            write_after - write_before,
+            10,
+            "streaming write counter must increment by message_start cache_creation_input_tokens"
+        );
     }
 }

--- a/crates/gateway/src/providers/cache_usage.rs
+++ b/crates/gateway/src/providers/cache_usage.rs
@@ -1,0 +1,185 @@
+//! Cross-provider prompt-cache token metering — OBSERVABILITY ONLY.
+//!
+//! This module captures per-provider prompt-cache token counts (read/write)
+//! and exposes them as Prometheus counters so the discount the gateway already
+//! captures via prompt caching becomes observable to operators.
+//!
+//! ## NOT a billing path
+//!
+//! Nothing here feeds cost computation, the 402 quote, settlement, `Usage`, or
+//! what any agent is charged. The agent's `prompt_tokens` (and therefore its
+//! bill) is reconstructed independently in each adapter's response conversion
+//! (e.g. `from_anthropic_response` folds the cache fields back into
+//! `prompt_tokens` so the charge is cache-invariant). [`CacheUsage`] is a
+//! parallel, internal-only read of the same provider fields used purely to
+//! drive counters. It is deliberately NOT `Serialize`/`Deserialize`: it never
+//! crosses a wire and never reaches the public `solvela_protocol::Usage`.
+//!
+//! ## Emitted metrics
+//!
+//! All labelled by `provider` + `model` (model cardinality is bounded — the
+//! registry carries ≤ 26 models, so `{provider,model}` is safe):
+//!
+//! - `solvela_provider_cache_read_tokens_total{provider,model}` — prompt tokens
+//!   served from the provider's cache (the captured discount).
+//! - `solvela_provider_cache_write_tokens_total{provider,model}` — prompt tokens
+//!   written INTO the provider's cache (the one-time write premium). Only
+//!   Anthropic reports a distinct cache-write count today; for providers that
+//!   do not, this stays 0.
+//! - `solvela_provider_requests_total{provider,model}` — a DENOMINATOR. Emitted
+//!   once per metered response so that a flat cache-read counter is
+//!   unambiguous: if `requests_total` keeps climbing while
+//!   `cache_read_tokens_total` goes to zero, an operator can distinguish
+//!   "cacheable traffic continues but cache reads dropped to zero" (a possible
+//!   silent field rename — see below) from "no traffic at all". Without a
+//!   denominator a bare cache-token counter flatlining is ambiguous (could be
+//!   legitimate cache misses).
+//!
+//! ## Why the denominator matters (PR-1 review follow-up)
+//!
+//! The provider cache fields are parsed with `#[serde(default)]`, so a future
+//! provider-side rename of a cache field would silently read 0. For Anthropic
+//! that would also under-bill (the billing path folds those fields into
+//! `prompt_tokens`); this metering is the mitigation, and pairing the read
+//! counter with `requests_total` makes the flatline detectable on a dashboard
+//! rather than invisible.
+
+use metrics::counter;
+
+/// Internal per-response prompt-cache token counts.
+///
+/// `cache_read_tokens` — prompt tokens served from the provider's cache.
+/// `cache_write_tokens` — prompt tokens written into the provider's cache
+/// (only Anthropic reports this distinctly today; 0 elsewhere).
+///
+/// Internal-only: no `Serialize`/`Deserialize`. It must never reach the frozen
+/// public `solvela_protocol::Usage` / `ChatResponse` wire types.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CacheUsage {
+    pub(crate) cache_read_tokens: u32,
+    pub(crate) cache_write_tokens: u32,
+}
+
+impl CacheUsage {
+    /// Emit the cache-token counters plus the request denominator for one
+    /// metered response, labelled by `provider` + `model`.
+    ///
+    /// Always emits `solvela_provider_requests_total` (the denominator), even
+    /// when both token counts are 0 — that is the whole point: a zero
+    /// cache-read against a climbing request count is the signal an operator
+    /// needs. Pure observability; touches no money path.
+    pub(crate) fn emit(&self, provider: &str, model: &str) {
+        // Denominator first: one increment per metered response regardless of
+        // whether any cache tokens were reported.
+        counter!(
+            "solvela_provider_requests_total",
+            "provider" => provider.to_string(),
+            "model" => model.to_string(),
+        )
+        .increment(1);
+
+        counter!(
+            "solvela_provider_cache_read_tokens_total",
+            "provider" => provider.to_string(),
+            "model" => model.to_string(),
+        )
+        .increment(u64::from(self.cache_read_tokens));
+
+        counter!(
+            "solvela_provider_cache_write_tokens_total",
+            "provider" => provider.to_string(),
+            "model" => model.to_string(),
+        )
+        .increment(u64::from(self.cache_write_tokens));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reuse the single process-wide test recorder owned by the `cache` module.
+    // The `metrics` crate allows exactly one global recorder install; that
+    // module's `OnceLock` is the crate's single source of truth, so importing
+    // it here (rather than installing a second recorder) avoids the
+    // `FailedToSetGlobalRecorder` panic when both test trees run in one binary.
+    use crate::cache::test_metrics::{counter_value_filtered, install_test_recorder};
+
+    #[test]
+    fn default_is_zero_zero() {
+        let cu = CacheUsage::default();
+        assert_eq!(cu.cache_read_tokens, 0);
+        assert_eq!(cu.cache_write_tokens, 0);
+    }
+
+    /// `emit` increments the read, write, and denominator counters by the
+    /// parsed amounts for the labelled `{provider,model}` family.
+    ///
+    /// The single process-wide recorder is shared across all tests, so we
+    /// isolate this test with a UNIQUE `model` label and read only that series
+    /// via `counter_value_filtered` — making the before/after deltas immune to
+    /// sibling tests incrementing the same families in parallel. Falsifiable:
+    /// the deltas must equal the struct's fields (read/write) and 1
+    /// (denominator).
+    #[test]
+    fn emit_increments_counters_by_parsed_amounts() {
+        let handle = install_test_recorder();
+
+        let provider = "test-emit-provider";
+        let model = "test-emit-model-unique-a";
+        let key = format!("model=\"{model}\"");
+
+        let read_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let write_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_write_tokens_total", &key);
+        let req_before = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        CacheUsage {
+            cache_read_tokens: 1800,
+            cache_write_tokens: 500,
+        }
+        .emit(provider, model);
+
+        let read_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let write_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_write_tokens_total", &key);
+        let req_after = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        assert_eq!(
+            read_after - read_before,
+            1800,
+            "read counter must increment by cache_read_tokens"
+        );
+        assert_eq!(
+            write_after - write_before,
+            500,
+            "write counter must increment by cache_write_tokens"
+        );
+        assert_eq!(
+            req_after - req_before,
+            1,
+            "request denominator must increment exactly once per emit"
+        );
+    }
+
+    /// A zero-token `emit` still increments the denominator — the unambiguous
+    /// flatline signal. Falsifiable: if `emit` skipped the denominator when
+    /// tokens were 0, `req_after - req_before` would be 0.
+    #[test]
+    fn emit_with_zero_tokens_still_increments_denominator() {
+        let handle = install_test_recorder();
+        let key = "model=\"test-zero-model-unique-b\"";
+        let req_before = counter_value_filtered(&handle, "solvela_provider_requests_total", key);
+
+        CacheUsage::default().emit("test-zero-provider", "test-zero-model-unique-b");
+
+        let req_after = counter_value_filtered(&handle, "solvela_provider_requests_total", key);
+        assert_eq!(
+            req_after - req_before,
+            1,
+            "denominator must increment even when no cache tokens were reported"
+        );
+    }
+}

--- a/crates/gateway/src/providers/cache_usage.rs
+++ b/crates/gateway/src/providers/cache_usage.rs
@@ -43,6 +43,14 @@
 //! `prompt_tokens`); this metering is the mitigation, and pairing the read
 //! counter with `requests_total` makes the flatline detectable on a dashboard
 //! rather than invisible.
+//!
+//! ## Streaming scope
+//!
+//! For OpenAI/xAI/DeepSeek the `requests_total` denominator counts NON-STREAMING
+//! completions only: their streaming SSE path exposes no usage block, so it is
+//! not instrumented. Anthropic streaming IS metered (counts arrive in
+//! `message_start`). Read cross-provider or streaming-vs-non-streaming ratios
+//! with that caveat — an OpenAI denominator omits its streamed traffic.
 
 use metrics::counter;
 

--- a/crates/gateway/src/providers/deepseek.rs
+++ b/crates/gateway/src/providers/deepseek.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use serde::Deserialize;
+use tracing::warn;
 
 use solvela_protocol::{ChatRequest, ChatResponse, ModelRegistration};
 
@@ -30,11 +31,25 @@ struct DeepSeekUsage {
 /// Returns `CacheUsage::default()` (0/0) when `usage` or the field is absent —
 /// fail-safe, never an error.
 fn cache_usage_from_deepseek_body(body: &serde_json::Value) -> CacheUsage {
-    let read = body
-        .get("usage")
-        .and_then(|u| serde_json::from_value::<DeepSeekUsage>(u.clone()).ok())
-        .map(|u| u.prompt_cache_hit_tokens)
-        .unwrap_or(0);
+    // Absent `usage` (or no-cache) ⇒ 0 silently — the normal fail-safe. A
+    // `usage` block that is PRESENT but fails to deserialize is a real error
+    // (e.g. the provider sends `prompt_cache_hit_tokens` as a string/float/null,
+    // or renames the field): log it before falling back to 0 so the counter
+    // reading 0 is not silent (Finding 1). Only an actual deserialize error
+    // warns; the absent/no-cache path stays quiet.
+    let read = match body.get("usage") {
+        None => 0,
+        Some(usage) => match serde_json::from_value::<DeepSeekUsage>(usage.clone()) {
+            Ok(parsed) => parsed.prompt_cache_hit_tokens,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "deepseek: failed to parse usage details for cache metering; cache counts will be 0"
+                );
+                0
+            }
+        },
+    };
     CacheUsage {
         cache_read_tokens: read,
         cache_write_tokens: 0,
@@ -275,6 +290,24 @@ mod tests {
         assert_eq!(cache_usage_from_deepseek_body(&body), CacheUsage::default());
 
         let body = serde_json::json!({ "id": "x", "choices": [] });
+        assert_eq!(cache_usage_from_deepseek_body(&body), CacheUsage::default());
+    }
+
+    /// A `usage` block whose `prompt_cache_hit_tokens` has the WRONG type
+    /// (string / negative) is a real deserialize error: the parser must fall
+    /// back to `CacheUsage::default()` (0/0) — never panic — while flagging the
+    /// failure (Finding 1: the old `.ok()` swallowed this silently). Falsifiable:
+    /// an `unwrap` on the parse Result would panic here.
+    #[test]
+    fn cache_usage_from_deepseek_body_falls_back_on_parse_error() {
+        let body = serde_json::json!({
+            "usage": { "prompt_tokens": 1000, "prompt_cache_hit_tokens": "not-a-number" }
+        });
+        assert_eq!(cache_usage_from_deepseek_body(&body), CacheUsage::default());
+
+        let body = serde_json::json!({
+            "usage": { "prompt_cache_hit_tokens": -7 }
+        });
         assert_eq!(cache_usage_from_deepseek_body(&body), CacheUsage::default());
     }
 

--- a/crates/gateway/src/providers/deepseek.rs
+++ b/crates/gateway/src/providers/deepseek.rs
@@ -1,11 +1,45 @@
 use async_trait::async_trait;
+use serde::Deserialize;
 
 use solvela_protocol::{ChatRequest, ChatResponse, ModelRegistration};
 
+use super::cache_usage::CacheUsage;
 use super::{ChatStream, LLMProvider, ProviderError};
 
 const DEEPSEEK_PREFIX: &str = "deepseek/";
 const DEEPSEEK_URL: &str = "https://api.deepseek.com/chat/completions";
+/// Provider label for cache-token metering counters.
+const PROVIDER_LABEL: &str = "deepseek";
+
+/// Internal, parse-only view of DeepSeek's cache-usage fields.
+///
+/// DeepSeek reports cache READS via `usage.prompt_cache_hit_tokens` (and the
+/// uncached remainder via `prompt_cache_miss_tokens`, which we do not need)
+/// — verified against api-docs.deepseek.com/guides/kv_cache 2026-06-17. There
+/// is no separate cache-WRITE count, so the metering write counter stays 0.
+/// `#[serde(default)]` makes a response without the field yield 0 (fail-safe).
+/// OBSERVABILITY ONLY — never reaches billing or the public `Usage` type.
+#[derive(Debug, Default, Deserialize)]
+struct DeepSeekUsage {
+    #[serde(default)]
+    prompt_cache_hit_tokens: u32,
+}
+
+/// Extract the cache-read token count from a DeepSeek response body.
+///
+/// Returns `CacheUsage::default()` (0/0) when `usage` or the field is absent —
+/// fail-safe, never an error.
+fn cache_usage_from_deepseek_body(body: &serde_json::Value) -> CacheUsage {
+    let read = body
+        .get("usage")
+        .and_then(|u| serde_json::from_value::<DeepSeekUsage>(u.clone()).ok())
+        .map(|u| u.prompt_cache_hit_tokens)
+        .unwrap_or(0);
+    CacheUsage {
+        cache_read_tokens: read,
+        cache_write_tokens: 0,
+    }
+}
 
 /// DeepSeek provider adapter.
 ///
@@ -55,6 +89,7 @@ impl LLMProvider for DeepSeekProvider {
         &self,
         req: ChatRequest,
     ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+        let original_model = req.model.clone();
         let req_body = build_chat_body(&req)?;
         let response = super::retry_with_backoff(2, || {
             self.client
@@ -66,7 +101,18 @@ impl LLMProvider for DeepSeekProvider {
         })
         .await?;
 
-        let body = response.error_for_status()?.json::<ChatResponse>().await?;
+        // Read the body once as a Value to drive OBSERVABILITY-ONLY cache
+        // metering (`usage.prompt_cache_hit_tokens`), then deserialize the
+        // public `ChatResponse` for the agent. Billing is untouched.
+        let value = response
+            .error_for_status()?
+            .json::<serde_json::Value>()
+            .await?;
+        let cache_usage = cache_usage_from_deepseek_body(&value);
+        let body: ChatResponse = serde_json::from_value(value)?;
+        // Emit metering only after a successful ChatResponse deserialize, so the
+        // request denominator never counts a 200-OK-but-unparseable body.
+        cache_usage.emit(PROVIDER_LABEL, &original_model);
         Ok(body)
     }
 
@@ -194,5 +240,64 @@ mod tests {
     fn supported_models_is_empty_by_design() {
         let provider = DeepSeekProvider::new(reqwest::Client::new(), "ds-test".to_string());
         assert!(provider.supported_models().is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // PR-2 cache-token metering (OBSERVABILITY ONLY).
+    // -----------------------------------------------------------------------
+
+    use crate::cache::test_metrics::{counter_value_filtered, install_test_recorder};
+
+    /// A body WITH `usage.prompt_cache_hit_tokens` yields a `CacheUsage` with
+    /// that count as the READ (DeepSeek has no separate cache-write count).
+    #[test]
+    fn cache_usage_from_deepseek_body_reads_hit_tokens() {
+        let body = serde_json::json!({
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 20,
+                "prompt_cache_hit_tokens": 640,
+                "prompt_cache_miss_tokens": 360
+            }
+        });
+        let cu = cache_usage_from_deepseek_body(&body);
+        assert_eq!(cu.cache_read_tokens, 640);
+        assert_eq!(cu.cache_write_tokens, 0);
+    }
+
+    /// A body WITHOUT the cache field (or without `usage`) yields
+    /// `CacheUsage::default()` (0/0) — never a parse error.
+    #[test]
+    fn cache_usage_from_deepseek_body_defaults_when_absent() {
+        let body = serde_json::json!({
+            "usage": { "prompt_tokens": 1000, "completion_tokens": 20 }
+        });
+        assert_eq!(cache_usage_from_deepseek_body(&body), CacheUsage::default());
+
+        let body = serde_json::json!({ "id": "x", "choices": [] });
+        assert_eq!(cache_usage_from_deepseek_body(&body), CacheUsage::default());
+    }
+
+    /// Emitting the parsed `CacheUsage` increments the read counter by the hit
+    /// count and the denominator by 1.
+    #[test]
+    fn deepseek_emit_increments_read_and_denominator() {
+        let handle = install_test_recorder();
+        let model = "deepseek/metering-unique-model";
+        let key = format!("model=\"{model}\"");
+        let read_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let req_before = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        let body = serde_json::json!({
+            "usage": { "prompt_cache_hit_tokens": 128 }
+        });
+        cache_usage_from_deepseek_body(&body).emit(PROVIDER_LABEL, model);
+
+        let read_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let req_after = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+        assert_eq!(read_after - read_before, 128);
+        assert_eq!(req_after - req_before, 1);
     }
 }

--- a/crates/gateway/src/providers/google.rs
+++ b/crates/gateway/src/providers/google.rs
@@ -7,7 +7,11 @@ use solvela_protocol::{
     ModelRegistration, ParseImageError, ParsedImage, Role, Usage,
 };
 
+use super::cache_usage::CacheUsage;
 use super::LLMProvider;
+
+/// Provider label for cache-token metering counters.
+const PROVIDER_LABEL: &str = "google";
 
 /// Google (Gemini) provider adapter.
 ///
@@ -155,6 +159,15 @@ struct GeminiUsageMetadata {
     prompt_token_count: Option<u32>,
     candidates_token_count: Option<u32>,
     total_token_count: Option<u32>,
+    /// Prompt tokens served from Gemini context cache. Maps to the wire field
+    /// `cachedContentTokenCount` (verified against ai.google.dev generateContent
+    /// docs 2026-06-17). `Option` + camelCase rename: absent on responses
+    /// without context caching, yielding 0 for metering. OBSERVABILITY ONLY —
+    /// not part of billing (`from_gemini_response` bills off `promptTokenCount`,
+    /// which Gemini reports as the FULL prompt size including cached tokens, so
+    /// this is purely a discount-visibility read).
+    #[serde(default)]
+    cached_content_token_count: Option<u32>,
 }
 
 // ---------------------------------------------------------------------------
@@ -357,6 +370,24 @@ fn from_gemini_response(resp: GeminiResponse, original_model: &str) -> ChatRespo
             (String::new(), Some("content_filter".to_string()))
         }
     };
+
+    // OBSERVABILITY ONLY: emit the context-cache read counter (plus the request
+    // denominator) before `resp.usage_metadata` is consumed below. Gemini
+    // reports cache reads via `cachedContentTokenCount`; there is no separate
+    // cache-write count, so write stays 0. Absent metadata / field → 0, which
+    // still emits the denominator (the unambiguous-flatline signal). This reads
+    // a field billing does not use (Gemini's `promptTokenCount` is the full
+    // prompt size), so it cannot affect the agent's charge.
+    let cache_read = resp
+        .usage_metadata
+        .as_ref()
+        .and_then(|u| u.cached_content_token_count)
+        .unwrap_or(0);
+    CacheUsage {
+        cache_read_tokens: cache_read,
+        cache_write_tokens: 0,
+    }
+    .emit(PROVIDER_LABEL, original_model);
 
     let usage = match resp.usage_metadata {
         Some(u) => {
@@ -841,6 +872,7 @@ mod tests {
                 prompt_token_count: Some(5),
                 candidates_token_count: Some(3),
                 total_token_count: Some(8),
+                cached_content_token_count: None,
             }),
         };
 
@@ -848,6 +880,70 @@ mod tests {
         assert_eq!(chat_resp.choices[0].message.content.as_text(), "Hi there!");
         assert_eq!(chat_resp.choices[0].finish_reason, Some("stop".to_string()));
         assert_eq!(chat_resp.usage.as_ref().unwrap().total_tokens, 8);
+    }
+
+    // ---------------------------------------------------------------------
+    // PR-2 cache-token metering (OBSERVABILITY ONLY).
+    // ---------------------------------------------------------------------
+
+    /// `cachedContentTokenCount` deserializes into `cached_content_token_count`
+    /// via the camelCase rename, and is absent (None) when the wire field is
+    /// missing — never a parse error (backward-compat).
+    #[test]
+    fn gemini_usage_metadata_parses_cached_content_token_count() {
+        let raw = r#"{"promptTokenCount":1000,"candidatesTokenCount":20,"totalTokenCount":1020,"cachedContentTokenCount":700}"#;
+        let u: GeminiUsageMetadata = serde_json::from_str(raw).unwrap();
+        assert_eq!(u.cached_content_token_count, Some(700));
+
+        // Absent → None, not an error.
+        let raw_no_cache =
+            r#"{"promptTokenCount":1000,"candidatesTokenCount":20,"totalTokenCount":1020}"#;
+        let u2: GeminiUsageMetadata = serde_json::from_str(raw_no_cache).unwrap();
+        assert_eq!(u2.cached_content_token_count, None);
+    }
+
+    /// `from_gemini_response` emits the read counter (by
+    /// `cachedContentTokenCount`) and the denominator, and leaves the billed
+    /// usage (`prompt_tokens`/`total_tokens`) untouched — Gemini's
+    /// `promptTokenCount` is the FULL prompt size, so metering is purely
+    /// additive observability.
+    #[test]
+    fn from_gemini_response_emits_read_counter_without_touching_billing() {
+        use crate::cache::test_metrics::{counter_value_filtered, install_test_recorder};
+
+        let handle = install_test_recorder();
+        let model = "google/metering-unique-model";
+        let key = format!("model=\"{model}\"");
+        let read_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let req_before = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        let gemini_resp = GeminiResponse {
+            candidates: Some(vec![GeminiCandidate {
+                content: GeminiContent {
+                    role: Some("model".to_string()),
+                    parts: vec![GeminiPart::text("ok".to_string())],
+                },
+                finish_reason: Some("STOP".to_string()),
+            }]),
+            usage_metadata: Some(GeminiUsageMetadata {
+                prompt_token_count: Some(1000),
+                candidates_token_count: Some(20),
+                total_token_count: Some(1020),
+                cached_content_token_count: Some(700),
+            }),
+        };
+        let chat_resp = from_gemini_response(gemini_resp, model);
+
+        // Billing unchanged: full prompt size from Gemini's promptTokenCount.
+        assert_eq!(chat_resp.usage.as_ref().unwrap().prompt_tokens, 1000);
+        assert_eq!(chat_resp.usage.as_ref().unwrap().total_tokens, 1020);
+
+        let read_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let req_after = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+        assert_eq!(read_after - read_before, 700, "read counter delta");
+        assert_eq!(req_after - req_before, 1, "denominator delta");
     }
 
     // ---------------------------------------------------------------------

--- a/crates/gateway/src/providers/mod.rs
+++ b/crates/gateway/src/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub(crate) mod cache_usage;
 pub mod deepseek;
 pub mod fallback;
 pub mod google;

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -1,11 +1,59 @@
 use async_trait::async_trait;
+use serde::Deserialize;
 
 use solvela_protocol::{ChatRequest, ChatResponse, ModelRegistration};
 
+use super::cache_usage::CacheUsage;
 use super::{ChatStream, LLMProvider, ProviderError};
 
 const OPENAI_PREFIX: &str = "openai/";
 const OPENAI_URL: &str = "https://api.openai.com/v1/chat/completions";
+/// Provider label for cache-token metering counters.
+const PROVIDER_LABEL: &str = "openai";
+
+/// Internal, parse-only view of the OpenAI `usage.prompt_tokens_details`
+/// sub-object purely to read `cached_tokens` for metering. This deliberately
+/// does NOT extend the frozen public `solvela_protocol::Usage`: the response is
+/// still deserialized into `ChatResponse` for the agent, and this struct reads
+/// the same JSON body a SECOND time only to pull the nested cache field for a
+/// Prometheus counter. OBSERVABILITY ONLY — never reaches billing or the wire.
+///
+/// OpenAI reports cache READS via `usage.prompt_tokens_details.cached_tokens`
+/// (verified against developers.openai.com prompt-caching docs 2026-06-17).
+/// There is no separate cache-WRITE count, so the metering write counter stays
+/// 0 for OpenAI. Both layers are `Option`/`#[serde(default)]` so a response
+/// without the nested object yields `CacheUsage::default()` (0/0), never an
+/// error.
+#[derive(Debug, Default, Deserialize)]
+struct OpenAiExtendedUsage {
+    #[serde(default)]
+    prompt_tokens_details: Option<OpenAiPromptTokensDetails>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct OpenAiPromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: u32,
+}
+
+/// Extract the cache-read token count from an OpenAI-family response body.
+///
+/// Reads the top-level `usage.prompt_tokens_details.cached_tokens`. Returns
+/// `CacheUsage::default()` (0/0) when `usage` or the nested object is absent —
+/// fail-safe, never an error. Shared by OpenAI and xAI (xAI mirrors OpenAI's
+/// usage shape).
+pub(super) fn cache_usage_from_openai_body(body: &serde_json::Value) -> CacheUsage {
+    let read = body
+        .get("usage")
+        .and_then(|u| serde_json::from_value::<OpenAiExtendedUsage>(u.clone()).ok())
+        .and_then(|u| u.prompt_tokens_details)
+        .map(|d| d.cached_tokens)
+        .unwrap_or(0);
+    CacheUsage {
+        cache_read_tokens: read,
+        cache_write_tokens: 0,
+    }
+}
 
 /// OpenAI provider adapter.
 ///
@@ -56,6 +104,7 @@ impl LLMProvider for OpenAIProvider {
         &self,
         req: ChatRequest,
     ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+        let original_model = req.model.clone();
         let req_body = build_chat_body(&req)?;
         let response = super::retry_with_backoff(2, || {
             self.client
@@ -67,7 +116,20 @@ impl LLMProvider for OpenAIProvider {
         })
         .await?;
 
-        let body = response.error_for_status()?.json::<ChatResponse>().await?;
+        // Read the body once as a Value so we can BOTH (a) deserialize the
+        // public `ChatResponse` for the agent and (b) read the nested
+        // `usage.prompt_tokens_details.cached_tokens` for OBSERVABILITY-ONLY
+        // metering — without extending the frozen public `Usage` type. The
+        // billing path is untouched: `ChatResponse` is built exactly as before.
+        let value = response
+            .error_for_status()?
+            .json::<serde_json::Value>()
+            .await?;
+        let cache_usage = cache_usage_from_openai_body(&value);
+        let body: ChatResponse = serde_json::from_value(value)?;
+        // Emit metering only after a successful ChatResponse deserialize, so the
+        // request denominator never counts a 200-OK-but-unparseable body.
+        cache_usage.emit(PROVIDER_LABEL, &original_model);
         Ok(body)
     }
 
@@ -228,5 +290,69 @@ mod tests {
     fn supported_models_is_empty_by_design() {
         let provider = OpenAIProvider::new(reqwest::Client::new(), "sk-test".to_string());
         assert!(provider.supported_models().is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // PR-2 cache-token metering (OBSERVABILITY ONLY).
+    // -----------------------------------------------------------------------
+
+    use crate::cache::test_metrics::{counter_value_filtered, install_test_recorder};
+
+    /// A response body WITH `usage.prompt_tokens_details.cached_tokens` yields a
+    /// `CacheUsage` carrying the cached count as the READ (OpenAI has no
+    /// separate cache-write count, so write stays 0).
+    #[test]
+    fn cache_usage_from_openai_body_reads_cached_tokens() {
+        let body = serde_json::json!({
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 20,
+                "total_tokens": 1020,
+                "prompt_tokens_details": { "cached_tokens": 768 }
+            }
+        });
+        let cu = cache_usage_from_openai_body(&body);
+        assert_eq!(cu.cache_read_tokens, 768);
+        assert_eq!(cu.cache_write_tokens, 0);
+    }
+
+    /// A response body WITHOUT the nested details (or without `usage`) yields
+    /// `CacheUsage::default()` (0/0) — never a parse error (backward-compat).
+    #[test]
+    fn cache_usage_from_openai_body_defaults_when_absent() {
+        // No prompt_tokens_details.
+        let body = serde_json::json!({
+            "usage": { "prompt_tokens": 1000, "completion_tokens": 20, "total_tokens": 1020 }
+        });
+        assert_eq!(cache_usage_from_openai_body(&body), CacheUsage::default());
+
+        // No usage block at all.
+        let body = serde_json::json!({ "id": "x", "choices": [] });
+        assert_eq!(cache_usage_from_openai_body(&body), CacheUsage::default());
+    }
+
+    /// Emitting the parsed `CacheUsage` increments the read counter by the
+    /// cached-token count and the denominator by 1. (The `chat_completion` path
+    /// wires `cache_usage_from_openai_body(...).emit(...)`; this proves the
+    /// parse+emit composition end to end at the unit level.)
+    #[test]
+    fn openai_emit_increments_read_and_denominator() {
+        let handle = install_test_recorder();
+        let model = "openai/metering-unique-model";
+        let key = format!("model=\"{model}\"");
+        let read_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let req_before = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        let body = serde_json::json!({
+            "usage": { "prompt_tokens_details": { "cached_tokens": 512 } }
+        });
+        cache_usage_from_openai_body(&body).emit(PROVIDER_LABEL, model);
+
+        let read_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let req_after = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+        assert_eq!(read_after - read_before, 512);
+        assert_eq!(req_after - req_before, 1);
     }
 }

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use serde::Deserialize;
+use tracing::warn;
 
 use solvela_protocol::{ChatRequest, ChatResponse, ModelRegistration};
 
@@ -43,12 +44,28 @@ struct OpenAiPromptTokensDetails {
 /// fail-safe, never an error. Shared by OpenAI and xAI (xAI mirrors OpenAI's
 /// usage shape).
 pub(super) fn cache_usage_from_openai_body(body: &serde_json::Value) -> CacheUsage {
-    let read = body
-        .get("usage")
-        .and_then(|u| serde_json::from_value::<OpenAiExtendedUsage>(u.clone()).ok())
-        .and_then(|u| u.prompt_tokens_details)
-        .map(|d| d.cached_tokens)
-        .unwrap_or(0);
+    // Absent `usage` (or no-cache) ⇒ 0 silently — that is the normal fail-safe.
+    // A `usage` block that is PRESENT but fails to deserialize is a real error
+    // (e.g. the provider sends `cached_tokens` as a string/float/null, or
+    // renames the field shape): log it before falling back to 0 so the counter
+    // reading 0 is not silent (Finding 1). Only an actual deserialize error
+    // warns; the absent/no-cache path stays quiet.
+    let read = match body.get("usage") {
+        None => 0,
+        Some(usage) => match serde_json::from_value::<OpenAiExtendedUsage>(usage.clone()) {
+            Ok(parsed) => parsed
+                .prompt_tokens_details
+                .map(|d| d.cached_tokens)
+                .unwrap_or(0),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "openai: failed to parse usage details for cache metering; cache counts will be 0"
+                );
+                0
+            }
+        },
+    };
     CacheUsage {
         cache_read_tokens: read,
         cache_write_tokens: 0,
@@ -328,6 +345,30 @@ mod tests {
 
         // No usage block at all.
         let body = serde_json::json!({ "id": "x", "choices": [] });
+        assert_eq!(cache_usage_from_openai_body(&body), CacheUsage::default());
+    }
+
+    /// A `usage` block whose `prompt_tokens_details.cached_tokens` has the WRONG
+    /// type (string instead of integer) is a real deserialize error: the parser
+    /// must fall back to `CacheUsage::default()` (0/0) — never panic — while
+    /// still flagging the failure (Finding 1: the old `.ok()` swallowed this
+    /// silently, so the counter read 0 with no signal). Falsifiable: an `unwrap`
+    /// on the parse Result would panic here.
+    #[test]
+    fn cache_usage_from_openai_body_falls_back_on_parse_error() {
+        // `cached_tokens` as a string is not deserializable into u32.
+        let body = serde_json::json!({
+            "usage": {
+                "prompt_tokens": 1000,
+                "prompt_tokens_details": { "cached_tokens": "not-a-number" }
+            }
+        });
+        assert_eq!(cache_usage_from_openai_body(&body), CacheUsage::default());
+
+        // `cached_tokens` as a negative number also fails u32 deserialization.
+        let body = serde_json::json!({
+            "usage": { "prompt_tokens_details": { "cached_tokens": -5 } }
+        });
         assert_eq!(cache_usage_from_openai_body(&body), CacheUsage::default());
     }
 

--- a/crates/gateway/src/providers/xai.rs
+++ b/crates/gateway/src/providers/xai.rs
@@ -2,10 +2,13 @@ use async_trait::async_trait;
 
 use solvela_protocol::{ChatRequest, ChatResponse, ModelRegistration};
 
+use super::openai::cache_usage_from_openai_body;
 use super::{ChatStream, LLMProvider, ProviderError};
 
 const XAI_PREFIX: &str = "xai/";
 const XAI_URL: &str = "https://api.x.ai/v1/chat/completions";
+/// Provider label for cache-token metering counters.
+const PROVIDER_LABEL: &str = "xai";
 
 /// xAI (Grok) provider adapter.
 ///
@@ -53,6 +56,7 @@ impl LLMProvider for XAIProvider {
         &self,
         req: ChatRequest,
     ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+        let original_model = req.model.clone();
         let req_body = build_chat_body(&req)?;
         let response = super::retry_with_backoff(2, || {
             self.client
@@ -64,7 +68,19 @@ impl LLMProvider for XAIProvider {
         })
         .await?;
 
-        let body = response.error_for_status()?.json::<ChatResponse>().await?;
+        // xAI mirrors OpenAI's usage shape, including
+        // `usage.prompt_tokens_details.cached_tokens`. Read the body once as a
+        // Value to drive OBSERVABILITY-ONLY cache metering, then deserialize the
+        // public `ChatResponse` for the agent. Billing is untouched.
+        let value = response
+            .error_for_status()?
+            .json::<serde_json::Value>()
+            .await?;
+        let cache_usage = cache_usage_from_openai_body(&value);
+        let body: ChatResponse = serde_json::from_value(value)?;
+        // Emit metering only after a successful ChatResponse deserialize, so the
+        // request denominator never counts a 200-OK-but-unparseable body.
+        cache_usage.emit(PROVIDER_LABEL, &original_model);
         Ok(body)
     }
 
@@ -189,5 +205,51 @@ mod tests {
     fn supported_models_is_empty_by_design() {
         let provider = XAIProvider::new(reqwest::Client::new(), "xai-test".to_string());
         assert!(provider.supported_models().is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // PR-2 cache-token metering (OBSERVABILITY ONLY).
+    // -----------------------------------------------------------------------
+
+    use crate::cache::test_metrics::{counter_value_filtered, install_test_recorder};
+    use crate::providers::cache_usage::CacheUsage;
+
+    /// xAI shares OpenAI's usage shape, so it reuses
+    /// `cache_usage_from_openai_body` to read `cached_tokens` as the read count.
+    #[test]
+    fn xai_reads_cached_tokens_via_shared_helper() {
+        let body = serde_json::json!({
+            "usage": { "prompt_tokens_details": { "cached_tokens": 333 } }
+        });
+        let cu = cache_usage_from_openai_body(&body);
+        assert_eq!(cu.cache_read_tokens, 333);
+        assert_eq!(cu.cache_write_tokens, 0);
+
+        // Absent → 0/0, no error.
+        let empty = serde_json::json!({ "usage": { "prompt_tokens": 5 } });
+        assert_eq!(cache_usage_from_openai_body(&empty), CacheUsage::default());
+    }
+
+    /// Emitting under the xAI provider label increments the read counter and the
+    /// denominator.
+    #[test]
+    fn xai_emit_increments_read_and_denominator() {
+        let handle = install_test_recorder();
+        let model = "xai/metering-unique-model";
+        let key = format!("model=\"{model}\"");
+        let read_before =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let req_before = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+
+        let body = serde_json::json!({
+            "usage": { "prompt_tokens_details": { "cached_tokens": 256 } }
+        });
+        cache_usage_from_openai_body(&body).emit(PROVIDER_LABEL, model);
+
+        let read_after =
+            counter_value_filtered(&handle, "solvela_provider_cache_read_tokens_total", &key);
+        let req_after = counter_value_filtered(&handle, "solvela_provider_requests_total", &key);
+        assert_eq!(read_after - read_before, 256);
+        assert_eq!(req_after - req_before, 1);
     }
 }


### PR DESCRIPTION
> **Stacked on #614** (`feat/anthropic-prompt-cache-capture`). Base auto-retargets to `main` once #614 merges. Its Anthropic counters consume the `AnthropicUsage` cache fields #614 added.

## What

Makes the provider prompt-cache discount the gateway captures **observable**. PR #614 made Anthropic caching activate (and silently captured the discount as margin); this PR meters cache read/write tokens across **all** providers as Prometheus counters. **Observability-only — no billing, settlement, or public wire-type change.**

## Changes

- **Internal `CacheUsage`** (`pub(crate)`, no serde — never touches the frozen `solvela_protocol::Usage`) with `emit(provider, model)` →
  - `solvela_provider_cache_read_tokens_total{provider,model}`
  - `solvela_provider_cache_write_tokens_total{provider,model}`
  - `solvela_provider_requests_total{provider,model}` — a **denominator**, so a future provider-side cache-field rename surfaces as a flatline against climbing requests instead of silent under-counting.
- **Per-adapter parse** of each provider's native cache field: Anthropic `cache_read/creation_input_tokens` (non-streaming + streaming `message_start`), OpenAI/xAI `usage.prompt_tokens_details.cached_tokens`, DeepSeek `prompt_cache_hit_tokens`, Gemini `cachedContentTokenCount`.
- Counters emitted **only after a successful response parse**; the `model` label is the **router-resolved** id (bounded cardinality, not raw user input).

## Coverage (no silent caps)

| Provider | Non-streaming | Streaming |
|---|---|---|
| Anthropic | ✅ read + write | ✅ read + write (`message_start.usage`) |
| OpenAI / xAI / DeepSeek | ✅ read | ❌ no usage on stream (gateway sets no `stream_options.include_usage`) |
| Gemini | ✅ read | n/a (no streaming impl) |

OpenAI-family streaming carries no usage, so it's intentionally not metered — documented in code, not silently dropped.

## Why it's billing-safe

`CacheUsage` has no serde derives and is referenced by zero billing-path files. The diff touches only `crates/gateway/src/providers/*` (+ a test helper). `prompt_tokens` and the public wire types are unchanged — proven by `..._emits_counters_without_touching_billing` tests for Anthropic and Gemini.

## Tests & review

17 new tests (per-adapter present/absent-field, counter emission via the metrics test recorder, Anthropic streaming capture, billing-untouched assertions). Gate green (`fmt`, `clippy -D warnings`, `cargo test -p gateway`: 843 lib + 6 + 269 integration; only pre-existing Postgres-less `escrow_queue` tests fail).

Two-round money-path review (rust-reviewer + silent-failure-hunter + independent pass). Both Mediums fixed in this branch: **emit-only-after-successful-parse** (no denominator overcount on a 200-OK-but-malformed body) and **`pub(crate)` visibility** for the internal type. Cardinality confirmed bounded (model resolved/rejected at the router before any provider call); the `Value`→`from_value` read confirmed equivalent to the prior `.json::<ChatResponse>()` with `error_for_status()` still gating.

## Folds in PR #614's follow-ups

Streaming `message_start.usage` capture and field-rename visibility.
