### PR TITLE
fix(deps): bump quinn-proto 0.11.14→0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What

Bumps `quinn-proto` 0.11.14 → 0.11.15 in `Cargo.lock` (transitive dep).

## Why

A freshly-published advisory **RUSTSEC-2026-0185** flags `quinn-proto` 0.11.14 and started failing the `cargo audit` job on the newest CI run (#635). Older PR runs are stale-green; the advisory DB is fetched live, so **every open PR and `main` will turn red as their checks re-run**.

`0.11.15` is the patched, latest semver-compatible release. Durable lock bump over an audit ignore (per the "default CI to fully green" convention).

## Verification

- `cargo audit` clean after the bump — only the pre-existing allow-listed `paste` unmaintained warning (RUSTSEC-2024-0436) remains.
- Diff is `Cargo.lock`-only, 2 lines (version + checksum).