### PR TITLE
ci(sdks): tag-triggered npm publish for signer-core + mcp-server

### DIFF
--- a/.github/workflows/sdk-mcp-publish.yml
+++ b/.github/workflows/sdk-mcp-publish.yml
@@ -1,0 +1,352 @@
+name: sdk-mcp publish
+
+# Tag-triggered npm publish for @solvela/mcp-server (sdks/mcp/).
+#
+# The MCP server signs and broadcasts real USDC-SPL transactions on
+# Solana mainnet, so every payment-sdk-publisher guardrail applies. It is
+# LAYER 2 of the MCP publish set: it depends on @solvela/signer-core
+# (LAYER 1) via `"@solvela/signer-core": "file:../signer-core"` in the
+# repo. signer-core MUST already be published and visible on npm before
+# this workflow publishes the MCP server. See sdk-signer-core-publish.yml
+# and docs/runbooks/mcp-npm-publish.md for the full firing sequence.
+#
+# DEP-ORDER + file:->registry SWAP (the two things that make this workflow
+# more than a copy of sdk-signer-core-publish.yml):
+#   1. Before publishing, this job polls npm until
+#      @solvela/signer-core@<version> (the version in the repo) is
+#      resolvable, so the MCP tarball never references a dep that isn't on
+#      the registry yet.
+#   2. The repo keeps `file:../signer-core` for local dev. This job
+#      rewrites that, on the checked-out copy ONLY, to a `^<version>`
+#      registry range so the PUBLISHED tarball carries a real npm dep —
+#      never `file:`. The swap is never committed.
+#
+# Authoring provenance (tool versions cited so a future maintainer can
+# tell correct-at-the-time guidance from speculation):
+#   - Verified locally 2026-06-29 against Node 22.22.0 + npm 10.9.4,
+#     using the publish-ready package.json from PR #646 (drops `private`,
+#     adds the `files` allowlist + `prepublishOnly`): `npm ci`,
+#     `npm run build` (tsc), `npm test` (112 tests pass), the jq swap
+#     (file:../signer-core -> ^0.1.0), and `npm publish --dry-run`
+#     -> tarball = dist/ + README.md + package.json only (34 files,
+#     54.4 kB; no src/tests/AGENTS.md/secrets; bin dist/index.js present
+#     with its `#!/usr/bin/env node` shebang; packed package.json has
+#     `private` removed and the swapped `^0.1.0` dep).
+#   - Mirrors the npm-family publish workflows (sdk-typescript-publish.yml,
+#     ai-sdk-provider-publish.yml) for the auth/provenance/verify mechanics
+#     and the multi-job verify/test/publish shape from the python/rust
+#     publish workflows. Actions at floating @v6 to match the npm family;
+#     SHA-pinning (as in the python/rust workflows) is a future hardening.
+#
+# PROVENANCE PRECONDITION (read before the first tag):
+#   `npm publish --provenance` REQUIRES a `repository` field in
+#   package.json matching (case-sensitive) the building repo, and
+#   `npm publish --dry-run` does NOT validate it — the failure only
+#   surfaces on the REAL publish. The verify job enforces it up front and
+#   fails closed. Source: https://docs.npmjs.com/generating-provenance-statements
+#   As of 2026-06-29 the #646 sdks/mcp/package.json has NO repository
+#   field; #646 (or a follow-up) must add one before the first tag — see
+#   the runbook.
+
+on:
+  push:
+    tags:
+      - 'sdks/mcp/v*'
+
+concurrency:
+  group: sdk-mcp-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: sdks/mcp
+
+jobs:
+  # --------------------------------------------------------------------
+  # Guardrail job: tag-vs-manifest, already-published, and the provenance
+  # repository precondition. Runs first; halts in seconds on any failure.
+  # --------------------------------------------------------------------
+  verify:
+    name: Verify tag, version, provenance precondition
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history so tag is reachable)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Verify tag matches package.json, repo + version preconditions
+        run: |
+          set -euo pipefail
+
+          # Tag format: sdks/mcp/v0.1.0  ->  TAG_VERSION=0.1.0
+          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_VERSION="${TAG_NAME#sdks/mcp/v}"
+          if [ "$TAG_VERSION" = "$TAG_NAME" ]; then
+            echo "ERROR: tag '$TAG_NAME' does not match 'sdks/mcp/v<version>'"
+            exit 1
+          fi
+
+          MANIFEST_VERSION=$(jq -r '.version' package.json)
+          PKG_NAME=$(jq -r '.name' package.json)
+          echo "Package:          $PKG_NAME"
+          echo "Tag version:      $TAG_VERSION"
+          echo "Manifest version: $MANIFEST_VERSION"
+          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "ERROR: tag version ($TAG_VERSION) != package.json version ($MANIFEST_VERSION)"
+            echo "Bump sdks/mcp/package.json or retag at the correct commit."
+            exit 1
+          fi
+
+          # Fail fast if the publish-ready manifest from #646 has not
+          # landed on this commit (e.g. someone tagged before #646 merged).
+          if [ "$(jq -r '.private // false' package.json)" = "true" ]; then
+            echo "ERROR: sdks/mcp/package.json still has \"private\": true."
+            echo "The publish-ready manifest (PR #646) must be merged to main"
+            echo "before tagging. Refusing to publish a package marked private."
+            exit 1
+          fi
+
+          # Provenance precondition (see header). dry-run does NOT catch this.
+          REPO_URL=$(jq -r '.repository.url // .repository // empty' package.json)
+          echo "repository: ${REPO_URL:-<missing>}"
+          case "$REPO_URL" in
+            *github.com/solvela-ai/solvela*) : ;;
+            *)
+              echo "ERROR: package.json has no 'repository' field matching"
+              echo "github.com/solvela-ai/solvela. npm provenance requires it."
+              echo "Add it to sdks/mcp/package.json (fold into #646), e.g.:"
+              echo '  "repository": { "type": "git",'
+              echo '    "url": "git+https://github.com/solvela-ai/solvela.git",'
+              echo '    "directory": "sdks/mcp" }'
+              exit 1
+              ;;
+          esac
+
+          # Stop-and-ask guard: never re-publish an existing version.
+          PUBLISHED=$(npm view "${PKG_NAME}@${TAG_VERSION}" version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "ERROR: ${PKG_NAME}@${TAG_VERSION} is already published on npm."
+            echo "Halting — bump the version or pick a new tag."
+            exit 1
+          fi
+          echo "OK: ${PKG_NAME}@${TAG_VERSION} is not yet published — clear to release."
+
+  # --------------------------------------------------------------------
+  # Re-run the MCP server's test suite at the tagged commit. Mirrors
+  # mcp.yml: Node 22 (its `node --test *.ts` runner needs strip-types),
+  # and signer-core's dist/ is built first because npm does NOT auto-build
+  # a `file:` dep. Tests run against the LOCAL file: signer-core (the swap
+  # happens only in the publish job).
+  # --------------------------------------------------------------------
+  test:
+    name: Test (Node 22)
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/mcp/package-lock.json
+
+      - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
+        working-directory: sdks/signer-core
+        run: npm ci && npm run build
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  # --------------------------------------------------------------------
+  # Publish to npm with provenance. Depends on [verify, test]. Dep-order
+  # gate + file:->registry swap live here. Order matters:
+  #   build signer-core dist -> npm ci -> build mcp -> swap -> dry-run
+  #   -> poll signer-core live -> live publish -> SHA verify -> npx smoke.
+  # --------------------------------------------------------------------
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: [verify, test]
+    environment: npm-publish
+    permissions:
+      id-token: write   # MANDATORY for npm provenance OIDC; do not remove.
+      contents: read
+    steps:
+      - name: Checkout (full history so tag is reachable)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/mcp/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+
+      # signer-core's dist/ must exist for mcp's `npm ci` + build + dry-run
+      # while the dep is still `file:` (npm does not auto-build a file: dep).
+      - name: "Build signer-core dist/ (file: dep — npm doesn't auto-build)"
+        working-directory: sdks/signer-core
+        run: npm ci --ignore-scripts && npm run build
+
+      - name: Install dependencies (ignore-scripts)
+        run: npm ci --ignore-scripts
+
+      - name: Build
+        run: npm run build
+
+      # CI-only swap: rewrite the signer-core dep from file:../signer-core
+      # to the just-published `^<version>` so the PUBLISHED tarball carries
+      # a registry dep, never `file:`. Done on the checked-out copy only;
+      # never committed. <version> is read from the repo's signer-core
+      # manifest (its tag was published first, so this is the live version).
+      - name: "Swap file: dep -> published registry range"
+        run: |
+          set -euo pipefail
+          SIGNER_VERSION=$(jq -r '.version' ../signer-core/package.json)
+          if [ -z "$SIGNER_VERSION" ] || [ "$SIGNER_VERSION" = "null" ]; then
+            echo "ERROR: could not read @solvela/signer-core version from ../signer-core/package.json"
+            exit 1
+          fi
+          jq --arg v "^$SIGNER_VERSION" \
+            '.dependencies["@solvela/signer-core"] = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          echo "Rewrote @solvela/signer-core: file:../signer-core -> ^$SIGNER_VERSION"
+          echo "  published dependency line:"
+          jq '.dependencies["@solvela/signer-core"]' package.json
+
+      # Charter-mandated dry-run BEFORE live publish, AFTER the swap so the
+      # tarball reflects exactly what ships (dist/ + README.md + the
+      # registry dep). Does not resolve the dep from the registry.
+      - name: Dry-run publish (verify post-swap tarball)
+        run: npm publish --dry-run --access public
+
+      # Dep-order gate: do NOT publish the MCP server until its
+      # signer-core dependency is actually resolvable on npm. Polls ~5 min
+      # (30 x 10s), matching the propagation loops in the other workflows.
+      # If signer-core was tagged/published just before this run, this
+      # absorbs the index-propagation lag; if it was never published, this
+      # fails closed rather than shipping a broken dep.
+      - name: Wait for @solvela/signer-core to be resolvable on npm
+        run: |
+          set -euo pipefail
+          SIGNER_VERSION=$(jq -r '.version' ../signer-core/package.json)
+          echo "Requiring @solvela/signer-core@${SIGNER_VERSION} on the registry"
+          for i in $(seq 1 30); do
+            if npm view "@solvela/signer-core@${SIGNER_VERSION}" version >/dev/null 2>&1; then
+              echo "Attempt $i/30: @solvela/signer-core@${SIGNER_VERSION} is resolvable."
+              exit 0
+            fi
+            echo "Attempt $i/30: not resolvable yet; sleeping 10s"
+            sleep 10
+          done
+          echo "ERROR: @solvela/signer-core@${SIGNER_VERSION} is not on npm after ~5 minutes."
+          echo "Publish sdks/signer-core (tag sdks/signer-core/v${SIGNER_VERSION}) first."
+          exit 1
+
+      # --access public on both paths: scoped first publish + provenance.
+      - name: Publish (provenance)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG_NAME="${{ github.ref_name }}"
+          if [[ "$TAG_NAME" =~ -rc\.[0-9]+$ ]]; then
+            echo "RC tag detected — publishing with --tag rc"
+            npm publish --tag rc --access public --provenance
+          else
+            echo "Release tag detected — publishing with --tag latest"
+            npm publish --access public --provenance
+          fi
+
+      # Post-publish: poll until visible, then SHA-256 compare the registry
+      # tarball against a locally-packed one. The local pack reproduces the
+      # POST-SWAP tarball (the swap persists in this job's working copy), so
+      # this confirms the published bytes carry the registry dep.
+      - name: Verify published tarball SHA matches local build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(jq -r '.version' package.json)
+          PKG_NAME=$(jq -r '.name' package.json)
+          echo "Verifying $PKG_NAME@$PKG_VERSION"
+
+          LOCAL_TARBALL=$(npm pack --dry-run --json 2>/dev/null | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)[0]['filename'])")
+          npm pack 2>/dev/null
+          LOCAL_SHA=$(shasum -a 256 "$LOCAL_TARBALL" | awk '{print $1}')
+          echo "Local tarball SHA256: $LOCAL_SHA"
+
+          TARBALL_URL=""
+          for i in $(seq 1 30); do
+            TARBALL_URL=$(npm view "${PKG_NAME}@${PKG_VERSION}" dist.tarball 2>/dev/null || true)
+            if [ -n "$TARBALL_URL" ]; then
+              break
+            fi
+            echo "Attempt $i/30: ${PKG_NAME}@${PKG_VERSION} not visible yet; sleeping 10s"
+            sleep 10
+          done
+          if [ -z "$TARBALL_URL" ]; then
+            echo "ERROR: ${PKG_NAME}@${PKG_VERSION} not visible on the registry after ~5 minutes"
+            exit 1
+          fi
+          echo "Registry tarball URL: $TARBALL_URL"
+          curl -fsSL "$TARBALL_URL" -o registry.tgz
+          REGISTRY_SHA=$(shasum -a 256 registry.tgz | awk '{print $1}')
+          echo "Registry tarball SHA256: $REGISTRY_SHA"
+
+          if [ "$LOCAL_SHA" = "$REGISTRY_SHA" ]; then
+            echo "SHA match confirmed — tarball integrity verified."
+          else
+            echo "ERROR: SHA mismatch! Local=$LOCAL_SHA Registry=$REGISTRY_SHA"
+            exit 1
+          fi
+
+      # End-to-end smoke: prove `npx -y @solvela/mcp-server` resolves from a
+      # clean install (which pulls @solvela/signer-core from the registry —
+      # the real test that the dep-order publish worked) and that the bin
+      # launches. SOLVELA_SIGNING_MODE=off means no wallet/RPC is needed;
+      # we send one MCP `initialize` request and assert a JSON-RPC result.
+      # `timeout` backstops the stdio server (it may keep stdin open after
+      # responding). Mirrors the existing post-publish smoke discipline.
+      - name: Smoke test npx resolution (initialize round-trip)
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(jq -r '.version' package.json)
+          PKG="@solvela/mcp-server@${PKG_VERSION}"
+
+          # Read path can lag the publish; poll until npx can resolve it.
+          for i in $(seq 1 30); do
+            if npm view "$PKG" version >/dev/null 2>&1; then break; fi
+            echo "Attempt $i/30: $PKG not resolvable yet; sleeping 10s"
+            sleep 10
+          done
+
+          INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"publish-smoke","version":"0"}}}'
+          set +e
+          OUT=$(printf '%s\n' "$INIT" | SOLVELA_SIGNING_MODE=off timeout 120 npx -y "$PKG" 2>smoke.err)
+          set -e
+          if echo "$OUT" | grep -q '"result"'; then
+            echo "npx smoke OK — $PKG resolved, installed signer-core from the registry, and answered initialize."
+          else
+            echo "ERROR: npx smoke failed for $PKG"
+            echo "--- stdout ---"; echo "$OUT"
+            echo "--- stderr ---"; cat smoke.err
+            exit 1
+          fi

--- a/.github/workflows/sdk-signer-core-publish.yml
+++ b/.github/workflows/sdk-signer-core-publish.yml
@@ -1,0 +1,269 @@
+name: sdk-signer-core publish
+
+# Tag-triggered npm publish for @solvela/signer-core (sdks/signer-core/).
+#
+# signer-core is the shared x402 signing/parsing library that
+# @solvela/mcp-server (and the other TS SDKs) build on. It helps sign and
+# broadcast real USDC-SPL transactions on Solana mainnet, so every
+# payment-sdk-publisher guardrail applies. It is LAYER 1 of the MCP
+# publish set: it MUST be published and visible on npm BEFORE
+# @solvela/mcp-server (which depends on it via a registry range) is
+# published. See sdk-mcp-publish.yml for the dependent layer and
+# docs/runbooks/mcp-npm-publish.md for the full firing sequence.
+#
+# Authoring provenance (tool versions cited so a future maintainer can
+# tell correct-at-the-time guidance from speculation):
+#   - Verified locally 2026-06-29 against Node 22.22.0 + npm 10.9.4:
+#     `npm ci`, `npm run build` (tsc), `npm test` (125 tests pass), and
+#     `npm publish --dry-run` -> tarball = dist/ + README.md +
+#     package.json only (the `files` allowlist holds; no src/tests/secrets
+#     leak; 38 files, 37.6 kB).
+#   - Mirrors the npm-family publish workflows in this repo
+#     (sdk-typescript-publish.yml, ai-sdk-provider-publish.yml): tag
+#     trigger, `npm-publish` environment, NODE_AUTH_TOKEN=secrets.NPM_TOKEN,
+#     `--access public --provenance`, post-publish SHA-match verify. Adopts
+#     the multi-job verify/test/publish shape (verify-first guardrail) from
+#     sdk-python-publish.yml / sdk-rust-publish.yml.
+#   - Actions left at floating major tags (@v6) to match the two npm-family
+#     publish workflows above. sdk-python-publish.yml / sdk-rust-publish.yml
+#     pin full commit SHAs; adopting that here is a clean future hardening.
+#
+# PROVENANCE PRECONDITION (read before the first tag):
+#   `npm publish --provenance` REQUIRES a `repository` field in
+#   package.json that matches (case-sensitive) the building repo, and
+#   `npm publish --dry-run` does NOT validate it (confirmed locally
+#   2026-06-29: a dry-run with --provenance and no repository field prints
+#   the tarball and exits 0). The failure only surfaces on the REAL
+#   publish. The verify job below enforces the field up front and fails
+#   closed with remediation if it is missing.
+#   Source: https://docs.npmjs.com/generating-provenance-statements
+#   As of 2026-06-29 sdks/signer-core/package.json has NO repository field
+#   (@solvela/sdk, which has one, publishes with provenance fine;
+#   @solvela/ai-sdk-provider, which lacks one, has never published). The
+#   field must be added before the first tag — see the runbook.
+
+on:
+  push:
+    tags:
+      - 'sdks/signer-core/v*'
+
+# Never cancel a publish mid-run; a cancelled publish can leave the
+# registry in a partial state.
+concurrency:
+  group: sdk-signer-core-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+# Least privilege at the root; the publish job escalates to id-token:write
+# per-job (required for npm provenance OIDC).
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: sdks/signer-core
+
+jobs:
+  # --------------------------------------------------------------------
+  # Guardrail job: runs first, fails the whole run on any of:
+  #   - tag does not match the package.json version
+  #   - the exact version is already published on npm
+  #   - the provenance `repository` precondition is unmet
+  # Cheap checks up front so a mistagged or already-published release
+  # halts in seconds, before the test matrix or any publish step.
+  # --------------------------------------------------------------------
+  verify:
+    name: Verify tag, version, provenance precondition
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history so tag is reachable)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Verify tag matches package.json, repo + version preconditions
+        run: |
+          set -euo pipefail
+
+          # Tag format: sdks/signer-core/v0.1.0  ->  TAG_VERSION=0.1.0
+          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_VERSION="${TAG_NAME#sdks/signer-core/v}"
+          if [ "$TAG_VERSION" = "$TAG_NAME" ]; then
+            echo "ERROR: tag '$TAG_NAME' does not match 'sdks/signer-core/v<version>'"
+            exit 1
+          fi
+
+          MANIFEST_VERSION=$(jq -r '.version' package.json)
+          PKG_NAME=$(jq -r '.name' package.json)
+          echo "Package:          $PKG_NAME"
+          echo "Tag version:      $TAG_VERSION"
+          echo "Manifest version: $MANIFEST_VERSION"
+          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "ERROR: tag version ($TAG_VERSION) != package.json version ($MANIFEST_VERSION)"
+            echo "Bump sdks/signer-core/package.json or retag at the correct commit."
+            exit 1
+          fi
+
+          # Provenance precondition: package.json MUST carry a `repository`
+          # field pointing at this repo, or `npm publish --provenance`
+          # fails on the real publish (dry-run does NOT catch it).
+          REPO_URL=$(jq -r '.repository.url // .repository // empty' package.json)
+          echo "repository: ${REPO_URL:-<missing>}"
+          case "$REPO_URL" in
+            *github.com/solvela-ai/solvela*) : ;;
+            *)
+              echo "ERROR: package.json has no 'repository' field matching"
+              echo "github.com/solvela-ai/solvela. npm provenance requires it."
+              echo "Add, e.g.:"
+              echo '  "repository": { "type": "git",'
+              echo '    "url": "git+https://github.com/solvela-ai/solvela.git",'
+              echo '    "directory": "sdks/signer-core" }'
+              exit 1
+              ;;
+          esac
+
+          # Stop-and-ask guard: refuse to re-publish an existing version.
+          # `npm view <pkg>@<ver> version` prints the version if published,
+          # is empty for a missing version, and 404s (non-zero) for a
+          # never-published package — all three handled here.
+          PUBLISHED=$(npm view "${PKG_NAME}@${TAG_VERSION}" version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "ERROR: ${PKG_NAME}@${TAG_VERSION} is already published on npm."
+            echo "Halting — bump the version or pick a new tag. Never re-publish over an existing version."
+            exit 1
+          fi
+          echo "OK: ${PKG_NAME}@${TAG_VERSION} is not yet published — clear to release."
+
+  # --------------------------------------------------------------------
+  # Re-run the SDK's test suite at the tagged commit. Node version, cache,
+  # and lockfile usage mirror the package's CI (mcp.yml builds signer-core
+  # the same way). Node 22 specifically: the SDKs' `node --test *.ts`
+  # runner relies on Node 22's strip-types support (see mcp.yml).
+  # --------------------------------------------------------------------
+  test:
+    name: Test (Node 22)
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/signer-core/package-lock.json
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  # --------------------------------------------------------------------
+  # Publish to npm with provenance. Depends on [verify, test] so a
+  # mistagged or failing release never reaches the registry. Runs in the
+  # `npm-publish` environment; NODE_AUTH_TOKEN comes from the repo-level
+  # NPM_TOKEN secret (same mechanism as sdk-typescript-publish.yml).
+  # --------------------------------------------------------------------
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: [verify, test]
+    environment: npm-publish
+    permissions:
+      id-token: write   # MANDATORY for npm provenance OIDC; do not remove.
+      contents: read
+    steps:
+      - name: Checkout (full history so tag is reachable)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/signer-core/package-lock.json
+          # Registry URL required for NODE_AUTH_TOKEN injection by setup-node.
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies (ignore-scripts)
+        run: npm ci --ignore-scripts
+
+      - name: Build
+        run: npm run build
+
+      # Charter-mandated: a dry-run that exercises the package BEFORE any
+      # live publish. Verified locally that this lists dist/ + README.md +
+      # package.json only. (Note: dry-run does NOT validate provenance/
+      # repository — that precondition is enforced in the verify job.)
+      - name: Dry-run publish (verify tarball contents)
+        run: npm publish --dry-run --access public
+
+      # Determine dist-tag from the git tag name:
+      #   sdks/signer-core/v0.1.0-rc.1  -> --tag rc
+      #   sdks/signer-core/v0.1.0       -> --tag latest (default, omit flag)
+      # --access public on BOTH paths: a scoped package's first publish
+      # defaults to restricted, and provenance requires a public package.
+      - name: Publish (provenance)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG_NAME="${{ github.ref_name }}"
+          if [[ "$TAG_NAME" =~ -rc\.[0-9]+$ ]]; then
+            echo "RC tag detected — publishing with --tag rc"
+            npm publish --tag rc --access public --provenance
+          else
+            echo "Release tag detected — publishing with --tag latest"
+            npm publish --access public --provenance
+          fi
+
+      # Post-publish: poll the registry until the version is visible (npm's
+      # read path can lag the publish by seconds-to-minutes), then compare
+      # the registry tarball SHA-256 against a locally-packed one. Mirrors
+      # sdk-typescript-publish.yml.
+      - name: Verify published tarball SHA matches local build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(jq -r '.version' package.json)
+          PKG_NAME=$(jq -r '.name' package.json)
+          echo "Verifying $PKG_NAME@$PKG_VERSION"
+
+          LOCAL_TARBALL=$(npm pack --dry-run --json 2>/dev/null | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)[0]['filename'])")
+          npm pack 2>/dev/null
+          LOCAL_SHA=$(shasum -a 256 "$LOCAL_TARBALL" | awk '{print $1}')
+          echo "Local tarball SHA256: $LOCAL_SHA"
+
+          TARBALL_URL=""
+          for i in $(seq 1 30); do
+            TARBALL_URL=$(npm view "${PKG_NAME}@${PKG_VERSION}" dist.tarball 2>/dev/null || true)
+            if [ -n "$TARBALL_URL" ]; then
+              break
+            fi
+            echo "Attempt $i/30: ${PKG_NAME}@${PKG_VERSION} not visible yet; sleeping 10s"
+            sleep 10
+          done
+          if [ -z "$TARBALL_URL" ]; then
+            echo "ERROR: ${PKG_NAME}@${PKG_VERSION} not visible on the registry after ~5 minutes"
+            exit 1
+          fi
+          echo "Registry tarball URL: $TARBALL_URL"
+          curl -fsSL "$TARBALL_URL" -o registry.tgz
+          REGISTRY_SHA=$(shasum -a 256 registry.tgz | awk '{print $1}')
+          echo "Registry tarball SHA256: $REGISTRY_SHA"
+
+          if [ "$LOCAL_SHA" = "$REGISTRY_SHA" ]; then
+            echo "SHA match confirmed — tarball integrity verified."
+          else
+            echo "ERROR: SHA mismatch! Local=$LOCAL_SHA Registry=$REGISTRY_SHA"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/docs/runbooks/mcp-npm-publish.md
+++ b/docs/runbooks/mcp-npm-publish.md
@@ -1,0 +1,180 @@
+# Runbook: publishing `@solvela/signer-core` + `@solvela/mcp-server` to npm
+
+Bootstrap (and ongoing) release procedure for the two-package MCP publish
+set. Goal: `npx -y @solvela/mcp-server` resolves and runs. Both packages
+sign/broadcast real USDC-SPL transactions on Solana mainnet, so this is a
+money-path release — follow the gates in order, halt on the first failure.
+
+Workflows:
+- `.github/workflows/sdk-signer-core-publish.yml` — Layer 1.
+- `.github/workflows/sdk-mcp-publish.yml` — Layer 2 (depends on Layer 1).
+
+## Dependency order
+
+```
+@solvela/mcp-server          (Layer 2, sdks/mcp/)
+        │  depends on
+        │    "@solvela/signer-core": "file:../signer-core"   (in-repo, local dev)
+        │    -> rewritten in CI to "^<version>"              (in the published tarball)
+        ▼
+@solvela/signer-core         (Layer 1, sdks/signer-core/)
+        │  depends on
+        ▼
+@solana/web3.js, @solana/spl-token, valibot, bs58 …   (already on npm)
+```
+
+Publish strictly bottom-up: **signer-core first, then mcp-server.** The
+mcp workflow will not publish until signer-core@<version> is resolvable on
+npm (it polls and fails closed otherwise).
+
+## Pre-fire gates (operator checklist — stop on first failure)
+
+### Gate 0 — `repository` field on BOTH manifests (provenance precondition)
+
+`npm publish --provenance` **requires** a `repository` field in
+`package.json` that matches `github.com/solvela-ai/solvela`, and
+`npm publish --dry-run` does **not** catch its absence — the failure only
+appears on the real publish. As of 2026-06-29 **neither** manifest has it:
+
+- `sdks/signer-core/package.json` — no `repository` field.
+- `sdks/mcp/package.json` (the PR #646 publish-ready version) — no
+  `repository` field.
+
+Add to each (the `directory` differs per package):
+
+```jsonc
+"repository": {
+  "type": "git",
+  "url": "git+https://github.com/solvela-ai/solvela.git",
+  "directory": "sdks/signer-core"   // or "sdks/mcp"
+}
+```
+
+Fold the mcp change into **PR #646** (it owns the publish-ready mcp
+manifest); add the signer-core change via a small follow-up commit on
+main. Both publish workflows' `verify` job enforces this field and fails
+closed with the exact snippet if it is missing — so a forgotten field
+halts the run in seconds, it never publishes-without-provenance.
+
+Source: https://docs.npmjs.com/generating-provenance-statements
+Evidence: `@solvela/sdk` (has the field) publishes with provenance fine;
+`@solvela/ai-sdk-provider` (lacks it) has never published.
+
+### Gate 1 — PR #646 merged to main
+
+The publish-ready `sdks/mcp/package.json` (drops `private`, adds the
+`files` allowlist + `prepublishOnly`) lives on PR #646
+(`feat/publish-mcp-web-search`). It **must** be merged to `main` before
+tagging mcp. The mcp `verify` job hard-fails if it sees `"private": true`,
+so a too-early tag halts safely — but don't rely on that; merge #646
+first. (signer-core's publish-ready manifest is already on main.)
+
+### Gate 2 — environment + secret
+
+- Environment `npm-publish` exists on the repo (confirmed 2026-06-29).
+  The publish jobs run in it; any required-reviewer / branch protection on
+  that environment will gate the publish (desirable for a money path).
+- `NPM_TOKEN` is a **repo-level** secret (confirmed present, last rotated
+  2026-06-06). It is the same secret the existing npm publish workflows
+  (`sdk-typescript-publish.yml`, `ai-sdk-provider-publish.yml`) use, and
+  `@solvela/sdk@0.3.0` published with it recently — so it is known-good.
+  Confirm it is an **automation/granular token** with publish rights to
+  the `@solvela/*` scope and not expired. There is no token fallback:
+  a missing/expired token fails the publish closed (correct behavior).
+
+### Gate 3 — versions correct and unpublished
+
+- Both first versions are `0.1.0` (matches both manifests).
+- Both are unpublished on npm as of 2026-06-29 (`npm view` → 404 for
+  `@solvela/signer-core` and `@solvela/mcp-server`).
+- The `verify` job re-checks tag==version and not-already-published at fire
+  time; if either version has since been published, it halts.
+
+## Firing sequence (maintainer pushes the release tags, in dep-order)
+
+Tag the **same** post-#646-merge commit on `main` for both packages. Tags
+are immutable — never force-move, retag, or delete a published tag.
+
+```bash
+# 1. Layer 1 — signer-core. Trigger sdk-signer-core-publish.yml.
+git tag sdks/signer-core/v0.1.0 <main-commit-sha>
+git push origin sdks/signer-core/v0.1.0
+
+# 2. Wait for the "sdk-signer-core publish" run to go fully green.
+#    It ends with a registry SHA-match: signer-core@0.1.0 is now live.
+#    (Do NOT push the mcp tag until this is green — the mcp workflow
+#     polls for signer-core@0.1.0 and fails closed if it isn't there.)
+
+# 3. Layer 2 — mcp-server. Trigger sdk-mcp-publish.yml.
+git tag sdks/mcp/v0.1.0 <same-main-commit-sha>
+git push origin sdks/mcp/v0.1.0
+
+# 4. Wait for the "sdk-mcp publish" run to go fully green. Its final step
+#    runs `npx -y @solvela/mcp-server@0.1.0` (pulling signer-core from the
+#    registry) and asserts an MCP `initialize` response — i.e. it proves
+#    the end goal: `npx -y @solvela/mcp-server` resolves.
+```
+
+What each workflow enforces, in order (so you can trust the gates):
+`verify` (tag==version, not-private, repository present, not-already-
+published) → `test` (full suite at the tagged commit, Node 22) → `publish`
+(dry-run tarball check → [mcp only] swap `file:`→`^<version>` → [mcp only]
+poll signer-core resolvable → `npm publish --access public --provenance` →
+registry SHA-256 match → [mcp only] npx smoke).
+
+## Rollback plan (partial / failed publish)
+
+npm publishes are **not** transactionally reversible and **yanking is a
+human decision** — this runbook never yanks.
+
+- **signer-core published, mcp failed before publishing:** signer-core@0.1.0
+  is live and harmless on its own (it is a library dep). Fix the mcp issue,
+  then re-run the **failed mcp workflow run** from the Actions UI (idempotent:
+  `verify` re-passes, publish proceeds). Only if the tag itself was wrong
+  (wrong commit/version) cut a **new** tag at a new version — do not delete
+  or move `sdks/mcp/v0.1.0`.
+- **mcp published, then SHA-match or npx smoke failed:** mcp@0.1.0 IS live.
+  Investigate immediately — a SHA mismatch or smoke failure on a money-path
+  package is release-blocking. Whether to **yank** `@solvela/mcp-server@0.1.0`
+  (or `@solvela/signer-core@0.1.0`) is an **operator decision**; this agent
+  will not run `npm unpublish`/yank. If the bytes are bad, the operator
+  yanks and a fixed `0.1.1` is cut.
+- **Re-running against the same tag:** safe. `verify`'s already-published
+  check makes a second live publish of the same version fail closed rather
+  than corrupt state.
+- Never: `npm unpublish`, yank, force-move/retag/delete a tag, or
+  `--no-verify`.
+
+## Test plan / rehearsal
+
+- **Local dry-runs (done 2026-06-29, Node 22.22.0 + npm 10.9.4):**
+  - signer-core: `npm ci` + `npm run build` + `npm test` (125 pass);
+    `npm publish --dry-run` → 38 files / 37.6 kB, `dist/` + `README.md` +
+    `package.json` only.
+  - mcp (against the #646 manifest): `npm ci` + `npm run build` +
+    `npm test` (112 pass); jq swap `file:../signer-core` → `^0.1.0`;
+    `npm publish --dry-run` → 34 files / 54.4 kB, `dist/` + `README.md` +
+    `package.json` only; packed `package.json` has `private` removed, the
+    `bin` `dist/index.js` present (shebang preserved), and the swapped
+    `^0.1.0` dep. No `src`/`tests`/`AGENTS.md`/secrets in either tarball.
+- **CI plumbing rehearsal (optional, before the real tags):** push an rc
+  tag pair (`sdks/signer-core/v0.1.0-rc.1`, then `sdks/mcp/v0.1.0-rc.1`).
+  The workflows publish under the `rc` dist-tag — note this is a **real**
+  publish to the prerelease channel, not a dry run. To exercise CI without
+  any real publish, run the workflows on a **fork** where `NPM_TOKEN` is
+  absent: `verify`/`test`/dry-run pass and the live publish fails closed.
+
+## Cross-references
+
+- Workflows authored here:
+  `.github/workflows/sdk-signer-core-publish.yml`,
+  `.github/workflows/sdk-mcp-publish.yml`.
+- Mirrored reference workflows: `sdk-typescript-publish.yml`,
+  `ai-sdk-provider-publish.yml` (npm auth/provenance/SHA-verify),
+  `sdk-python-publish.yml`, `sdk-rust-publish.yml` (verify-first multi-job
+  shape, propagation polls).
+- SDK CI mirrored for the `test` jobs: `.github/workflows/mcp.yml`
+  (Node 22, signer-core `file:` dep build dance).
+- PR #646 (`feat/publish-mcp-web-search`) — makes the mcp manifest
+  publish-ready; must merge before tagging mcp.
+- Related: `docs/runbooks/sdk-consolidation.md`.

--- a/sdks/signer-core/package.json
+++ b/sdks/signer-core/package.json
@@ -32,6 +32,11 @@
     "uuid": "^11.1.1"
   },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solvela-ai/solvela.git",
+    "directory": "sdks/signer-core"
+  },
   "files": [
     "dist",
     "README.md"


### PR DESCRIPTION
## What

Two tag-triggered, provenance-enabled npm publish workflows that ship the MCP publish set so `npx -y @solvela/mcp-server` resolves, plus a release runbook. **No package was published and no tag was pushed** — this PR is workflow + runbook only.

- `.github/workflows/sdk-signer-core-publish.yml` — Layer 1, publishes `@solvela/signer-core`.
- `.github/workflows/sdk-mcp-publish.yml` — Layer 2, publishes `@solvela/mcp-server` (depends on Layer 1).
- `docs/runbooks/mcp-npm-publish.md` — firing sequence, gates, rollback, rehearsal.

## Dependency order

```
@solvela/mcp-server          (Layer 2, sdks/mcp/)
        │  "@solvela/signer-core": "file:../signer-core"   (in-repo, local dev)
        │  -> rewritten in CI to "^<version>"              (published tarball only)
        ▼
@solvela/signer-core         (Layer 1, sdks/signer-core/)
        ▼
@solana/web3.js, @solana/spl-token, valibot, bs58 …        (already on npm)
```

Publish strictly bottom-up. The mcp workflow polls npm until `signer-core@<version>` is resolvable and fails closed if it isn't, so it can never ship a dangling dep.

## Pattern mirrored (not reinvented)

- **Auth/provenance:** `environment: npm-publish`, `NODE_AUTH_TOKEN=${{ secrets.NPM_TOKEN }}` (repo-level secret), `npm publish --access public --provenance`, `id-token: write` per publish job, post-publish registry SHA-256 match — same mechanism as `sdk-typescript-publish.yml` / `ai-sdk-provider-publish.yml`.
- **Shape:** verify-first `verify` → `test` → `publish` multi-job structure from `sdk-python-publish.yml` / `sdk-rust-publish.yml`.
- **Tag scheme:** `sdks/signer-core/v*` and `sdks/mcp/v*` (matches `sdks/typescript/v*`). rc-suffix → `--tag rc`, else `--tag latest`.
- **Node 22 + signer-core `file:`-dep build dance:** mirrors `mcp.yml` CI (its `node --test *.ts` runner needs Node 22 strip-types; npm doesn't auto-build a `file:` dep). This is the one deliberate deviation from the Node-20 npm publish workflows, commented inline.
- **Actions** left at floating `@v6` to match the npm-family workflows; SHA-pinning (as in python/rust) noted as a future hardening.

## CI-only `file:` → registry swap

Before publishing mcp, CI rewrites `"@solvela/signer-core": "file:../signer-core"` → `"^<version>"` on the checked-out copy only (never committed) so the published tarball carries a real registry dep. Verified locally that the packed `package.json` carries `^0.1.0` and the repo keeps `file:` for local dev.

## Dry-run results (local, 2026-06-29 — Node 22.22.0, npm 10.9.4)

- **signer-core:** `npm ci` + build + `npm test` (125 pass); `npm publish --dry-run` → 38 files / 37.6 kB = `dist/` + `README.md` + `package.json` only.
- **mcp** (against the **#646** publish-ready manifest): `npm ci` + build + `npm test` (112 pass); jq swap `file:../signer-core` → `^0.1.0`; `npm publish --dry-run` → 34 files / 54.4 kB = `dist/` + `README.md` + `package.json` only; packed manifest has `private` removed, `bin: dist/index.js` present (shebang preserved), swapped `^0.1.0` dep. No `src`/`tests`/`AGENTS.md`/secrets in either tarball.

Both packages are unpublished (npm 404) and `0.1.0` is the correct first version.

## ⚠️ Operator gates before the first tag (details in the runbook)

1. **`repository` field on BOTH manifests.** `npm publish --provenance` requires a `repository` field matching `github.com/solvela-ai/solvela`, and `npm publish --dry-run` does **not** catch its absence — it only fails on the real publish. **Neither `sdks/signer-core/package.json` nor the #646 `sdks/mcp/package.json` has one today.** The `verify` jobs enforce it and fail closed with the exact snippet. Fold the mcp change into **#646**; add signer-core's via a small follow-up. (Evidence: `@solvela/sdk` has the field and publishes with provenance; `@solvela/ai-sdk-provider` lacks it and has never published.)
2. **PR #646 must merge to `main` first** so main's mcp manifest is publish-ready (drops `private`, adds `files` + `prepublishOnly`). The mcp `verify` job hard-fails on `"private": true`.
3. **Confirm `NPM_TOKEN`** is a current automation token scoped to publish `@solvela/*` (it published `@solvela/sdk@0.3.0` recently, so it's known-good; just confirm not expired). The `npm-publish` environment exists.

## Firing sequence (maintainer, in dep-order)

```bash
git tag sdks/signer-core/v0.1.0 <main-sha> && git push origin sdks/signer-core/v0.1.0
# wait for "sdk-signer-core publish" to go green (signer-core@0.1.0 live)
git tag sdks/mcp/v0.1.0 <same-main-sha> && git push origin sdks/mcp/v0.1.0
# "sdk-mcp publish" ends by running `npx -y @solvela/mcp-server@0.1.0` and asserting MCP initialize
```

## Rollback plan

npm publishes aren't transactionally reversible and **yanking is a human decision — these workflows never yank**. If signer-core publishes but mcp fails pre-publish, signer-core@0.1.0 is harmless; re-run the failed mcp run (idempotent) or cut a new tag (never move `sdks/mcp/v0.1.0`). If mcp publishes but SHA-match/smoke fails, mcp@0.1.0 is live and the bad-bytes/yank call is the operator's. Full matrix in the runbook.

## Test plan

Local dry-runs above are the primary evidence. Optional CI-plumbing rehearsal: rc-tag pair (real prerelease publish under `--tag rc`) or run on a fork where `NPM_TOKEN` is absent (verify/test/dry-run pass, live publish fails closed).

## Notes

- YAML validated with `yaml.safe_load` (both parse). actionlint not available locally.
- Cross-refs: `sdk-typescript-publish.yml`, `sdk-python-publish.yml`, `sdk-rust-publish.yml`, `ai-sdk-provider-publish.yml`, `mcp.yml`, `docs/runbooks/sdk-consolidation.md`, PR #646.

Do not merge until the operator gates above are satisfied.
