### PR TITLE
fix(ci): resync openclaw-provider lock with package.json (ws@8.21.0)

### DIFF
--- a/sdks/openclaw-provider/package-lock.json
+++ b/sdks/openclaw-provider/package-lock.json
@@ -36,7 +36,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.9.1",
-        "tsx": "^4.22.3",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3"
       }
     },
@@ -887,6 +887,30 @@
           "optional": true
         },
         "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }


### PR DESCRIPTION
## Problem

`npm ci` fails in `sdks/openclaw-provider`:

```
npm error Missing: ws@8.21.0 from lock file
```

The committed `package-lock.json` is out of sync with `package.json`: it lacked the nested `node_modules/@earendil-works/pi-ai/node_modules/ws@8.21.0` that `@earendil-works/pi-ai@0.74.0` now resolves to, and its embedded `../signer-core` mirror pinned `tsx ^4.22.3` while signer-core's `package.json` is `^4.22.4`.

This is a latent lock drift on `main` (path-filtered workflow doesn't run on every push); it surfaced on a PR that touched `sdks/openclaw-provider/**`.

## Fix

Resynced via `npm install --package-lock-only` (lock-only, no transitive churn). One file: `sdks/openclaw-provider/package-lock.json` (+25/−1).

## Verification

- `sdks/openclaw-provider`: `npm ci` now passes (exit 0).
- All other SDK workspaces (`ai-sdk-provider`, `mcp`, `signer-core`, `typescript`, `dashboard`) already in sync — `npm ci` confirmed passing, untouched.
- cargo-audit / cargo-deny already green on current `main` (sqlx 0.9.0 dropped the `rsa` advisory) — no Rust change needed.