### PR TITLE
feat(models): add Claude Opus 4.8 and 4.7, route opus/premium to 4.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,8 @@ jobs:
             bash -c '
               body=$(curl -sf "$0/v1/models")
               for id in \
+                "anthropic/claude-opus-4-8" \
+                "anthropic/claude-opus-4-7" \
                 "anthropic/claude-opus-4-6" \
                 "anthropic/claude-sonnet-4-6" \
                 "anthropic/claude-sonnet-4-5-20250929" \

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ The 402 response includes a `cost_breakdown` with per-token pricing, estimated t
 | OpenAI | `o3-mini` | $1.10 | $4.40 | 200K |
 | OpenAI | `o4-mini` | $1.10 | $4.40 | 200K |
 | OpenAI | `gpt-oss-120b` | Free | Free | 128K |
+| Anthropic | `claude-opus-4-8` | $5.00 | $25.00 | 200K |
+| Anthropic | `claude-opus-4-7` | $5.00 | $25.00 | 200K |
 | Anthropic | `claude-opus-4-6` | $5.00 | $25.00 | 200K |
 | Anthropic | `claude-sonnet-4-6` | $3.00 | $15.00 | 200K |
 | Anthropic | `claude-sonnet-4-5-20250929` | $3.00 | $15.00 | 200K |

--- a/config/models.toml
+++ b/config/models.toml
@@ -57,6 +57,30 @@ supports_streaming = true
 
 # --- Anthropic ---
 
+[models.anthropic-claude-opus-4-8]
+provider = "anthropic"
+model_id = "claude-opus-4-8"
+display_name = "Claude Opus 4.8"
+input_cost_per_million = 5.00
+output_cost_per_million = 25.00
+context_window = 200000
+supports_streaming = true
+supports_tools = true
+supports_vision = true
+reasoning = true
+
+[models.anthropic-claude-opus-4-7]
+provider = "anthropic"
+model_id = "claude-opus-4-7"
+display_name = "Claude Opus 4.7"
+input_cost_per_million = 5.00
+output_cost_per_million = 25.00
+context_window = 200000
+supports_streaming = true
+supports_tools = true
+supports_vision = true
+reasoning = true
+
 [models.anthropic-claude-opus-4-6]
 provider = "anthropic"
 model_id = "claude-opus-4-6"

--- a/crates/gateway/src/providers/fallback.rs
+++ b/crates/gateway/src/providers/fallback.rs
@@ -537,6 +537,23 @@ pub fn fallback_chain(primary: &str) -> Vec<String> {
 pub fn model_fallback_chain<'a>(provider: &'a str, model: &'a str) -> Vec<(&'a str, &'a str)> {
     let chain: Vec<(&str, &str)> = match (provider, model) {
         // --- Premium tier (reasoning, high capability) ---
+        // Opus degrades newest -> older within Anthropic first, then falls
+        // through to the same cross-provider tail the 4.6 chain uses.
+        ("anthropic", "claude-opus-4-8") => vec![
+            ("anthropic", "claude-opus-4-8"),
+            ("anthropic", "claude-opus-4-7"),
+            ("anthropic", "claude-opus-4-6"),
+            ("openai", "gpt-5.2"),
+            ("google", "gemini-3.1-pro"),
+            ("openai", "o3"),
+        ],
+        ("anthropic", "claude-opus-4-7") => vec![
+            ("anthropic", "claude-opus-4-7"),
+            ("anthropic", "claude-opus-4-6"),
+            ("openai", "gpt-5.2"),
+            ("google", "gemini-3.1-pro"),
+            ("openai", "o3"),
+        ],
         ("anthropic", "claude-opus-4-6") => vec![
             ("anthropic", "claude-opus-4-6"),
             ("openai", "gpt-5.2"),
@@ -1234,6 +1251,25 @@ supports_streaming = true
         assert!(chain.iter().any(|(p, _)| *p != "anthropic"));
     }
 
+    /// The newest Opus models degrade newest -> older within Anthropic before
+    /// crossing providers. Pins the 2026-06 4.8/4.7 additions so the
+    /// degradation order can't silently regress.
+    #[test]
+    fn test_model_fallback_chain_opus_4_8_and_4_7() {
+        let chain = model_fallback_chain("anthropic", "claude-opus-4-8");
+        assert_eq!(chain[0], ("anthropic", "claude-opus-4-8"));
+        // Anthropic-internal degradation: 4.8 -> 4.7 -> 4.6 come first, in order.
+        assert_eq!(chain[1], ("anthropic", "claude-opus-4-7"));
+        assert_eq!(chain[2], ("anthropic", "claude-opus-4-6"));
+        // Then cross-provider fallbacks.
+        assert!(chain.iter().any(|(p, _)| *p != "anthropic"));
+
+        let chain = model_fallback_chain("anthropic", "claude-opus-4-7");
+        assert_eq!(chain[0], ("anthropic", "claude-opus-4-7"));
+        assert_eq!(chain[1], ("anthropic", "claude-opus-4-6"));
+        assert!(chain.iter().any(|(p, _)| *p != "anthropic"));
+    }
+
     #[test]
     fn test_model_fallback_chain_gpt4o() {
         let chain = model_fallback_chain("openai", "gpt-4o");
@@ -1281,6 +1317,8 @@ supports_streaming = true
     /// `every_fallback_chain_id_is_registered` exercises it.
     fn fallback_chain_keys() -> Vec<(&'static str, &'static str)> {
         vec![
+            ("anthropic", "claude-opus-4-8"),
+            ("anthropic", "claude-opus-4-7"),
             ("anthropic", "claude-opus-4-6"),
             ("openai", "gpt-5.2"),
             ("google", "gemini-3.1-pro"),

--- a/crates/router/src/profiles.rs
+++ b/crates/router/src/profiles.rs
@@ -73,7 +73,7 @@ pub fn resolve_model(profile: Profile, tier: Tier) -> &'static str {
         // PREMIUM: best quality regardless of cost
         (Profile::Premium, Tier::Simple) => "openai/gpt-4o",
         (Profile::Premium, Tier::Medium) => "anthropic/claude-sonnet-4-6",
-        (Profile::Premium, Tier::Complex) => "anthropic/claude-opus-4-6",
+        (Profile::Premium, Tier::Complex) => "anthropic/claude-opus-4-8",
         (Profile::Premium, Tier::Reasoning) => "openai/o3",
 
         // FREE: only free-tier models
@@ -89,7 +89,7 @@ pub fn resolve_alias(alias: &str) -> Option<&'static str> {
     match alias.to_lowercase().as_str() {
         "gpt5" | "gpt-5" => Some("openai/gpt-5.2"),
         "sonnet" | "claude-sonnet" => Some("anthropic/claude-sonnet-4-6"),
-        "opus" | "claude-opus" => Some("anthropic/claude-opus-4-6"),
+        "opus" | "claude-opus" => Some("anthropic/claude-opus-4-8"),
         // The canonical key here MUST match one registered by `from_toml`
         // — see the cross-check test below. Previously this pointed at
         // `claude-3-5-haiku-20241022`, which has never been in
@@ -200,10 +200,55 @@ mod tests {
         );
     }
 
+    /// The `opus` / `claude-opus` aliases and the Premium/Complex tier MUST
+    /// point at the newest registered Opus (`claude-opus-4-8`). Pins the
+    /// 2026-06 repoint off 4.6 onto 4.8 so a future drift back to an older
+    /// (or unregistered) Opus is a test failure, not a silent regression.
+    #[test]
+    fn opus_alias_and_premium_complex_route_to_opus_4_8() {
+        assert_eq!(resolve_alias("opus"), Some("anthropic/claude-opus-4-8"));
+        assert_eq!(
+            resolve_alias("claude-opus"),
+            Some("anthropic/claude-opus-4-8")
+        );
+        assert_eq!(
+            resolve_model(Profile::Premium, Tier::Complex),
+            "anthropic/claude-opus-4-8"
+        );
+        // The alias and the Premium/Complex tier must agree on the Opus target.
+        assert_eq!(
+            resolve_alias("opus"),
+            Some(resolve_model(Profile::Premium, Tier::Complex))
+        );
+    }
+
+    /// The two newest Opus entries MUST load from the production
+    /// `config/models.toml` with the agreed Opus-tier pricing and the repo's
+    /// uniform 200K context-window convention. A pricing typo in the TOML
+    /// would otherwise mis-bill every Opus request (the 5% fee is applied to
+    /// these per-million rates).
+    #[test]
+    fn opus_4_8_and_4_7_load_with_correct_pricing() {
+        let toml_str = include_str!("../../../config/models.toml");
+        let registry = crate::models::ModelRegistry::from_toml(toml_str)
+            .expect("config/models.toml must parse");
+
+        for id in ["anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7"] {
+            let m = registry
+                .get(id)
+                .unwrap_or_else(|| panic!("{id} must be registered in models.toml"));
+            assert_eq!(m.input_cost_per_million, 5.00, "{id} input cost");
+            assert_eq!(m.output_cost_per_million, 25.00, "{id} output cost");
+            assert_eq!(m.context_window, 200_000, "{id} context window");
+            assert!(m.reasoning, "{id} must be reasoning-capable");
+        }
+    }
+
     #[test]
     fn test_resolve_alias() {
         assert_eq!(resolve_alias("gpt5"), Some("openai/gpt-5.2"));
         assert_eq!(resolve_alias("sonnet"), Some("anthropic/claude-sonnet-4-6"));
+        assert_eq!(resolve_alias("opus"), Some("anthropic/claude-opus-4-8"));
         // R1 regression: this used to point at the unregistered
         // `claude-3-5-haiku-20241022`. The canonical key MUST match a
         // model registered in `config/models.toml`.

--- a/docs/CODEMAPS/dependencies.md
+++ b/docs/CODEMAPS/dependencies.md
@@ -40,7 +40,7 @@ pub async fn chat(
 ### Anthropic (providers/anthropic.rs)
 **Endpoint:** https://api.anthropic.com/v1/messages  
 **Auth:** `x-api-key: {ANTHROPIC_API_KEY}`  
-**Models:** Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5  
+**Models:** Claude Opus 4.8, Claude Opus 4.7, Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5  
 **Features:** Streaming, vision, tools, extended thinking (native support)  
 **Cost:** Per-token pricing (input/output may differ)
 

--- a/sdks/ai-sdk-provider/src/generated/models.ts
+++ b/sdks/ai-sdk-provider/src/generated/models.ts
@@ -4,6 +4,8 @@
 export type SolvelaModelId =
   | "anthropic-claude-haiku-4-5"
   | "anthropic-claude-opus-4-6"
+  | "anthropic-claude-opus-4-7"
+  | "anthropic-claude-opus-4-8"
   | "anthropic-claude-sonnet-4-5"
   | "anthropic-claude-sonnet-4-6"
   | "deepseek-chat"
@@ -49,6 +51,34 @@ export const MODELS = [
     provider: "anthropic",
     modelId: "claude-opus-4-6",
     displayName: "Claude Opus 4.6",
+    inputCostPerMillion: 5,
+    outputCostPerMillion: 25,
+    contextWindow: 200000,
+    supportsStreaming: true,
+    supportsTools: true,
+    supportsVision: true,
+    reasoning: true,
+    supportsStructuredOutput: false,
+  },
+  {
+    id: "anthropic-claude-opus-4-7",
+    provider: "anthropic",
+    modelId: "claude-opus-4-7",
+    displayName: "Claude Opus 4.7",
+    inputCostPerMillion: 5,
+    outputCostPerMillion: 25,
+    contextWindow: 200000,
+    supportsStreaming: true,
+    supportsTools: true,
+    supportsVision: true,
+    reasoning: true,
+    supportsStructuredOutput: false,
+  },
+  {
+    id: "anthropic-claude-opus-4-8",
+    provider: "anthropic",
+    modelId: "claude-opus-4-8",
+    displayName: "Claude Opus 4.8",
     inputCostPerMillion: 5,
     outputCostPerMillion: 25,
     contextWindow: 200000,

--- a/sdks/ai-sdk-provider/tests/unit/codegen.test.ts
+++ b/sdks/ai-sdk-provider/tests/unit/codegen.test.ts
@@ -8,12 +8,12 @@
  *
  * Assertions:
  *   1. Banner — file starts with the exact AUTO-GENERATED banner (em-dash U+2014).
- *   2. Union members — SolvelaModelId union contains exactly the 26 known model IDs.
+ *   2. Union members — SolvelaModelId union contains exactly the 27 known model IDs.
  *   3. Escape-hatch tail — last union member is `| (string & {})`.
  *   4. Type-level assignability — a non-enumerated string is assignable to SolvelaModelId
  *      without a TypeScript error (runtime proof of the `(string & {})` tail).
- *   5. MODELS array — exports an array of exactly 26 entries.
- *   6. MODELS id coverage — every entry's `id` field is one of the 26 known keys.
+ *   5. MODELS array — exports an array of exactly 27 entries.
+ *   6. MODELS id coverage — every entry's `id` field is one of the 27 known keys.
  *   7. Drift guard — re-running the codegen script produces byte-identical output.
  *
  * Note on type-level test (assertion 4):
@@ -21,7 +21,7 @@
  *   does not validate this file. The runtime assertion below proves only that a plain
  *   string value can be constructed as a SolvelaModelId variable; the real TS safety is
  *   that the type does NOT extend `string` without the `(string & {})` tail — if the
- *   tail were removed, only the 26 literal members would be valid at compile time. The
+ *   tail were removed, only the 27 literal members would be valid at compile time. The
  *   comment below doubles as an in-file annotation that reviewers can copy into a
  *   strict-tsc context to verify.
  *
@@ -51,13 +51,15 @@ const PACKAGE_ROOT = path.resolve(__dirname, "../../");
 const GENERATED_FILE = path.resolve(PACKAGE_ROOT, "src/generated/models.ts");
 
 // ---------------------------------------------------------------------------
-// The 26 known model IDs (sorted alphabetically — matches script's `sortedKeys`).
+// The 27 known model IDs (sorted alphabetically — matches script's `sortedKeys`).
 // Update this list when config/models.toml gains new entries.
 // ---------------------------------------------------------------------------
 
 const KNOWN_MODEL_IDS: readonly string[] = [
   "anthropic-claude-haiku-4-5",
   "anthropic-claude-opus-4-6",
+  "anthropic-claude-opus-4-7",
+  "anthropic-claude-opus-4-8",
   "anthropic-claude-sonnet-4-5",
   "anthropic-claude-sonnet-4-6",
   "deepseek-chat",
@@ -83,7 +85,7 @@ const KNOWN_MODEL_IDS: readonly string[] = [
   "xai-grok-code-fast-1",
 ] as const;
 
-const EXPECTED_COUNT = 25;
+const EXPECTED_COUNT = 27;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -144,13 +146,13 @@ describe("codegen — src/generated/models.ts", () => {
   // 2. Union members
   // -------------------------------------------------------------------------
 
-  it("SolvelaModelId union contains exactly 26 enumerated string members", () => {
+  it("SolvelaModelId union contains exactly 27 enumerated string members", () => {
     const text = generatedFileText();
     const members = extractUnionMembers(text);
     expect(members).toHaveLength(EXPECTED_COUNT);
   });
 
-  it("SolvelaModelId union members match the known set of 26 model IDs exactly", () => {
+  it("SolvelaModelId union members match the known set of 27 model IDs exactly", () => {
     const text = generatedFileText();
     const members = extractUnionMembers(text);
     // Sort both for set-equality regardless of insertion order (though the
@@ -193,7 +195,7 @@ describe("codegen — src/generated/models.ts", () => {
 
   it("a non-enumerated string is assignable to SolvelaModelId at runtime without error", () => {
     // This proves the (string & {}) tail is present and effective.
-    // If the tail were absent, only the 26 literal members would be the type —
+    // If the tail were absent, only the 27 literal members would be the type —
     // but the runtime assignment below would still succeed because JS has no
     // type guards. The real TS proof is in the comment at the top of this file.
     //
@@ -216,7 +218,7 @@ describe("codegen — src/generated/models.ts", () => {
     expect(Array.isArray(MODELS)).toBe(true);
   });
 
-  it("MODELS contains exactly 26 entries", () => {
+  it("MODELS contains exactly 27 entries", () => {
     expect(MODELS).toHaveLength(EXPECTED_COUNT);
   });
 
@@ -224,7 +226,7 @@ describe("codegen — src/generated/models.ts", () => {
   // 6. MODELS id coverage
   // -------------------------------------------------------------------------
 
-  it("every MODELS entry has an id that is in the known 26-key set", () => {
+  it("every MODELS entry has an id that is in the known 27-key set", () => {
     const knownSet = new Set<string>(KNOWN_MODEL_IDS);
     for (const model of MODELS) {
       expect(knownSet.has(model.id), `unexpected id: ${model.id}`).toBe(true);
@@ -232,7 +234,7 @@ describe("codegen — src/generated/models.ts", () => {
   });
 
   it("every known model ID has a corresponding entry in MODELS", () => {
-    const idsInArray = new Set(MODELS.map((m) => m.id));
+    const idsInArray = new Set<string>(MODELS.map((m) => m.id));
     for (const knownId of KNOWN_MODEL_IDS) {
       expect(idsInArray.has(knownId), `missing id: ${knownId}`).toBe(true);
     }

--- a/sdks/openclaw-provider/src/models.generated.ts
+++ b/sdks/openclaw-provider/src/models.generated.ts
@@ -100,6 +100,34 @@ export const SOLVELA_MODELS: SolvelaModel[] = [
     "reasoning": false
   },
   {
+    "id": "solvela/claude-opus-4-8",
+    "name": "Claude Opus 4.8",
+    "provider": "anthropic",
+    "contextWindow": 200000,
+    "maxTokens": 32768,
+    "inputCostPerMillion": 5,
+    "outputCostPerMillion": 25,
+    "supportsStreaming": true,
+    "supportsTools": true,
+    "supportsVision": true,
+    "supportsStructuredOutput": false,
+    "reasoning": true
+  },
+  {
+    "id": "solvela/claude-opus-4-7",
+    "name": "Claude Opus 4.7",
+    "provider": "anthropic",
+    "contextWindow": 200000,
+    "maxTokens": 32768,
+    "inputCostPerMillion": 5,
+    "outputCostPerMillion": 25,
+    "supportsStreaming": true,
+    "supportsTools": true,
+    "supportsVision": true,
+    "supportsStructuredOutput": false,
+    "reasoning": true
+  },
+  {
     "id": "solvela/claude-opus-4-6",
     "name": "Claude Opus 4.6",
     "provider": "anthropic",
@@ -381,4 +409,4 @@ export const SOLVELA_MODELS: SolvelaModel[] = [
   }
 ];
 
-export const MODEL_COUNT = 25;
+export const MODEL_COUNT = 27;


### PR DESCRIPTION
## What

Adds the two latest Anthropic Opus models to the gateway registry and repoints the `opus`/`claude-opus` alias and the **Premium** routing tier to the newest (**4.8**). Registry's previous newest Opus was 4.6.

## Changes

- **`config/models.toml`** — add `claude-opus-4-8` and `claude-opus-4-7`, both **$5/$25 per MTok** (matching the existing 4.6 entry). `context_window=200000` to stay uniform with the repo's existing Anthropic convention.
- **`crates/router/src/profiles.rs`** — `opus`/`claude-opus` alias and the Premium/Complex tier now resolve to `anthropic/claude-opus-4-8`.
- **`crates/gateway/src/providers/fallback.rs`** — fallback chains for 4.8 (4.8→4.7→4.6→cross-provider tail) and 4.7.
- **Model-ID cascade** (CI-enforced): regenerated both SDK model lists (`ai-sdk-provider`, `openclaw-provider`; 25→27), bumped count/known-set tests, README model table, `docs/CODEMAPS/dependencies.md`, and the CI `/v1/models` presence check.

## Notes

- **Routing/cost change**: traffic asking for `opus` or the `premium`/`best`/`quality` profile now hits Opus 4.8 instead of 4.6.
- **`context_window=200000`** mirrors the repo convention (every Anthropic entry uses 200K despite the real 1M Opus context). Bumping to 1M would be a separate, registry-wide change.

## Verification

- `cargo test --all` + `clippy -D warnings` + `fmt` — clean (only pre-existing DB-less `escrow_queue` `#[sqlx::test]` cases fail, as documented).
- ai-sdk-provider: `tsc --noEmit` clean, 261/261 unit tests. openclaw-provider: `typecheck` + `typecheck:tests` clean, 71/71.