### PR TITLE
docs(mcp): correct SOLANA_RPC_URL / SOLANA_WALLET_KEY required-ness

### DIFF
--- a/dashboard/content/docs/sdks/mcp.mdx
+++ b/dashboard/content/docs/sdks/mcp.mdx
@@ -33,8 +33,8 @@ The server reads these environment variables on startup:
 
 | Variable | Required | Description |
 |---|---|---|
-| `SOLANA_WALLET_KEY` | Yes (for paid calls) | Base58-encoded Solana keypair secret |
-| `SOLANA_RPC_URL` | Yes (for paid calls) | Solana JSON-RPC endpoint |
+| `SOLANA_WALLET_KEY` | No | Base58-encoded Solana keypair secret. When unset, the server loads `~/.solvela/wallet.json`, auto-creating a new wallet on first run. Set this to use a specific keypair instead. |
+| `SOLANA_RPC_URL` | Yes, unless `SOLVELA_SIGNING_MODE=off` | Solana JSON-RPC endpoint. With signing enabled (the default) the server **exits at startup** if this is unset — set `SOLVELA_SIGNING_MODE=off` to run signing-free (e.g. just `list_models`). |
 | `SOLVELA_API_URL` | No | Gateway base URL (default `https://api.solvela.ai`) |
 | `SOLVELA_SESSION_BUDGET` | No | Per-session USDC cap (e.g. `2.00`) |
 | `SOLVELA_TIMEOUT_MS` | No | HTTP timeout for gateway calls |


### PR DESCRIPTION
## What

Fixes two stale rows in the MCP server env table (`dashboard/content/docs/sdks/mcp.mdx`) that disagreed with the server's actual startup behavior. Verified by building the server from the documented steps and booting it.

- **`SOLANA_RPC_URL`** — was `Yes (for paid calls)`, implying free tools (`list_models`) run without it. They don't: with signing enabled (the default), the server **exits at startup** if RPC is unset. Now `Yes, unless SOLVELA_SIGNING_MODE=off`, with the signing-free escape hatch documented.
- **`SOLANA_WALLET_KEY`** — was `Yes (for paid calls)`, but the gas-drip onboarding made it optional. Precedence is now `SOLANA_WALLET_KEY` env > `~/.solvela/wallet.json` > auto-generate, so a first run with no key creates a wallet instead of failing. Now marked `No`.

## Verification

Followed the doc's own install steps (`npm install` → `npm run build` → `node dist/index.js`): clean build, MCP `initialize` + `tools/list` respond. Confirmed the no-RPC fatal exit and the auto-wallet creation paths directly, and the precedence in `sdks/mcp/src/index.ts:674`.

Docs-only change.