### PR TITLE
style(landing): vary eyebrow cadence with a quiet .kicker treatment

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -543,6 +543,18 @@ pre code [data-highlighted-line] {
   color: var(--accent-salmon);
 }
 
+/* Quiet companion to .eyebrow. The salmon mono-uppercase eyebrow marks the
+   loud anchor sections; .kicker opens the connective/explanatory ones in
+   sentence-case muted text, so the landing has cadence instead of the same
+   eyebrow on every section. */
+.kicker {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: var(--muted-foreground);
+}
+
 /* ==========================================================
    SECTION HEADER UTILITY
    ========================================================== */

--- a/dashboard/src/components/landing/architecture-section.tsx
+++ b/dashboard/src/components/landing/architecture-section.tsx
@@ -13,7 +13,7 @@ export function ArchitectureSection() {
     <section aria-labelledby="arch-heading" className="border-t border-border/60">
       <div className="mx-auto max-w-[1320px] px-6 py-16 lg:py-24">
         <Reveal>
-          <span className="eyebrow">under the hood</span>
+          <span className="kicker">Under the hood</span>
           <h2
             id="arch-heading"
             className="display-wonk mt-3 max-w-[18ch] text-[var(--heading-color)]"

--- a/dashboard/src/components/landing/enterprise-panel.tsx
+++ b/dashboard/src/components/landing/enterprise-panel.tsx
@@ -60,7 +60,7 @@ export function EnterprisePanel() {
         <div className="rule-tipped mb-10" />
         <div className="flex flex-col gap-3 pb-10 sm:flex-row sm:items-end sm:justify-between">
           <div className="flex flex-col gap-3">
-            <span className="eyebrow">for teams &amp; enterprise</span>
+            <span className="kicker">For teams &amp; enterprise</span>
             <h2
               id="enterprise-heading"
               className="display-wonk max-w-[16ch] text-[var(--heading-color)]"

--- a/dashboard/src/components/landing/lifecycle-scene.tsx
+++ b/dashboard/src/components/landing/lifecycle-scene.tsx
@@ -129,7 +129,7 @@ export function LifecycleScene() {
         <div className="rule-tipped mb-7" />
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div className="flex flex-col gap-3">
-            <span className="eyebrow">one transaction, start to finish</span>
+            <span className="kicker">One transaction, start to finish</span>
             <h2
               id="lifecycle-heading"
               className="display-wonk max-w-[18ch] text-[var(--heading-color)]"


### PR DESCRIPTION
## What

Follow-up to the `/impeccable critique` re-run (33/40). Addresses the three recommended actions; only **quieter** needed code.

### `quieter` — landing eyebrow cadence (the change)
The salmon mono-uppercase `.eyebrow` opened **6 consecutive** landing sections — the "eyebrow above every section" reflex the critique flagged as the one item gating Aesthetic & Minimalist (H8) from a clean 4.

Adds a quiet companion **`.kicker`** (sentence-case, `--muted-foreground`, no salmon, no uppercase) and converts the three connective/explanatory sections to it:

| Section | Treatment |
|---|---|
| a2a — "agent-to-agent" | **salmon eyebrow** (anchor: lead differentiator) |
| lifecycle — "One transaction, start to finish" | → quiet kicker |
| why-solvela — "why agents pick solvela" | **salmon eyebrow** (anchor: core value) |
| provider-row | (no kicker — dropped in #652) |
| enterprise — "For teams & enterprise" | → quiet kicker |
| architecture — "Under the hood" | → quiet kicker |
| sdk-cta — "your first 402" | **salmon eyebrow** (anchor: conversion CTA) |

The salmon eyebrow now marks 3 anchor moments; quiet kickers open the explanatory ones — cadence instead of one note. `.kicker` uses `--muted-foreground` (~6:1, AA-safe — the same token as body copy, already contrast-verified).

### `adapt` — forced-dark landing → **no change needed**
The landing's forced `dark` is already a deliberate, documented decision (`page.tsx:80-83`) with `disableTransitionOnChange` + a server-rendered `dark` class (no flash), and responsive was already verified clean in the critique. Building a full light-theme port for a deliberately dark-only brand surface isn't warranted. Documenting/confirming the decision is the correct `adapt` outcome here.

### `polish` — this PR is the polish pass
No additional issues surfaced beyond the cadence item.

## Verification
className/text swaps + one global CSS class — no type surface touched, so no `tsc` run (the worktree has no `node_modules`; installing 629 packages to check string literals isn't warranted). Branch is cut from current `main`, so `Cargo.lock` is current — security CI should pass without a rebase.

Net **+15 / −3**.
