### PR TITLE
chore(github): add PR template and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Review routing. Solo-maintained — @sky64 owns everything by default.
+# This file is advisory unless "Require review from Code Owners" is enabled
+# in branch protection; PR approvals are satisfied by the Solvela-bot reviewer.
+
+* @sky64
+
+# Money path — flagged explicitly so these directories never get a casual review.
+/crates/x402/            @sky64
+/crates/gateway/src/routes/chat/   @sky64
+/crates/gateway/src/providers/     @sky64
+/programs/escrow/        @sky64
+/sdks/                   @sky64

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+One reviewer, one maintainer. Keep this tight — a clear PR gets merged faster.
+Security issues do NOT go here: email security@solvela.ai per SECURITY.md.
+-->
+
+## What & why
+
+<!-- One or two sentences. Link the issue/PR if there is one (e.g. Closes #123). -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor / cleanup (no behavior change)
+- [ ] Docs / config / CI
+- [ ] Money path (touches USDC amounts, the 5% fee, cost breakdowns, spend/budget, or x402/escrow verify)
+
+## Checklist
+
+- [ ] `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` pass
+- [ ] `cargo test` passes (added/updated tests for the change)
+- [ ] `STATUS.md` / `CHANGELOG.md` updated if this ships a user-visible change
+- [ ] No secrets in the diff (provider keys, fee-payer key, wallet keys stay in env)
+- [ ] DCO `Signed-off-by` trailer present (the `.githooks` hook adds it; CI enforces it)
+
+<!-- Money-path PRs: a second independent review pass is expected before merge. -->


### PR DESCRIPTION
## What & why

The `/harness-audit` flagged 9 failing checks; 7 were Rust-vs-JS-rubric artifacts (it can't see `cargo test`, and the Vercel/Fly `package.json`/`.env.example` checks don't apply to a Rust workspace). Two were real gaps — no PR template, no review routing. This closes both.

Moves GitHub Integration **7/10 → 10/10**.

## What's here

- **`.github/PULL_REQUEST_TEMPLATE.md`** — tight checklist matching the existing solo-maintainer voice (cf. the bug-report issue template): fmt/clippy/test gates, STATUS/CHANGELOG reminder, no-secrets, DCO signoff. Adds a **money-path** type so PRs touching USDC/fee/x402/escrow are flagged for the expected second-pass review.
- **`.github/CODEOWNERS`** — `@sky64` catch-all plus explicit money-path entries (`crates/x402`, `routes/chat`, `providers`, `programs/escrow`, `sdks`). All paths verified to exist. Advisory unless "Require review from Code Owners" is enabled in branch protection; the Solvela-bot reviewer still satisfies approval either way.

## Type

- [x] Docs / config / CI

No code paths touched.