### PR TITLE
fix(ci): bump quinn-proto to 0.11.15 in sdks/rust (RUSTSEC-2026-0185)

### DIFF
--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Problem

The `sdks-rust` workflow's `cargo audit` job fails on a new advisory:

- **RUSTSEC-2026-0185** — remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly (`patched = [">= 0.11.15"]`).

It scans `sdks/rust/Cargo.lock` (a separate workspace from the monorepo root, per the workflow comment), which still pinned `quinn-proto 0.11.14`. The root workspace already carries 0.11.15 (pulled in via the sqlx 0.9.0 update), so only the SDK lock was affected. Not caused by any recent feature change — a fresh advisory landed in the RustSec DB.

## Fix

`cargo update -p quinn-proto --precise 0.11.15` in `sdks/rust` — transitive pin 0.11.14 → 0.11.15. One file, 2 lines.

## Verification

- `cargo audit -f sdks/rust/Cargo.lock` → exit 0 (no vulnerabilities; only the pre-existing allowlisted `bincode` unmaintained warning remains).
- `cargo check --workspace` (sdks/rust) → clean.