### PR TITLE
test(cli): hold ENV_MUTEX across all HOME mutations to kill flaky env race

### DIFF
--- a/crates/cli/src/commands/mcp/mod.rs
+++ b/crates/cli/src/commands/mcp/mod.rs
@@ -619,10 +619,14 @@ mod tests {
     }
 
     /// home_dir() returns Err when neither HOME nor USERPROFILE is set.
-    #[test]
-    fn test_home_dir_err_when_unset() {
-        // Cannot use ENV_MUTEX here (sync test) — this is a unit test of the logic only.
-        // We remove HOME and USERPROFILE temporarily.
+    #[tokio::test]
+    async fn test_home_dir_err_when_unset() {
+        // MUST hold ENV_MUTEX: this test *removes* HOME/USERPROFILE, and any
+        // concurrent locked test reading HOME (e.g. run_install) would otherwise
+        // panic with "neither HOME nor USERPROFILE is set". std::env is
+        // process-global, so the remove + restore must stay inside the critical
+        // section. _lock is declared first so it drops last (after restore).
+        let _lock = crate::ENV_MUTEX.lock().await;
         let old_home = std::env::var("HOME").ok();
         let old_up = std::env::var("USERPROFILE").ok();
         std::env::remove_var("HOME");


### PR DESCRIPTION
## Problem

`commands::mcp::tests::test_dry_run_does_not_write_file` flakily fails in CI:

```
called `Result::unwrap()` on an `Err` value: Cannot determine user config directory: neither HOME nor USERPROFILE is set
```

## Root cause

`commands::mcp::tests::test_home_dir_err_when_unset` was a **sync `#[test]`** that did `std::env::remove_var("HOME")` / `remove_var("USERPROFILE")` **without holding `ENV_MUTEX`** (its comment said "Cannot use ENV_MUTEX here (sync test)"). `std::env` is process-global and libtest runs tests on parallel threads, so during that unlocked window a concurrently-running *locked* test that reads `HOME` (e.g. `test_dry_run_does_not_write_file` → `run_install` → `home_dir()`) saw `HOME` unset and panicked. Test isolation only — no production code involved.

Audited every `set_var`/`remove_var` and both `Drop` guards in `crates/cli/src/**`: all others correctly hold `_lock` before mutating and declare the `SOLANA_RPC_URL` `EnvGuard` after `_lock` (drops first, while still locked). This sync test was the sole offender.

## Fix

Convert `test_home_dir_err_when_unset` to `#[tokio::test]` and acquire `crate::ENV_MUTEX` first (declared first → drops last, after the env restoration), moving the HOME/USERPROFILE remove+restore inside the critical section. Test-only: 8 insertions, 4 deletions in `crates/cli/src/commands/mcp/mod.rs`.

## Verification

- Full CLI suite: 196 passed.
- Stress loops: **20/20** full-suite at `--test-threads=8`; **80/80** racing module at `--test-threads=16`.
- Causality proof: with the unlocked window artificially widened to 20ms, original code flaked **30/30** with the exact panic; fixed code flaked **0/30** (repro sleep removed before commit).
- `cargo fmt --all` + `cargo clippy -p solvela-cli --all-targets -- -D warnings`: clean.