### PR TITLE
docs(web): sync landing + docs to live state (NVIDIA free tier, Opus 4.8, MCP on npm)

### DIFF
--- a/dashboard/content/docs/api/chat-completions.mdx
+++ b/dashboard/content/docs/api/chat-completions.mdx
@@ -42,7 +42,7 @@ Pass any of the following as `model`:
 
 - **Routing profile**: `auto`, `eco`, `premium`, `free` — smart router picks the model
 - **Alias**: `gpt5`, `sonnet`, `opus`, `gemini`, `flash`, `grok`, `deepseek`
-- **Full model ID**: `openai/gpt-4o`, `anthropic/claude-opus-4-6`, etc.
+- **Full model ID**: `openai/gpt-4o`, `anthropic/claude-opus-4-8`, etc.
 
 See [Smart Router](/docs/concepts/smart-router) for how profiles work.
 

--- a/dashboard/content/docs/api/index.mdx
+++ b/dashboard/content/docs/api/index.mdx
@@ -58,6 +58,9 @@ All endpoints accept and return `application/json`. Streaming responses use SSE 
 | `GET` | `/v1/supported` | Supported payment networks and schemes |
 | `GET` | `/v1/nonce` | Fetch a durable nonce for replay-safe transactions |
 | `POST` | `/v1/images/generations` | Image generation (OpenAI-compatible) |
+| `POST` | `/v1/messages` | Anthropic-native relay — forwards a validated Anthropic request byte-for-byte to Anthropic-provider models, preserving thinking-block `signature`s, `redacted_thinking`, and native `tool_use` (only `usage` is parsed, for billing). Single-turn works today; multi-turn extended thinking is not yet supported. |
+| `POST` | `/v1/search` | x402-paid web search ($0.01/query + 5% platform fee). Returns normalized `title`/`url`/`snippet`. |
+| `GET` | `/v1/services` | Lists the x402 service-marketplace tools (e.g. web search) with per-call pricing |
 | `POST` | `/v1/escrow/settle` | Client-initiated early escrow claim after stream completion (see [Escrow → F4 settle](/docs/concepts/escrow#client-initiated-settle-f4)) |
 | `GET` | `/.well-known/agent-card.json` | A2A AgentCard for agent discovery (v0.3 canonical path; /.well-known/agent.json kept as alias) |
 | `POST` | `/a2a` | A2A protocol JSON-RPC endpoint |

--- a/dashboard/content/docs/api/models.mdx
+++ b/dashboard/content/docs/api/models.mdx
@@ -6,7 +6,7 @@ description: GET /v1/models — list available models with pricing and capabilit
 
 ## GET /v1/models
 
-Returns all available models with pricing, context window size, and capability flags. No payment required.
+Returns all available models — the paid catalog plus the free NVIDIA NIM tier — with pricing, context window size, and capability flags. No payment required.
 
 ```bash
 curl https://api.solvela.ai/v1/models
@@ -47,7 +47,7 @@ curl https://api.solvela.ai/v1/models
 |-------|------|-------------|
 | `id` | string | The model ID to pass in the `model` field of requests |
 | `object` | string | Always `"model"` (OpenAI-compatible discriminator) |
-| `provider` | string | Upstream provider: `openai`, `anthropic`, `google`, `xai`, `deepseek` |
+| `provider` | string | Upstream provider: `openai`, `anthropic`, `google`, `xai`, `deepseek`, `nvidia` |
 | `display_name` | string | Human-readable model name |
 | `context_window` | integer | Maximum tokens in the combined input + output |
 | `pricing.input_per_million` | float | Provider cost per million input tokens, in `pricing.currency` |
@@ -61,7 +61,7 @@ curl https://api.solvela.ai/v1/models
 
 ## Available models
 
-For a full pricing table, see [Pricing](/docs/concepts/pricing).
+The table below is the **paid** catalog across the five marquee providers. Separately, NVIDIA NIM adds a **free tier** of 15 zero-cost Nemotron models (plus 2 paid) — see [Free tier](/docs/concepts/free-tier). The authoritative live list of all models is always `GET /v1/models`; for a full pricing table, see [Pricing](/docs/concepts/pricing).
 
 | Model ID | Provider | Input $/M | Output $/M |
 |----------|----------|-----------|------------|
@@ -75,6 +75,8 @@ For a full pricing table, see [Pricing](/docs/concepts/pricing).
 | `openai/gpt-4.1-mini` | OpenAI | $0.40 | $1.60 |
 | `openai/gpt-4.1-nano` | OpenAI | $0.10 | $0.40 |
 | `openai/gpt-oss-120b` | OpenAI | $0.00 | $0.00 |
+| `anthropic/claude-opus-4-8` | Anthropic | $5.00 | $25.00 |
+| `anthropic/claude-opus-4-7` | Anthropic | $5.00 | $25.00 |
 | `anthropic/claude-opus-4-6` | Anthropic | $5.00 | $25.00 |
 | `anthropic/claude-sonnet-4-6` | Anthropic | $3.00 | $15.00 |
 | `anthropic/claude-sonnet-4-5-20250929` | Anthropic | $3.00 | $15.00 |

--- a/dashboard/content/docs/api/rate-limits.mdx
+++ b/dashboard/content/docs/api/rate-limits.mdx
@@ -20,7 +20,7 @@ Operational endpoints — `/health`, `/v1/models`, and `/metrics` — are exempt
 
 ## Free tier vs paid limits
 
-A request is **free** if and only if its quoted cost is exactly `0` atomic USDC — i.e. the resolved model is zero-priced in the registry (currently `openai/gpt-oss-120b` and `google/gemini-3.1-flash-lite`, with `gemini-3.1-flash-lite` being the `free` routing profile's target). Free requests are served at $0 with no `payment-signature` header and never touch the payment path. A payment header sent with a free model is ignored — the quoted amount is `0`, so there is nothing to verify or claim.
+A request is **free** if and only if its quoted cost is exactly `0` atomic USDC — i.e. the resolved model is zero-priced in the registry. The `free` / `oss` / `open` routing profile targets the NVIDIA NIM Nemotron free-tier models (tiered by complexity), and `google/gemini-3.1-flash-lite` and `openai/gpt-oss-120b` are also zero-priced (Gemini 3.1 Flash-Lite is the fallback when NVIDIA NIM is down). Free requests are served at $0 with no `payment-signature` header and never touch the payment path. A payment header sent with a free model is ignored — the quoted amount is `0`, so there is nothing to verify or claim.
 
 Because the free path is anonymous (no payer wallet), its rate-limit identity is the actual TCP peer IP — never a client-supplied header such as `X-Forwarded-For`. Two gates run, in order, before any provider call:
 

--- a/dashboard/content/docs/concepts/architecture.mdx
+++ b/dashboard/content/docs/concepts/architecture.mdx
@@ -37,7 +37,7 @@ protocol (wire types, zero deps)
     └── gateway (Axum HTTP server — the only binary)
             ├── routes/chat/ (completions, cost, payment, provider)
             ├── middleware/ (rate limit, x402, API key, CORS)
-            ├── providers/ (OpenAI, Anthropic, Google, xAI, DeepSeek)
+            ├── providers/ (OpenAI, Anthropic, Google, xAI, DeepSeek, NVIDIA)
             └── a2a/ (Agent-to-Agent protocol adapter)
 ```
 
@@ -110,6 +110,7 @@ The `providers/` module inside `gateway` contains an adapter for each upstream L
 | Google | Gemini 3.1 Pro, Gemini 2.5 Flash, Gemini 3.1 Flash-Lite |
 | xAI | Grok 4 Fast, Grok Code Fast, Grok 3, Grok 3 Mini |
 | DeepSeek | DeepSeek V3.2 Chat, V3.2 Reasoner, Coder V3 |
+| NVIDIA | NIM Nemotron (15 free + 2 paid), Llama 4, Qwen3, DeepSeek-R1, Mistral, MiniMax |
 
 <Tip>
 All providers accept the same OpenAI-compatible request format. Switching models or providers requires only changing the `model` field — no client code changes needed.

--- a/dashboard/content/docs/concepts/free-tier.mdx
+++ b/dashboard/content/docs/concepts/free-tier.mdx
@@ -6,7 +6,15 @@ description: Zero-cost requests that skip the 402 challenge — no wallet, no si
 
 The free tier lets you call the gateway with no wallet, no USDC, and no payment signature. When the upfront cost estimate for a request is exactly zero, the gateway skips the entire 402 payment challenge and serves the request at $0. There is nothing to charge, so there is nothing to sign.
 
-The free model is `google/gemini-3.1-flash-lite`, registered with `0.0` input and output cost per million tokens.
+The free tier is a catalog of zero-cost models. The `free` / `oss` / `open` routing profile resolves to NVIDIA NIM **Nemotron** models — each registered with `0.0` input and output cost per million tokens — tiered by request complexity:
+
+| Tier | Model |
+|------|-------|
+| Simple | `nvidia/nvidia/llama-3.1-nemotron-nano-8b-v1` |
+| Medium | `nvidia/nvidia/llama-3.3-nemotron-super-49b-v1` |
+| Complex / Reasoning | `nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1` |
+
+If NVIDIA NIM is unavailable, these degrade to the `$0` `google/gemini-3.1-flash-lite` fallback, so the free tier keeps serving. (The doubled `nvidia/nvidia/` prefix is the real model id: the provider is `nvidia`, and NVIDIA publishes its own models under an `nvidia/` namespace.)
 
 ## How to use it
 
@@ -37,7 +45,7 @@ curl -s https://api.solvela.ai/v1/chat/completions \
   }'
 ```
 
-The `free` profile (aliases: `oss`, `open`) maps every complexity tier — Simple, Medium, Complex, Reasoning — to `google/gemini-3.1-flash-lite`.
+The `free` profile (aliases: `oss`, `open`) maps each complexity tier to an NVIDIA Nemotron `$0` model — Simple → Nemotron Nano 8B, Medium → Nemotron Super 49B, Complex and Reasoning → Nemotron Ultra 253B — with `google/gemini-3.1-flash-lite` as the `$0` fallback when NVIDIA NIM is down.
 
 ## How free-ness is decided
 
@@ -55,7 +63,7 @@ This means free-ness is a property of the **model's price**, not the profile nam
 | What it is | Router feature: resolves `"free"` to a model | Payment feature: serves estimate-`0` requests at $0 |
 | Where it lives | Smart router (model resolution) | Chat handler (payment path) |
 | Trigger | `model` set to `free` / `oss` / `open` | Computed atomic cost estimate is exactly `0` |
-| Effect | Picks `google/gemini-3.1-flash-lite` for every tier | Skips 402, skips payment decode/verify/settlement |
+| Effect | Picks an NVIDIA Nemotron `$0` model per complexity tier (Gemini 3.1 Flash-Lite as fallback) | Skips 402, skips payment decode/verify/settlement |
 
 <Note>
   A `payment-signature` header sent with a free request is ignored — the quoted amount is 0, so there is nothing to verify or claim. The request is served at $0 regardless.
@@ -75,7 +83,7 @@ For comparison, the paid per-client limit defaults to 60 requests per 60s — th
 
 **Per-IP limit.** Keyed on the actual TCP peer IP, never a client-supplied header like `X-Forwarded-For` (which is trivially spoofed). `SOLVELA_FREE_TIER_RATE_LIMIT` overrides only the per-IP value; the "unknown" bucket limit is fixed. Setting the override to `0` is rejected at startup (it would disable all free access) and the default is used instead.
 
-**Global aggregate cap.** The free model is served on Google's free Gemini API tier, whose hard limit is roughly 15 requests/min shared across the gateway's entire API key. Many distinct IPs each under their per-IP cap can still collectively exceed that, so a global counter caps combined free throughput at 12/min by default — leaving headroom so the gateway returns its own clean 429 before Google's leaks through. `SOLVELA_FREE_TIER_GLOBAL_RPM=0` is likewise rejected in favor of the default. (Legacy `RCR_`-prefixed forms of both env vars are accepted as fallbacks.)
+**Global aggregate cap.** The free tier's Gemini fallback is served on Google's free Gemini API tier, whose hard limit is roughly 15 requests/min shared across the gateway's entire API key, so the global cap is sized against that ceiling. Many distinct IPs each under their per-IP cap can still collectively exceed that, so a global counter caps combined free throughput at 12/min by default — leaving headroom so the gateway returns its own clean 429 before Google's leaks through. `SOLVELA_FREE_TIER_GLOBAL_RPM=0` is likewise rejected in favor of the default. (Legacy `RCR_`-prefixed forms of both env vars are accepted as fallbacks.)
 
 The cap counter lives in Redis when configured, so it is shared across gateway instances. Without Redis — or when Redis errors at runtime — it degrades to an in-memory per-instance counter. It never goes unbounded.
 
@@ -108,7 +116,7 @@ A global-cap 429 carries `x-ratelimit-limit: 12` instead. These headers are auth
 
 ## Limitations
 
-- **One model.** The free tier serves `google/gemini-3.1-flash-lite` only. The `free` profile does not pick different models by complexity tier the way `eco`/`auto`/`premium` do.
+- **Free-tier catalog.** The `free` profile tiers across NVIDIA Nemotron `$0` models by complexity (Nano 8B → Super 49B → Ultra 253B), just like `eco`/`auto`/`premium`. Any model priced `$0/$0` in the registry — the NVIDIA Nemotron tier plus `google/gemini-3.1-flash-lite` and `openai/gpt-oss-120b` — takes the zero-cost bypass when named directly.
 - **Tight capacity.** 5 requests/min per IP and 12/min total across all users of the gateway, by default. The free tier is for trying the gateway, not running workloads.
 - **Anonymous, IP-keyed.** Clients behind a shared NAT share one per-IP bucket. There is no per-wallet allowance — paying with a wallet is the way to get the paid limits.
 - **Prompt guard still runs.** Free requests reach a real provider, so they pass the same injection/jailbreak/PII checks as paid requests.

--- a/dashboard/content/docs/concepts/pricing.mdx
+++ b/dashboard/content/docs/concepts/pricing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pricing
-description: Per-token USDC pricing across all 25 models with 5% platform fee
+description: Per-token USDC pricing with a 5% platform fee — the paid model catalog plus a free NVIDIA NIM tier
 ---
 
 
@@ -51,6 +51,8 @@ All prices are USDC per million tokens (provider cost before the 5% fee).
 
 | Model | Model ID | Input ($/M) | Output ($/M) | Context |
 |-------|----------|-------------|--------------|---------|
+| Claude Opus 4.8 | `anthropic/claude-opus-4-8` | $5.00 | $25.00 | 200K |
+| Claude Opus 4.7 | `anthropic/claude-opus-4-7` | $5.00 | $25.00 | 200K |
 | Claude Opus 4.6 | `anthropic/claude-opus-4-6` | $5.00 | $25.00 | 200K |
 | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-6` | $3.00 | $15.00 | 200K |
 | Claude Sonnet 4.5 | `anthropic/claude-sonnet-4-5-20250929` | $3.00 | $15.00 | 200K |
@@ -81,6 +83,15 @@ All prices are USDC per million tokens (provider cost before the 5% fee).
 | DeepSeek V3.2 Chat | `deepseek/deepseek-chat` | $0.28 | $0.42 | 128K |
 | DeepSeek V3.2 Reasoner | `deepseek/deepseek-reasoner` | $0.28 | $0.42 | 128K |
 | DeepSeek Coder V3 | `deepseek/deepseek-coder` | $0.28 | $0.42 | 128K |
+
+### NVIDIA NIM
+
+The `free` / `oss` / `open` profile routes here. Fifteen Nemotron models are **free** (`$0/$0`) — see [Free tier](/docs/concepts/free-tier) for the per-tier mapping, or `GET /v1/models` for the full list. Two NVIDIA models are paid:
+
+| Model | Model ID | Input ($/M) | Output ($/M) | Context |
+|-------|----------|-------------|--------------|---------|
+| Llama 3.3 Nemotron Super 49B v1.5 | `nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5` | $0.10 | $0.40 | 128K |
+| NVIDIA Nemotron Nano 9B v2 | `nvidia/nvidia/nvidia-nemotron-nano-9b-v2` | $0.04 | $0.16 | 128K |
 
 <Note>
   These are provider list prices. The actual amount charged includes the 5% platform fee. Always check the `cost_breakdown` in the `402` response for the exact amount you will pay.

--- a/dashboard/content/docs/concepts/request-flow.mdx
+++ b/dashboard/content/docs/concepts/request-flow.mdx
@@ -106,8 +106,8 @@ Each routing profile then maps tiers to specific models:
 |---------|--------|--------|---------|-----------|
 | `eco` | DeepSeek Chat | Gemini Flash Lite | DeepSeek Chat | DeepSeek Reasoner |
 | `auto` | Gemini Flash | Grok Code Fast | Gemini 3.1 Pro | Grok 4 Fast |
-| `premium` | GPT-4o | Claude Sonnet 4.6 | Claude Opus 4.6 | o3 |
-| `free` | gpt-oss-120b | gpt-oss-120b | gpt-oss-120b | gpt-oss-120b |
+| `premium` | GPT-4o | Claude Sonnet 4.6 | Claude Opus 4.8 | o3 |
+| `free` | Nemotron Nano 8B | Nemotron Super 49B | Nemotron Ultra 253B | Nemotron Ultra 253B |
 
 See [Smart Router](/docs/concepts/smart-router#routing-table) for the authoritative `(profile, tier) → model ID` table.
 

--- a/dashboard/content/docs/concepts/smart-router.mdx
+++ b/dashboard/content/docs/concepts/smart-router.mdx
@@ -26,7 +26,7 @@ Set `model` to a routing profile name instead of a specific model ID:
 | `auto` | `balanced`, `default` | Balanced cost and quality. **Recommended default.** |
 | `eco` | `cheap`, `budget` | Cheapest capable model per tier. |
 | `premium` | `best`, `quality` | Best available model regardless of cost. |
-| `free` | `oss`, `open` | Free-tier model only (`google/gemini-3.1-flash-lite`). |
+| `free` | `oss`, `open` | Free NVIDIA Nemotron models, tiered by complexity (Gemini 3.1 Flash-Lite fallback). |
 
 You can also use model aliases as shortcuts to specific models:
 
@@ -34,7 +34,7 @@ You can also use model aliases as shortcuts to specific models:
 |-------|-------------|
 | `gpt5` | `openai/gpt-5.2` |
 | `sonnet` | `anthropic/claude-sonnet-4-6` |
-| `opus` | `anthropic/claude-opus-4-6` |
+| `opus` | `anthropic/claude-opus-4-8` |
 | `gemini` | `google/gemini-3.1-pro` |
 | `flash` | `google/gemini-2.5-flash` |
 | `grok` | `xai/grok-4-fast-reasoning` |
@@ -81,12 +81,12 @@ Each (Profile, Tier) pair maps to a specific model:
 
 | Tier | eco | auto | premium | free |
 |------|-----|------|---------|------|
-| Simple | `deepseek/deepseek-chat` | `google/gemini-2.5-flash` | `openai/gpt-4o` | `google/gemini-3.1-flash-lite` |
-| Medium | `google/gemini-2.5-flash-lite` | `xai/grok-code-fast-1` | `anthropic/claude-sonnet-4-6` | `google/gemini-3.1-flash-lite` |
-| Complex | `deepseek/deepseek-chat` | `google/gemini-3.1-pro` | `anthropic/claude-opus-4-6` | `google/gemini-3.1-flash-lite` |
-| Reasoning | `deepseek/deepseek-reasoner` | `xai/grok-4-fast-reasoning` | `openai/o3` | `google/gemini-3.1-flash-lite` |
+| Simple | `deepseek/deepseek-chat` | `google/gemini-2.5-flash` | `openai/gpt-4o` | `nvidia/nvidia/llama-3.1-nemotron-nano-8b-v1` |
+| Medium | `google/gemini-2.5-flash-lite` | `xai/grok-code-fast-1` | `anthropic/claude-sonnet-4-6` | `nvidia/nvidia/llama-3.3-nemotron-super-49b-v1` |
+| Complex | `deepseek/deepseek-chat` | `google/gemini-3.1-pro` | `anthropic/claude-opus-4-8` | `nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1` |
+| Reasoning | `deepseek/deepseek-reasoner` | `xai/grok-4-fast-reasoning` | `openai/o3` | `nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1` |
 
-> **`free` profile vs. the free tier:** the `free` profile is a routing choice — it sends every tier to the zero-cost model. Separately, any request whose estimated cost is zero (which is what routing to a zero-cost model produces) skips the 402 payment challenge entirely: no wallet or signature needed. Free-tier traffic is subject to per-IP and aggregate rate limits. See [Free tier](/docs/concepts/free-tier) for details.
+> **`free` profile vs. the free tier:** the `free` profile is a routing choice — it sends each tier to a zero-cost NVIDIA Nemotron model (a different one per tier). Separately, any request whose estimated cost is zero (which is what routing to a zero-cost model produces) skips the 402 payment challenge entirely: no wallet or signature needed. Free-tier traffic is subject to per-IP and aggregate rate limits. See [Free tier](/docs/concepts/free-tier) for details.
 
 ## Example: same prompt, different profiles
 
@@ -119,7 +119,7 @@ To use a specific model, pass its full ID directly:
 
 ```json
 {
-  "model": "anthropic/claude-opus-4-6",
+  "model": "anthropic/claude-opus-4-8",
   "messages": [...]
 }
 ```

--- a/dashboard/content/docs/enterprise/budgets.mdx
+++ b/dashboard/content/docs/enterprise/budgets.mdx
@@ -45,12 +45,7 @@ Content-Type: application/json
 
 ```json
 {
-  "hourly_limit": 5.0,
-  "daily_limit": 50.0,
-  "monthly_limit": 500.0,
-  "hourly_spend": 1.25,
-  "daily_spend": 12.50,
-  "monthly_spend": 87.00
+  "updated": true
 }
 ```
 
@@ -63,7 +58,18 @@ GET /v1/orgs/018f1a2b-.../teams/019c3d4e-.../budget
 Authorization: Bearer <admin-token | solvela_k_...>
 ```
 
-Response shape is the same as the set response above.
+**Response** — `200 OK`
+
+```json
+{
+  "hourly_limit": 5.0,
+  "daily_limit": 50.0,
+  "monthly_limit": 500.0,
+  "hourly_spend": 1.25,
+  "daily_spend": 12.50,
+  "monthly_spend": 87.00
+}
+```
 
 ## Org budget rollup
 

--- a/dashboard/content/docs/enterprise/orgs.mdx
+++ b/dashboard/content/docs/enterprise/orgs.mdx
@@ -48,7 +48,7 @@ Content-Type: application/json
 
 ## List organizations
 
-Returns all organizations. Accepts both the admin token and an org-scoped API key (which returns only the org the key belongs to).
+Returns up to the first 100 organizations. Accepts both the admin token and an org-scoped API key (which returns only the org the key belongs to).
 
 ```http title="GET /v1/orgs"
 GET /v1/orgs

--- a/dashboard/content/docs/enterprise/sponsorship.mdx
+++ b/dashboard/content/docs/enterprise/sponsorship.mdx
@@ -24,7 +24,7 @@ Every dollar of sponsorship maps to a real recurring line item, not a salary. In
 | **Security** | Quarterly `cargo-audit` / `cargo-deny` review; one external review per release of the Anchor escrow program. |
 | **Domains, certs, monitoring** | Registrar fees, BetterUptime, Sentry hobby tier, log retention. |
 
-If sponsorship ever exceeds these line items, the surplus funds an external security audit of the gateway and escrow program. We will not pay maintainer salaries from sponsorship — that's what commercial licenses and the optional [acquihire path](https://github.com/solvela-ai/solvela/blob/main/docs/exit-readiness.md) are for. Sponsorship is for the lights.
+If sponsorship ever exceeds these line items, the surplus funds an external security audit of the gateway and escrow program. We will not pay maintainer salaries from sponsorship — that's what commercial licenses and the optional acquihire path are for. Sponsorship is for the lights.
 
 ## Tiers
 

--- a/dashboard/content/docs/index.mdx
+++ b/dashboard/content/docs/index.mdx
@@ -39,7 +39,7 @@ The gateway is OpenAI-compatible, so any existing code that targets the OpenAI A
 ## Key capabilities
 
 <CardGroup>
-  <Card title="25 models across 5 providers" description="OpenAI, Anthropic, Google, xAI, and DeepSeek — all behind one endpoint with unified USDC pricing." href="/docs/api/models" />
+  <Card title="25 paid models across 5 providers" description="OpenAI, Anthropic, Google, xAI, and DeepSeek behind one endpoint with unified USDC pricing — plus a free NVIDIA NIM tier of 15 zero-cost Nemotron models." href="/docs/api/models" />
   <Card title="Smart routing" description="Set model to 'auto', 'eco', 'premium', or 'free' and the gateway picks the right model for your prompt's complexity." href="/docs/concepts/smart-router" />
   <Card title="Escrow payments" description="Trustless on-chain escrow with deposit/claim/refund — no upfront full payment required." href="/docs/concepts/escrow" />
   <Card title="OpenAI-compatible" description="Drop-in replacement for the OpenAI API. Change the base URL and add payment handling." href="/docs/api/chat-completions" />

--- a/dashboard/content/docs/operations/deployment.mdx
+++ b/dashboard/content/docs/operations/deployment.mdx
@@ -65,6 +65,7 @@ RUN cargo build --release --bin solvela-gateway 2>/dev/null || true
 COPY crates/ crates/
 COPY config/ config/
 COPY migrations/ migrations/
+COPY docs/openapi.json docs/openapi.json
 RUN touch crates/protocol/src/lib.rs crates/x402/src/lib.rs crates/router/src/lib.rs crates/gateway/src/lib.rs crates/gateway/src/main.rs
 RUN cargo build --release --bin solvela-gateway
 
@@ -109,7 +110,7 @@ docker run -p 8402:8402 \
   solvela
 ```
 
-The canonical env-var separator is **double underscore** (Fly.io convention; see `crates/gateway/src/main.rs:70`). The legacy single-underscore form (`SOLVELA_SOLANA_RPC_URL`) is also accepted as a fallback so existing deployments keep working.
+The canonical env-var separator is **double underscore** (Fly.io convention; see `crates/gateway/src/main.rs:72`). The legacy single-underscore form (`SOLVELA_SOLANA_RPC_URL`) is also accepted as a fallback so existing deployments keep working.
 
 ## Fly.io Deployment
 

--- a/dashboard/content/docs/operations/monitoring.mdx
+++ b/dashboard/content/docs/operations/monitoring.mdx
@@ -56,7 +56,7 @@ scrape_configs:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `solvela_provider_request_duration_seconds` | Histogram | `provider` | Upstream provider response time. Provider values: `openai`, `anthropic`, `google`, `xai`, `deepseek`. |
+| `solvela_provider_request_duration_seconds` | Histogram | `provider` | Upstream provider response time. Provider values: `openai`, `anthropic`, `google`, `xai`, `deepseek`, `nvidia`. |
 | `solvela_provider_errors_total` | Counter | `provider`, `error_type` | Provider errors. Error types: `timeout`, `auth`, `rate_limit`, `server_error`, `unknown`. |
 
 ### Cache Metrics

--- a/dashboard/content/docs/operations/security.mdx
+++ b/dashboard/content/docs/operations/security.mdx
@@ -31,7 +31,7 @@ Transaction signatures are tracked to prevent double-spending:
 
 - **Redis (primary)**: `SET NX EX 120` -- if the key already exists, the payment is rejected
 - **In-memory LRU (fallback)**: bounded to 10,000 entries when Redis is unavailable
-- The 120-second TTL exceeds Solana's ~60-second blockhash expiry window
+- The 120-second TTL exceeds Solana's ~90-second blockhash expiry window
 
 <Warning>
 When Redis is unavailable, replay protection uses an in-memory LRU cache. This is a degraded mode -- it cannot protect against replays across gateway restarts or multi-instance deployments. Always use Redis in production.
@@ -52,8 +52,10 @@ Blocked ranges:
 - `172.16.0.0/12` (private)
 - `192.168.0.0/16` (private)
 - `169.254.0.0/16` (link-local)
+- `0.0.0.0/8` ("this" network)
+- `100.64.0.0/10` (CGNAT)
 - `::1` (IPv6 loopback)
-- `fc00::/7` (IPv6 unique local)
+- `fe80::/10` (IPv6 link-local)
 
 ## Rate Limiting
 
@@ -118,6 +120,8 @@ Every response includes:
 | `X-Content-Type-Options` | `nosniff` | Prevents MIME type sniffing |
 | `X-Frame-Options` | `DENY` | Prevents clickjacking |
 | `Referrer-Policy` | `no-referrer` | Prevents referrer leakage |
+| `Content-Security-Policy` | `default-src 'none'` | Blocks all resource loading (always present) |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Enforces HTTPS (production only) |
 | `X-Solvela-Request-Id` | UUID | Request correlation (always present). The legacy `X-RCR-Request-Id` mirror is also emitted for pre-rebrand clients. |
 
 ## Prompt Guard

--- a/dashboard/content/docs/operations/troubleshooting.mdx
+++ b/dashboard/content/docs/operations/troubleshooting.mdx
@@ -7,7 +7,7 @@ description: Common issues, debug headers, and diagnostics
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Paid chat requests return 500 with `error.type = "internal_error"` and `"all providers failed"` | No upstream provider API key configured for the resolved model's provider | Set at least one matching provider key in `.env` (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `DEEPSEEK_API_KEY`) and restart the gateway |
+| Paid chat requests return 500 with `error.type = "internal_error"` and `"all providers failed"` | No upstream provider API key configured for the resolved model's provider | Set at least one matching provider key in `.env` (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `DEEPSEEK_API_KEY`, `NVIDIA_API_KEY`) and restart the gateway |
 | 402 response but SDK does not auto-pay | Wallet key env var not set, or read under the wrong name (the CLI reads `SOLANA_WALLET_KEY`; the TypeScript/Python SDK examples read `SOLANA_PRIVATE_KEY` — the env var name is whatever you pass to `Wallet.fromEnv()` / `Wallet.from_env()`) | Set the env var your code reads and verify the value is a base58-encoded Solana keypair |
 | Free-model request served at $0 even with a `PAYMENT-SIGNATURE` header | Using a free model (`google/gemini-3.1-flash-lite`) — zero-cost requests skip the 402 challenge entirely and any payment header is ignored | Expected behavior; no payment is needed for free models |
 | Redis connection refused | Redis not running | Run `docker compose up -d redis` |

--- a/dashboard/content/docs/sdks/index.mdx
+++ b/dashboard/content/docs/sdks/index.mdx
@@ -18,7 +18,7 @@ Official SDKs are available for four languages plus an MCP server. All SDKs hand
 | Python | `solvela-sdk` | `pip install "solvela-sdk>=0.3.0"` | Yes | Yes (async-only) |
 | Go | `github.com/solvela-ai/solvela/sdks/go` | `go get github.com/solvela-ai/solvela/sdks/go` | Yes (built-in `KeypairSigner`, escrow scheme; `exact` needs a custom Signer) | Yes (context-based) |
 | Rust CLI | `solvela-cli` | `cargo install solvela-cli` | Yes | — |
-| MCP Server | (in-monorepo, not on npm) | see [MCP page](/docs/sdks/mcp) | Yes | — |
+| MCP Server | `@solvela/mcp-server` | `npm install -g @solvela/mcp-server` | Yes | — |
 
 ## Source code
 
@@ -30,12 +30,12 @@ All four language SDKs live in the [`solvela-ai/solvela`](https://github.com/sol
 - MCP server — [`sdks/mcp/`](https://github.com/solvela-ai/solvela/tree/main/sdks/mcp)
 - Vercel AI SDK provider, OpenClaw provider, npm CLI shim, signer-core primitives — [`sdks/ai-sdk-provider/`](https://github.com/solvela-ai/solvela/tree/main/sdks/ai-sdk-provider), [`sdks/openclaw-provider/`](https://github.com/solvela-ai/solvela/tree/main/sdks/openclaw-provider), [`sdks/cli-npm/`](https://github.com/solvela-ai/solvela/tree/main/sdks/cli-npm), [`sdks/signer-core/`](https://github.com/solvela-ai/solvela/tree/main/sdks/signer-core)
 
-The Rust client SDK was consolidated into the monorepo on 2026-05-16 ([#316](https://github.com/solvela-ai/solvela/pull/316)) at [`sdks/rust/`](https://github.com/solvela-ai/solvela/tree/main/sdks/rust); the standalone `solvela-ai/solvela-client` repo is archived. The four legacy Rust crates (`solvela-client`, `solvela-client-cli`, `solvela-client-cli-args`, `solvela-client-proxy`) remain published on crates.io (currently `0.3.0`) — `cargo install solvela-client-cli` still works, and they now publish from the monorepo via a tag-triggered workflow. The monorepo's flagship CLI is `solvela-cli` (`cargo install solvela-cli`).
+The Rust client SDK was consolidated into the monorepo on 2026-05-16 ([#316](https://github.com/solvela-ai/solvela/pull/316)) at [`sdks/rust/`](https://github.com/solvela-ai/solvela/tree/main/sdks/rust); the standalone `solvela-ai/solvela-client` repo is archived. The four legacy Rust crates (`solvela-client`, `solvela-client-cli`, `solvela-client-cli-args`, `solvela-client-proxy`) remain published on crates.io (currently `0.4.0`) — `cargo install solvela-client-cli` still works, and they now publish from the monorepo via a tag-triggered workflow. The monorepo's flagship CLI is `solvela-cli` (`cargo install solvela-cli`).
 
 <CardGroup>
   <Card title="TypeScript" description="@solvela/sdk@^0.3.0 — async client with automatic x402 signing and built-in Solana wallet support" href="/docs/sdks/typescript" />
   <Card title="Python" description="solvela-sdk>=0.3.0 — async-first client with built-in Solana signing" href="/docs/sdks/python" />
   <Card title="Go" description="go get github.com/solvela-ai/solvela/sdks/go — context-aware, goroutine-safe; built-in KeypairSigner signs the escrow scheme (exact needs a custom Signer)" href="/docs/sdks/go" />
   <Card title="Rust CLI" description="cargo install solvela-cli — interactive chat, model listing, health checks" href="/docs/sdks/rust" />
-  <Card title="MCP Server" description="In-monorepo MCP server — expose Solvela to MCP-compatible AI agents" href="/docs/sdks/mcp" />
+  <Card title="MCP Server" description="@solvela/mcp-server — expose Solvela to MCP-compatible AI agents" href="/docs/sdks/mcp" />
 </CardGroup>

--- a/dashboard/content/docs/sdks/mcp.mdx
+++ b/dashboard/content/docs/sdks/mcp.mdx
@@ -10,8 +10,16 @@ The Solvela MCP server exposes the gateway's capabilities as MCP tools, enabling
 
 ## Installation
 
-The MCP server is **not published to npm** today (`package.json` is marked
-`private: true`). Build it from the monorepo:
+The MCP server is published to npm as `@solvela/mcp-server@0.1.0`. Install it
+globally, or run it on demand with `npx`:
+
+```bash
+npm install -g @solvela/mcp-server
+# or, no install:
+npx -y @solvela/mcp-server
+```
+
+Alternatively, build it from the monorepo:
 
 ```bash
 git clone https://github.com/solvela-ai/solvela.git
@@ -57,9 +65,27 @@ or your host's encrypted env-var store over a plaintext shell profile.
 
 ## Claude Desktop integration
 
-Add an entry to `claude_desktop_config.json` that points at your locally-built
-`dist/index.js` (absolute path required — `npx` is not available because the
-package is not on npm):
+Add an entry to `claude_desktop_config.json` that runs the published package via
+`npx`:
+
+```json
+{
+  "mcpServers": {
+    "solvela": {
+      "command": "npx",
+      "args": ["-y", "@solvela/mcp-server"],
+      "env": {
+        "SOLVELA_API_URL": "https://api.solvela.ai",
+        "SOLANA_WALLET_KEY": "<base58-keypair-secret>",
+        "SOLANA_RPC_URL": "https://api.mainnet-beta.solana.com"
+      }
+    }
+  }
+}
+```
+
+If you built from source instead, point `command` at `node` and `args` at the
+absolute path to your locally-built `dist/index.js`:
 
 ```json
 {
@@ -85,6 +111,7 @@ The MCP server exposes the following tools to connected agents:
 |------|-------------|
 | `chat` | Send a prompt to a specific LLM model |
 | `smart_chat` | Send a prompt via the smart router — it auto-selects the model |
+| `web_search` | Search the web and get titled, linked result snippets (always available; no escrow mode required) |
 | `wallet_status` | Check the configured Solana wallet's status and gateway connectivity |
 | `list_models` | List available models with pricing |
 | `spending` | Show USDC spending statistics for the current session |

--- a/dashboard/content/docs/sdks/rust.mdx
+++ b/dashboard/content/docs/sdks/rust.mdx
@@ -121,7 +121,7 @@ anthropic/claude-opus-4-6      anthropic    $5.00           $25.00
 google/gemini-2.5-flash        google       $0.30           $2.50
 ...
 
-25 models available. 5% platform fee included.
+44 models available. 5% platform fee included.
 
 $ solvela chat --model eco "Hello, what can you do?"
 Cost breakdown:

--- a/dashboard/src/components/landing/config.ts
+++ b/dashboard/src/components/landing/config.ts
@@ -12,8 +12,13 @@ export const ESCROW_PROGRAM_ID = '9neDHouXgEgHZDde5Sp'
 // claiming SLA-shaped numbers without one is the kind of statement
 // enterprise procurement will challenge. Re-add with hard data
 // behind them, not before.
+//
+// 'paid models' = the 25 paid models across the 5 marquee providers
+// below (OpenAI/Anthropic/Google/xAI/DeepSeek). The free NVIDIA NIM
+// Nemotron tier (15 zero-cost models) is surfaced as its own callout,
+// not folded into this figure. Full live list: GET /v1/models.
 export const METRICS = [
-  { label: 'models', value: 25, suffix: '+', decimals: 0 },
+  { label: 'paid models', value: 25, suffix: '+', decimals: 0 },
   { label: 'platform fee', value: 5, suffix: '%', decimals: 0 },
 ]
 

--- a/dashboard/src/components/landing/landing-ticker.tsx
+++ b/dashboard/src/components/landing/landing-ticker.tsx
@@ -4,7 +4,8 @@ import { useEffect, useRef, useState } from 'react'
 
 const TICKER_ITEMS = [
   'ESCROW · 9neDHouXgEgHZDde5Sp',
-  '25 models · 5 providers',
+  '25 paid models · 5 providers',
+  'free tier · nvidia nim · $0',
   '5% flat fee',
   'mainnet · x402 · usdc-spl',
   'a2a · agent-card · /.well-known',

--- a/dashboard/src/components/landing/provider-row.tsx
+++ b/dashboard/src/components/landing/provider-row.tsx
@@ -3,9 +3,9 @@ import { PROVIDERS } from './config'
 
 /**
  * Providers — an editorial poster, not a tile grid. A poster-scale figure ("25
- * models") anchors the left; the five providers run as a measured list down the
- * right, each a hairline row with its brand dot. The "auto" routing note sits
- * as a mono footnote, not a card.
+ * paid models") anchors the left; the five marquee providers run as a measured
+ * list down the right, each a hairline row with its brand dot. The free NVIDIA
+ * NIM tier is noted in the mono footnote below, not counted in the poster figure.
  */
 export function ProviderRow() {
   return (
@@ -18,14 +18,14 @@ export function ProviderRow() {
         <div className="grid gap-12 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:gap-16">
           {/* left — the poster figure */}
           <Reveal className="flex flex-col justify-center">
-            {/* ponytail: no eyebrow — the poster "25 models" figure self-labels */}
+            {/* ponytail: no eyebrow — the poster "25 paid models" figure self-labels */}
             <div className="flex items-end gap-4">
               <span className="poster-figure text-[clamp(6.5rem,18vw,14rem)]">
                 25
               </span>
               <div className="mb-3 flex flex-col">
                 <span className="display-calm text-[clamp(1.4rem,3vw,2.4rem)] font-normal text-muted-foreground">
-                  models
+                  paid models
                 </span>
                 <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-faint">
                   five providers
@@ -42,6 +42,7 @@ export function ProviderRow() {
             <p className="mt-5 max-w-[44ch] font-mono text-[11px] uppercase tracking-[0.14em] leading-[1.8] text-text-faint">
               call model=&quot;auto&quot; and the router places the request —
               or name a model directly. unified per-token pricing in usdc.
+              plus a free nvidia nim tier — 15 zero-cost nemotron models.
             </p>
           </Reveal>
 


### PR DESCRIPTION
## What

Website/docs truth audit. Corrects **33 stale/false claims across 23 files** that accumulated as recent shipping (#632 NVIDIA NIM free tier + Fly v417, #636 Opus 4.8, #649 `@solvela/mcp-server` publish) outran the static landing page and docs, plus several standalone doc bugs surfaced along the way.

## Model / provider framing

Live `/v1/models` returns **44 models across 6 providers** (17 NVIDIA: 15 free + 2 paid). The public surface still said "25 models / 5 providers". Framing chosen: **lead with the paid marquee catalog, present the NVIDIA NIM free tier as a callout.**

- Landing (`config.ts` metrics, ticker, provider-row): `25 paid models · 5 providers · + free NVIDIA NIM tier`
- `docs/index`, `api/models`, `concepts/pricing`, `concepts/architecture`: reference tables add the 6th provider **NVIDIA** (2 paid Nemotron models) and point to `GET /v1/models` for the full live list; add the missing paid **Opus 4.8 / 4.7** rows

> The 5 marquee providers account for exactly **25** paid models; NVIDIA holds the other 2 paid + 15 free — so the "5 providers" headline uses 25 (internally consistent), while reference tables list all 6/44 to match the live endpoint.

## Free tier (biggest correctness fix — 6 HIGH)

The `free` / `oss` / `open` profile now routes to **NVIDIA Nemotron** models tiered by complexity (nano 8B → super 49B → ultra 253B); `google/gemini-3.1-flash-lite` is the `$0` **fallback**, not "the free model". Fixed in `free-tier`, `smart-router`, `request-flow`, `api/rate-limits`.

## Other clusters

- **Stale model version**: `opus` alias + premium/Complex routing → **Claude Opus 4.8** (was 4.6; 4.6 kept in tables as a real model)
- **SDKs**: MCP documented as published `@solvela/mcp-server@0.1.0` (npx install) instead of "clone-and-build / not on npm"; Rust crates `0.4.0`; `web_search` tool row
- **New endpoints documented**: `POST /v1/messages` (Anthropic-native relay, with the honest multi-turn-extended-thinking caveat), `POST /v1/search`, `GET /v1/services`
- **Standalone bugs**: team SET-budget response is `{"updated":true}` (GET returns limits+spend); SSRF list corrected (`fe80::/10`, `0.0.0.0/8`, `100.64.0.0/10`; drop `fc00::/7`); CSP + HSTS header rows; Dockerfile snippet `COPY docs/openapi.json`; `NVIDIA_API_KEY` added to provider lists; dead `exit-readiness.md` link removed; org list capped-at-100

## How it was done

Four parallel audit agents verified every claim against live source (`config/models.toml`, `crates/router/src/profiles.rs`, gateway routes, SDK packages), then two agents applied the mechanical clusters while the framing-sensitive edits were done by hand for voice consistency. 7 concept files + the license/enterprise docs verified fully accurate (unchanged).

## Validation

- All edited markdown tables column-checked (uniform, no broken rows); no new JSX tags introduced
- Non-issues ruled out before editing: truncated landing escrow ID (intentional `…` display), animation values (`420ms`/`50%`), `router-cache-diagram` gemini-3.1-pro pick (correct), `/pricing` endpoint (real)
- No `next build` run locally (docs/prose edits) — **Vercel preview deploy is the authoritative MDX build gate**

Docs/marketing only. No gateway, protocol, or money-path code touched.