### PR TITLE
feat(gateway): inbound Anthropic-Messages endpoint POST /v1/messages

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -314,6 +314,17 @@ pub fn build_router(state: Arc<AppState>, rate_limiter: RateLimiter) -> Router {
             "/v1/chat/completions",
             get(routes::chat::chat_completions_discovery_get).post(routes::chat::chat_completions),
         )
+        // Inbound Anthropic-Messages-compatible endpoint. POST translates the
+        // Anthropic wire format to the internal OpenAI-shaped pipeline and back,
+        // riding the SAME x402 money path as /v1/chat/completions (via the
+        // shared `chat_completions_inner` core — no forked payment logic). GET
+        // serves the x402 discovery 402 for registry health-checkers, mirroring
+        // the chat route.
+        .route(
+            "/v1/messages",
+            get(routes::messages::create_message_discovery_get)
+                .post(routes::messages::create_message),
+        )
         .route(
             "/v1/images/generations",
             post(routes::images::image_generations),

--- a/crates/gateway/src/providers/anthropic_inbound.rs
+++ b/crates/gateway/src/providers/anthropic_inbound.rs
@@ -1,0 +1,717 @@
+//! Inbound Anthropic Messages API translation (`POST /v1/messages`).
+//!
+//! This is the MIRROR of [`crate::providers::anthropic`], which is
+//! OUTBOUND-only (gateway → Anthropic). Here Solvela acts as the SERVER of the
+//! Anthropic Messages wire format: a client (e.g. Claude Code) sends an
+//! Anthropic-shaped request, the gateway translates it into the internal
+//! OpenAI-shaped [`ChatRequest`], runs the EXISTING chat pipeline (model
+//! resolution → x402 payment → provider → record), then translates the
+//! resulting [`ChatResponse`] back into the Anthropic Messages response shape.
+//!
+//! The field-mapping decisions are settled in `anthropic.rs` and reused here so
+//! the inbound and outbound directions never drift:
+//! - `system` is a top-level param, NOT a message role (Anthropic carries only
+//!   `user`/`assistant` turns). Inbound, the `system` field becomes a
+//!   [`Role::System`] message at the head of `messages`.
+//! - `content` is either a bare string OR an array of typed content blocks;
+//!   text-only is a one-element `[{"type":"text"}]`. Claude Code sends BOTH the
+//!   bare-string `system` and the array-of-blocks `system`, so both are
+//!   accepted.
+//! - `stop_reason` maps `end_turn`/`stop_sequence` → OpenAI `stop`, `max_tokens`
+//!   → `length` (the outbound `from_anthropic_response` map). The INVERSE map is
+//!   applied here when emitting the Anthropic response: `stop` → `end_turn`,
+//!   `length` → `max_tokens`.
+//! - `usage` is reconstructed via [`solvela_protocol::Usage`]'s saturating
+//!   semantics; the Anthropic response exposes `input_tokens`/`output_tokens`
+//!   (which Claude Code reads).
+//!
+//! SCOPE (PR1): text-only, non-streaming. Streaming (SSE), tools/`tool_use`/
+//! `tool_result`, `count_tokens`, and images are OUT OF SCOPE. Image content is
+//! deferred: the inbound content parser rejects image blocks with a clear error
+//! rather than silently dropping them (a dropped image would change the prompt's
+//! meaning while still billing the agent — the same fail-loud posture the
+//! outbound adapter takes for system/tool-role images).
+
+use serde::{Deserialize, Serialize};
+
+use solvela_protocol::{ChatMessage, ChatRequest, ChatResponse, MessageContent, Role};
+
+/// Errors from translating an inbound Anthropic Messages request.
+///
+/// Mapped by the route handler to an Anthropic error envelope
+/// (`{"type":"error","error":{"type":"invalid_request_error","message":…}}`)
+/// with a 400 status. The message is a static/safe description of the
+/// client-side problem — it never carries internal detail.
+#[derive(Debug, thiserror::Error)]
+pub enum AnthropicInboundError {
+    /// The request body did not deserialize as an Anthropic Messages request.
+    #[error("invalid Anthropic Messages request: {0}")]
+    InvalidBody(String),
+
+    /// An image content block was present. Images are deferred to a later PR;
+    /// reject loudly rather than silently dropping (which would bill the agent
+    /// for a prompt the model never fully sees).
+    #[error(
+        "image content is not yet supported on POST /v1/messages; send text-only content \
+         (image support is planned for a later release)"
+    )]
+    ImageUnsupported,
+}
+
+// ---------------------------------------------------------------------------
+// Inbound request wire types (Anthropic Messages → ChatRequest)
+// ---------------------------------------------------------------------------
+
+/// The inbound Anthropic Messages request. Deserialize-only (the gateway is the
+/// server here). Unknown fields are ignored (forward-compat with newer Claude
+/// Code clients sending fields we do not yet model, e.g. `metadata`).
+#[derive(Debug, Deserialize)]
+pub struct AnthropicMessagesRequest {
+    pub model: String,
+    /// Anthropic requires `max_tokens`. We keep it optional on the wire so a
+    /// missing value degrades to the pipeline's own default rather than a hard
+    /// parse failure, matching the lenient posture of the OpenAI path.
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    /// `system` is either a bare string OR an array of text blocks (Claude Code
+    /// sends the array form). Both deserialize via [`AnthropicSystem`].
+    #[serde(default)]
+    pub system: Option<AnthropicSystem>,
+    pub messages: Vec<AnthropicInboundMessage>,
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    #[serde(default)]
+    pub top_p: Option<f32>,
+    #[serde(default)]
+    pub stop_sequences: Option<Vec<String>>,
+    /// Streaming is OUT OF SCOPE for PR1. Captured so a `stream:true` request
+    /// can be rejected with a clear error rather than silently served
+    /// non-streaming (which would break a client expecting SSE).
+    #[serde(default)]
+    pub stream: bool,
+}
+
+/// The `system` field: a bare string OR an array of text blocks.
+///
+/// `#[serde(untagged)]` tries the string variant first; a JSON array falls
+/// through to `Blocks`. This matches the two shapes Claude Code emits.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicSystem {
+    Text(String),
+    Blocks(Vec<AnthropicSystemTextBlock>),
+}
+
+impl AnthropicSystem {
+    /// Flatten the system field to a single string. Array-of-blocks joins the
+    /// text of each text block with `\n\n` (the same separator the outbound
+    /// adapter uses to join multiple system messages).
+    fn flatten(&self) -> String {
+        match self {
+            AnthropicSystem::Text(s) => s.clone(),
+            AnthropicSystem::Blocks(blocks) => blocks
+                .iter()
+                .map(|b| b.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        }
+    }
+
+    /// True when the flattened system text is empty (after trimming). An empty
+    /// system prompt is dropped rather than prepended as an empty System
+    /// message.
+    fn is_empty(&self) -> bool {
+        self.flatten().trim().is_empty()
+    }
+}
+
+/// A single `system` text block (`{"type":"text","text":"…"}`). Only the text
+/// is retained; `cache_control` and other annotations are ignored on the
+/// inbound side (the gateway re-derives its own caching on the outbound call).
+#[derive(Debug, Deserialize)]
+pub struct AnthropicSystemTextBlock {
+    pub text: String,
+}
+
+/// An inbound Anthropic message. Anthropic carries only `user`/`assistant`
+/// roles; an unknown role string is preserved as a raw string and mapped to
+/// [`Role::User`] (the safe default the outbound adapter also uses).
+#[derive(Debug, Deserialize)]
+pub struct AnthropicInboundMessage {
+    pub role: String,
+    pub content: AnthropicInboundContent,
+}
+
+/// Inbound message content: a bare string OR an array of content blocks.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicInboundContent {
+    Text(String),
+    Blocks(Vec<AnthropicInboundContentBlock>),
+}
+
+/// An inbound content block. PR1 models only `text`; an `image` block is
+/// captured by the `Image` variant so it can be rejected with a clear error
+/// (rather than silently dropped). Any other block type (e.g. `tool_use`,
+/// `tool_result`) is OUT OF SCOPE and lands in `Other`, which is also rejected.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AnthropicInboundContentBlock {
+    Text {
+        text: String,
+    },
+    Image,
+    #[serde(other)]
+    Other,
+}
+
+// ---------------------------------------------------------------------------
+// Outbound response wire types (ChatResponse → Anthropic Messages response)
+// ---------------------------------------------------------------------------
+
+/// The Anthropic Messages response the gateway emits. Serialize-only.
+///
+/// Wire shape (verified against the Anthropic Messages API docs
+/// platform.claude.com/docs/en/api/messages, 2026-06-19):
+/// ```json
+/// {
+///   "id": "msg_…",
+///   "type": "message",
+///   "role": "assistant",
+///   "model": "claude-…",
+///   "content": [{"type":"text","text":"…"}],
+///   "stop_reason": "end_turn",
+///   "stop_sequence": null,
+///   "usage": {"input_tokens": 10, "output_tokens": 8}
+/// }
+/// ```
+#[derive(Debug, Serialize)]
+pub struct AnthropicMessagesResponse {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub message_type: AnthropicMessageType,
+    pub role: AnthropicAssistantRole,
+    pub model: String,
+    pub content: Vec<AnthropicResponseTextBlock>,
+    /// `stop_reason` is `null` until the model finishes; once finished it is
+    /// `end_turn` / `max_tokens` / `stop_sequence`. We emit `null` only when the
+    /// internal `finish_reason` is absent.
+    pub stop_reason: Option<String>,
+    /// The matched stop sequence, or `null`. PR1 does not surface which stop
+    /// sequence matched (the internal pipeline does not expose it), so this is
+    /// always `null` — a field Claude Code tolerates being null.
+    pub stop_sequence: Option<String>,
+    pub usage: AnthropicResponseUsage,
+}
+
+/// Pins the literal `"message"` discriminant so it can never drift.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnthropicMessageType {
+    Message,
+}
+
+/// Pins the literal `"assistant"` role on the response.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnthropicAssistantRole {
+    Assistant,
+}
+
+/// A response text block (`{"type":"text","text":"…"}`).
+#[derive(Debug, Serialize)]
+pub struct AnthropicResponseTextBlock {
+    #[serde(rename = "type")]
+    pub block_type: AnthropicResponseTextBlockType,
+    pub text: String,
+}
+
+/// Pins the literal `"text"` discriminant for a response content block.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnthropicResponseTextBlockType {
+    Text,
+}
+
+/// Anthropic response usage. Claude Code reads `input_tokens`/`output_tokens`.
+#[derive(Debug, Serialize)]
+pub struct AnthropicResponseUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Translation
+// ---------------------------------------------------------------------------
+
+/// Translate one inbound Anthropic content value into an internal
+/// [`MessageContent`].
+///
+/// Text-only content (bare string, or array of text blocks) becomes
+/// [`MessageContent::Text`] — the same flattened representation the internal
+/// pipeline expects for text. An image (or any non-text) block returns
+/// [`AnthropicInboundError::ImageUnsupported`] so the request is rejected rather
+/// than billed with a silently-dropped image (PR1 is text-only).
+fn inbound_content_to_message_content(
+    content: &AnthropicInboundContent,
+) -> Result<MessageContent, AnthropicInboundError> {
+    match content {
+        AnthropicInboundContent::Text(s) => Ok(MessageContent::Text(s.clone())),
+        AnthropicInboundContent::Blocks(blocks) => {
+            let mut texts: Vec<&str> = Vec::with_capacity(blocks.len());
+            for block in blocks {
+                match block {
+                    AnthropicInboundContentBlock::Text { text } => texts.push(text.as_str()),
+                    AnthropicInboundContentBlock::Image | AnthropicInboundContentBlock::Other => {
+                        return Err(AnthropicInboundError::ImageUnsupported);
+                    }
+                }
+            }
+            // Join multiple text blocks with a single space, matching
+            // `MessageContent::as_text`'s separator so a multi-block message
+            // reads naturally to the prompt guard and string-based adapters.
+            Ok(MessageContent::Text(texts.join(" ")))
+        }
+    }
+}
+
+/// Map an inbound Anthropic role string to an internal [`Role`].
+///
+/// Anthropic carries only `user`/`assistant`; an unknown role maps to
+/// [`Role::User`] (the safe default the outbound adapter uses for the inverse).
+fn inbound_role(role: &str) -> Role {
+    match role {
+        "assistant" => Role::Assistant,
+        // "user" and anything unexpected both map to User.
+        _ => Role::User,
+    }
+}
+
+/// Deserialize and translate an inbound Anthropic Messages request into the
+/// internal [`ChatRequest`].
+///
+/// - `system` (bare string OR array-of-blocks) is prepended as a single
+///   [`Role::System`] message when non-empty.
+/// - Each `messages[]` entry's text content (string OR `[{type:"text"}]`)
+///   becomes a [`MessageContent::Text`]; an image/other block is rejected.
+/// - `model`, `max_tokens`, `temperature`, `top_p` carry across.
+/// - `stop_sequences` is carried via the request — the internal pipeline does
+///   not yet forward stop sequences to providers, so this is accepted and
+///   ignored for now (documented; a later PR can thread it through). It is NOT
+///   silently lost in a money-relevant way: it does not affect cost.
+///
+/// Streaming requests are rejected here (PR1 is non-streaming) rather than
+/// silently served as a single JSON body.
+pub fn anthropic_request_to_chat(
+    req: AnthropicMessagesRequest,
+) -> Result<ChatRequest, AnthropicInboundError> {
+    if req.stream {
+        return Err(AnthropicInboundError::InvalidBody(
+            "streaming responses are not yet supported on POST /v1/messages; \
+             set \"stream\": false (SSE support is planned for a later release)"
+                .to_string(),
+        ));
+    }
+
+    let mut messages: Vec<ChatMessage> = Vec::with_capacity(req.messages.len() + 1);
+
+    // Prepend the system prompt as a System message when present and non-empty.
+    if let Some(ref system) = req.system {
+        if !system.is_empty() {
+            messages.push(ChatMessage {
+                role: Role::System,
+                content: MessageContent::Text(system.flatten()),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            });
+        }
+    }
+
+    for m in &req.messages {
+        let content = inbound_content_to_message_content(&m.content)?;
+        messages.push(ChatMessage {
+            role: inbound_role(&m.role),
+            content,
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        });
+    }
+
+    Ok(ChatRequest {
+        model: req.model,
+        messages,
+        max_tokens: req.max_tokens,
+        temperature: req.temperature,
+        top_p: req.top_p,
+        stream: false,
+        tools: None,
+        tool_choice: None,
+    })
+}
+
+/// Map an internal OpenAI-style `finish_reason` to an Anthropic `stop_reason`.
+///
+/// This is the INVERSE of the outbound `from_anthropic_response` map in
+/// `anthropic.rs` (`end_turn`/`stop_sequence` → `stop`, `max_tokens` →
+/// `length`). Here: `stop` → `end_turn`, `length` → `max_tokens`. Any other
+/// value passes through unchanged (forward-compat) so a future internal reason
+/// is never lost. `None` (model still going / provider omitted it) stays
+/// `None` — Claude Code tolerates a null `stop_reason`.
+fn finish_reason_to_stop_reason(finish_reason: Option<&str>) -> Option<String> {
+    finish_reason.map(|r| match r {
+        "stop" => "end_turn".to_string(),
+        "length" => "max_tokens".to_string(),
+        other => other.to_string(),
+    })
+}
+
+/// Translate an internal [`ChatResponse`] into the Anthropic Messages response.
+///
+/// - Concatenates the text of every assistant choice's message into a single
+///   `text` content block (PR1 emits one block; the internal response carries a
+///   single choice).
+/// - `stop_reason` is the inverse-mapped `finish_reason` of the first choice.
+/// - `usage.{input_tokens,output_tokens}` come from the internal `Usage`
+///   (0/0 when the provider omitted usage — the same fallback the OpenAI path
+///   tolerates; Claude Code reads these but does not require them to be
+///   non-zero).
+pub fn chat_response_to_anthropic(resp: &ChatResponse) -> AnthropicMessagesResponse {
+    // Concatenate text content across choices (there is normally exactly one).
+    let text: String = resp
+        .choices
+        .iter()
+        .map(|c| c.message.content.as_text())
+        .collect::<Vec<_>>()
+        .join("");
+
+    let stop_reason = finish_reason_to_stop_reason(
+        resp.choices
+            .first()
+            .and_then(|c| c.finish_reason.as_deref()),
+    );
+
+    let (input_tokens, output_tokens) = match &resp.usage {
+        Some(u) => (u.prompt_tokens, u.completion_tokens),
+        None => (0, 0),
+    };
+
+    AnthropicMessagesResponse {
+        id: resp.id.clone(),
+        message_type: AnthropicMessageType::Message,
+        role: AnthropicAssistantRole::Assistant,
+        model: resp.model.clone(),
+        content: vec![AnthropicResponseTextBlock {
+            block_type: AnthropicResponseTextBlockType::Text,
+            text,
+        }],
+        stop_reason,
+        stop_sequence: None,
+        usage: AnthropicResponseUsage {
+            input_tokens,
+            output_tokens,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use solvela_protocol::{ChatChoice, Usage};
+
+    // -----------------------------------------------------------------------
+    // Inbound request translation (golden wire vectors)
+    // -----------------------------------------------------------------------
+
+    /// A real Claude-Code-shaped request: `system` as an ARRAY of text blocks,
+    /// a multi-turn user/assistant/user conversation with string content. The
+    /// asserted internal `ChatRequest` is the golden vector.
+    #[test]
+    fn claude_code_shaped_request_maps_to_expected_chat_request() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 1024,
+            "temperature": 0.7,
+            "system": [
+                {"type": "text", "text": "You are a coding assistant."},
+                {"type": "text", "text": "Always be concise."}
+            ],
+            "messages": [
+                {"role": "user", "content": "Write a haiku."},
+                {"role": "assistant", "content": [{"type": "text", "text": "Sure."}]},
+                {"role": "user", "content": [{"type": "text", "text": "About the sea."}]}
+            ]
+        }"#;
+
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+
+        assert_eq!(chat.model, "claude-sonnet-4-6");
+        assert_eq!(chat.max_tokens, Some(1024));
+        assert_eq!(chat.temperature, Some(0.7));
+        assert!(!chat.stream);
+
+        // System (array-of-blocks) → a single leading System message, joined
+        // with the "\n\n" separator the outbound adapter also uses.
+        assert_eq!(chat.messages.len(), 4);
+        assert_eq!(chat.messages[0].role, Role::System);
+        assert_eq!(
+            chat.messages[0].content.as_text(),
+            "You are a coding assistant.\n\nAlways be concise."
+        );
+
+        assert_eq!(chat.messages[1].role, Role::User);
+        assert_eq!(chat.messages[1].content.as_text(), "Write a haiku.");
+
+        assert_eq!(chat.messages[2].role, Role::Assistant);
+        assert_eq!(chat.messages[2].content.as_text(), "Sure.");
+
+        assert_eq!(chat.messages[3].role, Role::User);
+        assert_eq!(chat.messages[3].content.as_text(), "About the sea.");
+    }
+
+    /// `system` as a BARE STRING is accepted (the older / simpler shape).
+    #[test]
+    fn system_as_bare_string_maps_to_system_message() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "system": "You are helpful.",
+            "messages": [{"role": "user", "content": "hi"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+        assert_eq!(chat.messages.len(), 2);
+        assert_eq!(chat.messages[0].role, Role::System);
+        assert_eq!(chat.messages[0].content.as_text(), "You are helpful.");
+        assert_eq!(chat.messages[1].role, Role::User);
+    }
+
+    /// No `system` field → no System message is prepended.
+    #[test]
+    fn no_system_field_omits_system_message() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.messages[0].role, Role::User);
+    }
+
+    /// An empty/whitespace `system` is dropped, not prepended as an empty
+    /// System message.
+    #[test]
+    fn empty_system_is_dropped() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "system": "   ",
+            "messages": [{"role": "user", "content": "hi"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.messages[0].role, Role::User);
+    }
+
+    /// Multiple text blocks in a single user message are joined with a space.
+    #[test]
+    fn multiple_text_blocks_join_with_space() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "second"}
+            ]}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+        assert_eq!(chat.messages[0].content.as_text(), "first second");
+    }
+
+    /// An image content block is rejected (PR1 is text-only) rather than
+    /// silently dropped.
+    #[test]
+    fn image_block_is_rejected_not_dropped() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBOR"}}
+            ]}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let err = anthropic_request_to_chat(parsed).unwrap_err();
+        assert!(matches!(err, AnthropicInboundError::ImageUnsupported));
+    }
+
+    /// A `tool_use`/`tool_result` (any non-text) block is rejected (OUT OF
+    /// SCOPE for PR1) rather than silently dropped.
+    #[test]
+    fn tool_block_is_rejected() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [{"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "f", "input": {}}
+            ]}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        assert!(anthropic_request_to_chat(parsed).is_err());
+    }
+
+    /// A `stream: true` request is rejected (PR1 is non-streaming) rather than
+    /// silently served as a single JSON body.
+    #[test]
+    fn streaming_request_is_rejected() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "stream": true,
+            "messages": [{"role": "user", "content": "hi"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let err = anthropic_request_to_chat(parsed).unwrap_err();
+        assert!(matches!(err, AnthropicInboundError::InvalidBody(_)));
+    }
+
+    /// Unknown top-level fields (e.g. `metadata`, `anthropic_beta`) are ignored
+    /// — forward-compat with newer Claude Code clients.
+    #[test]
+    fn unknown_top_level_fields_are_ignored() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "metadata": {"user_id": "abc"},
+            "messages": [{"role": "user", "content": "hi"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+        assert_eq!(chat.model, "claude-sonnet-4-6");
+        assert_eq!(chat.messages.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Outbound response translation (byte-asserted golden wire vectors)
+    // -----------------------------------------------------------------------
+
+    fn chat_response(
+        id: &str,
+        model: &str,
+        text: &str,
+        finish_reason: Option<&str>,
+        usage: Option<Usage>,
+    ) -> ChatResponse {
+        ChatResponse {
+            id: id.to_string(),
+            object: "chat.completion".to_string(),
+            created: 1_700_000_000,
+            model: model.to_string(),
+            choices: vec![ChatChoice {
+                index: 0,
+                message: ChatMessage {
+                    role: Role::Assistant,
+                    content: text.into(),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: finish_reason.map(String::from),
+            }],
+            usage,
+        }
+    }
+
+    /// Byte-exact wire shape of the Anthropic response, including the
+    /// `stop` → `end_turn` stop_reason mapping and `usage` fields Claude Code
+    /// reads.
+    #[test]
+    fn chat_response_serializes_to_expected_anthropic_shape() {
+        let resp = chat_response(
+            "msg_abc",
+            "claude-sonnet-4-6",
+            "Hello there.",
+            Some("stop"),
+            Some(Usage::new(10, 8)),
+        );
+        let anthropic = chat_response_to_anthropic(&resp);
+        let v = serde_json::to_value(&anthropic).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "id": "msg_abc",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": "Hello there."}],
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "usage": {"input_tokens": 10, "output_tokens": 8}
+            })
+        );
+    }
+
+    /// `finish_reason: "length"` maps to `stop_reason: "max_tokens"` (the
+    /// inverse of the outbound `max_tokens` → `length` map).
+    #[test]
+    fn length_finish_reason_maps_to_max_tokens_stop_reason() {
+        let resp = chat_response(
+            "msg_len",
+            "claude-sonnet-4-6",
+            "truncated",
+            Some("length"),
+            Some(Usage::new(5, 100)),
+        );
+        let anthropic = chat_response_to_anthropic(&resp);
+        assert_eq!(anthropic.stop_reason, Some("max_tokens".to_string()));
+    }
+
+    /// An absent `finish_reason` (provider omitted) emits `stop_reason: null`,
+    /// which Claude Code tolerates.
+    #[test]
+    fn absent_finish_reason_emits_null_stop_reason() {
+        let resp = chat_response(
+            "msg_none",
+            "claude-sonnet-4-6",
+            "partial",
+            None,
+            Some(Usage::new(1, 1)),
+        );
+        let anthropic = chat_response_to_anthropic(&resp);
+        assert_eq!(anthropic.stop_reason, None);
+        let v = serde_json::to_value(&anthropic).unwrap();
+        assert!(v["stop_reason"].is_null());
+    }
+
+    /// An unknown internal finish_reason passes through unchanged
+    /// (forward-compat) rather than being lost.
+    #[test]
+    fn unknown_finish_reason_passes_through() {
+        let resp = chat_response(
+            "msg_x",
+            "claude-sonnet-4-6",
+            "x",
+            Some("content_filter"),
+            Some(Usage::new(1, 1)),
+        );
+        let anthropic = chat_response_to_anthropic(&resp);
+        assert_eq!(anthropic.stop_reason, Some("content_filter".to_string()));
+    }
+
+    /// A response with NO usage emits `input_tokens: 0, output_tokens: 0`
+    /// rather than failing — Claude Code reads the fields but tolerates zeros.
+    #[test]
+    fn missing_usage_emits_zero_token_counts() {
+        let resp = chat_response("msg_nousage", "claude-sonnet-4-6", "x", Some("stop"), None);
+        let anthropic = chat_response_to_anthropic(&resp);
+        assert_eq!(anthropic.usage.input_tokens, 0);
+        assert_eq!(anthropic.usage.output_tokens, 0);
+    }
+}

--- a/crates/gateway/src/providers/anthropic_inbound.rs
+++ b/crates/gateway/src/providers/anthropic_inbound.rs
@@ -25,12 +25,16 @@
 //!   semantics; the Anthropic response exposes `input_tokens`/`output_tokens`
 //!   (which Claude Code reads).
 //!
-//! SCOPE (PR1): text-only, non-streaming. Streaming (SSE), tools/`tool_use`/
-//! `tool_result`, `count_tokens`, and images are OUT OF SCOPE. Image content is
-//! deferred: the inbound content parser rejects image blocks with a clear error
-//! rather than silently dropping them (a dropped image would change the prompt's
-//! meaning while still billing the agent — the same fail-loud posture the
-//! outbound adapter takes for system/tool-role images).
+//! SCOPE (PR1): text-only, non-streaming. Streaming (SSE), tools (top-level
+//! `tools`/`tool_choice` definitions AND `tool_use`/`tool_result` content
+//! blocks), `count_tokens`, and images are OUT OF SCOPE. Every one of these is
+//! rejected LOUDLY rather than silently dropped: a dropped image or a discarded
+//! tool definition would change the prompt's meaning (or strip tool-calling)
+//! while still billing the agent — the same fail-loud posture the outbound
+//! adapter takes for system/tool-role images. Tool definitions in particular
+//! must be modeled on the wire (`AnthropicMessagesRequest::tools`), not left to
+//! serde's ignore-unknown-fields default, because Claude Code attaches them to
+//! nearly every request.
 
 use serde::{Deserialize, Serialize};
 
@@ -56,6 +60,18 @@ pub enum AnthropicInboundError {
          (image support is planned for a later release)"
     )]
     ImageUnsupported,
+
+    /// A tool definition (top-level `tools`/`tool_choice`) OR a tool content
+    /// block (`tool_use`/`tool_result`) was present. Tools are OUT OF SCOPE for
+    /// PR1; reject loudly rather than silently dropping the tool definitions and
+    /// billing the agent for a tool-blind text answer (Claude Code attaches its
+    /// tool definitions to nearly every request, so a silent drop is the common
+    /// case, not the edge case).
+    #[error(
+        "tool use is not yet supported on POST /v1/messages; remove `tools`/`tool_choice` \
+         and tool content blocks (tool support is planned for a later release)"
+    )]
+    ToolUseUnsupported,
 }
 
 // ---------------------------------------------------------------------------
@@ -89,6 +105,21 @@ pub struct AnthropicMessagesRequest {
     /// non-streaming (which would break a client expecting SSE).
     #[serde(default)]
     pub stream: bool,
+    /// Top-level tool DEFINITIONS. Tools are OUT OF SCOPE for PR1, but the field
+    /// MUST be modeled: Claude Code attaches `tools` to nearly every request, and
+    /// without a field here serde would silently discard them (unknown fields are
+    /// ignored) → the provider gets a tool-blind call and the agent PAYS for a
+    /// degraded text answer. Captured so a request carrying tools is rejected
+    /// loudly BEFORE the money path, mirroring the `stream:true` rejection. A
+    /// JSON `null` (absent) is the only accepted value.
+    #[serde(default)]
+    pub tools: Option<serde_json::Value>,
+    /// Tool-choice directive. OUT OF SCOPE for PR1 and rejected for the same
+    /// reason as `tools` (a `tool_choice` without `tools` is degenerate, but a
+    /// present value still signals the client expects tool-calling behavior we do
+    /// not yet support — reject rather than silently ignore).
+    #[serde(default)]
+    pub tool_choice: Option<serde_json::Value>,
 }
 
 /// The `system` field: a bare string OR an array of text blocks.
@@ -249,9 +280,12 @@ pub struct AnthropicResponseUsage {
 ///
 /// Text-only content (bare string, or array of text blocks) becomes
 /// [`MessageContent::Text`] — the same flattened representation the internal
-/// pipeline expects for text. An image (or any non-text) block returns
-/// [`AnthropicInboundError::ImageUnsupported`] so the request is rejected rather
-/// than billed with a silently-dropped image (PR1 is text-only).
+/// pipeline expects for text. An image block returns
+/// [`AnthropicInboundError::ImageUnsupported`]; any other non-text block
+/// (`tool_use`/`tool_result`) returns
+/// [`AnthropicInboundError::ToolUseUnsupported`] so the request is rejected with
+/// an accurate diagnostic rather than billed with a silently-dropped block (PR1
+/// is text-only).
 fn inbound_content_to_message_content(
     content: &AnthropicInboundContent,
 ) -> Result<MessageContent, AnthropicInboundError> {
@@ -262,8 +296,15 @@ fn inbound_content_to_message_content(
             for block in blocks {
                 match block {
                     AnthropicInboundContentBlock::Text { text } => texts.push(text.as_str()),
-                    AnthropicInboundContentBlock::Image | AnthropicInboundContentBlock::Other => {
+                    AnthropicInboundContentBlock::Image => {
                         return Err(AnthropicInboundError::ImageUnsupported);
+                    }
+                    // `tool_use`/`tool_result` (and any future non-text block)
+                    // land here. Return the tool-specific error so the client
+                    // gets an accurate diagnostic, not a misleading "image"
+                    // message that sends it down the wrong path.
+                    AnthropicInboundContentBlock::Other => {
+                        return Err(AnthropicInboundError::ToolUseUnsupported);
                     }
                 }
             }
@@ -300,8 +341,9 @@ fn inbound_role(role: &str) -> Role {
 ///   ignored for now (documented; a later PR can thread it through). It is NOT
 ///   silently lost in a money-relevant way: it does not affect cost.
 ///
-/// Streaming requests are rejected here (PR1 is non-streaming) rather than
-/// silently served as a single JSON body.
+/// Streaming requests, and requests carrying top-level tool definitions
+/// (`tools`/`tool_choice`) or tool content blocks, are rejected here (PR1 is
+/// text-only, non-streaming, no tools) rather than silently served / degraded.
 pub fn anthropic_request_to_chat(
     req: AnthropicMessagesRequest,
 ) -> Result<ChatRequest, AnthropicInboundError> {
@@ -311,6 +353,15 @@ pub fn anthropic_request_to_chat(
              set \"stream\": false (SSE support is planned for a later release)"
                 .to_string(),
         ));
+    }
+
+    // Reject top-level tool definitions LOUDLY, BEFORE the money path. Without
+    // this, a request carrying `tools`/`tool_choice` would translate to a
+    // tool-blind `ChatRequest` (we hard-code `tools: None` below) and the agent
+    // would PAY for a degraded text answer — the silent-degradation failure mode
+    // this endpoint explicitly forbids. Mirror the `stream:true` rejection.
+    if req.tools.is_some() || req.tool_choice.is_some() {
+        return Err(AnthropicInboundError::ToolUseUnsupported);
     }
 
     let mut messages: Vec<ChatMessage> = Vec::with_capacity(req.messages.len() + 1);
@@ -553,7 +604,8 @@ mod tests {
     }
 
     /// A `tool_use`/`tool_result` (any non-text) block is rejected (OUT OF
-    /// SCOPE for PR1) rather than silently dropped.
+    /// SCOPE for PR1) rather than silently dropped — and with the TOOL-specific
+    /// error, not the misleading image error.
     #[test]
     fn tool_block_is_rejected() {
         let body = r#"{
@@ -564,7 +616,100 @@ mod tests {
             ]}]
         }"#;
         let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
-        assert!(anthropic_request_to_chat(parsed).is_err());
+        let err = anthropic_request_to_chat(parsed).unwrap_err();
+        assert!(
+            matches!(err, AnthropicInboundError::ToolUseUnsupported),
+            "a tool content block must yield ToolUseUnsupported, not the image error; got {err:?}"
+        );
+        // The diagnostic must talk about tools, not images.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("tool use is not yet supported"),
+            "tool-block error message must reference tools, got: {msg}"
+        );
+        assert!(
+            !msg.contains("image"),
+            "tool-block error message must not mislead about images, got: {msg}"
+        );
+    }
+
+    /// A `tool_result` content block (the other tool block shape) is likewise
+    /// rejected with the tool-specific error.
+    #[test]
+    fn tool_result_block_is_rejected() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "ok"}
+            ]}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let err = anthropic_request_to_chat(parsed).unwrap_err();
+        assert!(matches!(err, AnthropicInboundError::ToolUseUnsupported));
+    }
+
+    /// A request carrying TOP-LEVEL `tools` definitions is rejected loudly
+    /// (PR1 has no tool support) rather than silently dropping the tools and
+    /// billing the agent for a tool-blind text answer. Claude Code attaches
+    /// these to nearly every request, so this is the common case.
+    #[test]
+    fn tools_definition_is_rejected() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "tools": [
+                {"name": "get_weather", "description": "Get weather",
+                 "input_schema": {"type": "object", "properties": {}}}
+            ],
+            "messages": [{"role": "user", "content": "What is the weather?"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        // The tools array MUST deserialize into the field, not be discarded.
+        assert!(
+            parsed.tools.is_some(),
+            "top-level `tools` must deserialize into the modeled field, not be ignored"
+        );
+        let err = anthropic_request_to_chat(parsed).unwrap_err();
+        assert!(
+            matches!(err, AnthropicInboundError::ToolUseUnsupported),
+            "a top-level `tools` array must be rejected with ToolUseUnsupported; got {err:?}"
+        );
+    }
+
+    /// A top-level `tool_choice` (without `tools`) is also rejected — a present
+    /// value still signals the client expects tool-calling behavior PR1 does not
+    /// support.
+    #[test]
+    fn tool_choice_is_rejected() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "tool_choice": {"type": "auto"},
+            "messages": [{"role": "user", "content": "hi"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        assert!(parsed.tool_choice.is_some());
+        let err = anthropic_request_to_chat(parsed).unwrap_err();
+        assert!(matches!(err, AnthropicInboundError::ToolUseUnsupported));
+    }
+
+    /// A request with NO `tools`/`tool_choice` is unaffected — the fields
+    /// default to `None` and the request translates normally.
+    #[test]
+    fn no_tools_field_translates_normally() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        assert!(parsed.tools.is_none());
+        assert!(parsed.tool_choice.is_none());
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+        assert_eq!(chat.messages.len(), 1);
+        assert!(chat.tools.is_none());
+        assert!(chat.tool_choice.is_none());
     }
 
     /// A `stream: true` request is rejected (PR1 is non-streaming) rather than

--- a/crates/gateway/src/providers/mod.rs
+++ b/crates/gateway/src/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod anthropic_inbound;
 pub(crate) mod cache_usage;
 pub mod deepseek;
 pub mod fallback;

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -93,9 +93,6 @@ pub async fn chat_completions(
     // still bounds it.
     body: axum::body::Bytes,
 ) -> Result<Response, GatewayError> {
-    let request_start = Instant::now();
-    let debug_enabled = is_debug_enabled(&headers);
-
     // Is a payment credential present? This single check decides how a
     // bad/empty body is handled (CLAUDE.md rule #8: the route, not middleware,
     // emits the 402). A `PAYMENT-SIGNATURE` header means a PAYING client, which
@@ -119,7 +116,7 @@ pub async fn chat_completions(
     // The discovery path returns here BEFORE any guard, model resolution,
     // payment verification, settlement, provider call, budget mutation, or
     // spend logging — it is read-only.
-    let mut req: ChatRequest = match serde_json::from_slice::<ChatRequest>(&body) {
+    let req: ChatRequest = match serde_json::from_slice::<ChatRequest>(&body) {
         Ok(req) => req,
         Err(e) => {
             if has_payment_header {
@@ -129,9 +126,41 @@ pub async fn chat_completions(
                 )));
             }
             // Unpaid probe with a bad/empty body → advertise the resource.
-            return Err(chat_completions_discovery(&state));
+            return Err(chat_completions_discovery(&state, "/v1/chat/completions"));
         }
     };
+
+    // Delegate to the shared inner core (the single home of the money path).
+    // `/v1/messages` (the Anthropic Messages adapter) calls the SAME core with
+    // its own `resource_url`, so the 402/cost/verify/settle/record logic is
+    // never forked — CLAUDE.md requires the payment path to live in one place.
+    chat_completions_inner(state, peer_addr, headers, req, "/v1/chat/completions").await
+}
+
+/// Shared inner core for every OpenAI-shaped chat request, regardless of the
+/// inbound wire dialect.
+///
+/// Runs the full money path: content validation → model resolution → prompt
+/// guard → cost estimate → free-tier bypass → 402 → payment decode/verify/
+/// settle → provider call → escrow claim / spend log / receipt → response.
+///
+/// `resource_url` is the endpoint the client posted to (`/v1/chat/completions`
+/// for the OpenAI route, `/v1/messages` for the Anthropic Messages adapter). It
+/// is used for BOTH (a) the `resource.url` the signed payment payload must match
+/// and (b) the `resource.url` advertised in the 402 challenge, so a payment is
+/// always bound to the exact endpoint it was signed for. Extracting this core
+/// (rather than duplicating it) keeps a single home for the payment logic; the
+/// `/v1/chat/completions` behavior is byte-for-byte unchanged because it passes
+/// the same `"/v1/chat/completions"` it always hard-coded.
+pub(crate) async fn chat_completions_inner(
+    state: Arc<AppState>,
+    peer_addr: crate::middleware::rate_limit::PeerAddr,
+    headers: HeaderMap,
+    mut req: ChatRequest,
+    resource_url: &str,
+) -> Result<Response, GatewayError> {
+    let request_start = Instant::now();
+    let debug_enabled = is_debug_enabled(&headers);
 
     // Validate message count before any processing
     if req.messages.len() > MAX_MESSAGES {
@@ -586,7 +615,9 @@ pub async fn chat_completions(
         // the discovery challenge are byte-shape-identical (same accepts /
         // legacy body / canonical PAYMENT-REQUIRED header). The CONFIGURED mint
         // and recipient are baked in there — never the compile-time constant.
-        let payment_required = build_payment_challenge(&state, atomic_amount, cost);
+        // The challenge advertises THIS endpoint's `resource_url` so the client
+        // signs a payment bound to the endpoint it called.
+        let payment_required = build_payment_challenge(&state, atomic_amount, cost, resource_url);
 
         // Emit the PaymentRequired body at the top level of the 402 response
         // per x402 spec — NOT wrapped in the OpenAI-style error envelope.
@@ -653,8 +684,11 @@ pub async fn chat_completions(
             // payment schemes returned with a 402 already tell the client what the
             // correct values are.
 
-            // Verify the resource URL matches this endpoint
-            if payload.resource.url != "/v1/chat/completions" {
+            // Verify the resource URL matches this endpoint. `resource_url` is
+            // the endpoint the client actually posted to (`/v1/chat/completions`
+            // or `/v1/messages`), so a payment signed for one endpoint can never
+            // be replayed against the other.
+            if payload.resource.url != resource_url {
                 // `resource.url` is client-controlled and unbounded (up to the
                 // 50KB header guard), so log a truncated copy server-side —
                 // mirrors the proxy-route truncation (chars-based so a
@@ -1669,6 +1703,9 @@ pub async fn chat_completions(
 /// - `amount` is the atomic-USDC string to advertise (the per-request quote on
 ///   the quote path; the non-binding discovery floor on the discovery path).
 /// - `cost_breakdown` is the matching breakdown to embed.
+/// - `resource_url` is the endpoint the challenge is for (`/v1/chat/completions`
+///   or `/v1/messages`); it becomes the `resource.url` the client must echo in
+///   its signed payment, binding the payment to the exact endpoint.
 ///
 /// The CONFIGURED mint / recipient are baked in here — never the compile-time
 /// constant — so a deployment with a non-default mint (e.g. devnet) advertises
@@ -1678,6 +1715,7 @@ fn build_payment_challenge(
     state: &AppState,
     amount: String,
     cost_breakdown: solvela_protocol::CostBreakdown,
+    resource_url: &str,
 ) -> solvela_x402::types::PaymentRequired {
     let mut accepts = vec![solvela_x402::types::PaymentAccept {
         scheme: "exact".to_string(),
@@ -1705,7 +1743,7 @@ fn build_payment_challenge(
     solvela_x402::types::PaymentRequired {
         x402_version: solvela_x402::types::X402_VERSION,
         resource: solvela_x402::types::Resource {
-            url: "/v1/chat/completions".to_string(),
+            url: resource_url.to_string(),
             method: "POST".to_string(),
         },
         accepts,
@@ -1743,7 +1781,11 @@ fn build_payment_challenge(
 ///
 /// This is a pure builder (no payment verification, no settlement, no provider
 /// call, no budget or spend mutation) — the discovery path is read-only.
-fn chat_completions_discovery(state: &AppState) -> GatewayError {
+///
+/// `resource_url` is the endpoint being advertised (`/v1/chat/completions` or
+/// `/v1/messages`), so a discovery probe to either endpoint advertises a
+/// challenge bound to that endpoint.
+pub(crate) fn chat_completions_discovery(state: &AppState, resource_url: &str) -> GatewayError {
     let floor_atomic = discovery_floor_atomic(&state.model_registry);
     // Atomic → decimal string (6 dp) for the wire `amount`/breakdown. Integer
     // math only (solvela-fintech): split the atomic value into whole + 6-digit
@@ -1780,6 +1822,7 @@ fn chat_completions_discovery(state: &AppState) -> GatewayError {
         state,
         amount,
         cost_breakdown,
+        resource_url,
     )))
 }
 
@@ -1792,7 +1835,7 @@ fn chat_completions_discovery(state: &AppState) -> GatewayError {
 pub async fn chat_completions_discovery_get(
     State(state): State<Arc<AppState>>,
 ) -> Result<Response, GatewayError> {
-    Err(chat_completions_discovery(&state))
+    Err(chat_completions_discovery(&state, "/v1/chat/completions"))
 }
 
 /// Inputs for one chat-path receipt (settlement-platform P2). Groups the

--- a/crates/gateway/src/routes/messages/mod.rs
+++ b/crates/gateway/src/routes/messages/mod.rs
@@ -1,0 +1,418 @@
+//! POST /v1/messages — inbound Anthropic-Messages-compatible endpoint.
+//!
+//! Translates an Anthropic Messages request into Solvela's internal
+//! OpenAI-shaped [`ChatRequest`], runs the EXISTING chat pipeline via
+//! [`chat_completions_inner`] (the single home of the x402 money path), then
+//! translates the resulting [`ChatResponse`] back into the Anthropic Messages
+//! response shape. No new auth, no new payment logic — this is a thin
+//! translate → call-core → translate wrapper (CLAUDE.md rule #14 posture: a
+//! protocol adapter, not new payment logic).
+//!
+//! SCOPE (PR1): text-only, non-streaming. Streaming (SSE), tools, `count_tokens`,
+//! and bearer/spend-down auth are LATER PRs. The translation layer rejects
+//! `stream:true`, image content, and tool blocks with a clear error rather than
+//! silently degrading.
+//!
+//! ## Error envelopes
+//!
+//! Two distinct shapes, by design:
+//!
+//! - **402 Payment Required** keeps the x402 [`PaymentRequired`] body verbatim
+//!   (identical to `/v1/chat/completions`), so an x402 client / registry probe
+//!   sees the canonical challenge regardless of which endpoint it called. This
+//!   includes the unpaid-quote 402, the discovery 402, and an invalid-payment
+//!   402.
+//! - **Every other 4xx/5xx** is re-wrapped into the Anthropic error envelope
+//!   `{"type":"error","error":{"type":…,"message":…}}` so a native Anthropic /
+//!   Claude Code client parses gateway errors the way it expects. The status
+//!   code is preserved from the underlying [`GatewayError`].
+
+use std::sync::Arc;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderName, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+use tracing::warn;
+
+use solvela_protocol::ChatResponse;
+
+use crate::error::GatewayError;
+use crate::providers::anthropic_inbound::{
+    anthropic_request_to_chat, chat_response_to_anthropic, AnthropicInboundError,
+    AnthropicMessagesRequest,
+};
+use crate::routes::chat::{chat_completions_discovery, chat_completions_inner};
+use crate::AppState;
+
+/// The resource URL this endpoint binds payments to. A payment signed for
+/// `/v1/messages` can never be replayed against `/v1/chat/completions` (and
+/// vice versa) — see the resource-URL check in `chat_completions_inner`.
+const MESSAGES_RESOURCE_URL: &str = "/v1/messages";
+
+/// Upper bound when buffering the inner-core response body to re-translate it.
+/// The served response is a serialized `ChatResponse` (an LLM completion);
+/// 10 MiB matches the `RequestBodyLimitLayer` ceiling and is well above any
+/// realistic completion. Exceeding it fails closed (a 502) rather than
+/// allocating unbounded memory.
+const MAX_RESPONSE_BODY_BYTES: usize = 10 * 1024 * 1024;
+
+/// Response headers worth carrying across from the inner OpenAI response onto
+/// the translated Anthropic response. These are payment/audit-relevant
+/// (receipt, session) and providers' debug/fallback markers — none are
+/// body-shape headers (content-type is reset by the new `Json` body).
+const FORWARDED_RESPONSE_HEADERS: &[&str] = &[
+    "x-solvela-receipt",
+    "x-solvela-session",
+    "x-rcr-session",
+    "x-session-id",
+    "x-solvela-fallback",
+    "x-rcr-fallback",
+    "x-solvela-debug",
+    "x-rcr-debug",
+];
+
+/// POST /v1/messages — Anthropic Messages API compatibility endpoint.
+///
+/// Flow:
+/// 1. Parse the Anthropic Messages request (raw `Bytes` so an unpaid bad/empty
+///    body returns the discovery 402, mirroring `/v1/chat/completions`).
+/// 2. Translate to the internal [`ChatRequest`].
+/// 3. Run the shared money-path core ([`chat_completions_inner`]) with this
+///    endpoint's `resource_url` — unpaid → 402, paid → provider call.
+/// 4. Translate the internal [`ChatResponse`] back into the Anthropic Messages
+///    response shape (preserving payment/audit headers).
+pub async fn create_message(
+    State(state): State<Arc<AppState>>,
+    peer_addr: crate::middleware::rate_limit::PeerAddr,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    // Mirror the chat route's discovery posture: a PAYING client gets a real
+    // validation error on a bad body; an UNPAID probe with a bad/empty body
+    // gets the discovery 402 so x402 registry health-checkers see the challenge.
+    let has_payment_header = headers
+        .get("payment-signature")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| !v.is_empty());
+
+    let anthropic_req: AnthropicMessagesRequest = match serde_json::from_slice(&body) {
+        Ok(req) => req,
+        Err(e) => {
+            if has_payment_header {
+                // Paying client, bad body → real validation error in the
+                // Anthropic envelope (a native client expects this shape).
+                return anthropic_error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    format!("invalid Anthropic Messages request body: {e}"),
+                );
+            }
+            // Unpaid probe with a bad/empty body → advertise the resource via
+            // the x402 discovery 402 (kept as the x402 body, NOT the Anthropic
+            // envelope — registry probes and x402 clients read this shape).
+            return chat_completions_discovery(&state, MESSAGES_RESOURCE_URL).into_response();
+        }
+    };
+
+    // Translate the Anthropic request into the internal ChatRequest. A
+    // translation error (image/tool block, or `stream:true`) is a client 4xx in
+    // the Anthropic envelope — it never reaches the money path.
+    let chat_req = match anthropic_request_to_chat(anthropic_req) {
+        Ok(req) => req,
+        Err(e) => {
+            let status = match &e {
+                AnthropicInboundError::InvalidBody(_) => StatusCode::BAD_REQUEST,
+                // Images are accepted on the wire but not yet processed — 415,
+                // matching the chat route's `UnsupportedMediaType` posture.
+                AnthropicInboundError::ImageUnsupported => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            };
+            let error_type = match &e {
+                AnthropicInboundError::InvalidBody(_) => "invalid_request_error",
+                AnthropicInboundError::ImageUnsupported => "invalid_request_error",
+            };
+            return anthropic_error_response(status, error_type, e.to_string());
+        }
+    };
+
+    // Run the SHARED money-path core. `/v1/messages` does NOT fork any
+    // 402/cost/verify/settle/record logic — it reuses the exact same inner core
+    // as `/v1/chat/completions`, only with its own `resource_url`.
+    match chat_completions_inner(state, peer_addr, headers, chat_req, MESSAGES_RESOURCE_URL).await {
+        Ok(response) => translate_success_response(response).await,
+        Err(err) => translate_error(err).await,
+    }
+}
+
+/// GET /v1/messages — x402 discovery probe.
+///
+/// A GET carries no body and cannot be paid, so it always returns the discovery
+/// 402 challenge bound to `/v1/messages`. Mirrors
+/// `chat_completions_discovery_get` so registry health-checkers can confirm the
+/// endpoint speaks x402.
+pub async fn create_message_discovery_get(State(state): State<Arc<AppState>>) -> Response {
+    chat_completions_discovery(&state, MESSAGES_RESOURCE_URL).into_response()
+}
+
+/// Translate a successful inner-core [`Response`] (a serialized OpenAI
+/// [`ChatResponse`] JSON body) into the Anthropic Messages response shape.
+///
+/// PR1 is non-streaming, so the inner response is always a JSON body; we
+/// buffer it, deserialize into a [`ChatResponse`], and re-emit as the Anthropic
+/// shape. Payment/audit headers (receipt, session) are carried across. If the
+/// body cannot be deserialized into a [`ChatResponse`] (e.g. an unexpected stub
+/// shape), we fail closed with a 502 in the Anthropic envelope rather than
+/// emitting a malformed Anthropic body.
+async fn translate_success_response(response: Response) -> Response {
+    let status = response.status();
+    let (parts, body) = response.into_parts();
+
+    // The inner core returns 200 with a JSON ChatResponse on the served path.
+    // Any non-success status reaching the Ok arm is unexpected; surface it as a
+    // 502 in the Anthropic envelope rather than guessing at its body shape.
+    if status != StatusCode::OK {
+        warn!(
+            status = %status,
+            "unexpected non-200 status on the inner-core Ok path for /v1/messages"
+        );
+        return anthropic_error_response(
+            StatusCode::BAD_GATEWAY,
+            "api_error",
+            "Upstream returned an unexpected response.".to_string(),
+        );
+    }
+
+    let bytes = match axum::body::to_bytes(body, MAX_RESPONSE_BODY_BYTES).await {
+        Ok(collected) => collected,
+        Err(e) => {
+            warn!(error = %e, "failed to buffer inner-core response body for /v1/messages");
+            return anthropic_error_response(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                "Upstream response could not be read.".to_string(),
+            );
+        }
+    };
+
+    let chat_resp: ChatResponse = match serde_json::from_slice(&bytes) {
+        Ok(resp) => resp,
+        Err(e) => {
+            // Fail closed: do NOT emit a partially-formed Anthropic body from a
+            // response we could not parse.
+            warn!(
+                error = %e,
+                "inner-core response was not a ChatResponse JSON body for /v1/messages"
+            );
+            return anthropic_error_response(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                "Upstream response had an unexpected shape.".to_string(),
+            );
+        }
+    };
+
+    let anthropic_resp = chat_response_to_anthropic(&chat_resp);
+    let mut out = (StatusCode::OK, Json(anthropic_resp)).into_response();
+
+    // Carry payment/audit headers from the inner response onto the Anthropic
+    // response so a receipt / session token issued by the money path is not
+    // dropped on this endpoint.
+    for name in FORWARDED_RESPONSE_HEADERS {
+        if let Some(value) = parts.headers.get(*name) {
+            out.headers_mut()
+                .insert(HeaderName::from_static(name), value.clone());
+        }
+    }
+
+    out
+}
+
+/// Map a [`GatewayError`] from the shared core onto the right response shape.
+///
+/// - 402 challenges/invalid-payment keep the x402 body verbatim (so x402
+///   clients and registry probes see the canonical challenge regardless of
+///   endpoint).
+/// - Every other error is re-wrapped into the Anthropic error envelope with the
+///   same HTTP status the chat route would have returned.
+async fn translate_error(err: GatewayError) -> Response {
+    match err {
+        // x402 challenge body — emit verbatim (identical to the chat route's
+        // 402). This carries the canonical PAYMENT-REQUIRED header too.
+        GatewayError::PaymentChallenge(_)
+        | GatewayError::PaymentRequired
+        | GatewayError::InvalidPayment(_) => err.into_response(),
+
+        // Everything else → Anthropic error envelope. Reuse the chat route's
+        // GatewayError::into_response to get the canonical status code, then
+        // re-shape the body into the Anthropic envelope (preserving the safe,
+        // already-sanitized message; GatewayError::into_response is the single
+        // place that decides what is safe to surface to clients).
+        other => {
+            let canonical = other.into_response();
+            reshape_to_anthropic_envelope(canonical).await
+        }
+    }
+}
+
+/// Re-shape an OpenAI-style `{"error":{"type","message"}}` error response into
+/// the Anthropic envelope `{"type":"error","error":{"type","message"}}`,
+/// preserving the HTTP status code.
+///
+/// Reusing `GatewayError::into_response` as the source keeps the
+/// sanitize-before-surface rules (GHSA-cgqx-mg48-949v) in exactly one place —
+/// this function only rewrites the JSON shape, never the message content or the
+/// decision about what is safe to expose.
+async fn reshape_to_anthropic_envelope(response: Response) -> Response {
+    let status = response.status();
+    // Buffer the OpenAI envelope body. This is the cold error path, so the
+    // extra buffering is acceptable. On any failure we fall back to a generic
+    // Anthropic error with the original status preserved.
+    let bytes = match axum::body::to_bytes(response.into_body(), MAX_RESPONSE_BODY_BYTES).await {
+        Ok(c) => c,
+        Err(_) => {
+            return anthropic_error_response(
+                status,
+                anthropic_error_type_for_status(status),
+                "An error occurred.".to_string(),
+            );
+        }
+    };
+    // Pull `error.type` / `error.message` out of the OpenAI envelope when
+    // present; otherwise use status-derived defaults.
+    let (error_type, message) = match serde_json::from_slice::<serde_json::Value>(&bytes) {
+        Ok(v) => {
+            let t = v["error"]["type"]
+                .as_str()
+                .map(String::from)
+                .unwrap_or_else(|| anthropic_error_type_for_status(status).to_string());
+            let m = v["error"]["message"]
+                .as_str()
+                .map(String::from)
+                .unwrap_or_else(|| "An error occurred.".to_string());
+            (t, m)
+        }
+        Err(_) => (
+            anthropic_error_type_for_status(status).to_string(),
+            "An error occurred.".to_string(),
+        ),
+    };
+    anthropic_error_response_owned(status, error_type, message)
+}
+
+/// Build an Anthropic error envelope response.
+///
+/// Wire shape: `{"type":"error","error":{"type":<error_type>,"message":<msg>}}`,
+/// per the Anthropic Messages API error schema.
+fn anthropic_error_response(status: StatusCode, error_type: &str, message: String) -> Response {
+    anthropic_error_response_owned(status, error_type.to_string(), message)
+}
+
+fn anthropic_error_response_owned(
+    status: StatusCode,
+    error_type: String,
+    message: String,
+) -> Response {
+    let body = json!({
+        "type": "error",
+        "error": {
+            "type": error_type,
+            "message": message,
+        }
+    });
+    (status, Json(body)).into_response()
+}
+
+/// Map an HTTP status to a reasonable Anthropic error `type` string when the
+/// underlying error does not carry one.
+fn anthropic_error_type_for_status(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::BAD_REQUEST => "invalid_request_error",
+        StatusCode::UNAUTHORIZED => "authentication_error",
+        StatusCode::FORBIDDEN => "permission_error",
+        StatusCode::NOT_FOUND => "not_found_error",
+        StatusCode::UNSUPPORTED_MEDIA_TYPE => "invalid_request_error",
+        StatusCode::TOO_MANY_REQUESTS => "rate_limit_error",
+        StatusCode::SERVICE_UNAVAILABLE => "overloaded_error",
+        _ => "api_error",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use http_body_util::BodyExt;
+
+    #[test]
+    fn status_to_anthropic_error_type_maps_known_codes() {
+        assert_eq!(
+            anthropic_error_type_for_status(StatusCode::BAD_REQUEST),
+            "invalid_request_error"
+        );
+        assert_eq!(
+            anthropic_error_type_for_status(StatusCode::NOT_FOUND),
+            "not_found_error"
+        );
+        assert_eq!(
+            anthropic_error_type_for_status(StatusCode::TOO_MANY_REQUESTS),
+            "rate_limit_error"
+        );
+        assert_eq!(
+            anthropic_error_type_for_status(StatusCode::SERVICE_UNAVAILABLE),
+            "overloaded_error"
+        );
+        assert_eq!(
+            anthropic_error_type_for_status(StatusCode::INTERNAL_SERVER_ERROR),
+            "api_error"
+        );
+    }
+
+    #[tokio::test]
+    async fn anthropic_error_response_has_expected_envelope() {
+        let resp = anthropic_error_response(
+            StatusCode::NOT_FOUND,
+            "not_found_error",
+            "model not found: foo".to_string(),
+        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "not_found_error");
+        assert_eq!(v["error"]["message"], "model not found: foo");
+    }
+
+    /// A `ModelNotFound` GatewayError (a 404, NOT a 402) is re-shaped into the
+    /// Anthropic envelope with the status preserved — proving non-402 errors do
+    /// not leak the OpenAI `{"error":{...}}` shape.
+    #[tokio::test]
+    async fn non_402_gateway_error_becomes_anthropic_envelope() {
+        let resp = translate_error(GatewayError::ModelNotFound("openai/nope".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Anthropic envelope: top-level type:"error", nested error object.
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "model_not_found");
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("openai/nope"));
+    }
+
+    /// An `InvalidPayment` GatewayError (a 402) keeps the x402/OpenAI shape
+    /// verbatim — NOT the Anthropic envelope — so x402 clients see the
+    /// canonical 402 regardless of endpoint.
+    #[tokio::test]
+    async fn invalid_payment_keeps_x402_body_shape() {
+        let resp = translate_error(GatewayError::InvalidPayment("bad sig".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // x402/OpenAI envelope, NOT the Anthropic top-level type:"error".
+        assert!(v["type"].is_null(), "must not be the Anthropic envelope");
+        assert_eq!(v["error"]["type"], "invalid_payment");
+    }
+}

--- a/crates/gateway/src/routes/messages/mod.rs
+++ b/crates/gateway/src/routes/messages/mod.rs
@@ -52,11 +52,11 @@ use crate::AppState;
 /// vice versa) — see the resource-URL check in `chat_completions_inner`.
 const MESSAGES_RESOURCE_URL: &str = "/v1/messages";
 
-/// Upper bound when buffering the inner-core response body to re-translate it.
-/// The served response is a serialized `ChatResponse` (an LLM completion);
-/// 10 MiB matches the `RequestBodyLimitLayer` ceiling and is well above any
-/// realistic completion. Exceeding it fails closed (a 502) rather than
-/// allocating unbounded memory.
+/// Upper bound when buffering the inner-core RESPONSE body (the upstream LLM
+/// completion) so it can be re-translated into the Anthropic shape. This is a
+/// RESPONSE-buffer ceiling — distinct from `RequestBodyLimitLayer`, which gates
+/// inbound REQUEST bodies. 10 MiB is well above any realistic completion;
+/// exceeding it fails closed (a 502) rather than allocating unbounded memory.
 const MAX_RESPONSE_BODY_BYTES: usize = 10 * 1024 * 1024;
 
 /// Response headers worth carrying across from the inner OpenAI response onto
@@ -128,10 +128,15 @@ pub async fn create_message(
                 // Images are accepted on the wire but not yet processed — 415,
                 // matching the chat route's `UnsupportedMediaType` posture.
                 AnthropicInboundError::ImageUnsupported => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                // Tools are an unsupported REQUEST feature, not an unsupported
+                // media type — 400 (415 is media-type-specific and would be a
+                // misleading status for `tools`/`tool_use`).
+                AnthropicInboundError::ToolUseUnsupported => StatusCode::BAD_REQUEST,
             };
             let error_type = match &e {
                 AnthropicInboundError::InvalidBody(_) => "invalid_request_error",
                 AnthropicInboundError::ImageUnsupported => "invalid_request_error",
+                AnthropicInboundError::ToolUseUnsupported => "invalid_request_error",
             };
             return anthropic_error_response(status, error_type, e.to_string());
         }

--- a/crates/gateway/src/routes/mod.rs
+++ b/crates/gateway/src/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod escrow_settle;
 pub mod faucet;
 pub mod health;
 pub mod images;
+pub mod messages;
 pub mod metrics;
 pub mod models;
 pub mod nonce;

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -15836,3 +15836,416 @@ price_per_request_usdc = 0.01
         );
     }
 }
+
+// ===========================================================================
+// POST /v1/messages — inbound Anthropic Messages compatibility (PR1)
+//
+// These tests drive the REAL route through `oneshot(test_app())` (CLAUDE.md
+// rule 10), proving the endpoint rides the SAME x402 money path as
+// /v1/chat/completions via the shared `chat_completions_inner` core. The
+// cost-parity test is the key money-path assertion: an identical prompt to both
+// endpoints must yield the SAME cost_breakdown, proving no payment-logic fork.
+// ===========================================================================
+mod messages_endpoint_tests {
+    use super::*;
+
+    /// An UNPAID request to /v1/messages returns the x402 402 challenge body
+    /// (NOT the Anthropic error envelope) — so x402 clients and registry probes
+    /// see the canonical challenge regardless of which endpoint they call. The
+    /// challenge's resource.url is bound to /v1/messages.
+    #[tokio::test]
+    async fn messages_unpaid_returns_x402_402() {
+        let app = test_app();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        // x402 PaymentRequired body at the top level (NOT the Anthropic
+        // {"type":"error",...} envelope).
+        assert_eq!(v["x402_version"], 2);
+        assert!(v["accepts"].is_array());
+        assert_eq!(v["resource"]["url"], "/v1/messages");
+        assert_eq!(v["cost_breakdown"]["currency"], "USDC");
+        assert_eq!(v["cost_breakdown"]["fee_percent"], 5);
+        assert!(
+            v["type"].is_null(),
+            "402 must be the x402 body, never the Anthropic error envelope"
+        );
+    }
+
+    /// A PAID request (exact scheme, AlwaysPassVerifier) returns a valid
+    /// Anthropic Messages response: type:"message", role:"assistant", a text
+    /// content block, stop_reason mapped from the mock's "stop" → "end_turn",
+    /// and usage.{input_tokens,output_tokens} Claude Code reads.
+    #[tokio::test]
+    async fn messages_paid_returns_anthropic_response_shape() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        // Anthropic Messages response shape.
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["role"], "assistant");
+        assert_eq!(v["content"][0]["type"], "text");
+        // The mock provider returns "[mock response]" content.
+        assert_eq!(v["content"][0]["text"], "[mock response]");
+        // The mock's finish_reason "stop" → Anthropic stop_reason "end_turn".
+        assert_eq!(v["stop_reason"], "end_turn");
+        // usage fields Claude Code reads (mock: prompt 10, completion 5).
+        assert_eq!(v["usage"]["input_tokens"], 10);
+        assert_eq!(v["usage"]["output_tokens"], 5);
+        // The internal `id` is carried through.
+        assert_eq!(v["id"], "mock-chatcmpl-001");
+        assert_eq!(v["model"], "anthropic/claude-sonnet-4-6");
+    }
+
+    /// A PAID request whose `system` is the ARRAY-OF-BLOCKS form Claude Code
+    /// sends (multi-turn) is accepted end-to-end and returns 200 — proving the
+    /// inbound translation reaches the served path with the system prompt
+    /// extracted, not rejected.
+    #[tokio::test]
+    async fn messages_paid_system_as_array_multiturn_succeeds() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 128,
+            "system": [
+                {"type": "text", "text": "You are a coding assistant."},
+                {"type": "text", "text": "Be concise."}
+            ],
+            "messages": [
+                {"role": "user", "content": "Write a haiku."},
+                {"role": "assistant", "content": [{"type": "text", "text": "Sure."}]},
+                {"role": "user", "content": [{"type": "text", "text": "About the sea."}]}
+            ]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["content"][0]["text"], "[mock response]");
+    }
+
+    /// COST PARITY (the key money-path assertion): an IDENTICAL prompt to
+    /// /v1/chat/completions and /v1/messages must produce the SAME 402
+    /// cost_breakdown. This proves /v1/messages does not fork the cost/fee math
+    /// — it computes cost through the same `chat_completions_inner` core. The
+    /// Anthropic `system` + user message maps to the same internal System +
+    /// User ChatRequest as the OpenAI body, so the token estimate (and thus the
+    /// 5%-fee-inclusive total) is identical.
+    #[tokio::test]
+    async fn messages_and_chat_have_identical_cost_breakdown() {
+        // OpenAI-shaped body: a system message + a user message.
+        let chat_body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Explain entropy briefly."}
+            ]
+        });
+        // Anthropic-shaped body carrying the SAME logical content: the `system`
+        // string becomes the leading System message, and the user turn matches.
+        let messages_body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 100,
+            "system": "You are helpful.",
+            "messages": [
+                {"role": "user", "content": "Explain entropy briefly."}
+            ]
+        });
+
+        let chat_app = test_app();
+        let chat_resp = chat_app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&chat_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chat_resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let chat_bytes = chat_resp.into_body().collect().await.unwrap().to_bytes();
+        let chat_v: serde_json::Value = serde_json::from_slice(&chat_bytes).unwrap();
+
+        let messages_app = test_app();
+        let messages_resp = messages_app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&messages_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(messages_resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let messages_bytes = messages_resp
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let messages_v: serde_json::Value = serde_json::from_slice(&messages_bytes).unwrap();
+
+        // The cost_breakdown (provider_cost, platform_fee, total, currency,
+        // fee_percent) must be byte-for-byte identical — proving the same cost
+        // path, the same 5% fee applied once, the same atomic math.
+        assert_eq!(
+            chat_v["cost_breakdown"], messages_v["cost_breakdown"],
+            "identical prompts must yield identical cost_breakdown across endpoints \
+             (no money-path fork)"
+        );
+        // The advertised `accepts[]` amount must also match.
+        assert_eq!(
+            chat_v["accepts"][0]["amount"], messages_v["accepts"][0]["amount"],
+            "the advertised exact-scheme amount must match across endpoints"
+        );
+        // Each challenge binds to its own endpoint.
+        assert_eq!(chat_v["resource"]["url"], "/v1/chat/completions");
+        assert_eq!(messages_v["resource"]["url"], "/v1/messages");
+    }
+
+    /// A non-402 error (unknown model → 404) is returned in the Anthropic error
+    /// envelope `{"type":"error","error":{"type","message"}}`, with the status
+    /// preserved — NOT the OpenAI envelope.
+    #[tokio::test]
+    async fn messages_unknown_model_returns_anthropic_error_envelope() {
+        // A paid request (so we get past the 402) for an unknown model. The
+        // model-resolution failure is a 404 that must come back in the
+        // Anthropic envelope.
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-does-not-exist",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "model_not_found");
+        assert!(v["error"]["message"].is_string());
+    }
+
+    /// A `stream: true` request is rejected (PR1 is non-streaming) with a 400 in
+    /// the Anthropic error envelope rather than silently served non-streaming.
+    #[tokio::test]
+    async fn messages_streaming_request_rejected_with_anthropic_envelope() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+    }
+
+    /// An image content block is rejected (PR1 is text-only) with a 415 in the
+    /// Anthropic envelope, never billed-then-silently-dropped.
+    #[tokio::test]
+    async fn messages_image_content_rejected_with_anthropic_envelope() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBOR"}}
+            ]}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+    }
+
+    /// GET /v1/messages returns the x402 discovery 402 (registry health-check
+    /// mirror of the chat route's discovery GET), bound to /v1/messages.
+    #[tokio::test]
+    async fn messages_discovery_get_returns_x402_402() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/messages")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["x402_version"], 2);
+        assert_eq!(v["resource"]["url"], "/v1/messages");
+    }
+
+    /// An UNPAID probe with an empty/malformed body returns the discovery 402
+    /// (mirrors the chat route) rather than a 400 — so registry health-checkers
+    /// see the challenge.
+    #[tokio::test]
+    async fn messages_unpaid_empty_body_returns_discovery_402() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["x402_version"], 2);
+        assert_eq!(v["resource"]["url"], "/v1/messages");
+    }
+
+    /// A payment signed for /v1/chat/completions must NOT be accepted at
+    /// /v1/messages — the resource.url binding prevents cross-endpoint replay.
+    /// The mismatched resource yields an invalid-payment 402 (kept in the x402
+    /// body shape).
+    #[tokio::test]
+    async fn messages_rejects_payment_signed_for_other_endpoint() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    // Header signed for the OTHER endpoint.
+                    .header(
+                        "payment-signature",
+                        valid_payment_header("/v1/chat/completions"),
+                    )
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // resource.url mismatch → invalid-payment 402 (x402 body, not Anthropic
+        // envelope, since it is a 402).
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_payment");
+    }
+}

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -15875,6 +15875,15 @@ mod messages_endpoint_tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        // The canonical x402 v2 PAYMENT-REQUIRED header (read by registry probes
+        // BEFORE body parse) must be present on the messages 402, exactly as on
+        // the chat 402.
+        assert!(
+            response
+                .headers()
+                .contains_key(CANONICAL_PAYMENT_REQUIRED_HEADER),
+            "messages unpaid 402 must carry the canonical payment-required header"
+        );
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
 
@@ -16180,6 +16189,13 @@ mod messages_endpoint_tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        // Registry health-checkers read the canonical header before the body.
+        assert!(
+            response
+                .headers()
+                .contains_key(CANONICAL_PAYMENT_REQUIRED_HEADER),
+            "messages discovery GET 402 must carry the canonical payment-required header"
+        );
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["x402_version"], 2);
@@ -16247,5 +16263,275 @@ mod messages_endpoint_tests {
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "invalid_payment");
+    }
+
+    /// REVERSE replay direction (the inverse of
+    /// `messages_rejects_payment_signed_for_other_endpoint`): a payment signed
+    /// for `/v1/messages` must NOT be accepted at `/v1/chat/completions`. The
+    /// resource.url binding is symmetric — cross-endpoint replay is rejected in
+    /// BOTH directions with an invalid-payment 402.
+    #[tokio::test]
+    async fn chat_rejects_payment_signed_for_messages_endpoint() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "messages": [{"role": "user", "content": "Hello!"}],
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    // Header signed for /v1/messages, presented at the chat route.
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_payment");
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("does not match"));
+    }
+
+    /// A request carrying top-level `tools` definitions is rejected with a 400
+    /// in the Anthropic error envelope — Claude Code attaches tools to nearly
+    /// every request, so silently dropping them and billing for a tool-blind
+    /// answer is the common-case failure this guards against.
+    #[tokio::test]
+    async fn messages_tools_definition_rejected_with_anthropic_envelope() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "tools": [
+                {"name": "get_weather", "description": "Get the weather",
+                 "input_schema": {"type": "object", "properties": {}}}
+            ],
+            "messages": [{"role": "user", "content": "What is the weather?"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // 400 (NOT 415 — tools is an unsupported request feature, not media).
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        // The message must reference tools, not images.
+        let msg = v["error"]["message"].as_str().unwrap();
+        assert!(
+            msg.contains("tool"),
+            "tools rejection must reference tools, got: {msg}"
+        );
+    }
+
+    /// A tool CONTENT block (`tool_use`) is rejected with a 400 and a
+    /// tool-specific diagnostic — NOT the misleading image error/415.
+    #[tokio::test]
+    async fn messages_tool_content_block_rejected_with_anthropic_envelope() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "messages": [{"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "f", "input": {}}
+            ]}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        let msg = v["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("tool"), "must reference tools, got: {msg}");
+        assert!(
+            !msg.contains("image"),
+            "tool-block error must not mislead about images, got: {msg}"
+        );
+    }
+
+    /// Money-path proof: streaming, image, AND tools rejections all occur with
+    /// NO settlement. We inject a `SettleRecordingVerifier`; for each rejected
+    /// request the settle flag must stay `false` — the agent is never charged
+    /// for a request that is rejected at the translation boundary, BEFORE the
+    /// money path.
+    #[tokio::test]
+    async fn messages_rejections_never_settle() {
+        // Each rejected shape, asserted independently with its own fresh app and
+        // settle flag.
+        let cases: Vec<(&str, serde_json::Value, StatusCode)> = vec![
+            (
+                "streaming",
+                serde_json::json!({
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "max_tokens": 64,
+                    "stream": true,
+                    "messages": [{"role": "user", "content": "hi"}]
+                }),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "image",
+                serde_json::json!({
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "max_tokens": 64,
+                    "messages": [{"role": "user", "content": [
+                        {"type": "text", "text": "what is this?"},
+                        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBOR"}}
+                    ]}]
+                }),
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            ),
+            (
+                "tools",
+                serde_json::json!({
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "max_tokens": 64,
+                    "tools": [{"name": "f", "description": "d",
+                               "input_schema": {"type": "object", "properties": {}}}],
+                    "messages": [{"role": "user", "content": "hi"}]
+                }),
+                StatusCode::BAD_REQUEST,
+            ),
+        ];
+
+        for (label, body, expected_status) in cases {
+            let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let (app, _state) =
+                test_app_with_mock_provider_and_exact_verifier(Arc::new(SettleRecordingVerifier {
+                    settled: Arc::clone(&settled),
+                }));
+
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/v1/messages")
+                        .header("content-type", "application/json")
+                        // A VALID payment header is attached so the only reason
+                        // settlement does not fire is the translation-boundary
+                        // rejection (not a missing/invalid payment).
+                        .header("payment-signature", valid_payment_header("/v1/messages"))
+                        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.status(),
+                expected_status,
+                "{label} request must be rejected at the translation boundary"
+            );
+            assert!(
+                !settled.load(std::sync::atomic::Ordering::SeqCst),
+                "{label} rejection must NOT reach settlement — the agent must not be charged"
+            );
+        }
+    }
+
+    /// DB-backed: a PAID /v1/messages response must forward the
+    /// `x-solvela-receipt` header through `translate_success_response` (the
+    /// receipt issued by the shared money path is not dropped on this endpoint).
+    /// Self-skips when Postgres is unavailable (mirrors the chat receipt tests).
+    #[tokio::test]
+    async fn messages_paid_forwards_receipt_header() {
+        let Some(pool) = try_receipts_db_pool().await else {
+            return;
+        };
+        let (app, _state) =
+            test_app_with_db_pool(mock_provider_registry(), Arc::new(AlwaysPassVerifier), pool);
+
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let path = receipt_header_path(&response);
+        assert!(
+            path.starts_with("/v1/receipts/"),
+            "messages receipt header must be the receipt path, got: {path}"
+        );
+    }
+
+    /// DB-less mirror: a paid /v1/messages response must NOT advertise a receipt
+    /// header (rule 12 graceful degradation — never promise an unfetchable
+    /// receipt).
+    #[tokio::test]
+    async fn messages_dbless_paid_emits_no_receipt_header() {
+        let app = test_app_with_mock_provider();
+
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response.headers().get("x-solvela-receipt").is_none(),
+            "a DB-less gateway must not advertise an unfetchable receipt on /v1/messages"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds an inbound Anthropic-Messages-compatible endpoint `POST /v1/messages` that translates to Solvela's internal OpenAI-shaped pipeline and back, riding the **existing x402 payment path** with no new auth. This is **PR1** of the "Claude Code drop-in" track — text-only, non-streaming. Streaming (SSE), tools, `count_tokens`, images, and bearer/spend-down auth are deferred to later PRs and are **rejected loudly**, never silently degraded.

Because `chat_completions` was a monolithic ~1500-line handler, this extracts a shared inner core `chat_completions_inner(…, resource_url)` that both `/v1/chat/completions` and `/v1/messages` call — so the 402 / cost / 5%-fee / verify / settle / record logic lives in exactly one place. A cost-parity test asserts an identical prompt yields a **byte-identical `cost_breakdown`** across both endpoints, proving the money path is not forked.

The extraction also parameterizes `resource.url`, binding a signed payment to the endpoint it was signed for — **cross-endpoint replay is now rejected** (both directions tested).

## In scope (PR1)
- `POST /v1/messages` (+ GET discovery-402 mirror) in Anthropic Messages wire format
- Anthropic↔OpenAI inbound translation (`providers/anthropic_inbound.rs`): `system` as string and as array of blocks, role filtering, inverse `stop_reason` map, `usage.{input,output}_tokens`
- 402 keeps the verbatim x402 body; other errors use the Anthropic error envelope
- Out-of-scope features (streaming, top-level `tools`/`tool_choice`, `tool_use`/`tool_result` blocks, images) rejected loudly **before** the money path

## Deferred (tracked follow-ups, non-blocking)
- Anthropic-format SSE streaming (PR2 — required before Claude Code works against its default streaming mode)
- `tools` round-trip (PR3); `count_tokens` endpoint; images
- `request_start` latency metric now excludes body-parse/translation time (observability only)
- `stop_sequences` accepted and ignored (billed on actual tokens; not money-relevant)

## Review
Built tests-first; cleared a 3-reviewer money-path gate (rust + silent-failure + test-coverage) plus an independent round-2 re-review. The round-1 Critical — top-level `tools` silently discarded (Claude Code attaches tools to nearly every request, so the agent would pay for a tool-blind answer) — is fixed and proven to reject **before** settlement (`messages_rejections_never_settle`).

## Tests
- 18 `anthropic_inbound` unit tests + integration suite **289 passed / 0 failed**
- Key: `messages_and_chat_have_identical_cost_breakdown`, `messages_rejections_never_settle`, replay both directions, receipt-header forwarding (DB + dbless), canonical 402 header
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean