### PR TITLE
docs(readme): add NVIDIA models to the Supported Models table

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,6 @@ The 402 response includes a `cost_breakdown` with per-token pricing, estimated t
 | Google | `gemini-3.1-pro` | $2.00 | $12.00 | 1M |
 | Google | `gemini-2.5-flash` | $0.30 | $2.50 | 1M |
 | Google | `gemini-2.5-flash-lite` | $0.10 | $0.40 | 1M |
-| Google | `gemini-2.0-flash` | $0.10 | $0.40 | 1M |
-| Google | `gemini-2.0-flash-lite` | $0.075 | $0.30 | 1M |
 | xAI | `grok-3` | $3.00 | $15.00 | 131K |
 | xAI | `grok-3-mini` | $0.30 | $0.50 | 131K |
 | xAI | `grok-4-fast-reasoning` | $0.20 | $0.50 | 2M |
@@ -196,6 +194,23 @@ The 402 response includes a `cost_breakdown` with per-token pricing, estimated t
 | DeepSeek | `deepseek-chat` | $0.28 | $0.42 | 128K |
 | DeepSeek | `deepseek-reasoner` | $0.28 | $0.42 | 128K |
 | DeepSeek | `deepseek-coder` | $0.28 | $0.42 | 128K |
+| NVIDIA | `nvidia/nvidia/llama-3.1-nemotron-nano-8b-v1` | Free | Free | 131K |
+| NVIDIA | `nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1` | Free | Free | 131K |
+| NVIDIA | `nvidia/nvidia/llama-3.3-nemotron-super-49b-v1` | Free | Free | 131K |
+| NVIDIA | `nvidia/nvidia/nemotron-3-nano-30b-a3b` | Free | Free | 131K |
+| NVIDIA | `nvidia/nvidia/nemotron-3-super-120b-a12b` | Free | Free | 131K |
+| NVIDIA | `nvidia/nvidia/nemotron-3-ultra-550b-a55b` | Free | Free | 131K |
+| NVIDIA | `nvidia/nvidia/nemotron-mini-4b-instruct` | Free | Free | 4K |
+| NVIDIA | `nvidia/meta/llama-4-maverick-17b-128e-instruct` | Free | Free | 1M |
+| NVIDIA | `nvidia/meta/llama-4-scout-17b-16e-instruct` | Free | Free | 1M |
+| NVIDIA | `nvidia/meta/llama-3.3-70b-instruct` | Free | Free | 131K |
+| NVIDIA | `nvidia/qwen/qwen3-coder-480b-a35b-instruct` | Free | Free | 256K |
+| NVIDIA | `nvidia/deepseek-ai/deepseek-r1` | Free | Free | 160K |
+| NVIDIA | `nvidia/mistralai/mistral-large-3-675b-instruct-2512` | Free | Free | 256K |
+| NVIDIA | `nvidia/minimaxai/minimax-m2.7` | Free | Free | 200K |
+| NVIDIA | `nvidia/minimaxai/minimax-m3` | Free | Free | 200K |
+| NVIDIA | `nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5` | $0.10 | $0.40 | 131K |
+| NVIDIA | `nvidia/nvidia/nvidia-nemotron-nano-9b-v2` | $0.04 | $0.16 | 131K |
 
 All prices are provider cost in USDC. A 5% platform fee is applied on top. See `config/models.toml` for the full registry or query `GET /pricing` at runtime.
 


### PR DESCRIPTION
## What

Syncs the hand-maintained **Supported Models** table in `README.md` with `config/models.toml`. The table was never updated when #632 added the NVIDIA NIM provider, so it omitted all NVIDIA models and showed only ~2 free models while the registry now has 17.

## Drift fixed

- **Added 17 NVIDIA models** under a new `NVIDIA` group — 15 free + 2 paid:
  - Free (15): the 7 Nemotron free-tier models, Llama 4 Maverick/Scout, Llama 3.3 70B Instruct, Qwen3 Coder 480B, DeepSeek-R1, Mistral Large 3 675B, MiniMax M2.7/M3. Marked `Free | Free` exactly like the existing `gpt-oss-120b` / `gemini-3.1-flash-lite` rows.
  - Paid (2): `nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5` ($0.10 / $0.40) and `nvidia/nvidia/nvidia-nemotron-nano-9b-v2` ($0.04 / $0.16).
- **Removed 2 stale Google rows** (`gemini-2.0-flash`, `gemini-2.0-flash-lite`) that are no longer in the registry.

Model strings use the canonical Solvela key `nvidia/<publisher>/<model>` (verified against `crates/router/src/profiles.rs` and `crates/gateway/src/providers/nvidia.rs`); context windows follow the existing `K`/`M` rounding style.

## Consistency check

The table now has **44 rows across 6 providers**, matching the existing `models.toml` config note ("6 providers, 44 models"), with **17 free-tier rows** — exactly the 17 free models in the registry. No existing correct rows were altered.

Docs-only; no code changes.