### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What

Lockfile-only bump `quinn-proto 0.11.14 → 0.11.15`.

## Why

`RUSTSEC-2026-0185` (remote memory exhaustion via unbounded out-of-order stream reassembly in `quinn-proto < 0.11.15`) landed in the advisory DB during the away-window. `cargo-audit` now fails on **every freshly-run PR**, which is why #629, #630, and #571 went red on the "Security audit" check. This unblocks the queue.

## Verification

- `cargo audit --ignore RUSTSEC-2023-0071` → clean (only the pre-allowed `paste` unmaintained warning remains)
- `cargo check --workspace` → green
- Transitive patch bump only; no source changes.