### PR TITLE
feat(gateway): Anthropic SSE streaming for POST /v1/messages

### DIFF
--- a/crates/gateway/src/providers/anthropic_inbound.rs
+++ b/crates/gateway/src/providers/anthropic_inbound.rs
@@ -25,20 +25,30 @@
 //!   semantics; the Anthropic response exposes `input_tokens`/`output_tokens`
 //!   (which Claude Code reads).
 //!
-//! SCOPE (PR1): text-only, non-streaming. Streaming (SSE), tools (top-level
-//! `tools`/`tool_choice` definitions AND `tool_use`/`tool_result` content
-//! blocks), `count_tokens`, and images are OUT OF SCOPE. Every one of these is
-//! rejected LOUDLY rather than silently dropped: a dropped image or a discarded
-//! tool definition would change the prompt's meaning (or strip tool-calling)
-//! while still billing the agent — the same fail-loud posture the outbound
-//! adapter takes for system/tool-role images. Tool definitions in particular
-//! must be modeled on the wire (`AnthropicMessagesRequest::tools`), not left to
-//! serde's ignore-unknown-fields default, because Claude Code attaches them to
-//! nearly every request.
+//! SCOPE (PR2): text-only, streaming (SSE) AND non-streaming. A `stream:true`
+//! request is framed into the Anthropic Messages SSE event sequence by
+//! [`frame_anthropic_stream`]; a `stream:false`/absent request runs the
+//! buffer-and-translate path. Tools (top-level `tools`/`tool_choice` definitions
+//! AND `tool_use`/`tool_result` content blocks), `count_tokens`, and images
+//! remain OUT OF SCOPE. Every one of these is rejected LOUDLY rather than
+//! silently dropped: a dropped image or a discarded tool definition would change
+//! the prompt's meaning (or strip tool-calling) while still billing the agent —
+//! the same fail-loud posture the outbound adapter takes for system/tool-role
+//! images. Tool definitions in particular must be modeled on the wire
+//! (`AnthropicMessagesRequest::tools`), not left to serde's ignore-unknown-fields
+//! default, because Claude Code attaches them to nearly every request.
 
+use std::collections::VecDeque;
+use std::convert::Infallible;
+
+use axum::response::sse;
+use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
-use solvela_protocol::{ChatMessage, ChatRequest, ChatResponse, MessageContent, Role};
+use solvela_protocol::{ChatChunk, ChatMessage, ChatRequest, ChatResponse, MessageContent, Role};
+
+use crate::providers::heartbeat::HeartbeatItem;
 
 /// Errors from translating an inbound Anthropic Messages request.
 ///
@@ -347,13 +357,10 @@ fn inbound_role(role: &str) -> Role {
 pub fn anthropic_request_to_chat(
     req: AnthropicMessagesRequest,
 ) -> Result<ChatRequest, AnthropicInboundError> {
-    if req.stream {
-        return Err(AnthropicInboundError::InvalidBody(
-            "streaming responses are not yet supported on POST /v1/messages; \
-             set \"stream\": false (SSE support is planned for a later release)"
-                .to_string(),
-        ));
-    }
+    // Streaming is now SUPPORTED (PR2): `stream` carries through to the internal
+    // `ChatRequest` and the shared core frames the OpenAI `ChatChunk` stream into
+    // the Anthropic SSE event sequence (see `frame_anthropic_stream`). Tools and
+    // images remain OUT OF SCOPE and are still rejected below.
 
     // Reject top-level tool definitions LOUDLY, BEFORE the money path. Without
     // this, a request carrying `tools`/`tool_choice` would translate to a
@@ -396,7 +403,11 @@ pub fn anthropic_request_to_chat(
         max_tokens: req.max_tokens,
         temperature: req.temperature,
         top_p: req.top_p,
-        stream: false,
+        // Carry the client's streaming choice through to the shared core. When
+        // `true`, the core frames the internal OpenAI `ChatChunk` stream into the
+        // Anthropic SSE event sequence; when `false`, the existing buffer-and-
+        // translate path runs. Tools/images stay rejected above either way.
+        stream: req.stream,
         tools: None,
         tool_choice: None,
     })
@@ -414,6 +425,13 @@ fn finish_reason_to_stop_reason(finish_reason: Option<&str>) -> Option<String> {
     finish_reason.map(|r| match r {
         "stop" => "end_turn".to_string(),
         "length" => "max_tokens".to_string(),
+        // INTENTIONAL passthrough (do NOT "fix" to a default): the provider
+        // boundary is trusted — adapters are registry-controlled, so an
+        // unrecognized reason is a forward-compat signal to forward verbatim,
+        // never client-injected. Coercing it to a default would silently lose a
+        // real provider signal. Locked by `unknown_finish_reason_passes_through`
+        // (non-streaming) and `framer_unknown_finish_reason_passes_through`
+        // (streaming).
         other => other.to_string(),
     })
 }
@@ -464,6 +482,495 @@ pub fn chat_response_to_anthropic(resp: &ChatResponse) -> AnthropicMessagesRespo
             output_tokens,
         },
     }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming response translation (ChatChunk stream → Anthropic SSE events)
+// ---------------------------------------------------------------------------
+
+/// The fixed index of the single text content block emitted for a streamed
+/// text response. PR2 is text-only, so there is exactly one block (`index: 0`).
+const ANTHROPIC_TEXT_BLOCK_INDEX: u32 = 0;
+
+/// The Anthropic streaming event discriminant. The SAME value drives BOTH the
+/// SSE `event:` name line AND the `data` JSON's `"type"` field, so the two can
+/// never diverge — a requirement of `@anthropic-ai/sdk`, which rejects a frame
+/// whose `data.type` does not equal its `event:` name.
+///
+/// Serialize-only: `#[serde(rename_all = "snake_case")]` produces the exact
+/// wire strings (`message_start`, `content_block_delta`, …). `event_name`
+/// returns the SAME string for the `event:` line, so the single source of truth
+/// is this enum value. There is no `Deserialize` (the gateway is the SERVER of
+/// this dialect — it only emits these events, never parses them).
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum AnthropicStreamEventKind {
+    MessageStart,
+    ContentBlockStart,
+    ContentBlockDelta,
+    ContentBlockStop,
+    MessageDelta,
+    MessageStop,
+    Ping,
+    Error,
+}
+
+impl AnthropicStreamEventKind {
+    /// The static `event:` name line value. Derived from the SAME variant the
+    /// `data.type` field serializes from (via the `#[serde(rename_all)]` above),
+    /// so name/type divergence is impossible at the type level.
+    fn event_name(self) -> &'static str {
+        match self {
+            AnthropicStreamEventKind::MessageStart => "message_start",
+            AnthropicStreamEventKind::ContentBlockStart => "content_block_start",
+            AnthropicStreamEventKind::ContentBlockDelta => "content_block_delta",
+            AnthropicStreamEventKind::ContentBlockStop => "content_block_stop",
+            AnthropicStreamEventKind::MessageDelta => "message_delta",
+            AnthropicStreamEventKind::MessageStop => "message_stop",
+            AnthropicStreamEventKind::Ping => "ping",
+            AnthropicStreamEventKind::Error => "error",
+        }
+    }
+}
+
+/// `message_start.message.usage`: `{input_tokens, output_tokens}`. Output is
+/// always `0` at start (no tokens generated yet); the billed input estimate is
+/// surfaced as `input_tokens`. Modeled as a typed struct so a wrong/missing
+/// field cannot silently serialize. Fields are declared in ALPHABETICAL order
+/// to keep the emitted bytes byte-for-byte identical to the BTreeMap-ordered
+/// `serde_json::Value` they replace.
+#[derive(Debug, Serialize)]
+struct MessageStartUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+}
+
+/// `message_delta.usage`: `{output_tokens}` ONLY — distinct from
+/// [`MessageStartUsage`], which also carries `input_tokens`. Using a separate
+/// typed struct makes it impossible to accidentally emit `input_tokens` here
+/// (the Anthropic contract omits it on `message_delta`).
+#[derive(Debug, Serialize)]
+struct MessageDeltaUsage {
+    output_tokens: u32,
+}
+
+// --- Per-event data payloads (each WITHOUT a `type` field; the helper injects
+//     `"type"` from the event kind). Fields are declared so the emitted JSON is
+//     a stable, well-typed shape; the `type` key is the helper's sole job. ---
+
+/// The `message` object nested inside `message_start`.
+#[derive(Debug, Serialize)]
+struct MessageStartMessage {
+    id: String,
+    #[serde(rename = "type")]
+    message_type: AnthropicMessageType,
+    role: AnthropicAssistantRole,
+    model: String,
+    /// Always empty at start (no content blocks emitted yet).
+    content: [(); 0],
+    stop_reason: Option<String>,
+    stop_sequence: Option<String>,
+    usage: MessageStartUsage,
+}
+
+/// `message_start` data (minus the helper-injected `"type"`).
+#[derive(Debug, Serialize)]
+struct MessageStartData {
+    message: MessageStartMessage,
+}
+
+/// The empty text content block opened by `content_block_start`.
+#[derive(Debug, Serialize)]
+struct ContentBlockStartBlock {
+    #[serde(rename = "type")]
+    block_type: AnthropicResponseTextBlockType,
+    text: &'static str,
+}
+
+/// `content_block_start` data.
+#[derive(Debug, Serialize)]
+struct ContentBlockStartData {
+    index: u32,
+    content_block: ContentBlockStartBlock,
+}
+
+/// Pins the literal `"text_delta"` discriminant on a streamed text delta.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TextDeltaType {
+    TextDelta,
+}
+
+/// The `delta` object inside `content_block_delta` (a streamed text fragment).
+#[derive(Debug, Serialize)]
+struct ContentBlockTextDelta {
+    #[serde(rename = "type")]
+    delta_type: TextDeltaType,
+    text: String,
+}
+
+/// `content_block_delta` data.
+#[derive(Debug, Serialize)]
+struct ContentBlockDeltaData {
+    index: u32,
+    delta: ContentBlockTextDelta,
+}
+
+/// `content_block_stop` data.
+#[derive(Debug, Serialize)]
+struct ContentBlockStopData {
+    index: u32,
+}
+
+/// The `delta` object inside `message_delta` (carries the final stop reason).
+#[derive(Debug, Serialize)]
+struct MessageDeltaDelta {
+    stop_reason: String,
+    stop_sequence: Option<String>,
+}
+
+/// `message_delta` data.
+#[derive(Debug, Serialize)]
+struct MessageDeltaData {
+    delta: MessageDeltaDelta,
+    usage: MessageDeltaUsage,
+}
+
+/// An empty-bodied event payload (`ping` / `message_stop` carry only the
+/// helper-injected `"type"`). A unit struct serializes to `{}`, into which the
+/// helper's flatten injects `"type"`.
+#[derive(Debug, Serialize)]
+struct EmptyEventData {}
+
+/// The `error` object inside an `error` event. The message is ALWAYS a generic,
+/// gateway-authored string — never the raw provider error (S3 redaction).
+#[derive(Debug, Serialize)]
+struct StreamErrorBody {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: &'static str,
+}
+
+/// `error` event data.
+#[derive(Debug, Serialize)]
+struct StreamErrorData {
+    error: StreamErrorBody,
+}
+
+/// Build one Anthropic SSE event with BOTH the `event:` name line AND a `data:`
+/// JSON line, as required by `@anthropic-ai/sdk` (the data JSON's `"type"` MUST
+/// equal the event name).
+///
+/// Both the `event:` name AND the `"type"` field injected into `data` are
+/// derived from the SAME `kind` value: the helper serializes `kind` for the
+/// `"type"` key (callers cannot forget or mistype it) and uses `kind.event_name()`
+/// for the `event:` line. Name/type divergence is therefore impossible.
+///
+/// `data` is any `Serialize` struct WITHOUT a `type` field; the helper injects
+/// `"type": <kind>` exactly once. The final `data:` string is produced by a
+/// SINGLE `serde_json::to_string` over a temporary tagged view of the typed
+/// payload — the prior code first built a `serde_json::Value` tree via `json!`
+/// and then re-walked it with `.to_string()`; this serializes the typed struct
+/// straight to the string with no hand-built `Value` tree. `kind` is
+/// gateway-controlled (never client/provider-derived), so the `event:` line can
+/// never carry injected bytes.
+///
+/// Serialization is infallible here (every payload is plain strings/numbers/
+/// nulls); on the impossible error we fail closed to an empty object rather than
+/// emitting a partial frame.
+fn anthropic_sse_event<T: Serialize>(kind: AnthropicStreamEventKind, data: T) -> sse::Event {
+    /// A transparent tagging view: serializes `data`'s fields inline alongside a
+    /// `"type"` key sourced from `kind`. Serde flattens `data`, so the output is
+    /// one object with `type` + the payload's fields — produced in a single pass.
+    #[derive(Serialize)]
+    struct Tagged<T: Serialize> {
+        #[serde(rename = "type")]
+        kind: AnthropicStreamEventKind,
+        #[serde(flatten)]
+        data: T,
+    }
+
+    let json = serde_json::to_string(&Tagged { kind, data }).unwrap_or_else(|e| {
+        // Unreachable in practice (payloads are plain data). Never emit a
+        // half-built frame — fall closed to a syntactically valid empty object.
+        error!(error = %e, "failed to serialize Anthropic SSE event data");
+        "{}".to_string()
+    });
+
+    sse::Event::default().event(kind.event_name()).data(json)
+}
+
+/// State machine for translating the internal OpenAI `ChatChunk` stream into the
+/// Anthropic Messages SSE event sequence.
+///
+/// The phases drive a deterministic event order:
+/// `message_start` → `content_block_start` → (`content_block_delta` | `ping`)\*
+/// → `content_block_stop` → `message_delta` → `message_stop`.
+///
+/// A mid-stream error chunk emits a single Anthropic `error` event with a
+/// GENERIC message (never the raw provider error — mirrors the S3 redaction in
+/// `execute_streaming_call`) and then ends the stream cleanly (no trailing
+/// `content_block_stop`/`message_delta`/`message_stop` — the Anthropic SDK treats
+/// an `error` event as terminal).
+enum FramePhase {
+    /// Have not yet emitted `message_start` + `content_block_start`.
+    Preamble,
+    /// Streaming `content_block_delta`/`ping` events; consuming upstream items.
+    Streaming,
+    /// Upstream ended normally; emit the trailer
+    /// (`content_block_stop`/`message_delta`/`message_stop`).
+    Trailer,
+    /// Terminal — nothing more to emit.
+    Done,
+}
+
+/// Per-stream framing state carried through `futures::stream::unfold`.
+///
+/// `async-stream` is deliberately NOT a dependency (supply-chain governance), so
+/// this is a hand-rolled state machine over `unfold` with a small pending-event
+/// buffer (`pending`) for phases that emit more than one event per poll.
+///
+/// Generic over the upstream item-stream (rather than the concrete
+/// `HeartbeatStream<ChatStream>`) so the state machine can be driven by a
+/// synthetic `stream::iter` of `HeartbeatItem`s in tests — deterministically
+/// covering the chunk / keep-alive / error-chunk cases without timer flakiness.
+/// In production, provider.rs passes the real `HeartbeatStream<ChatStream>`,
+/// which IS a `Stream<Item = HeartbeatItem>`.
+struct FrameState<S> {
+    /// The upstream heartbeat-wrapped provider stream.
+    upstream: S,
+    phase: FramePhase,
+    /// Buffered events not yet returned (e.g. the preamble emits two events).
+    pending: VecDeque<sse::Event>,
+    /// `message_start.message.id` — a freshly generated `msg_<uuid>`.
+    message_id: String,
+    /// The resolved request model echoed in `message_start` / `message_delta`.
+    model: String,
+    /// `message_start.usage.input_tokens` — the SAME input-token estimate the
+    /// streaming billing path records (`estimate_input_tokens`); see the
+    /// money-path note on `frame_anthropic_stream`.
+    input_tokens: u32,
+    /// `message_delta.usage.output_tokens` — the completion-token CEILING the
+    /// billing estimate reserves (`completion_token_ceiling`). The stream carries
+    /// no usage, and this is the figure the wallet is actually billed for on the
+    /// streaming path, so it is the honest number to surface here.
+    output_tokens: u32,
+    /// The last non-null `finish_reason` seen across upstream chunks; maps to the
+    /// Anthropic `stop_reason` in the trailer.
+    last_finish_reason: Option<String>,
+}
+
+/// Translate a heartbeat-wrapped internal `ChatChunk` stream into the Anthropic
+/// Messages SSE event sequence, passing the stream THROUGH (no buffering of the
+/// whole stream).
+///
+/// MONEY-PATH NOTE (consulted `solvela-fintech` §3): streaming settles via the
+/// ESTIMATE (the `EstimateFallback` arm in `chat/mod.rs` bills `estimated_cost`).
+/// The internal `ChatChunk` stream has NO usage field, so the usage surfaced here
+/// MUST be consistent with what the wallet is billed:
+/// - `input_tokens` = `estimate_input_tokens(&req)` — exactly the input figure
+///   the estimate prices and the streaming spend row records.
+/// - `output_tokens` = `completion_token_ceiling(req.max_tokens, model_info)` —
+///   the completion-token count the billing estimate RESERVES and the wallet is
+///   billed for on the streaming path. It is an integer `u32` (no f64 on the
+///   money path). This does not contradict the charge; it reports the reserved
+///   ceiling the estimate bills, not a fabricated post-hoc count.
+///
+/// The caller (provider.rs) computes both with those exact functions and passes
+/// them in (the adapter has no `model_info`).
+///
+/// `model` is the resolved request model. `message_id` is generated here as
+/// `msg_<uuid>` so each streamed message carries a unique id.
+///
+/// `upstream` is any `Stream<Item = HeartbeatItem>` — in production the real
+/// `HeartbeatStream<ChatStream>` from `fallback::stream_*`; in tests a synthetic
+/// `stream::iter` of `HeartbeatItem`s.
+pub fn frame_anthropic_stream<S>(
+    upstream: S,
+    model: String,
+    input_tokens: u32,
+    output_tokens: u32,
+) -> impl Stream<Item = Result<sse::Event, Infallible>> + Send
+where
+    S: Stream<Item = HeartbeatItem> + Send + Unpin,
+{
+    let message_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+    let state = FrameState {
+        upstream,
+        phase: FramePhase::Preamble,
+        pending: VecDeque::new(),
+        message_id,
+        model,
+        input_tokens,
+        output_tokens,
+        last_finish_reason: None,
+    };
+
+    futures::stream::unfold(state, |mut state| async move {
+        loop {
+            // Drain any buffered events first (preamble/trailer emit several).
+            if let Some(event) = state.pending.pop_front() {
+                return Some((Ok(event), state));
+            }
+
+            match state.phase {
+                FramePhase::Preamble => {
+                    // Emit `message_start` then `content_block_start`, BEFORE
+                    // consuming any upstream chunk. `message_start.usage` carries
+                    // the input-token estimate (billed) and `output_tokens: 0`.
+                    let message_start = anthropic_sse_event(
+                        AnthropicStreamEventKind::MessageStart,
+                        MessageStartData {
+                            message: MessageStartMessage {
+                                id: state.message_id.clone(),
+                                message_type: AnthropicMessageType::Message,
+                                role: AnthropicAssistantRole::Assistant,
+                                model: state.model.clone(),
+                                content: [],
+                                stop_reason: None,
+                                stop_sequence: None,
+                                // `output_tokens` is always 0 at start (no tokens
+                                // generated yet); `input_tokens` is the billed
+                                // input estimate.
+                                usage: MessageStartUsage {
+                                    input_tokens: state.input_tokens,
+                                    output_tokens: 0,
+                                },
+                            },
+                        },
+                    );
+                    let content_block_start = anthropic_sse_event(
+                        AnthropicStreamEventKind::ContentBlockStart,
+                        ContentBlockStartData {
+                            index: ANTHROPIC_TEXT_BLOCK_INDEX,
+                            content_block: ContentBlockStartBlock {
+                                block_type: AnthropicResponseTextBlockType::Text,
+                                text: "",
+                            },
+                        },
+                    );
+                    state.pending.push_back(content_block_start);
+                    state.phase = FramePhase::Streaming;
+                    return Some((Ok(message_start), state));
+                }
+
+                FramePhase::Streaming => match state.upstream.next().await {
+                    Some(HeartbeatItem::Chunk(Ok(chunk))) => {
+                        // Track the last non-null finish_reason for the trailer.
+                        if let Some(reason) =
+                            chunk.choices.first().and_then(|c| c.finish_reason.clone())
+                        {
+                            state.last_finish_reason = Some(reason);
+                        }
+                        // Emit a `content_block_delta` for non-empty text only.
+                        // An empty/absent delta (e.g. the final finish-reason-only
+                        // chunk) produces no event — loop to the next item.
+                        match delta_text(&chunk) {
+                            Some(text) if !text.is_empty() => {
+                                let event = anthropic_sse_event(
+                                    AnthropicStreamEventKind::ContentBlockDelta,
+                                    ContentBlockDeltaData {
+                                        index: ANTHROPIC_TEXT_BLOCK_INDEX,
+                                        delta: ContentBlockTextDelta {
+                                            delta_type: TextDeltaType::TextDelta,
+                                            text: text.to_string(),
+                                        },
+                                    },
+                                );
+                                return Some((Ok(event), state));
+                            }
+                            _ => continue,
+                        }
+                    }
+                    Some(HeartbeatItem::Chunk(Err(e))) => {
+                        // S3 redaction: NEVER reflect raw provider errors. Emit a
+                        // generic Anthropic `error` event and end the stream. The
+                        // message is a fixed, gateway-authored string (typed below),
+                        // so a provider error string can never reach the client.
+                        error!(
+                            error = %e,
+                            "stream chunk error on /v1/messages (details redacted from client)"
+                        );
+                        let event = anthropic_sse_event(
+                            AnthropicStreamEventKind::Error,
+                            StreamErrorData {
+                                error: StreamErrorBody {
+                                    error_type: "api_error",
+                                    message: "stream processing error",
+                                },
+                            },
+                        );
+                        state.phase = FramePhase::Done;
+                        return Some((Ok(event), state));
+                    }
+                    Some(HeartbeatItem::KeepAlive) => {
+                        // Translate the internal heartbeat into an Anthropic ping.
+                        let event =
+                            anthropic_sse_event(AnthropicStreamEventKind::Ping, EmptyEventData {});
+                        return Some((Ok(event), state));
+                    }
+                    None => {
+                        // Upstream ended normally → emit the trailer.
+                        state.phase = FramePhase::Trailer;
+                        continue;
+                    }
+                },
+
+                FramePhase::Trailer => {
+                    // `content_block_stop` → `message_delta` → `message_stop`.
+                    // `stop_reason` defaults to "end_turn" when the upstream never
+                    // reported a finish_reason.
+                    let stop_reason =
+                        finish_reason_to_stop_reason(state.last_finish_reason.as_deref())
+                            .unwrap_or_else(|| "end_turn".to_string());
+
+                    let content_block_stop = anthropic_sse_event(
+                        AnthropicStreamEventKind::ContentBlockStop,
+                        ContentBlockStopData {
+                            index: ANTHROPIC_TEXT_BLOCK_INDEX,
+                        },
+                    );
+                    let message_delta = anthropic_sse_event(
+                        AnthropicStreamEventKind::MessageDelta,
+                        MessageDeltaData {
+                            delta: MessageDeltaDelta {
+                                stop_reason,
+                                stop_sequence: None,
+                            },
+                            // `message_delta.usage` carries ONLY `output_tokens`
+                            // (the billed completion ceiling) — never `input_tokens`.
+                            usage: MessageDeltaUsage {
+                                output_tokens: state.output_tokens,
+                            },
+                        },
+                    );
+                    let message_stop = anthropic_sse_event(
+                        AnthropicStreamEventKind::MessageStop,
+                        EmptyEventData {},
+                    );
+                    state.pending.push_back(message_delta);
+                    state.pending.push_back(message_stop);
+                    state.phase = FramePhase::Done;
+                    return Some((Ok(content_block_stop), state));
+                }
+
+                FramePhase::Done => return None,
+            }
+        }
+    })
+}
+
+/// Extract the assistant text delta from a streaming `ChatChunk`, if any.
+///
+/// PR2 is text-only: only `choices[0].delta.content` is surfaced. Tool-call
+/// deltas are ignored here (tools are rejected at the request boundary, so a
+/// well-behaved stream never carries them; ignoring is defense-in-depth, not a
+/// silent money-path drop).
+fn delta_text(chunk: &ChatChunk) -> Option<&str> {
+    chunk
+        .choices
+        .first()
+        .and_then(|c| c.delta.content.as_deref())
 }
 
 #[cfg(test)]
@@ -712,10 +1219,11 @@ mod tests {
         assert!(chat.tool_choice.is_none());
     }
 
-    /// A `stream: true` request is rejected (PR1 is non-streaming) rather than
-    /// silently served as a single JSON body.
+    /// A `stream: true` request is now ACCEPTED (PR2) and carries the streaming
+    /// flag through to the internal `ChatRequest`, so the shared core frames the
+    /// Anthropic SSE event sequence. (Replaces the PR1 rejection test.)
     #[test]
-    fn streaming_request_is_rejected() {
+    fn streaming_request_carries_through() {
         let body = r#"{
             "model": "claude-sonnet-4-6",
             "max_tokens": 100,
@@ -723,8 +1231,26 @@ mod tests {
             "messages": [{"role": "user", "content": "hi"}]
         }"#;
         let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
-        let err = anthropic_request_to_chat(parsed).unwrap_err();
-        assert!(matches!(err, AnthropicInboundError::InvalidBody(_)));
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+        assert!(
+            chat.stream,
+            "stream:true must carry through to the internal ChatRequest"
+        );
+        assert_eq!(chat.messages.len(), 1);
+    }
+
+    /// A `stream: false` (or absent) request still produces a non-streaming
+    /// `ChatRequest` — the default path is unchanged.
+    #[test]
+    fn non_streaming_request_does_not_set_stream() {
+        let body = r#"{
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}]
+        }"#;
+        let parsed: AnthropicMessagesRequest = serde_json::from_str(body).unwrap();
+        let chat = anthropic_request_to_chat(parsed).unwrap();
+        assert!(!chat.stream, "absent stream must default to non-streaming");
     }
 
     /// Unknown top-level fields (e.g. `metadata`, `anthropic_beta`) are ignored
@@ -858,5 +1384,397 @@ mod tests {
         let anthropic = chat_response_to_anthropic(&resp);
         assert_eq!(anthropic.usage.input_tokens, 0);
         assert_eq!(anthropic.usage.output_tokens, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Streaming framer (ChatChunk stream → Anthropic SSE event sequence)
+    // -----------------------------------------------------------------------
+
+    use solvela_protocol::{ChatChunk, ChatChunkChoice, ChatDelta};
+
+    use crate::providers::heartbeat::HeartbeatItem;
+    use crate::providers::ProviderError;
+
+    /// A text-delta chunk carrying `content` and an optional `finish_reason`.
+    fn text_chunk(content: &str, finish_reason: Option<&str>) -> ChatChunk {
+        ChatChunk {
+            id: "chunk".to_string(),
+            object: "chat.completion.chunk".to_string(),
+            created: 0,
+            model: "openai/gpt-4o".to_string(),
+            choices: vec![ChatChunkChoice {
+                index: 0,
+                delta: ChatDelta {
+                    role: None,
+                    content: Some(content.to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: finish_reason.map(String::from),
+            }],
+        }
+    }
+
+    /// A finish-reason-only chunk (no content) — the common final OpenAI chunk.
+    fn finish_only_chunk(finish_reason: &str) -> ChatChunk {
+        ChatChunk {
+            id: "chunk".to_string(),
+            object: "chat.completion.chunk".to_string(),
+            created: 0,
+            model: "openai/gpt-4o".to_string(),
+            choices: vec![ChatChunkChoice {
+                index: 0,
+                delta: ChatDelta {
+                    role: None,
+                    content: None,
+                    tool_calls: None,
+                },
+                finish_reason: Some(finish_reason.to_string()),
+            }],
+        }
+    }
+
+    /// Collect a framed stream into `(event_name, data_json)` pairs.
+    ///
+    /// `sse::Event` exposes no public wire-rendering API, so we render through
+    /// the REAL `Sse::into_response()` path (exactly as production does), collect
+    /// the response body, and parse the `event:`/`data:` SSE lines. This asserts
+    /// BOTH lines are present (the @anthropic-ai/sdk requirement) on the actual
+    /// transmitted bytes, not on an introspected struct.
+    async fn frame_to_pairs(
+        items: Vec<HeartbeatItem>,
+        model: &str,
+        input_tokens: u32,
+        output_tokens: u32,
+    ) -> Vec<(String, serde_json::Value)> {
+        use axum::response::{IntoResponse, Sse};
+
+        let upstream = futures::stream::iter(items);
+        let framed =
+            frame_anthropic_stream(upstream, model.to_string(), input_tokens, output_tokens);
+        let response = Sse::new(framed).into_response();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("collect SSE body");
+        let wire = String::from_utf8(bytes.to_vec()).expect("SSE body is UTF-8");
+
+        // SSE frames are separated by a blank line. Each frame here has an
+        // `event:` line and a `data:` line.
+        wire.split("\n\n")
+            .filter(|frame| !frame.trim().is_empty())
+            .map(|frame| {
+                let mut name = None;
+                let mut data = None;
+                for line in frame.lines() {
+                    if let Some(rest) = line.strip_prefix("event:") {
+                        name = Some(rest.trim().to_string());
+                    } else if let Some(rest) = line.strip_prefix("data:") {
+                        data = Some(rest.trim().to_string());
+                    }
+                }
+                let name = name.expect("every Anthropic SSE event must set an event: name line");
+                let data = data.expect("every Anthropic SSE event must set a data: line");
+                let json: serde_json::Value =
+                    serde_json::from_str(&data).expect("data line must be valid JSON");
+                (name, json)
+            })
+            .collect()
+    }
+
+    /// A single text chunk with a `stop` finish_reason produces the full, ordered
+    /// Anthropic event sequence with the exact field shapes the SDK requires.
+    #[tokio::test]
+    async fn framer_emits_full_ordered_sequence_for_text_stream() {
+        let items = vec![HeartbeatItem::Chunk(Ok(text_chunk("Hello", Some("stop"))))];
+        let pairs = frame_to_pairs(items, "openai/gpt-4o", 7, 9).await;
+
+        let names: Vec<&str> = pairs.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "message_start",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop",
+            ],
+            "Anthropic streaming event order must match the SDK contract"
+        );
+
+        // The data JSON's "type" must equal the event name on every frame.
+        for (name, data) in &pairs {
+            assert_eq!(
+                data["type"], *name,
+                "data.type must equal the event name for {name}"
+            );
+        }
+
+        // message_start: usage carries the input-token estimate + output 0.
+        let (_, ms) = &pairs[0];
+        assert_eq!(ms["message"]["role"], "assistant");
+        assert_eq!(ms["message"]["model"], "openai/gpt-4o");
+        assert_eq!(ms["message"]["content"], serde_json::json!([]));
+        assert!(ms["message"]["stop_reason"].is_null());
+        assert_eq!(ms["message"]["usage"]["input_tokens"], 7);
+        assert_eq!(ms["message"]["usage"]["output_tokens"], 0);
+        let id = ms["message"]["id"].as_str().unwrap();
+        assert!(
+            id.starts_with("msg_"),
+            "message id must be msg_<uuid>, got {id}"
+        );
+
+        // content_block_start: empty text block at index 0.
+        let (_, cbs) = &pairs[1];
+        assert_eq!(cbs["index"], 0);
+        assert_eq!(
+            cbs["content_block"],
+            serde_json::json!({"type":"text","text":""})
+        );
+
+        // content_block_delta: the text_delta carries the chunk content.
+        let (_, cbd) = &pairs[2];
+        assert_eq!(cbd["index"], 0);
+        assert_eq!(
+            cbd["delta"],
+            serde_json::json!({"type":"text_delta","text":"Hello"})
+        );
+
+        // message_delta: mapped stop_reason ("stop" → "end_turn") + output ceiling.
+        let (_, md) = &pairs[4];
+        assert_eq!(md["delta"]["stop_reason"], "end_turn");
+        assert!(md["delta"]["stop_sequence"].is_null());
+        assert_eq!(
+            md["usage"]["output_tokens"], 9,
+            "message_delta must report the billed completion-token ceiling"
+        );
+    }
+
+    /// Multiple content chunks each yield one content_block_delta, in order; a
+    /// trailing finish-reason-only chunk yields NO delta but sets the stop_reason.
+    #[tokio::test]
+    async fn framer_streams_multiple_deltas_and_maps_length_stop_reason() {
+        let items = vec![
+            HeartbeatItem::Chunk(Ok(text_chunk("Hel", None))),
+            HeartbeatItem::Chunk(Ok(text_chunk("lo", None))),
+            HeartbeatItem::Chunk(Ok(finish_only_chunk("length"))),
+        ];
+        let pairs = frame_to_pairs(items, "openai/gpt-4o", 3, 100).await;
+
+        let deltas: Vec<&str> = pairs
+            .iter()
+            .filter(|(n, _)| n == "content_block_delta")
+            .map(|(_, d)| d["delta"]["text"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            deltas,
+            vec!["Hel", "lo"],
+            "each non-empty content chunk yields one ordered text_delta; \
+             the finish-only chunk yields none"
+        );
+
+        let (_, md) = pairs.iter().find(|(n, _)| n == "message_delta").unwrap();
+        assert_eq!(
+            md["delta"]["stop_reason"], "max_tokens",
+            "length finish_reason must map to the max_tokens stop_reason"
+        );
+    }
+
+    /// A keep-alive heartbeat is translated into an Anthropic `ping` event,
+    /// interleaved in order between deltas.
+    #[tokio::test]
+    async fn framer_translates_keepalive_to_ping() {
+        let items = vec![
+            HeartbeatItem::Chunk(Ok(text_chunk("a", None))),
+            HeartbeatItem::KeepAlive,
+            HeartbeatItem::Chunk(Ok(text_chunk("b", Some("stop")))),
+        ];
+        let pairs = frame_to_pairs(items, "openai/gpt-4o", 1, 5).await;
+        let names: Vec<&str> = pairs.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "message_start",
+                "content_block_start",
+                "content_block_delta", // "a"
+                "ping",                // keep-alive
+                "content_block_delta", // "b"
+                "content_block_stop",
+                "message_delta",
+                "message_stop",
+            ]
+        );
+        let (_, ping) = pairs.iter().find(|(n, _)| n == "ping").unwrap();
+        assert_eq!(*ping, serde_json::json!({"type": "ping"}));
+    }
+
+    /// A mid-stream error chunk emits a single Anthropic `error` event with a
+    /// GENERIC, REDACTED message (never the raw provider error) and ends the
+    /// stream cleanly (no trailing content_block_stop/message_delta/message_stop).
+    #[tokio::test]
+    async fn framer_redacts_error_chunk_and_ends_stream() {
+        let raw = "OpenAI 500: api key sk-secret-LEAK rate exceeded at https://internal";
+        let err: ProviderError = raw.into();
+        let items = vec![
+            HeartbeatItem::Chunk(Ok(text_chunk("partial", None))),
+            HeartbeatItem::Chunk(Err(err)),
+            // Anything after the error must never be emitted.
+            HeartbeatItem::Chunk(Ok(text_chunk("should-not-appear", Some("stop")))),
+        ];
+        let pairs = frame_to_pairs(items, "openai/gpt-4o", 1, 5).await;
+        let names: Vec<&str> = pairs.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "message_start",
+                "content_block_start",
+                "content_block_delta",
+                "error",
+            ],
+            "an error chunk must terminate the stream after a generic error event"
+        );
+
+        let (_, err) = pairs.last().unwrap();
+        assert_eq!(err["error"]["type"], "api_error");
+        assert_eq!(err["error"]["message"], "stream processing error");
+        // The redacted message must NOT leak any of the raw provider error.
+        let serialized = err.to_string();
+        assert!(
+            !serialized.contains("sk-secret-LEAK")
+                && !serialized.contains("internal")
+                && !serialized.contains("500"),
+            "the error event must not reflect the raw provider error: {serialized}"
+        );
+        // The post-error chunk must not have produced a delta.
+        assert!(
+            !pairs
+                .iter()
+                .any(|(_, d)| d["delta"]["text"] == "should-not-appear"),
+            "no events may be emitted after the terminal error event"
+        );
+    }
+
+    /// An empty upstream (no chunks at all) still produces a well-formed sequence
+    /// with the default `end_turn` stop_reason (no finish_reason was seen).
+    #[tokio::test]
+    async fn framer_empty_stream_defaults_to_end_turn() {
+        let pairs = frame_to_pairs(vec![], "openai/gpt-4o", 4, 8).await;
+        let names: Vec<&str> = pairs.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "message_start",
+                "content_block_start",
+                "content_block_stop",
+                "message_delta",
+                "message_stop",
+            ]
+        );
+        let (_, md) = pairs.iter().find(|(n, _)| n == "message_delta").unwrap();
+        assert_eq!(
+            md["delta"]["stop_reason"], "end_turn",
+            "absent finish_reason must default the stop_reason to end_turn"
+        );
+        assert_eq!(md["usage"]["output_tokens"], 8);
+    }
+
+    /// T6: an UNKNOWN provider `finish_reason` (e.g. `content_filter`) on the
+    /// STREAMING path passes through unchanged into the trailer
+    /// `message_delta.stop_reason` — the streaming-side lock for the same
+    /// provider-boundary passthrough the non-streaming
+    /// `unknown_finish_reason_passes_through` test pins. The provider boundary is
+    /// trusted (registry-controlled adapters), so an unrecognized reason is
+    /// forwarded verbatim rather than coerced or dropped.
+    #[tokio::test]
+    async fn framer_unknown_finish_reason_passes_through() {
+        let items = vec![HeartbeatItem::Chunk(Ok(text_chunk(
+            "x",
+            Some("content_filter"),
+        )))];
+        let pairs = frame_to_pairs(items, "openai/gpt-4o", 1, 5).await;
+        let (_, md) = pairs.iter().find(|(n, _)| n == "message_delta").unwrap();
+        assert_eq!(
+            md["delta"]["stop_reason"], "content_filter",
+            "an unknown finish_reason must pass through to stop_reason unchanged \
+             (provider boundary is trusted/registry-controlled)"
+        );
+    }
+
+    /// An error as the FIRST upstream item (no preceding Ok chunk) must STILL be
+    /// preceded by the `message_start` + `content_block_start` preamble before the
+    /// redacted `error` event — the `@anthropic-ai/sdk` requires the preamble
+    /// ahead of any error event, even when the upstream fails immediately.
+    #[tokio::test]
+    async fn framer_error_on_first_chunk_still_emits_preamble() {
+        let err: ProviderError = "OpenAI 500: sk-secret-LEAK".into();
+        let items = vec![HeartbeatItem::Chunk(Err(err))];
+        let pairs = frame_to_pairs(items, "openai/gpt-4o", 1, 5).await;
+        let names: Vec<&str> = pairs.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["message_start", "content_block_start", "error"],
+            "an immediate error must still be preceded by the preamble events"
+        );
+        // The error stays generic/redacted even on the first-item path.
+        let (_, err_ev) = pairs.last().unwrap();
+        assert_eq!(err_ev["type"], "error");
+        assert_eq!(err_ev["error"]["message"], "stream processing error");
+        assert!(
+            !err_ev.to_string().contains("sk-secret-LEAK"),
+            "the error event must not leak the raw provider error"
+        );
+    }
+
+    /// Byte-shape lock for `anthropic_sse_event`: the helper derives BOTH the
+    /// `event:` name AND the data JSON's `"type"` from the SAME kind, injecting
+    /// `"type"` exactly once. This pins the exact emitted SSE wire bytes of a
+    /// representative frame so a future change to the typed payloads / helper that
+    /// alters the wire shape is caught. Asserting on the literal bytes (not parsed
+    /// JSON) is what makes name/type single-source-of-truth and the typed usage
+    /// shapes observable at the wire level.
+    #[tokio::test]
+    async fn framer_message_start_and_delta_have_exact_typed_wire_shape() {
+        use axum::response::{IntoResponse, Sse};
+
+        let items = vec![HeartbeatItem::Chunk(Ok(text_chunk("Hi", Some("stop"))))];
+        let upstream = futures::stream::iter(items);
+        let framed = frame_anthropic_stream(upstream, "openai/gpt-4o".to_string(), 7, 9);
+        let response = Sse::new(framed).into_response();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("collect SSE body");
+        let wire = String::from_utf8(bytes.to_vec()).expect("SSE body is UTF-8");
+
+        // The `event:` name and the data `"type"` are produced from the same kind
+        // — assert both the name line and the matching `"type"` appear together
+        // for message_start, with the typed usage shape (input + output:0).
+        assert!(
+            wire.contains("event: message_start\n")
+                && wire.contains("data: {\"type\":\"message_start\",\"message\":{\"id\":"),
+            "message_start frame must carry the event name line and a type-tagged \
+             data line:\n{wire}"
+        );
+        // message_start.usage is the {input_tokens, output_tokens} typed shape
+        // with output always 0 at start.
+        assert!(
+            wire.contains("\"usage\":{\"input_tokens\":7,\"output_tokens\":0}}}"),
+            "message_start.usage must be the typed {{input_tokens,output_tokens}} \
+             shape with output 0:\n{wire}"
+        );
+        // message_delta.usage is the DISTINCT {output_tokens}-only typed shape
+        // (no input_tokens), carrying the billed completion ceiling.
+        assert!(
+            wire.contains("event: message_delta\n")
+                && wire.contains("\"usage\":{\"output_tokens\":9}"),
+            "message_delta.usage must be the {{output_tokens}}-only typed shape:\n{wire}"
+        );
+        // The message_delta data must NOT carry input_tokens (separate usage type).
+        let md_frame = wire
+            .split("\n\n")
+            .find(|f| f.contains("event: message_delta"))
+            .expect("message_delta frame present");
+        assert!(
+            !md_frame.contains("input_tokens"),
+            "message_delta.usage must omit input_tokens:\n{md_frame}"
+        );
     }
 }

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -39,6 +39,11 @@ use cost::{
 };
 use payment::{decode_payment_from_header, extract_payment_info, fire_escrow_claim};
 use provider::{ProviderCallContext, ProviderCallError, ProviderCallResult};
+
+// Re-export the SSE wire-dialect selector so the `/v1/messages` Anthropic
+// adapter can pass `StreamWire::Anthropic` into the shared core (symmetric with
+// how it imports `chat_completions_inner`).
+pub(crate) use provider::StreamWire;
 use response::{build_session_token, validate_session_id, validate_tenant};
 
 // Re-export `uses_durable_nonce` for use by `crate::routes::proxy`
@@ -134,7 +139,18 @@ pub async fn chat_completions(
     // `/v1/messages` (the Anthropic Messages adapter) calls the SAME core with
     // its own `resource_url`, so the 402/cost/verify/settle/record logic is
     // never forked — CLAUDE.md requires the payment path to live in one place.
-    chat_completions_inner(state, peer_addr, headers, req, "/v1/chat/completions").await
+    //
+    // The OpenAI route always frames streaming responses in the OpenAI SSE
+    // dialect (`StreamWire::OpenAi`), so its behavior is byte-for-byte unchanged.
+    chat_completions_inner(
+        state,
+        peer_addr,
+        headers,
+        req,
+        "/v1/chat/completions",
+        StreamWire::OpenAi,
+    )
+    .await
 }
 
 /// Shared inner core for every OpenAI-shaped chat request, regardless of the
@@ -152,12 +168,20 @@ pub async fn chat_completions(
 /// (rather than duplicating it) keeps a single home for the payment logic; the
 /// `/v1/chat/completions` behavior is byte-for-byte unchanged because it passes
 /// the same `"/v1/chat/completions"` it always hard-coded.
+///
+/// `stream_wire` selects the SSE dialect for a STREAMING response: the OpenAI
+/// route passes [`StreamWire::OpenAi`] (its framing is byte-for-byte unchanged);
+/// the Anthropic Messages adapter passes [`StreamWire::Anthropic`] so the same
+/// money path produces an Anthropic-framed SSE stream WITHOUT forking. It only
+/// affects streaming response framing — never the cost/verify/settle/record
+/// logic — and is ignored for non-streaming requests.
 pub(crate) async fn chat_completions_inner(
     state: Arc<AppState>,
     peer_addr: crate::middleware::rate_limit::PeerAddr,
     headers: HeaderMap,
     mut req: ChatRequest,
     resource_url: &str,
+    stream_wire: StreamWire,
 ) -> Result<Response, GatewayError> {
     let request_start = Instant::now();
     let debug_enabled = is_debug_enabled(&headers);
@@ -407,6 +431,7 @@ pub(crate) async fn chat_completions_inner(
             routing_profile: &routing_profile,
             session_id: &session_id,
             payment_status: PaymentStatus::DevBypass,
+            stream_wire,
         };
 
         return provider::execute_provider_call(&ctx)
@@ -559,6 +584,7 @@ pub(crate) async fn chat_completions_inner(
             routing_profile: &routing_profile,
             session_id: &session_id,
             payment_status: PaymentStatus::Free,
+            stream_wire,
         };
 
         return match provider::execute_provider_call(&ctx).await {
@@ -1158,6 +1184,7 @@ pub(crate) async fn chat_completions_inner(
         routing_profile: &routing_profile,
         session_id: &session_id,
         payment_status: PaymentStatus::Verified,
+        stream_wire,
     };
 
     match provider::execute_provider_call(&ctx).await {

--- a/crates/gateway/src/routes/chat/provider.rs
+++ b/crates/gateway/src/routes/chat/provider.rs
@@ -23,7 +23,8 @@ use crate::routes::debug_headers::{attach_debug_headers, CacheStatus, PaymentSta
 use crate::AppState;
 
 use super::cost::{
-    cap_usage_to_request_limits, estimate_input_tokens, semantic_hit_full_atomic, SemanticDiscount,
+    cap_usage_to_request_limits, completion_token_ceiling, estimate_input_tokens,
+    semantic_hit_full_atomic, SemanticDiscount,
 };
 use super::response::{attach_session_id, build_debug_info};
 
@@ -71,6 +72,23 @@ pub(crate) fn parse_fallback_preference(header: &str) -> Vec<(&str, &str)> {
         .collect()
 }
 
+/// Which SSE wire dialect a STREAMING response is framed in.
+///
+/// Threaded through the shared core (symmetric with `resource_url`) so the
+/// streaming framer in [`execute_streaming_call`] knows which event shape to
+/// emit, WITHOUT forking the money path. The OpenAI route always selects
+/// [`StreamWire::OpenAi`] (its framing is byte-for-byte unchanged); the
+/// Anthropic Messages adapter selects [`StreamWire::Anthropic`].
+///
+/// Non-streaming requests ignore this field entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StreamWire {
+    /// OpenAI `data: {ChatChunk}` SSE frames (the existing behavior).
+    OpenAi,
+    /// Anthropic Messages SSE event sequence (message_start → … → message_stop).
+    Anthropic,
+}
+
 /// Context for a provider call -- captures all routing/debug metadata that
 /// both the paid and dev-bypass paths need.
 pub(crate) struct ProviderCallContext<'a> {
@@ -85,6 +103,9 @@ pub(crate) struct ProviderCallContext<'a> {
     pub routing_profile: &'a str,
     pub session_id: &'a Option<String>,
     pub payment_status: PaymentStatus,
+    /// The SSE dialect to frame a streaming response in. Ignored for
+    /// non-streaming requests.
+    pub stream_wire: StreamWire,
 }
 
 /// Metadata returned alongside the HTTP response from a provider call.
@@ -358,35 +379,74 @@ async fn execute_streaming_call(
 
     match result {
         Ok(result) => {
+            // Capture model/usage-estimate inputs the Anthropic framer needs
+            // BEFORE `result.data` is moved into the heartbeat wrapper. These are
+            // computed here (provider.rs has `model_info`; the inbound adapter
+            // does not) and are consistent with the streaming BILLING estimate:
+            //   - `input_tokens`  = `estimate_input_tokens(req)` — the input figure
+            //     the estimate prices and the `EstimateFallback` spend row records.
+            //   - `output_tokens` = `completion_token_ceiling(req.max_tokens,
+            //     model_info)` — the completion-token count the billing estimate
+            //     RESERVES (the streaming charge). The stream carries no usage, so
+            //     this reserved ceiling is the honest, billing-consistent figure to
+            //     surface (see `frame_anthropic_stream`'s money-path note and
+            //     solvela-fintech §3). Integer `u32` — no f64 on the money path.
+            let anthropic_model = result.actual_model.clone();
+            let anthropic_input_tokens = estimate_input_tokens(ctx.req);
+            let anthropic_output_tokens =
+                completion_token_ceiling(ctx.req.max_tokens, ctx.model_info);
+
             // Wrap with adaptive heartbeat
             let heartbeat_stream = HeartbeatStream::new(result.data, HeartbeatConfig::default());
 
-            // S3 FIX: Generic error message instead of raw provider errors
-            let sse_stream = heartbeat_stream.map(|item| match item {
-                HeartbeatItem::Chunk(Ok(chunk)) => match serde_json::to_string(&chunk) {
-                    Ok(json) => Ok::<_, Infallible>(sse::Event::default().data(json)),
-                    // A serialise failure here is essentially impossible
-                    // (`ChatChunk` is plain strings + numbers), but if it ever
-                    // happens we must NOT emit `data:` with an empty body —
-                    // that frame is structurally valid SSE and the agent would
-                    // bill on close having received zero content. Emit a
-                    // typed error frame instead so the client can distinguish
-                    // it from a normal chunk and surface a failure upstream.
-                    Err(e) => {
-                        tracing::error!(error = %e, "failed to serialise chat chunk for SSE");
-                        Ok(sse::Event::default()
-                            .data("{\"error\": \"stream serialisation error\"}"))
-                    }
-                },
-                HeartbeatItem::Chunk(Err(e)) => {
-                    tracing::error!(error = %e, "stream chunk error (details redacted from client)");
-                    Ok(sse::Event::default()
-                        .data("{\"error\": \"stream processing error\"}"))
+            // Build the SSE response BODY per wire dialect. The OpenAi arm is the
+            // existing framing, byte-for-byte unchanged. The Anthropic arm hands
+            // the same heartbeat stream to the inbound adapter's event state
+            // machine. Both then attach the SAME fallback/session/debug headers
+            // below — the only dialect-specific code is the body framing.
+            let mut resp = match ctx.stream_wire {
+                StreamWire::OpenAi => {
+                    // S3 FIX: Generic error message instead of raw provider errors
+                    let sse_stream = heartbeat_stream.map(|item| match item {
+                        HeartbeatItem::Chunk(Ok(chunk)) => match serde_json::to_string(&chunk) {
+                            Ok(json) => Ok::<_, Infallible>(sse::Event::default().data(json)),
+                            // A serialise failure here is essentially impossible
+                            // (`ChatChunk` is plain strings + numbers), but if it
+                            // ever happens we must NOT emit `data:` with an empty
+                            // body — that frame is structurally valid SSE and the
+                            // agent would bill on close having received zero
+                            // content. Emit a typed error frame instead so the
+                            // client can distinguish it from a normal chunk and
+                            // surface a failure upstream.
+                            Err(e) => {
+                                tracing::error!(error = %e, "failed to serialise chat chunk for SSE");
+                                Ok(sse::Event::default()
+                                    .data("{\"error\": \"stream serialisation error\"}"))
+                            }
+                        },
+                        HeartbeatItem::Chunk(Err(e)) => {
+                            tracing::error!(error = %e, "stream chunk error (details redacted from client)");
+                            Ok(sse::Event::default()
+                                .data("{\"error\": \"stream processing error\"}"))
+                        }
+                        HeartbeatItem::KeepAlive => Ok(sse::Event::default().comment("keep-alive")),
+                    });
+                    sse::Sse::new(sse_stream).into_response()
                 }
-                HeartbeatItem::KeepAlive => Ok(sse::Event::default().comment("keep-alive")),
-            });
-
-            let mut resp = sse::Sse::new(sse_stream).into_response();
+                StreamWire::Anthropic => {
+                    // `frame_anthropic_stream` is generic over the upstream item
+                    // stream; box-pin the (`!Unpin`) heartbeat stream so it
+                    // satisfies the framer's `Unpin` bound.
+                    let upstream = Box::pin(heartbeat_stream);
+                    let sse_stream = crate::providers::anthropic_inbound::frame_anthropic_stream(
+                        upstream,
+                        anthropic_model,
+                        anthropic_input_tokens,
+                        anthropic_output_tokens,
+                    );
+                    sse::Sse::new(sse_stream).into_response()
+                }
+            };
 
             // Add fallback header if served by a different model
             if result.was_fallback {

--- a/crates/gateway/src/routes/messages/mod.rs
+++ b/crates/gateway/src/routes/messages/mod.rs
@@ -8,10 +8,13 @@
 //! translate → call-core → translate wrapper (CLAUDE.md rule #14 posture: a
 //! protocol adapter, not new payment logic).
 //!
-//! SCOPE (PR1): text-only, non-streaming. Streaming (SSE), tools, `count_tokens`,
-//! and bearer/spend-down auth are LATER PRs. The translation layer rejects
-//! `stream:true`, image content, and tool blocks with a clear error rather than
-//! silently degrading.
+//! SCOPE (PR2): text-only, streaming (SSE) AND non-streaming. A `stream:true`
+//! request is framed into the Anthropic Messages SSE event sequence inside the
+//! shared money path (see [`StreamWire::Anthropic`]); a `stream:false`/absent
+//! request is buffered and re-shaped into the Anthropic non-streaming JSON body.
+//! Tools, `count_tokens`, images, and bearer/spend-down auth are LATER PRs. The
+//! translation layer rejects image content and tool blocks with a clear error
+//! rather than silently degrading.
 //!
 //! ## Error envelopes
 //!
@@ -44,7 +47,7 @@ use crate::providers::anthropic_inbound::{
     anthropic_request_to_chat, chat_response_to_anthropic, AnthropicInboundError,
     AnthropicMessagesRequest,
 };
-use crate::routes::chat::{chat_completions_discovery, chat_completions_inner};
+use crate::routes::chat::{chat_completions_discovery, chat_completions_inner, StreamWire};
 use crate::AppState;
 
 /// The resource URL this endpoint binds payments to. A payment signed for
@@ -118,8 +121,10 @@ pub async fn create_message(
     };
 
     // Translate the Anthropic request into the internal ChatRequest. A
-    // translation error (image/tool block, or `stream:true`) is a client 4xx in
-    // the Anthropic envelope — it never reaches the money path.
+    // translation error (image or tool block) is a client 4xx in the Anthropic
+    // envelope — it never reaches the money path. `stream:true` is NO LONGER a
+    // rejection (PR2): it carries through to the shared core, which frames the
+    // Anthropic SSE event sequence.
     let chat_req = match anthropic_request_to_chat(anthropic_req) {
         Ok(req) => req,
         Err(e) => {
@@ -142,11 +147,43 @@ pub async fn create_message(
         }
     };
 
+    // Capture the streaming flag BEFORE handing `chat_req` to the core. A
+    // streaming request reaches the core with `StreamWire::Anthropic`, which
+    // frames the provider stream as an Anthropic SSE event sequence inside the
+    // shared money path — so the response is ALREADY in the Anthropic dialect and
+    // must be returned verbatim (NOT buffered/re-translated).
+    let is_stream = chat_req.stream;
+
     // Run the SHARED money-path core. `/v1/messages` does NOT fork any
     // 402/cost/verify/settle/record logic — it reuses the exact same inner core
-    // as `/v1/chat/completions`, only with its own `resource_url`.
-    match chat_completions_inner(state, peer_addr, headers, chat_req, MESSAGES_RESOURCE_URL).await {
-        Ok(response) => translate_success_response(response).await,
+    // as `/v1/chat/completions`, only with its own `resource_url` and the
+    // Anthropic streaming dialect.
+    match chat_completions_inner(
+        state,
+        peer_addr,
+        headers,
+        chat_req,
+        MESSAGES_RESOURCE_URL,
+        StreamWire::Anthropic,
+    )
+    .await
+    {
+        Ok(response) => {
+            if is_stream {
+                // The core already produced an Anthropic-framed SSE response
+                // (text/event-stream). Return it directly — buffering or
+                // re-translating it would break the stream and is wrong (the
+                // body is the Anthropic event sequence, not a JSON ChatResponse).
+                response
+            } else {
+                // Non-streaming: the core returned a JSON ChatResponse; buffer
+                // and re-shape it into the Anthropic non-streaming response.
+                translate_success_response(response).await
+            }
+        }
+        // Pre-stream errors (402 challenge, invalid payment, validation) are
+        // unchanged for streaming requests — they fire BEFORE any provider call,
+        // so `translate_error` handles them identically regardless of `is_stream`.
         Err(err) => translate_error(err).await,
     }
 }
@@ -164,12 +201,16 @@ pub async fn create_message_discovery_get(State(state): State<Arc<AppState>>) ->
 /// Translate a successful inner-core [`Response`] (a serialized OpenAI
 /// [`ChatResponse`] JSON body) into the Anthropic Messages response shape.
 ///
-/// PR1 is non-streaming, so the inner response is always a JSON body; we
-/// buffer it, deserialize into a [`ChatResponse`], and re-emit as the Anthropic
-/// shape. Payment/audit headers (receipt, session) are carried across. If the
-/// body cannot be deserialized into a [`ChatResponse`] (e.g. an unexpected stub
-/// shape), we fail closed with a 502 in the Anthropic envelope rather than
-/// emitting a malformed Anthropic body.
+/// This is called ONLY on the non-streaming branch (`is_stream == false`) in
+/// [`create_message`]: the inner response is then a JSON [`ChatResponse`] body,
+/// which we buffer, deserialize, and re-emit as the Anthropic non-streaming
+/// shape. (A streaming request is returned verbatim by `create_message` BEFORE
+/// reaching here, because the core already produced an Anthropic-framed SSE
+/// body — re-buffering it would break the stream.) Payment/audit headers
+/// (receipt, session) are carried across. If the body cannot be deserialized
+/// into a [`ChatResponse`] (e.g. an unexpected stub shape), we fail closed with
+/// a 502 in the Anthropic envelope rather than emitting a malformed Anthropic
+/// body.
 async fn translate_success_response(response: Response) -> Response {
     let status = response.status();
     let (parts, body) = response.into_parts();

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -16107,10 +16107,12 @@ mod messages_endpoint_tests {
         assert!(v["error"]["message"].is_string());
     }
 
-    /// A `stream: true` request is rejected (PR1 is non-streaming) with a 400 in
-    /// the Anthropic error envelope rather than silently served non-streaming.
+    /// A `stream: true` request is now ACCEPTED (PR2) and served as an Anthropic
+    /// SSE stream — NOT rejected with a 400 (the PR1 behavior this replaces).
+    /// (The full event-sequence assertions live in
+    /// `messages_paid_streaming_returns_anthropic_sse_sequence`.)
     #[tokio::test]
-    async fn messages_streaming_request_rejected_with_anthropic_envelope() {
+    async fn messages_streaming_request_is_accepted_as_sse() {
         let app = test_app_with_mock_provider();
         let body = serde_json::json!({
             "model": "anthropic/claude-sonnet-4-6",
@@ -16132,11 +16134,21 @@ mod messages_endpoint_tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(v["type"], "error");
-        assert_eq!(v["error"]["type"], "invalid_request_error");
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "stream:true is now accepted (PR2), not rejected with a 400"
+        );
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .expect("streaming response must carry a content-type")
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("text/event-stream"),
+            "an accepted streaming /v1/messages request must be SSE, got: {content_type}"
+        );
     }
 
     /// An image content block is rejected (PR1 is text-only) with a 415 in the
@@ -16385,26 +16397,19 @@ mod messages_endpoint_tests {
         );
     }
 
-    /// Money-path proof: streaming, image, AND tools rejections all occur with
-    /// NO settlement. We inject a `SettleRecordingVerifier`; for each rejected
-    /// request the settle flag must stay `false` — the agent is never charged
-    /// for a request that is rejected at the translation boundary, BEFORE the
-    /// money path.
+    /// Money-path proof: image AND tools rejections occur with NO settlement.
+    /// We inject a `SettleRecordingVerifier`; for each rejected request the
+    /// settle flag must stay `false` — the agent is never charged for a request
+    /// that is rejected at the translation boundary, BEFORE the money path.
+    ///
+    /// NOTE (PR2): streaming is no longer a translation-boundary rejection — it
+    /// is a valid paid path that DOES settle, so it is intentionally NOT in this
+    /// "rejections never settle" set. Images and tools remain rejected.
     #[tokio::test]
     async fn messages_rejections_never_settle() {
         // Each rejected shape, asserted independently with its own fresh app and
         // settle flag.
         let cases: Vec<(&str, serde_json::Value, StatusCode)> = vec![
-            (
-                "streaming",
-                serde_json::json!({
-                    "model": "anthropic/claude-sonnet-4-6",
-                    "max_tokens": 64,
-                    "stream": true,
-                    "messages": [{"role": "user", "content": "hi"}]
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
             (
                 "image",
                 serde_json::json!({
@@ -16534,4 +16539,565 @@ mod messages_endpoint_tests {
             "a DB-less gateway must not advertise an unfetchable receipt on /v1/messages"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // PR2: streaming /v1/messages (Anthropic SSE event sequence)
+    // -----------------------------------------------------------------------
+
+    /// A PAID `stream:true` request to /v1/messages returns an Anthropic-framed
+    /// SSE response (`text/event-stream`) whose body contains the full Anthropic
+    /// event sequence IN ORDER (message_start → content_block_start →
+    /// content_block_delta → content_block_stop → message_delta → message_stop).
+    /// Drives the REAL route through `oneshot(test_app_with_mock_provider())`
+    /// (CLAUDE.md rule 10): the AlwaysPassVerifier exact path reaches the mock
+    /// provider's streaming impl with no real keys.
+    #[tokio::test]
+    async fn messages_paid_streaming_returns_anthropic_sse_sequence() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Must be an SSE response — NOT a buffered JSON ChatResponse.
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .expect("streaming /v1/messages response must carry a content-type")
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("text/event-stream"),
+            "streaming /v1/messages must be SSE, got: {content_type}"
+        );
+
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body_str = String::from_utf8_lossy(&bytes);
+
+        // The Anthropic event NAMES must appear, in order, as `event:` lines.
+        let expected_order = [
+            "event: message_start",
+            "event: content_block_start",
+            "event: content_block_delta",
+            "event: content_block_stop",
+            "event: message_delta",
+            "event: message_stop",
+        ];
+        let mut search_from = 0usize;
+        for name in expected_order {
+            let idx = body_str[search_from..].find(name).unwrap_or_else(|| {
+                panic!(
+                    "missing or out-of-order Anthropic SSE event {name:?} in stream body:\n{body_str}"
+                )
+            });
+            search_from += idx + name.len();
+        }
+
+        // The mock stream's "[mock stream response]" content must surface as a
+        // text_delta, and message_start must carry the usage object.
+        assert!(
+            body_str.contains("\"type\":\"text_delta\"")
+                && body_str.contains("[mock stream response]"),
+            "the content_block_delta must carry the streamed text_delta:\n{body_str}"
+        );
+        assert!(
+            body_str.contains("\"input_tokens\"") && body_str.contains("\"output_tokens\""),
+            "message_start/message_delta must carry the usage token fields:\n{body_str}"
+        );
+        // The mock's "stop" finish_reason must map to the Anthropic end_turn.
+        assert!(
+            body_str.contains("\"stop_reason\":\"end_turn\""),
+            "message_delta must carry the mapped end_turn stop_reason:\n{body_str}"
+        );
+    }
+
+    /// A PAID STREAMING /v1/messages response must emit the `x-solvela-receipt`
+    /// header AND persist a receipt recording the BILLED ESTIMATE — the same
+    /// shared-core behavior locked at /v1/chat/completions by
+    /// [`super::paid_streaming_chat_emits_receipt_header_and_records_estimate`],
+    /// now pinned at the Anthropic surface. This guards two things at once:
+    /// (1) `create_message`'s verbatim streaming pass-through preserves the
+    /// receipt header that `emit_chat_receipt` puts on the response HEAD before
+    /// the SSE body streams, and (2) the stored amount is the 402-quoted
+    /// estimate (no usage exists at head time for a stream), billed in full on
+    /// the `exact` scheme (no refund path), so `amount_paid_atomic` and
+    /// `cost_breakdown.total_atomic` both equal that reservation.
+    ///
+    /// The receipt header is DB-gated (`emit_chat_receipt` returns early when
+    /// `db_pool.is_none()`; the header is a path to a DB-stored resource), so
+    /// this uses a real Postgres pool and SELF-SKIPS when one is unavailable —
+    /// a no-op in CI without Postgres, exactly like the chat receipt test.
+    #[tokio::test]
+    async fn messages_paid_streaming_emits_receipt_header_and_records_estimate() {
+        let Some(pool) = try_receipts_db_pool().await else {
+            return;
+        };
+        // Anthropic /v1/messages body: same model/shape as the chat receipt test
+        // (`openai/gpt-4o`, which the messages route accepts), streaming.
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}],
+        });
+        // The reservation/estimate observed through the REAL /v1/messages 402
+        // (the same endpoint we pay) — the amount the streaming receipt must
+        // record (no usage at head time → the billed estimate).
+        let reserved_atomic = messages_quote_402_amount_atomic(&body).await;
+
+        let (app, _state) =
+            test_app_with_db_pool(mock_provider_registry(), Arc::new(AlwaysPassVerifier), pool);
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .expect("streaming /v1/messages response has content-type")
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("text/event-stream"),
+            "must be an SSE response, got {content_type}"
+        );
+        // Header present on the response HEAD — decided before the body streams,
+        // and preserved through `create_message`'s verbatim pass-through.
+        let path = receipt_header_path(&response);
+
+        let receipt = poll_receipt_until_ok(&app, &path).await;
+        assert_eq!(receipt["payment_scheme"], "exact");
+        assert_eq!(
+            receipt["amount_paid_atomic"].as_u64(),
+            Some(reserved_atomic),
+            "streaming /v1/messages receipt must record the billed estimate \
+             (the 402-quoted amount)"
+        );
+        assert_eq!(
+            receipt["cost_breakdown"]["total_atomic"].as_u64(),
+            Some(reserved_atomic),
+            "streaming /v1/messages receipt breakdown total must equal the quoted estimate"
+        );
+        assert!(
+            receipt.get("vendor").is_none(),
+            "chat-core receipts must not carry vendor fields"
+        );
+    }
+
+    /// T1 — streaming settlement proof. A PAID `stream:true` /v1/messages request
+    /// MUST reach on-chain settlement (the deferred `exact` broadcast fires once
+    /// the streamed provider response is constructed). We inject a
+    /// `SettleRecordingVerifier`; the settle flag must flip `true`. Without this
+    /// guard, a future regression that returned the SSE response BEFORE settlement
+    /// (delivering the stream for free) would pass unnoticed — the agent paid the
+    /// estimate on-chain, so the gateway must actually collect it.
+    #[tokio::test]
+    async fn messages_streaming_paid_request_settles() {
+        let settled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (app, _state) = test_app_with_provider_registry_and_exact_verifier(
+            mock_provider_registry(),
+            Arc::new(SettleRecordingVerifier {
+                settled: Arc::clone(&settled),
+            }),
+        );
+
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}],
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "a delivered paid streaming /v1/messages request must return 200"
+        );
+        // Drain the SSE body so the constructed response (and its post-delivery
+        // settle) fully completes before we inspect the flag.
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            content_type.contains("text/event-stream"),
+            "streaming /v1/messages must be SSE, got: {content_type}"
+        );
+        let _ = response.into_body().collect().await.unwrap().to_bytes();
+
+        assert!(
+            settled.load(std::sync::atomic::Ordering::SeqCst),
+            "EXACT settlement MUST be reached for a paid streaming /v1/messages \
+             request — returning the SSE response must not drop the deferred \
+             broadcast (the agent paid the estimate on-chain)"
+        );
+    }
+
+    /// T2 — streaming spend-log proof. A settled paid `stream:true` /v1/messages
+    /// request (usage absent, no semantic-cache hit) must write EXACTLY ONE
+    /// spend-log entry at the ESTIMATE — the `EstimateFallback` arm — mirroring
+    /// `streaming_paid_request_logs_spend_from_estimate` but for the Anthropic
+    /// endpoint. Output tokens are recorded as 0 (no usage on the stream).
+    #[tokio::test]
+    async fn messages_streaming_paid_request_logs_spend_from_estimate() {
+        use tracing::instrument::WithSubscriber;
+
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}],
+        });
+
+        // The /v1/messages 402 amount is the observable proxy for the reserved
+        // estimate on this exact request shape.
+        let reserved_atomic = messages_quote_402_amount_atomic(&body).await;
+
+        let app = test_app_with_mock_provider();
+        let capture = CaptureWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_writer(capture.clone())
+            .with_max_level(tracing::Level::INFO)
+            .finish();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .with_subscriber(subscriber)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        // Drain the SSE body so the (fire-and-forget) spend-log event is emitted
+        // before we read the capture buffer.
+        let _ = response.into_body().collect().await.unwrap().to_bytes();
+
+        let events = spend_logged_events(&capture);
+        assert_eq!(
+            events.len(),
+            1,
+            "a settled streaming paid /v1/messages request MUST write exactly one \
+             spend entry (got {}): the agent paid the estimate on-chain",
+            events.len()
+        );
+        let logged_usdc = events[0]["cost_usdc"]
+            .as_f64()
+            .expect("spend logged event carries cost_usdc");
+        let logged_atomic = (logged_usdc * 1_000_000.0).round() as u64;
+        assert!(
+            logged_atomic.abs_diff(reserved_atomic) <= 1,
+            "streaming /v1/messages spend must be billed at the reserved estimate \
+             ({reserved_atomic} atomic), got {logged_atomic} atomic"
+        );
+        assert_eq!(
+            events[0]["output_tokens"].as_u64(),
+            Some(0),
+            "streaming has no token usage — output_tokens must be recorded as 0"
+        );
+        assert!(
+            events[0]["input_tokens"].as_u64().unwrap_or(0) >= 1,
+            "input tokens are estimated from the request (minimum 1)"
+        );
+    }
+
+    /// T3 — non-streaming still translates. A PAID `stream:false` (here omitted)
+    /// /v1/messages request must return the Anthropic NON-streaming JSON body
+    /// (`{"type":"message",...}`), proving `translate_success_response` is still
+    /// reached after the `is_stream` refactor — i.e. a non-streaming response is
+    /// NOT accidentally framed as an SSE stream.
+    #[tokio::test]
+    async fn messages_non_streaming_paid_still_translates_json() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Hello!"}],
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        // It must be a JSON body, NOT an SSE stream.
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            content_type.contains("application/json"),
+            "a non-streaming /v1/messages response must be JSON (not SSE), got: {content_type}"
+        );
+        assert!(
+            !content_type.contains("text/event-stream"),
+            "a non-streaming /v1/messages response must NOT be framed as SSE"
+        );
+
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            v["type"], "message",
+            "non-streaming /v1/messages must return the Anthropic message shape, got: {v}"
+        );
+        assert_eq!(v["role"], "assistant");
+        assert!(
+            v["content"].is_array() && v["content"][0]["type"] == "text",
+            "non-streaming /v1/messages must carry a text content block, got: {v}"
+        );
+        assert!(
+            v["usage"]["input_tokens"].is_u64() && v["usage"]["output_tokens"].is_u64(),
+            "non-streaming /v1/messages must carry usage tokens, got: {v}"
+        );
+    }
+
+    /// T4 — exact token values end-to-end. The streamed `message_start` /
+    /// `message_delta` usage figures must be the SAME billing-consistent values
+    /// that drive the spend ledger: `input_tokens` = the request's input estimate
+    /// and `output_tokens` = the completion-token ceiling
+    /// (`completion_token_ceiling(max_tokens, model_info)`). We prove this by
+    /// feeding the streamed `(input_tokens, output_tokens)` back through the
+    /// registry quote and asserting it reproduces the endpoint's own 402 estimate
+    /// — i.e. the framer surfaces exactly the billed reservation, not a fabricated
+    /// count. We also pin `output_tokens` to the deterministic ceiling (max_tokens
+    /// 64, no tighter model cap in the test registry → 64).
+    #[tokio::test]
+    async fn messages_streaming_usage_matches_billed_estimate() {
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}],
+        });
+
+        // The endpoint's own reserved/quoted estimate for this exact request.
+        let reserved_atomic = messages_quote_402_amount_atomic(&body).await;
+
+        let app = test_app_with_mock_provider();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let wire = String::from_utf8_lossy(&bytes).to_string();
+
+        // Parse the message_start data JSON and extract the usage tokens.
+        let ms_data = sse_frame_data(&wire, "message_start");
+        let streamed_input = ms_data["message"]["usage"]["input_tokens"]
+            .as_u64()
+            .expect("message_start.usage.input_tokens present") as u32;
+        assert_eq!(
+            ms_data["message"]["usage"]["output_tokens"].as_u64(),
+            Some(0),
+            "message_start output_tokens must be 0 at start"
+        );
+
+        let md_data = sse_frame_data(&wire, "message_delta");
+        let streamed_output = md_data["usage"]["output_tokens"]
+            .as_u64()
+            .expect("message_delta.usage.output_tokens present")
+            as u32;
+
+        // The completion-token ceiling for this request: max_tokens=64, and the
+        // test registry declares no tighter `max_output_tokens` for gpt-4o, and
+        // the default cap is 8192 — so the ceiling is 64.
+        assert_eq!(
+            streamed_output, 64,
+            "message_delta output_tokens must equal completion_token_ceiling \
+             (max_tokens 64, no tighter cap) — the billed completion reservation"
+        );
+
+        // Feeding the streamed (input, output) back through the SAME registry
+        // quote the route uses must reproduce the endpoint's 402 reservation,
+        // proving the streamed usage IS the billed estimate (not a fabrication).
+        let streamed_quote =
+            registry_quote_atomic("openai/gpt-4o", streamed_input, streamed_output);
+        assert!(
+            streamed_quote.abs_diff(reserved_atomic) <= 1,
+            "streamed usage ({streamed_input} in / {streamed_output} out) must \
+             reproduce the endpoint's reserved estimate ({reserved_atomic} atomic), \
+             got {streamed_quote} atomic — the framer must surface the billed values"
+        );
+    }
+
+    /// T5 — `data.type == event name` at the integration level. The
+    /// `@anthropic-ai/sdk` requires each SSE frame's data JSON `"type"` to equal
+    /// its `event:` name. Parse every frame in the real streamed response and
+    /// assert the equality holds on the actual transmitted bytes.
+    #[tokio::test]
+    async fn messages_streaming_every_frame_data_type_matches_event_name() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            "model": "openai/gpt-4o",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}],
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let wire = String::from_utf8_lossy(&bytes).to_string();
+
+        let mut frames_checked = 0usize;
+        for frame in wire.split("\n\n").filter(|f| !f.trim().is_empty()) {
+            let mut name = None;
+            let mut data = None;
+            for line in frame.lines() {
+                if let Some(rest) = line.strip_prefix("event:") {
+                    name = Some(rest.trim().to_string());
+                } else if let Some(rest) = line.strip_prefix("data:") {
+                    data = Some(rest.trim().to_string());
+                }
+            }
+            let name = name.expect("every Anthropic SSE frame must set an event: name");
+            let data = data.expect("every Anthropic SSE frame must set a data: line");
+            let json: serde_json::Value =
+                serde_json::from_str(&data).expect("data line must be valid JSON");
+            assert_eq!(
+                json["type"].as_str(),
+                Some(name.as_str()),
+                "data.type must equal the event name for every frame; \
+                 mismatch on {name}: {data}"
+            );
+            frames_checked += 1;
+        }
+        assert!(
+            frames_checked >= 6,
+            "expected the full Anthropic event sequence (>= 6 frames), got {frames_checked}"
+        );
+    }
+}
+
+/// Parse the `data:` JSON of the first SSE frame whose `event:` name is
+/// `event_name` from a collected SSE wire body.
+fn sse_frame_data(wire: &str, event_name: &str) -> serde_json::Value {
+    let needle = format!("event: {event_name}");
+    let frame = wire
+        .split("\n\n")
+        .find(|f| f.lines().any(|l| l.trim() == needle))
+        .unwrap_or_else(|| panic!("missing SSE frame for event {event_name}:\n{wire}"));
+    let data_line = frame
+        .lines()
+        .find_map(|l| l.strip_prefix("data:"))
+        .unwrap_or_else(|| panic!("SSE frame for {event_name} has no data line:\n{frame}"));
+    serde_json::from_str(data_line.trim()).expect("SSE data line must be valid JSON")
+}
+
+/// Fetch the `exact`-scheme reserved/quoted atomic amount from the /v1/messages
+/// 402 challenge for an Anthropic-shaped request body. Mirrors
+/// [`quote_402_amount_atomic`] but posts the Anthropic request shape to
+/// `/v1/messages` (the estimate is over the TRANSLATED ChatRequest, so this is
+/// the right reservation proxy for a /v1/messages streaming request).
+async fn messages_quote_402_amount_atomic(body: &serde_json::Value) -> u64 {
+    let app = test_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYMENT_REQUIRED,
+        "no-payment /v1/messages request must return 402"
+    );
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let pr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let accepts = pr["accepts"].as_array().expect("accepts array");
+    let exact = accepts
+        .iter()
+        .find(|a| a["scheme"] == "exact")
+        .expect("exact scheme present");
+    exact["amount"]
+        .as_str()
+        .expect("amount is a string")
+        .parse()
+        .expect("amount parses as u64 atomic units")
 }


### PR DESCRIPTION
## What

PR2 of the Claude Code drop-in **Messages track**. Adds **text streaming** to `POST /v1/messages` so Claude Code works in its default (streaming) mode. PR1 (#619) was non-streaming only.

## How

Threads a typed `StreamWire { OpenAi, Anthropic }` dialect through the shared chat money-path core (`chat_completions_inner`) — symmetric with how PR1 added `resource_url`. The streaming branch frames the internal OpenAI `ChatChunk` stream **directly** (typed, no SSE byte re-parse, no buffering) into the Anthropic event sequence:

```
message_start → content_block_start → content_block_delta(text_delta)…
  → content_block_stop → message_delta(stop_reason + usage) → message_stop
```

plus `ping` (from the internal keep-alive) and a **redacted** `error` event on upstream failure. Each frame sets both the `event:` name and a `data:` JSON whose `type` is derived from the **same** kind value, so the two can't drift. The Anthropic state machine lives in `providers/anthropic_inbound.rs`; `provider.rs` stays OpenAI-centric (CLAUDE.md rule #4).

## Money path (unchanged)

- Settlement is **not forked**: streaming still settles via the estimate (`EstimateFallback` arm). `create_message` returns the SSE response **verbatim** for `stream:true` (vs. buffer-and-translate for non-streaming).
- The OpenAI `/v1/chat/completions` path is **byte-identical** (default `StreamWire::OpenAi` arm = the original framing).
- Displayed usage matches the billed estimate: `message_start.usage.input_tokens = estimate_input_tokens`, `message_delta.usage.output_tokens = completion_token_ceiling` — the same figures the 402 quote / settlement bill.

## Tests

- **Framer units**: ordered event sequence, `stop`→`end_turn` / `length`→`max_tokens` mapping, keep-alive→`ping`, redacted error (incl. error-on-first-chunk, with a leaked-secret assertion), exact byte-shape lock, unknown-`finish_reason` passthrough.
- **Integration**: streaming **settlement** proof, **spend-log-from-estimate** proof, non-streaming-still-translates regression guard, exact token values end-to-end, every-frame `data.type == event-name`, and a DB-gated **streaming receipt** records the billed estimate (`exact` scheme).
- Full workspace green; `fmt`/`clippy -D warnings` clean. OpenAI streaming + non-streaming regressions all still pass.

## Review

Cleared a **2-round money-path review**: round 1 = 5 specialized reviewers (rust / security / silent-failure / type-design / test-analysis); round 2 = an independent holistic pass + an independent test-quality audit confirming the money-path tests are non-vacuous. All findings resolved.

## Verification gate (pending)

The SSE contract is mechanically verified byte-for-byte against the authoritative `@anthropic-ai/sdk` streaming contract by the integration tests. The remaining gate before merge is a **live Claude Code end-to-end run** against the streaming endpoint (needs a provider key + dev-bypass) — set up but not yet run.

Scope: TEXT streaming only. Tools / images stay rejected (PR3). `count_tokens` and bearer/escrow auth are later PRs.