### PR TITLE
feat(gateway): native Anthropic SSE streaming passthrough for POST /v1/messages

### DIFF
--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -286,11 +286,22 @@ async fn main() -> anyhow::Result<()> {
     // ── Shared HTTP client ─────────────────────────────────────────────────
     //
     // A single reqwest::Client is shared across all provider adapters and
-    // general-purpose outbound calls (Solana RPC, health checks). The 10s
-    // client-level timeout applies to non-LLM calls; each provider adapter
-    // overrides it with a 90s per-request timeout for LLM API calls.
+    // general-purpose outbound calls (Solana RPC, health checks). The 10s TOTAL
+    // timeout applies to non-LLM calls; each provider adapter overrides it with a
+    // longer per-request total timeout for LLM API calls.
+    //
+    // `read_timeout` is a PER-CHUNK IDLE deadline (resets on each received byte),
+    // distinct from the total `timeout` deadline. It is the correct liveness
+    // check for STREAMING responses: `timeout` is a wall-clock total across
+    // headers + body, so on a long SSE stream it would truncate the whole
+    // response mid-flight (charge-without-full-delivery on a settled `exact`
+    // request). The 120s idle timeout kills a genuinely-stalled stream but never
+    // truncates a healthy stream that keeps emitting tokens. Safe for buffered/
+    // non-streaming calls too (they pull continuously, so 120s idle is never hit
+    // legitimately). Covers idle-liveness for ALL SSE paths, native + OpenAI.
     let http_client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
+        .read_timeout(std::time::Duration::from_secs(120))
         .build()
         .expect("failed to build HTTP client");
 

--- a/crates/gateway/src/providers/anthropic.rs
+++ b/crates/gateway/src/providers/anthropic.rs
@@ -178,6 +178,111 @@ impl AnthropicProvider {
 
         Ok((raw, envelope.usage))
     }
+
+    /// Native `/v1/messages` STREAMING passthrough relay (the twin of
+    /// [`relay_native`]).
+    ///
+    /// Forwards the ORIGINAL validated Anthropic request `body` (which already
+    /// carries `"stream": true`) to `{base_url}/v1/messages` VERBATIM, then — on
+    /// a 2xx — returns an [`axum::response::Response`] whose body is the upstream
+    /// SSE byte stream relayed UNTOUCHED via `Body::from_stream(bytes_stream())`.
+    /// The `content-type` is forced to `text/event-stream`. NO event re-framing:
+    /// the upstream event names, `content_block_delta`, `signature_delta`,
+    /// `message_delta` usage, and `ping`/error events all pass through
+    /// byte-for-byte (re-framing through the internal OpenAI `ChatChunk` stream is
+    /// what PR #621 did, and it DROPS the thinking-block `signature` → multi-turn
+    /// extended thinking hard-400s on turn 2).
+    ///
+    /// Headers are identical to [`relay_native`]: the gateway's own `x-api-key`
+    /// (NEVER the inbound Solvela bearer), `anthropic-version` (forwarded or the
+    /// GA default), and `anthropic-beta` verbatim when present.
+    ///
+    /// FAIL-CLOSED: the upstream status is checked BEFORE the stream body is
+    /// returned. On a non-2xx (or a transport failure) it returns a redacted
+    /// [`NativeRelayError`] — NEVER the upstream body or raw error
+    /// (GHSA-cgqx-mg48-949v) — so the caller maps it to `AllProvidersFailed`
+    /// (reservation released, no settle). A stream cannot be un-sent once its
+    /// 200 headers leave, so the status MUST be decided here, up front.
+    ///
+    /// Unlike [`relay_native`], this returns NO [`AnthropicUsage`]: streaming bills
+    /// off the request-side estimate (the `EstimateFallback` settlement posture),
+    /// exactly like the OpenAI streaming path. Reading per-token usage out of the
+    /// `message_delta` event would only affect the spend-log record (under x402
+    /// `exact` the client's signed quote settles regardless), not the customer
+    /// charge — so no usage tap is built here (see the route-level money-path
+    /// notes).
+    pub(crate) async fn relay_native_stream(
+        &self,
+        body: axum::body::Bytes,
+        anthropic_version: Option<&str>,
+        anthropic_beta: Option<&str>,
+    ) -> Result<axum::response::Response, NativeRelayError> {
+        use axum::response::IntoResponse;
+        // `.map_err` on the reqwest byte stream below requires `TryStreamExt`.
+        use futures::TryStreamExt;
+
+        let version = anthropic_version.unwrap_or(DEFAULT_ANTHROPIC_VERSION);
+
+        let mut request = self
+            .client
+            // ponytail: 600s is an ABSOLUTE total-deadline ceiling only — NOT the
+            // real liveness check. `timeout` is wall-clock across headers + body,
+            // so a tighter total (e.g. the buffered path's 90s) would truncate a
+            // long but healthy SSE stream mid-flight while `exact` has already
+            // settled (charge-without-full-delivery). The real liveness check is
+            // the shared client's `read_timeout` (per-chunk idle, main.rs); a
+            // healthy multi-minute Claude stream completes well within 600s.
+            .post(self.messages_url())
+            .timeout(std::time::Duration::from_secs(600))
+            // Gateway key replaces the client's auth — the inbound Solvela bearer
+            // is NEVER forwarded to Anthropic.
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", version)
+            .header("content-type", "application/json")
+            // The ORIGINAL validated bytes, verbatim — `.body()` (not `.json()`)
+            // so no re-serialization can perturb a single byte. The body already
+            // carries `"stream": true`, so the upstream request is a stream.
+            .body(body);
+
+        if let Some(beta) = anthropic_beta {
+            request = request.header("anthropic-beta", beta);
+        }
+
+        // Transport / send failure: redact (the inner reqwest::Error can carry
+        // the upstream URL). Full detail is logged at the call site.
+        let response = request.send().await.map_err(|e| {
+            tracing::debug!(error = %e, "native stream relay transport error (redacted from client)");
+            NativeRelayError::Transport
+        })?;
+
+        // FAIL-CLOSED status gate — decided BEFORE any stream body is returned.
+        // Once a 200 + SSE headers leave the gateway the stream cannot be
+        // un-sent, so a non-2xx MUST short-circuit to a redacted error here. The
+        // upstream body is NOT carried (attacker/provider-controlled bytes,
+        // GHSA-cgqx-mg48-949v) — only the numeric status survives, for logging.
+        let status = response.status();
+        if !status.is_success() {
+            return Err(NativeRelayError::UpstreamStatus(status.as_u16()));
+        }
+
+        // 2xx → relay the upstream SSE byte stream UNTOUCHED. `bytes_stream()`
+        // yields the raw response bytes as they arrive; `Body::from_stream`
+        // forwards them verbatim with no re-framing. The error type of the
+        // stream is mapped to `std::io::Error` (what `Body::from_stream`
+        // requires); a mid-stream upstream/transport error therefore terminates
+        // the body — the client sees a truncated SSE stream rather than a
+        // fabricated success frame, and no upstream error detail is surfaced.
+        let byte_stream = response.bytes_stream().map_err(std::io::Error::other);
+        let out = (
+            [(
+                axum::http::header::CONTENT_TYPE,
+                axum::http::HeaderValue::from_static("text/event-stream"),
+            )],
+            axum::body::Body::from_stream(byte_stream),
+        )
+            .into_response();
+        Ok(out)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/gateway/src/providers/anthropic_inbound.rs
+++ b/crates/gateway/src/providers/anthropic_inbound.rs
@@ -418,15 +418,27 @@ pub fn anthropic_request_to_chat(
 /// This skeleton is NEVER serialized to a provider (the raw body is relayed) and
 /// is NEVER used to compute the native cost estimate (that is computed directly
 /// from the original bytes by `estimate_native_anthropic_input_tokens`). So it
-/// only needs to carry: the model, `max_tokens`, and the flattened text of the
-/// `system` prompt + every message — including the text inside `thinking` /
-/// `tool_use` / `tool_result` / image blocks — so the empty-prompt check sees
-/// real content and the guard scans it. All content is flattened to
-/// [`MessageContent::Text`] (never `Parts`), so the inner vision-gate /
-/// image-validation path is not engaged for the relay's verbatim images.
+/// only needs to carry: the model, `max_tokens`, the inbound `stream` flag, and
+/// the flattened text of the `system` prompt + every message — including the
+/// text inside `thinking` / `tool_use` / `tool_result` / image blocks — so the
+/// empty-prompt check sees real content and the guard scans it. All content is
+/// flattened to [`MessageContent::Text`] (never `Parts`), so the inner
+/// vision-gate / image-validation path is not engaged for the relay's verbatim
+/// images.
 ///
-/// Infallible by design: the native path rejects only `stream:true` (handled by
-/// the route before this is called); every other shape is forwarded.
+/// The `stream` flag is carried through (`stream: req.stream`) so the shared
+/// money-path core treats a native streaming request AS streaming — selecting the
+/// `EstimateFallback` settlement posture (no post-stream usage tap / session-token
+/// attach), identical to the OpenAI streaming path. The relayed body still
+/// carries `stream:true` itself (it is the original bytes), so the upstream
+/// request is a stream regardless; this flag only steers the core's settlement
+/// arm. The strict reshape builder ([`anthropic_request_to_chat`]) is a SEPARATE
+/// path and still hard-rejects `stream:true` — cross-provider streaming is out of
+/// scope.
+///
+/// Infallible by design: every shape is forwarded (the native streaming relay
+/// handles `stream:true`; the route still rejects `stream:true` on the reshape
+/// branch).
 pub fn anthropic_request_to_native_skeleton(req: &AnthropicMessagesRequest) -> ChatRequest {
     let mut messages: Vec<ChatMessage> = Vec::with_capacity(req.messages.len() + 1);
 
@@ -458,7 +470,10 @@ pub fn anthropic_request_to_native_skeleton(req: &AnthropicMessagesRequest) -> C
         max_tokens: req.max_tokens,
         temperature: req.temperature,
         top_p: req.top_p,
-        stream: false,
+        // Carry the inbound stream flag so the shared core takes the streaming
+        // settlement posture (EstimateFallback) for a native streaming relay.
+        // The reshape builder above stays non-streaming (it rejects stream:true).
+        stream: req.stream,
         tools: None,
         tool_choice: None,
     }

--- a/crates/gateway/src/routes/chat/mod.rs
+++ b/crates/gateway/src/routes/chat/mod.rs
@@ -1901,6 +1901,66 @@ async fn run_native_relay(
         }
     };
 
+    // STREAMING native passthrough: relay the upstream SSE bytes VERBATIM. This
+    // is the streaming twin of the buffered path below. It returns
+    // `usage: None` / `cost_outcome: None`, so the caller takes the
+    // `EstimateFallback` settlement arm — IDENTICAL to the OpenAI streaming path:
+    // bill the request-side estimate (the amount reserved in `check_budget` and,
+    // on `exact`, settled on-chain), never `.await` settlement on the streamed
+    // bytes, and read no per-token usage out of the stream. The native streaming
+    // path adds NO new financial math. On any failure (transport / non-2xx /
+    // unbillable) the relay returns a redacted `NativeRelayError` mapped to the
+    // all-providers-failed arm below (reservation released, no settle, no body
+    // leak) — never a silent reshape fallback.
+    if req.stream {
+        info!(model = %req.model, "native /v1/messages streaming passthrough to Anthropic");
+        // No `solvela_provider_request_duration_seconds` here: `relay_native_stream`
+        // returns as soon as upstream HEADERS arrive (the body streams lazily), so
+        // recording it would measure TTFB under a metric name whose other (buffered)
+        // users mean TOTAL duration — a mislabel. Streaming latency observability
+        // can be added later under a properly-named TTFB/stream metric.
+        let stream_result = relay
+            .relay_native_stream(relay_body, anthropic_version, anthropic_beta)
+            .await;
+
+        let mut response = match stream_result {
+            Ok(resp) => resp,
+            Err(e) => {
+                let error_type = match &e {
+                    NativeRelayError::Transport => "timeout",
+                    NativeRelayError::UpstreamStatus(_) => "server_error",
+                    NativeRelayError::Unbillable => "unknown",
+                };
+                counter!(
+                    "solvela_provider_errors_total",
+                    "provider" => "anthropic".to_string(),
+                    "error_type" => error_type
+                )
+                .increment(1);
+                warn!(
+                    model = %req.model,
+                    error = %e,
+                    "native /v1/messages streaming relay failed — failing closed (no charge)"
+                );
+                return Err(ProviderCallError::AllProvidersFailed {
+                    model: req.model.clone(),
+                    provider: "anthropic".to_string(),
+                    // Fixed category only — never the upstream body / raw error.
+                    error: e.to_string(),
+                });
+            }
+        };
+        response::attach_session_id(&mut response, session_id);
+        return Ok(ProviderCallResult {
+            response,
+            // Streaming carries no response-side usage; the caller bills the
+            // estimate via the EstimateFallback arm (same as OpenAI streaming).
+            usage: None,
+            actual_provider: Some("anthropic".to_string()),
+            cost_outcome: None,
+        });
+    }
+
     info!(model = %req.model, "native /v1/messages passthrough to Anthropic");
     let provider_start = Instant::now();
     let relay_result = relay

--- a/crates/gateway/src/routes/messages/mod.rs
+++ b/crates/gateway/src/routes/messages/mod.rs
@@ -119,20 +119,16 @@ pub async fn create_message(
         }
     };
 
-    // Streaming is OUT OF SCOPE on both the native and reshape branches (native
-    // SSE is a follow-up). Reject it LOUDLY here, before model resolution, so a
-    // `stream:true` request never silently serves non-streaming on either path
-    // (mirrors the strict translator's rejection; keeps the branch's current
-    // behavior per the scope decision).
-    if anthropic_req.stream {
-        return anthropic_error_response(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            "streaming responses are not yet supported on POST /v1/messages; \
-             set \"stream\": false (SSE support is planned for a later release)"
-                .to_string(),
-        );
-    }
+    // Streaming is supported ONLY on the NATIVE branch (an Anthropic-resolved
+    // model relays the upstream SSE bytes verbatim). The RESHAPE branch
+    // (cross-provider) still rejects `stream:true` — re-framing through the
+    // internal OpenAI `ChatChunk` stream drops the thinking-block `signature`
+    // (PR #621). The rejection is NOT done here, before the fork: it is handled
+    // per-branch below — the native branch lets `stream:true` through to the
+    // relay; the reshape branch's strict translator (`anthropic_request_to_chat`)
+    // keeps its hard `stream:true` rejection. This guarantees a native streaming
+    // request is never silently down-converted, and a reshape request is never
+    // silently served non-streaming.
 
     // Decide the NATIVE-vs-RESHAPE fork from the RESOLVED model's provider.
     // Build a lenient skeleton (model + flattened text) so the resolver can run

--- a/crates/gateway/tests/integration.rs
+++ b/crates/gateway/tests/integration.rs
@@ -1015,6 +1015,132 @@ fn spawn_mock_anthropic_server(fixture: &'static str) -> String {
     format!("http://{addr}")
 }
 
+/// The golden NATIVE Anthropic STREAMING (SSE) fixture for the `/v1/messages`
+/// streaming-passthrough byte-survival tests.
+///
+/// A real Anthropic Messages SSE event sequence: `message_start` (carrying
+/// `usage` with all three cache fields), a `content_block_start` for a
+/// `thinking` block, a `signature_delta` carrying the cryptographic
+/// `signature`, a text `content_block_delta`, `message_delta` (output usage +
+/// stop_reason), and `message_stop`. The native streaming relay must forward
+/// THESE BYTES byte-for-byte to the client — re-framing through the internal
+/// OpenAI `ChatChunk` stream (PR #621) DROPS the `signature_delta`, which
+/// hard-400s multi-turn extended thinking on the next turn. The literal
+/// `signature` here is the survival witness.
+const NATIVE_ANTHROPIC_STREAM_FIXTURE: &str = concat!(
+    "event: message_start\n",
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream_native_01\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-6\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":40,\"cache_creation_input_tokens\":200,\"cache_read_input_tokens\":1800,\"output_tokens\":1}}}\n\n",
+    "event: content_block_start\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n",
+    "event: content_block_delta\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me reason.\"}}\n\n",
+    "event: content_block_delta\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"ErcBCkgIARABGAIiQ_GOLDEN_STREAM_SIGNATURE_xyz==\"}}\n\n",
+    "event: content_block_stop\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "event: content_block_start\n",
+    "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+    "event: content_block_delta\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi there.\"}}\n\n",
+    "event: content_block_stop\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+    "event: message_delta\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":25}}\n\n",
+    "event: message_stop\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+/// Spawn a minimal local mock Anthropic Messages server that returns the given
+/// SSE `fixture` verbatim with `content-type: text/event-stream` for
+/// `POST /v1/messages`, and return its base URL. The twin of
+/// [`spawn_mock_anthropic_server`] for streaming: pointing the REAL
+/// `AnthropicProvider::relay_native_stream` at this proves SSE byte-survival
+/// THROUGH the real reqwest serialize → byte-stream passthrough.
+fn spawn_mock_anthropic_stream_server(fixture: &'static str) -> String {
+    use axum::routing::post;
+    use axum::Router as AxumRouter;
+
+    let app = AxumRouter::new().route(
+        "/v1/messages",
+        post(move || async move {
+            (
+                [(
+                    axum::http::header::CONTENT_TYPE,
+                    axum::http::HeaderValue::from_static("text/event-stream"),
+                )],
+                fixture,
+            )
+        }),
+    );
+
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    std_listener.set_nonblocking(true).unwrap();
+    let addr = std_listener.local_addr().unwrap();
+    let listener = tokio::net::TcpListener::from_std(std_listener).unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Spawn a mock Anthropic server that always responds with a non-2xx status
+/// (500) and a body that LOOKS like a leak (it contains a fake `sk-` token).
+/// Used by the streaming fail-closed test: the relay MUST check the status
+/// BEFORE returning the stream body and surface a redacted `NativeRelayError`,
+/// never forward this upstream error body. Returns its base URL.
+fn spawn_mock_anthropic_error_server() -> String {
+    use axum::routing::post;
+    use axum::Router as AxumRouter;
+
+    let app = AxumRouter::new().route(
+        "/v1/messages",
+        post(move || async move {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                // A body crafted to detect a leak: if the relay forwarded the
+                // upstream error body, this fake key would surface to the client.
+                "{\"error\":{\"type\":\"api_error\",\"message\":\"sk-leaked-upstream-key-should-never-surface\"}}",
+            )
+        }),
+    );
+
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    std_listener.set_nonblocking(true).unwrap();
+    let addr = std_listener.local_addr().unwrap();
+    let listener = tokio::net::TcpListener::from_std(std_listener).unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Build a test app whose native relay points at a STREAMING mock Anthropic
+/// server (returns [`NATIVE_ANTHROPIC_STREAM_FIXTURE`] as `text/event-stream`).
+/// An Anthropic-resolved `stream:true` `/v1/messages` request takes the native
+/// streaming passthrough and the client receives the SSE bytes verbatim.
+fn test_app_with_streaming_native_relay() -> axum::Router {
+    let base_url = spawn_mock_anthropic_stream_server(NATIVE_ANTHROPIC_STREAM_FIXTURE);
+    let (router, _state) = test_app_with_provider_registry_and_exact_verifier_native(
+        mock_provider_registry(),
+        Arc::new(AlwaysPassVerifier),
+        Some(native_relay_pointed_at(&base_url)),
+    );
+    router
+}
+
+/// Build a test app whose native relay points at an ERROR (500) mock Anthropic
+/// server, to exercise the streaming fail-closed path (non-2xx upstream → no
+/// charge, redacted Anthropic error envelope, no upstream body leak).
+fn test_app_with_erroring_native_relay() -> axum::Router {
+    let base_url = spawn_mock_anthropic_error_server();
+    let (router, _state) = test_app_with_provider_registry_and_exact_verifier_native(
+        mock_provider_registry(),
+        Arc::new(AlwaysPassVerifier),
+        Some(native_relay_pointed_at(&base_url)),
+    );
+    router
+}
+
 /// Spawn a mock Anthropic server that CAPTURES the relayed request's top-level
 /// `model` field into the returned shared slot, then responds with
 /// [`NATIVE_ANTHROPIC_FIXTURE`]. Lets a test assert the EXACT `model` string the
@@ -16626,11 +16752,17 @@ mod messages_endpoint_tests {
         assert!(v["error"]["message"].is_string());
     }
 
-    /// A `stream: true` request is rejected (PR1 is non-streaming) with a 400 in
-    /// the Anthropic error envelope rather than silently served non-streaming.
+    /// A `stream: true` request to an ANTHROPIC-resolved model is now SERVED via
+    /// the native SSE passthrough (200, `text/event-stream`) — the streaming
+    /// follow-up to the #635 native non-streaming relay. (Byte-survival of the
+    /// SSE frames + the thinking `signature` is pinned by
+    /// `messages_native_passthrough_tests::native_streaming_response_is_byte_identical_sse`;
+    /// the RESHAPE branch's continued `stream:true` rejection by
+    /// `reshape_branch_still_rejects_streaming`.) This asserts the native branch
+    /// no longer hard-rejects `stream:true`.
     #[tokio::test]
-    async fn messages_streaming_request_rejected_with_anthropic_envelope() {
-        let app = test_app_with_mock_provider();
+    async fn messages_native_streaming_request_is_served_as_sse() {
+        let app = test_app_with_streaming_native_relay();
         let body = serde_json::json!({
             "model": "anthropic/claude-sonnet-4-6",
             "max_tokens": 64,
@@ -16651,11 +16783,20 @@ mod messages_endpoint_tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(v["type"], "error");
-        assert_eq!(v["error"]["type"], "invalid_request_error");
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "an Anthropic-resolved stream:true request must now be served natively, not 400-rejected"
+        );
+        let ct = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.starts_with("text/event-stream"),
+            "native streaming response must be text/event-stream; got '{ct}'"
+        );
     }
 
     /// On the RESHAPE branch (a NON-Anthropic resolved model) an image content
@@ -17830,5 +17971,201 @@ mod messages_native_passthrough_tests {
         // Anthropic error envelope (top-level type:"error").
         assert_eq!(v["type"], "error");
         assert_eq!(v["error"]["type"], "model_not_found");
+    }
+
+    // =======================================================================
+    // NATIVE SSE STREAMING passthrough (`stream: true`).
+    //
+    // The streaming twin of the byte-survival tests above. The native relay
+    // forwards the upstream `text/event-stream` body VERBATIM via
+    // `Body::from_stream(reqwest.bytes_stream())` — NEVER re-framed through the
+    // internal OpenAI `ChatChunk` stream (PR #621), which drops the
+    // `signature_delta`. These tests prove the SSE frames (event names +
+    // `signature`) survive a message → stream → replay round-trip.
+    // =======================================================================
+
+    /// BYTE-SURVIVAL GOLDEN VECTOR (streaming): a paid `stream:true`
+    /// `/v1/messages` request to an Anthropic-resolved model takes the NATIVE
+    /// streaming relay, which forwards the upstream SSE body UNTOUCHED. The
+    /// response must be `text/event-stream` and carry the literal Anthropic SSE
+    /// frames (`event: message_start` / `content_block_delta` / `message_delta`
+    /// / `message_stop`) byte-for-byte — and the thinking-block `signature` (the
+    /// thing PR #621's re-framing drops) must survive verbatim in the stream.
+    #[tokio::test]
+    async fn native_streaming_response_is_byte_identical_sse() {
+        let app = test_app_with_streaming_native_relay();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 256,
+            "stream": true,
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+            "messages": [{"role": "user", "content": "Think first, then answer."}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "paid native streaming request must serve 200"
+        );
+        // The content-type MUST be text/event-stream (NOT application/json) — the
+        // client is told this is an SSE stream, not a buffered body.
+        let ct = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.starts_with("text/event-stream"),
+            "native streaming response must be text/event-stream; got '{ct}'"
+        );
+
+        // Collect the whole streamed body and assert it is the upstream SSE
+        // fixture BYTE-FOR-BYTE (verbatim passthrough — no re-framing).
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            bytes.as_ref(),
+            NATIVE_ANTHROPIC_STREAM_FIXTURE.as_bytes(),
+            "native streaming passthrough must relay the upstream Anthropic SSE bytes \
+             UNTOUCHED — event names, content_block_delta, signature_delta, and \
+             message_delta usage must all survive byte-for-byte"
+        );
+
+        // Spot-pin the load-bearing SSE frames for a readable failure if the
+        // byte-equality above ever regresses.
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            text.contains("event: message_start\n"),
+            "the message_start event frame must survive verbatim"
+        );
+        assert!(
+            text.contains("event: content_block_delta\n"),
+            "content_block_delta event frames must survive verbatim"
+        );
+        assert!(
+            text.contains("event: message_delta\n"),
+            "the message_delta event frame (output usage) must survive verbatim"
+        );
+        assert!(
+            text.contains("event: message_stop\n"),
+            "the message_stop event frame must survive verbatim"
+        );
+        // THE PR #621 REGRESSION WITNESS: the cryptographic thinking-block
+        // signature, carried in a signature_delta, must survive the stream. A
+        // re-framed OpenAI ChatChunk stream cannot carry it → multi-turn extended
+        // thinking hard-400s on the next turn. Here it must be present verbatim.
+        assert!(
+            text.contains("\"type\":\"signature_delta\""),
+            "the signature_delta event must survive the native stream (re-framing drops it)"
+        );
+        assert!(
+            text.contains("ErcBCkgIARABGAIiQ_GOLDEN_STREAM_SIGNATURE_xyz=="),
+            "the literal thinking-block signature must survive the native stream verbatim — \
+             this is exactly the byte PR #621's re-framing dropped; body={text}"
+        );
+    }
+
+    /// SCOPE GUARD: the RESHAPE branch (a NON-Anthropic resolved model) still
+    /// REJECTS `stream:true` with a 400 in the Anthropic error envelope.
+    /// Cross-provider streaming is OUT OF SCOPE — only the native Anthropic
+    /// branch streams. This proves the streaming arm did not accidentally open
+    /// the reshape path to streaming (which would re-frame and drop signatures).
+    #[tokio::test]
+    async fn reshape_branch_still_rejects_streaming() {
+        let app = test_app_with_mock_provider();
+        let body = serde_json::json!({
+            // openai/gpt-4o resolves to the openai provider → reshape branch.
+            "model": "openai/gpt-4o",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "the reshape branch must still reject stream:true (cross-provider streaming is OUT)"
+        );
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+    }
+
+    /// FAIL-CLOSED (streaming): when the upstream returns a non-2xx status, the
+    /// native streaming relay must check the status BEFORE returning a stream
+    /// body, fail closed (no 200, no charge-without-delivery), surface a redacted
+    /// Anthropic error envelope, and NEVER leak the upstream error body (which
+    /// here contains a fake `sk-` token to detect a leak — GHSA-cgqx-mg48-949v).
+    #[tokio::test]
+    async fn native_streaming_upstream_error_fails_closed_redacted() {
+        let app = test_app_with_erroring_native_relay();
+        let body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("payment-signature", valid_payment_header("/v1/messages"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Upstream non-2xx → NOT 200 (no charge-without-delivery).
+        assert!(
+            response.status().is_server_error() || response.status().is_client_error(),
+            "an upstream non-2xx on the native streaming relay must NOT return 200; got {}",
+            response.status()
+        );
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value =
+            serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+        // Redacted Anthropic error envelope.
+        assert_eq!(
+            v["type"], "error",
+            "a native streaming upstream failure must surface the Anthropic error envelope; body={v}"
+        );
+        // No upstream body / key leak: the fake upstream `sk-` token must never
+        // appear in the client-facing body.
+        let body_str = String::from_utf8(bytes.to_vec()).unwrap_or_default();
+        assert!(
+            !body_str.contains("sk-leaked-upstream-key-should-never-surface")
+                && !body_str.contains("sk-"),
+            "fail-closed streaming error must never leak the upstream body/key; body={body_str}"
+        );
     }
 }


### PR DESCRIPTION
## What

Native Anthropic **SSE streaming passthrough** for `POST /v1/messages` — item 2 of the Claude Code drop-in track (follows #635's native non-streaming relay). A `stream:true` request whose model resolves to an Anthropic provider now relays `api.anthropic.com/v1/messages` SSE response bytes **verbatim** to the client.

This is what makes Claude Code (which streams by default) actually work against Solvela as a backend.

## The one design rule

Relay the upstream SSE bytes byte-for-byte via `axum::body::Body::from_stream(reqwest.bytes_stream())` + `content-type: text/event-stream` — **not** `axum::response::sse::Sse`. Re-framing through the internal OpenAI `ChatChunk` stream is exactly what #621 did, and it drops the thinking-block `signature` → multi-turn extended thinking hard-400s on turn 2. Verbatim relay preserves the `signature`, native `tool_use` blocks, and cache-token usage.

The **reshape branch** (a cross-provider model in Anthropic shape, reachable only via an eco/auto alias) still rejects `stream:true` — cross-provider streaming stays out of scope.

## Money path

- Streaming returns `usage:None` / `cost_outcome:None` → the existing `EstimateFallback` settlement arm fires. **Byte-identical billing posture to OpenAI streaming; no new financial math.** Under x402 `exact` the client's signed quote settles regardless, so no `message_delta` usage tap is added here (it would only affect the spend-log record, not the charge — settle-on-actuals is the Track-2 voucher channel's job).
- **Fail-closed:** the upstream status is checked *before* the stream body is returned (a 200+headers stream can't be un-sent); a non-2xx / transport error maps to a redacted `NativeRelayError` (never the upstream body, gateway key, or raw reqwest error — GHSA-cgqx-mg48-949v) → `AllProvidersFailed` → reservation released, no settle, no silent reshape fallback.
- All three native dispatch sites (dev-bypass, free-tier, paid) are **unchanged** — they already route through `run_native_relay`, which now forks on `req.stream`.

## Files

- `providers/anthropic.rs` — `relay_native_stream()`, the streaming twin of `relay_native()`.
- `routes/chat/mod.rs` — `run_native_relay` forks on `req.stream`.
- `providers/anthropic_inbound.rs` — native skeleton carries `stream: req.stream`.
- `routes/messages/mod.rs` — `stream:true` reject moved from pre-fork to the reshape branch only.
- `main.rs` — shared reqwest client gains a `read_timeout` (per-chunk idle). reqwest's total `.timeout()` is a wall-clock deadline across headers + body, so it would truncate a long streamed completion mid-flight while `exact` had already settled. The idle timeout is the correct streaming-liveness primitive (resets per frame) and covers all SSE paths; the relay keeps a generous absolute ceiling as a backstop.

## Tests

New integration tests (mock server, no live key):
- `native_streaming_response_is_byte_identical_sse` — body is byte-equal to the upstream fixture; a `signature_delta` survives a message→stream→replay round-trip (the #621 witness).
- `native_streaming_upstream_error_fails_closed_redacted` — upstream 500 whose body contains a fake `sk-` key → not surfaced to the client.
- `messages_native_streaming_request_is_served_as_sse` — native `stream:true` → 200 + `text/event-stream`.
- `reshape_branch_still_rejects_streaming` — cross-provider `stream:true` → 400.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt` clean. `cargo test -p gateway`: lib 906/0, main 6/0, integration 318/0. (The 12 `escrow_queue` failures are the documented no-`DATABASE_URL` `#[sqlx::test]` cases.)

Reviewed across a 2-round money-path pass (specialized rust / silent-failure / security agents, then an independent reviewer): one BLOCKER (the `.timeout()` truncation above) and one HIGH (a TTFB/total metric-name collision) found and fixed; final independent pass clean.

> Live end-to-end Claude Code confirmation needs a funded `ANTHROPIC_API_KEY` (the SSE wire bytes are pinned by the byte-identity test, so this is last-mile, not a correctness gate).
